### PR TITLE
fix system language judging bug in loadSystemLanguage

### DIFF
--- a/pkg/util/i18n/i18n.go
+++ b/pkg/util/i18n/i18n.go
@@ -49,12 +49,12 @@ var knownTranslations = map[string][]string{
 func loadSystemLanguage() string {
 	langStr := os.Getenv("LANG")
 	if langStr == "" {
-		glog.V(3).Infof("Couldn't find the LANG environment variable, defaulting to en-US")
+		glog.V(3).Infof("Couldn't find the LANG environment variable, defaulting to en_US")
 		return "default"
 	}
 	pieces := strings.Split(langStr, ".")
-	if len(pieces) == 0 {
-		glog.V(3).Infof("Unexpected system language (%s), defaulting to en-US", langStr)
+	if len(pieces) != 2 {
+		glog.V(3).Infof("Unexpected system language (%s), defaulting to en_US", langStr)
 		return "default"
 	}
 	return pieces[0]


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR removes some unused code in loadSystemLanguage. Since in code `pieces := strings.Split(langStr, ".")`, even `langStr` is an empty string, `piece` is a slice with one element of empty string, so there is no chance that len(pieces) == 0.

According to these, I think it is OK to remove the unused code in loadSystemLanguage.

According to the discuss we had, finally we decided to use a more accurate way to change the code, using `if len(pieces) != 1` to make the decision. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
