### PR TITLE
modify the error message of  kubectl stop command when rc overlapped

### DIFF
--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -192,7 +192,7 @@ func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout 
 	}
 	if len(overlapRCs) > 0 {
 		return fmt.Errorf(
-			"Detected overlapping controllers for rc %v: %v, please manage deletion individually with --cascade=false.",
+			"overlapped controllers are detected for rc %v: %v, please manage deletion individually with --cascade=false.",
 			ctrl.Name, strings.Join(overlapRCs, ","))
 	}
 	if len(exactMatchRCs) == 1 {
@@ -262,7 +262,7 @@ func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Durati
 			names = append(names, overlappingRS.Name)
 		}
 		return fmt.Errorf(
-			"Detected overlapping ReplicaSets for ReplicaSet %v: %v, please manage deletion individually with --cascade=false.",
+			"overlapped ReplicaSets are detected for ReplicaSet %v: %v, please manage deletion individually with --cascade=false.",
 			rs.Name, strings.Join(names, ","))
 	}
 	if len(exactMatchRSs) == 0 {

--- a/pkg/kubectl/delete_test.go
+++ b/pkg/kubectl/delete_test.go
@@ -122,7 +122,7 @@ func TestReplicationControllerStop(t *testing.T) {
 					},
 				},
 			},
-			StopError:       fmt.Errorf("Detected overlapping controllers for rc foo: baz, please manage deletion individually with --cascade=false."),
+			StopError:       fmt.Errorf("overlapped controllers are detected for rc foo: baz, please manage deletion individually with --cascade=false."),
 			ExpectedActions: []string{"get", "list"},
 		},
 
@@ -163,7 +163,7 @@ func TestReplicationControllerStop(t *testing.T) {
 				},
 			},
 
-			StopError:       fmt.Errorf("Detected overlapping controllers for rc foo: baz,zaz, please manage deletion individually with --cascade=false."),
+			StopError:       fmt.Errorf("overlapped controllers are detected for rc foo: baz,zaz, please manage deletion individually with --cascade=false."),
 			ExpectedActions: []string{"get", "list"},
 		},
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We found that the error message of kubectl stop command when the rc is overlapped has some 
syntax error. We modified "Detected overlapping controllers " to  "overlapped controllers are detected ".

**Special notes for your reviewer**:
None

```release-note
NONE
```