### PR TITLE
make proto time precision match json

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_proto.go
@@ -42,7 +42,10 @@ func (m *Time) ProtoTime() *Timestamp {
 	}
 	return &Timestamp{
 		Seconds: m.Time.Unix(),
-		Nanos:   int32(m.Time.Nanosecond()),
+		// leaving this here for the record.  our JSON only handled seconds, so this results in writes by
+		// protobuf clients storing values that aren't read by json clients, which results in unexpected
+		// field mutation, which fails various validation and equality code.
+		// Nanos:   int32(m.Time.Nanosecond()),
 	}
 }
 
@@ -64,7 +67,11 @@ func (m *Time) Unmarshal(data []byte) error {
 	if err := p.Unmarshal(data); err != nil {
 		return err
 	}
-	m.Time = time.Unix(p.Seconds, int64(p.Nanos)).Local()
+	// leaving this here for the record.  our JSON only handled seconds, so this results in writes by
+	// protobuf clients storing values that aren't read by json clients, which results in unexpected
+	// field mutation, which fails various validation and equality code.
+	// m.Time = time.Unix(p.Seconds, int64(p.Nanos)).Local()
+	m.Time = time.Unix(p.Seconds, int64(0)).Local()
 	return nil
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -152,7 +152,7 @@ func TestTimeProto(t *testing.T) {
 		input Time
 	}{
 		{Time{}},
-		{Date(1998, time.May, 5, 1, 5, 5, 50, time.Local)},
+		{Date(1998, time.May, 5, 1, 5, 5, 0, time.Local)},
 		{Date(1998, time.May, 5, 5, 5, 5, 0, time.Local)},
 	}
 


### PR DESCRIPTION
json readers/writers see second precision, but protobuf readers/writers seen nanosecond precision.  This means that a json client can read and write and accidentally mutate fields as seen by protobuf clients.

This makes the precision consistent.

@kubernetes/sig-api-machinery-misc @smarterclayton 

```release-note
Update protobuf time serialization for a one second granularity
```