### PR TITLE
clone map for labels in a safe way

### DIFF
--- a/pkg/util/labels/labels.go
+++ b/pkg/util/labels/labels.go
@@ -21,32 +21,30 @@ import (
 )
 
 // Clones the given map and returns a new map with the given key and value added.
-// Returns the given map, if labelKey is empty.
 func CloneAndAddLabel(labels map[string]string, labelKey, labelValue string) map[string]string {
-	if labelKey == "" {
-		// Don't need to add a label.
-		return labels
-	}
 	// Clone.
 	newLabels := map[string]string{}
 	for key, value := range labels {
 		newLabels[key] = value
+	}
+	if labelKey == "" {
+		// Don't need to add a label.
+		return newLabels
 	}
 	newLabels[labelKey] = labelValue
 	return newLabels
 }
 
 // CloneAndRemoveLabel clones the given map and returns a new map with the given key removed.
-// Returns the given map, if labelKey is empty.
 func CloneAndRemoveLabel(labels map[string]string, labelKey string) map[string]string {
-	if labelKey == "" {
-		// Don't need to add a label.
-		return labels
-	}
 	// Clone.
 	newLabels := map[string]string{}
 	for key, value := range labels {
 		newLabels[key] = value
+	}
+	if labelKey == "" {
+		// Don't need to remove a label.
+		return newLabels
 	}
 	delete(newLabels, labelKey)
 	return newLabels

--- a/pkg/util/labels/labels_test.go
+++ b/pkg/util/labels/labels_test.go
@@ -37,8 +37,13 @@ func TestCloneAndAddLabel(t *testing.T) {
 		want       map[string]string
 	}{
 		{
-			labels: labels,
-			want:   labels,
+			labels:   labels,
+			labelKey: "", // this case will add an empty label key
+			want: map[string]string{
+				"foo1": "bar1",
+				"foo2": "bar2",
+				"foo3": "bar3",
+			},
 		},
 		{
 			labels:     labels,
@@ -58,10 +63,44 @@ func TestCloneAndAddLabel(t *testing.T) {
 		if !reflect.DeepEqual(got, tc.want) {
 			t.Errorf("[Add] got %v, want %v", got, tc.want)
 		}
-		// now test the inverse.
-		got_rm := CloneAndRemoveLabel(got, tc.labelKey)
-		if !reflect.DeepEqual(got_rm, tc.labels) {
-			t.Errorf("[RM] got %v, want %v", got_rm, tc.labels)
+	}
+}
+
+func TestCloneAndRemoveLabel(t *testing.T) {
+	labels := map[string]string{
+		"foo1": "bar1",
+		"foo2": "bar2",
+		"foo3": "bar3",
+	}
+
+	cases := []struct {
+		labels   map[string]string
+		labelKey string
+		want     map[string]string
+	}{
+		{
+			labels:   labels,
+			labelKey: "", // this case will remove an empty label key
+			want: map[string]string{
+				"foo1": "bar1",
+				"foo2": "bar2",
+				"foo3": "bar3",
+			},
+		},
+		{
+			labels:   labels,
+			labelKey: "foo3",
+			want: map[string]string{
+				"foo1": "bar1",
+				"foo2": "bar2",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		got := CloneAndRemoveLabel(tc.labels, tc.labelKey)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Errorf("[Add] got %v, want %v", got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
In pkg/util/labels, I found that there are two functions that seem some kind of insecure: `CloneAndAddLabel ` and `CloneAndRemoveLabel `.

When the input key is an empty string, functions return the original string. I think this is not a clone, this common function may case some insecure issues. While it is proper to deep copy the original map even if the input key is an empty string.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
