### PR TITLE
fix CopyStrings and ShuffleStrings for slice when slice is nil

### DIFF
--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -26,6 +26,9 @@ import (
 // CopyStrings copies the contents of the specified string slice
 // into a new slice.
 func CopyStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
 	c := make([]string, len(s))
 	copy(c, s)
 	return c
@@ -41,6 +44,9 @@ func SortStrings(s []string) []string {
 // ShuffleStrings copies strings from the specified slice into a copy in random
 // order. It returns a new slice.
 func ShuffleStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
 	shuffled := make([]string, len(s))
 	perm := utilrand.Perm(len(s))
 	for i, j := range perm {

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -22,15 +22,29 @@ import (
 )
 
 func TestCopyStrings(t *testing.T) {
-	src := []string{"a", "c", "b"}
-	dest := CopyStrings(src)
+	var src1 []string
+	dest1 := CopyStrings(src1)
 
-	if !reflect.DeepEqual(src, dest) {
-		t.Errorf("%v and %v are not equal", src, dest)
+	if !reflect.DeepEqual(src1, dest1) {
+		t.Errorf("%v and %v are not equal", src1, dest1)
 	}
 
-	src[0] = "A"
-	if reflect.DeepEqual(src, dest) {
+	src2 := []string{}
+	dest2 := CopyStrings(src2)
+
+	if !reflect.DeepEqual(src2, dest2) {
+		t.Errorf("%v and %v are not equal", src2, dest2)
+	}
+
+	src3 := []string{"a", "c", "b"}
+	dest3 := CopyStrings(src3)
+
+	if !reflect.DeepEqual(src3, dest3) {
+		t.Errorf("%v and %v are not equal", src3, dest3)
+	}
+
+	src3[0] = "A"
+	if reflect.DeepEqual(src3, dest3) {
 		t.Errorf("CopyStrings didn't make a copy")
 	}
 }
@@ -50,8 +64,15 @@ func TestSortStrings(t *testing.T) {
 }
 
 func TestShuffleStrings(t *testing.T) {
-	src := []string{"a", "b", "c", "d", "e", "f"}
+	var src []string
 	dest := ShuffleStrings(src)
+
+	if dest != nil {
+		t.Errorf("ShuffleStrings for a nil slice got a non-nil slice")
+	}
+
+	src = []string{"a", "b", "c", "d", "e", "f"}
+	dest = ShuffleStrings(src)
 
 	if len(src) != len(dest) {
 		t.Errorf("Shuffled slice is wrong length, expected %v got %v", len(src), len(dest))


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR fixes two functions in util/slice.go, in which I think `CopyStrings` and `ShuffleStrings` miss one case. The case is input data is nil, in this case I think the data returned should be nil as well rather than a non-nil slice with 0 element.
In addition, I added some test code for this.
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE, I did not raise a issue for this code. I ran into this when code learning.

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
