### PR TITLE
Skip statefulset scaling should happen in predictable order test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -361,6 +361,16 @@ func SkipUnlessServerVersionGTE(v *utilversion.Version, c discovery.ServerVersio
 	}
 }
 
+func SkipUnlessServerVersionLT(v *utilversion.Version, c discovery.ServerVersionInterface) {
+	gte, err := ServerVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		Skipf("Not supported for server versions starting %q", v)
+	}
+}
+
 func SkipIfMissingResource(clientPool dynamic.ClientPool, gvr schema.GroupVersionResource, namespace string) {
 	dynamicClient, err := clientPool.ClientForGroupVersionResource(gvr)
 	if err != nil {

--- a/test/e2e/statefulset.go
+++ b/test/e2e/statefulset.go
@@ -34,6 +34,7 @@ import (
 	apps "k8s.io/kubernetes/pkg/apis/apps/v1beta1"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/clientset"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -343,6 +344,8 @@ var _ = framework.KubeDescribe("StatefulSet", func() {
 		})
 
 		It("Scaling should happen in predictable order and halt if any stateful pod is unhealthy", func() {
+			framework.SkipUnlessServerVersionLT(version.MustParseSemantic("v1.7.0"), f.ClientSet.Discovery())
+
 			psLabels := klabels.Set(labels)
 			By("Initializing watcher for selector " + psLabels.String())
 			watcher, err := f.ClientSet.Core().Pods(ns).Watch(metav1.ListOptions{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR skips v1.6 test named "Scaling should happen in predictable order and halt if any stateful pod is unhealthy" to ensure the 1.6-1.7 upgrade test passes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47378

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
