### PR TITLE
Fix initial exec terminal dimensions

### DIFF
--- a/pkg/kubelet/dockershim/exec.go
+++ b/pkg/kubelet/dockershim/exec.go
@@ -135,6 +135,9 @@ func (*NsenterExecHandler) ExecInContainer(client libdocker.Interface, container
 type NativeExecHandler struct{}
 
 func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
+	done := make(chan struct{})
+	defer close(done)
+
 	createOpts := dockertypes.ExecConfig{
 		Cmd:          cmd,
 		AttachStdin:  stdin != nil,
@@ -149,9 +152,23 @@ func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container 
 
 	// Have to start this before the call to client.StartExec because client.StartExec is a blocking
 	// call :-( Otherwise, resize events don't get processed and the terminal never resizes.
-	kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
-		client.ResizeExecTTY(execObj.ID, uint(size.Height), uint(size.Width))
-	})
+	//
+	// We also have to delay attempting to send a terminal resize request to docker until after the
+	// exec has started; otherwise, the initial resize request will fail.
+	execStarted := make(chan struct{})
+	go func() {
+		select {
+		case <-execStarted:
+			// client.StartExec has started the exec, so we can start resizing
+		case <-done:
+			// ExecInContainer has returned, so short-circuit
+			return
+		}
+
+		kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
+			client.ResizeExecTTY(execObj.ID, uint(size.Height), uint(size.Width))
+		})
+	}()
 
 	startOpts := dockertypes.ExecStartCheck{Detach: false, Tty: tty}
 	streamOpts := libdocker.StreamOptions{
@@ -159,6 +176,7 @@ func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container 
 		OutputStream: stdout,
 		ErrorStream:  stderr,
 		RawTerminal:  tty,
+		ExecStarted:  execStarted,
 	}
 	err = client.StartExec(execObj.ID, startOpts, streamOpts)
 	if err != nil {

--- a/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
+++ b/pkg/kubelet/dockershim/libdocker/kube_docker_client.go
@@ -454,6 +454,15 @@ func (d *kubeDockerClient) StartExec(startExec string, opts dockertypes.ExecStar
 		return err
 	}
 	defer resp.Close()
+
+	if sopts.ExecStarted != nil {
+		// Send a message to the channel indicating that the exec has started. This is needed so
+		// interactive execs can handle resizing correctly - the request to resize the TTY has to happen
+		// after the call to d.client.ContainerExecAttach, and because d.holdHijackedConnection below
+		// blocks, we use sopts.ExecStarted to signal the caller that it's ok to resize.
+		sopts.ExecStarted <- struct{}{}
+	}
+
 	return d.holdHijackedConnection(sopts.RawTerminal || opts.Tty, sopts.InputStream, sopts.OutputStream, sopts.ErrorStream, resp)
 }
 
@@ -584,6 +593,7 @@ type StreamOptions struct {
 	InputStream  io.Reader
 	OutputStream io.Writer
 	ErrorStream  io.Writer
+	ExecStarted  chan struct{}
 }
 
 // operationTimeout is the error returned when the docker operations are timeout.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Delay attempting to send a terminal resize request to docker until after
the exec has started; otherwise, the initial resize request will fail.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47990

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix initial exec terminal dimensions
```
