### PR TITLE
[WIP] allow for multiple node CIDRs allocation for IPv6

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -192,8 +192,10 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
 	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster")
 	fs.StringVar(&s.ClusterCIDR, "cluster-cidr", s.ClusterCIDR, "CIDR Range for Pods in cluster.")
+	fs.StringSliceVar(&s.ClusterCIDRs, "cluster-cidrs", s.ClusterCIDRs, "list of CIDR Ranges for Pods in cluster.")
 	fs.StringVar(&s.ServiceCIDR, "service-cluster-ip-range", s.ServiceCIDR, "CIDR Range for Services in cluster.")
 	fs.Int32Var(&s.NodeCIDRMaskSize, "node-cidr-mask-size", s.NodeCIDRMaskSize, "Mask size for node cidr in cluster.")
+	fs.IntSliceVar(&s.NodeCIDRMaskSizes, "node-cidr-mask-sizes", s.NodeCIDRMaskSizes, "Mask sizes for node cidrs in cluster.")
 	fs.BoolVar(&s.AllocateNodeCIDRs, "allocate-node-cidrs", false,
 		"Should CIDRs for Pods be allocated and set on the cloud provider.")
 	fs.StringVar(&s.CIDRAllocatorType, "cidr-allocator-type", "RangeAllocator",

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -387,12 +387,16 @@ type KubeControllerManagerConfiguration struct {
 	EnableContentionProfiling bool
 	// clusterName is the instance prefix for the cluster.
 	ClusterName string
-	// clusterCIDR is CIDR Range for Pods in cluster.
+	// (will be) DEPRECATED: // clusterCIDR is CIDR Range for Pods in cluster.
 	ClusterCIDR string
+	// clusterCIDRs is a CIDR Range list for Pods in cluster.
+	ClusterCIDRs []string
 	// serviceCIDR is CIDR Range for Services in cluster.
 	ServiceCIDR string
-	// NodeCIDRMaskSize is the mask size for node cidr in cluster.
+	// (will be) DEPRECATED: // NodeCIDRMaskSize is the mask size for node cidr in cluster.
 	NodeCIDRMaskSize int32
+	// NodeCIDRMaskSize is the mask size for node cidr in cluster.
+	NodeCIDRMaskSizes []int
 	// AllocateNodeCIDRs enables CIDRs for Pods to be allocated and, if
 	// ConfigureCloudRoutes is true, to be set on the cloud provider.
 	AllocateNodeCIDRs bool

--- a/pkg/controller/node/ipam/cidr_allocator.go
+++ b/pkg/controller/node/ipam/cidr_allocator.go
@@ -73,7 +73,7 @@ type CIDRAllocator interface {
 }
 
 // New creates a new CIDR range allocator.
-func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, allocatorType CIDRAllocatorType, clusterCIDR, serviceCIDR *net.IPNet, nodeCIDRMaskSize int) (CIDRAllocator, error) {
+func New(kubeClient clientset.Interface, cloud cloudprovider.Interface, allocatorType CIDRAllocatorType, clusterCIDR []*net.IPNet, serviceCIDR *net.IPNet, nodeCIDRMaskSize []int) (CIDRAllocator, error) {
 	nodeList, err := listNodes(kubeClient)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/node/ipam/cidrset/cidr_set.go
+++ b/pkg/controller/node/ipam/cidrset/cidr_set.go
@@ -226,3 +226,7 @@ func (s *CidrSet) getIndexForIP(ip net.IP) (int, error) {
 
 	return 0, fmt.Errorf("invalid IP: %v", ip)
 }
+
+func (s *CidrSet) Contains(ip net.IP) bool {
+	return s.clusterCIDR.Contains(ip)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds two cli args to kube-controller-manager,  cluster-cidrs and node-cidr-mask-sizes, with the intent to eventually depreciate cluster-cidr and node-cidr-mask-size.
We need this to support dual stack IPv6, where there would be an IPv4 address and IPv6 address.
Also, IPv6 only may have more multiple addresses, so this case is aupported also. 

This is WIP, looking for comments form the community.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47924

**Special notes for your reviewer**:



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
