### PR TITLE
Fix validateportrange

### DIFF
--- a/pkg/kubectl/cmd/create_service_test.go
+++ b/pkg/kubectl/cmd/create_service_test.go
@@ -26,63 +26,117 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
+var tests = []struct {
+	name      string
+	flag      string
+	value     string
+	expected  string
+	expectErr bool
+}{
+	{
+		name:      "TCP-single-port-valid",
+		flag:      "tcp",
+		value:     "8080",
+		expected:  "service/TCP-single-port-valid" + "\n",
+		expectErr: false,
+	},
+	{
+		name:      "TCP-single-port-invalid",
+		flag:      "tcp",
+		value:     "65536",
+		expected:  "service/TCP-single-port-invalid" + "\n",
+		expectErr: true,
+	},
+	{
+		name:      "TCP-multi-port-valid",
+		flag:      "tcp",
+		value:     "8080:8080",
+		expected:  "service/TCP-multi-port-valid" + "\n",
+		expectErr: false,
+	},
+	{
+		name:      "TCP-multi-port-invalid",
+		flag:      "tcp",
+		value:     "8080:65536",
+		expected:  "service/TCP-multi-port-invalid" + "\n",
+		expectErr: true,
+	},
+	{
+		name:      "mismatching-name",
+		flag:      "tcp",
+		value:     "8080:8080",
+		expected:  "service/mismatching" + "\n",
+		expectErr: true,
+	},
+}
+
 func TestCreateService(t *testing.T) {
-	service := &api.Service{}
-	service.Name = "my-service"
-	f, tf, codec, negSer := cmdtesting.NewAPIFactory()
-	tf.Printer = &testPrinter{}
-	tf.Client = &fake.RESTClient{
-		APIRegistry:          api.Registry,
-		NegotiatedSerializer: negSer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == "POST":
-				return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, service)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
-			}
-		}),
-	}
-	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdCreateServiceClusterIP(f, buf)
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("tcp", "8080:8000")
-	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
-	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
+	for index, test := range tests {
+		service := &api.Service{}
+		service.Name = test.name
+		f, tf, codec, negSer := cmdtesting.NewAPIFactory()
+		tf.Printer = &testPrinter{}
+		tf.Client = &fake.RESTClient{
+			APIRegistry:          api.Registry,
+			NegotiatedSerializer: negSer,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/namespaces/test/services" && m == "POST":
+					return &http.Response{StatusCode: 201, Header: defaultHeader(), Body: objBody(codec, service)}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			}),
+		}
+		tf.Namespace = "test"
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdCreateServiceClusterIP(f, buf)
+		cmd.Flags().Set("output", "name")
+		cmd.Flags().Set(test.flag, test.value)
+		cmd.Run(cmd, []string{service.Name})
+		testPass := buf.String() == test.expected
+		if test.expectErr && testPass {
+			t.Errorf("testdata index: %d, this test must fail but it passed", index)
+		}
+		if !test.expectErr && !testPass {
+			t.Errorf("testdata index: %d, expected output: %s, but got: %s", index, test.expected, buf.String())
+		}
 	}
 }
 
 func TestCreateServiceNodePort(t *testing.T) {
-	service := &api.Service{}
-	service.Name = "my-node-port-service"
-	f, tf, codec, negSer := cmdtesting.NewAPIFactory()
-	tf.Printer = &testPrinter{}
-	tf.Client = &fake.RESTClient{
-		APIRegistry:          api.Registry,
-		NegotiatedSerializer: negSer,
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			switch p, m := req.URL.Path, req.Method; {
-			case p == "/namespaces/test/services" && m == http.MethodPost:
-				return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, service)}, nil
-			default:
-				t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-				return nil, nil
-			}
-		}),
-	}
-	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdCreateServiceNodePort(f, buf)
-	cmd.Flags().Set("output", "name")
-	cmd.Flags().Set("tcp", "30000:8000")
-	cmd.Run(cmd, []string{service.Name})
-	expectedOutput := "service/" + service.Name + "\n"
-	if buf.String() != expectedOutput {
-		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
+	for index, test := range tests {
+		service := &api.Service{}
+		service.Name = test.name
+		f, tf, codec, negSer := cmdtesting.NewAPIFactory()
+		tf.Printer = &testPrinter{}
+		tf.Client = &fake.RESTClient{
+			APIRegistry:          api.Registry,
+			NegotiatedSerializer: negSer,
+			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+				switch p, m := req.URL.Path, req.Method; {
+				case p == "/namespaces/test/services" && m == http.MethodPost:
+					return &http.Response{StatusCode: http.StatusCreated, Header: defaultHeader(), Body: objBody(codec, service)}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			}),
+		}
+		tf.Namespace = "test"
+		buf := bytes.NewBuffer([]byte{})
+		cmd := NewCmdCreateServiceNodePort(f, buf)
+		cmd.Flags().Set("output", "name")
+		cmd.Flags().Set(test.flag, test.value)
+		cmd.Run(cmd, []string{service.Name})
+		testPass := buf.String() == test.expected
+		if test.expectErr && testPass {
+			t.Errorf("testdata index: %d, this test must fail but it passed", index)
+		}
+		if !test.expectErr && !testPass {
+			t.Errorf("testdata index: %d, expected output: %s, but got: %s", index, test.expected, buf.String())
+		}
 	}
 }
 

--- a/pkg/kubectl/service_basic.go
+++ b/pkg/kubectl/service_basic.go
@@ -87,16 +87,32 @@ func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 
 	port, err := strconv.Atoi(portStringSlice[0])
 	if err != nil {
+		// port cannot be converted to int
 		return 0, intstr.FromInt(0), err
 	}
+
+	if err := validation.IsValidPortNum(port); len(err) != 0 {
+		// port is not valid
+		return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(err[:],","))
+	}
+
 	if len(portStringSlice) == 1 {
+		// port is valid, targetPort missing
 		return int32(port), intstr.FromInt(int(port)), nil
 	}
 
 	var targetPort intstr.IntOrString
 	if portNum, err := strconv.Atoi(portStringSlice[1]); err != nil {
+		// targetPort is string
+		if err := validation.IsValidPortName(portStringSlice[1]); len(err) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(err[:],","))
+		}
 		targetPort = intstr.FromString(portStringSlice[1])
 	} else {
+		// targetPort is int
+		if err := validation.IsValidPortNum(portNum); len(err) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(err[0])
+		}
 		targetPort = intstr.FromInt(portNum)
 	}
 	return int32(port), targetPort, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
kubectl create service allows invalid ports, this pr validates them  

**Which issue this PR fixes** :
fixes # https://github.com/kubernetes/kubectl/issues/35

**Special notes for your reviewer**:

**Release note**:
