### PR TITLE
Add more pdbs in autoscaling e2e to reduce flakiness

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1144,6 +1144,7 @@ func addKubeSystemPdbs(f *framework.Framework) (func(), error) {
 		{label: "kube-dns-autoscaler", min_available: 1},
 		{label: "kube-dns", min_available: 1},
 		{label: "event-exporter", min_available: 0},
+		{label: "kubernetes-dashboard", min_available: 0},
 	}
 	for _, pdbData := range pdbsToAdd {
 		By(fmt.Sprintf("Create PodDisruptionBudget for %v", pdbData.label))


### PR DESCRIPTION
Ref: https://github.com/kubernetes/autoscaler/issues/89
There are still too many system pods without PDB that can spread all over nodes and cause scale-down tests to randomly fail, adding PDB for kubernetes-dashboard in test to help with that.
