### PR TITLE
restrict events in NodeRestriction

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -101,7 +101,8 @@ func NodeRules() []rbac.PolicyRule {
 		rbac.NewRule("update", "patch").Groups(legacyGroup).Resources("nodes/status").RuleOrDie(),
 		rbac.NewRule("update", "patch", "delete").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
 
-		// TODO: restrict to the bound node as creator in the NodeRestrictions admission plugin
+		// Node can create or update Event objects.
+		// Use the NodeRestriction admission plugin to limit a node to creating/updating events from itself.
 		rbac.NewRule("create", "update", "patch").Groups(legacyGroup).Resources("events").RuleOrDie(),
 
 		// TODO: restrict to pods scheduled on the bound node once field selectors are supported by list/watch authorization


### PR DESCRIPTION


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
restrict events in NodeRestriction, now NodeRestriction admission only allows kubelet node to create/update events from itself.
```
