### PR TITLE
Refresh cluster-proportional-autoscaler, etcd-empty-dir-cleanup, fluentd-gcp, and kube-addon-manager addons

### DIFF
--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -15,8 +15,8 @@
 IMAGE=gcr.io/google-containers/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
-VERSION=v6.1.1
-KUBECTL_VERSION?=v1.5.0-beta.2
+VERSION=v6.1.2
+KUBECTL_VERSION?=v1.5.7
 
 ifeq ($(ARCH),amd64)
 	BASEIMAGE?=bashell/alpine-bash

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0-r2
+        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.0-r3
         resources:
             requests:
                 cpu: "20m"

--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -10,4 +10,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.2
+    image: gcr.io/google_containers/etcd-empty-dir-cleanup:0.0.3

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Dockerfile
@@ -20,7 +20,7 @@
 # scope and that the Logging API has been enabled for the project
 # in the Google Developer Console.
 
-FROM gcr.io/google-containers/ubuntu-slim:0.8
+FROM gcr.io/google-containers/ubuntu-slim:0.12
 
 MAINTAINER Mik Vyatskov "vmik@google.com"
 

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-image/Makefile
@@ -29,7 +29,7 @@
 .PHONY:	build push
 
 PREFIX=gcr.io/google-containers
-TAG = 1.28.3
+TAG = 1.28.4
 
 build:
 	docker build --pull -t $(PREFIX)/fluentd-gcp:$(TAG) .

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gliderlabs/alpine
+FROM alpine
 MAINTAINER Mehdy Bohlool <mehdy@google.com>
 
-RUN apk-install bash
+RUN apk add --update bash && rm -rf /var/cache/apk/*
 ADD etcd-empty-dir-cleanup.sh etcd-empty-dir-cleanup.sh
 ADD etcdctl etcdctl
 ENV ETCDCTL /etcdctl

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -16,7 +16,7 @@
 
 ETCD_VERSION = 2.2.1
 IMAGE = gcr.io/google_containers/etcd-empty-dir-cleanup
-TAG = 0.0.2
+TAG = 0.0.3
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp-gci/fluentd-gcp-gci.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.3
+    image: gcr.io/google_containers/fluentd-gcp:1.28.4
     command:
       - '/bin/sh'
       - '-c'

--- a/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
+++ b/cluster/saltbase/salt/fluentd-gcp/fluentd-gcp.yaml
@@ -11,7 +11,7 @@ spec:
   dnsPolicy: Default
   containers:
   - name: fluentd-cloud-logging
-    image: gcr.io/google_containers/fluentd-gcp:1.28.3
+    image: gcr.io/google_containers/fluentd-gcp:1.28.4
     resources:
       limits:
         memory: 200Mi

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -10,7 +10,7 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in cluster/images/hyperkube/static-pods/addon-manager.json
-    image: gcr.io/google-containers/kube-addon-manager:v6.1.1
+    image: gcr.io/google-containers/kube-addon-manager:v6.1.2
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
**What this PR does / why we need it**: refreshes a number of addons with new base images:

* gcr.io/google-containers/cluster-proportional-autoscaler-amd64:1.1.0-r3 (rebuilt at 1.1.0)
* gcr.io/google-containers/etcd-empty-dir-cleanup:0.0.3
* gcr.io/google-containers/fluentd-gcp:1.28.4
* gcr.io/google-containers/kube-addon-manager:v6.1.2, including kubectl v1.5.7

These include upstream fixes to base images with fixes for the following CVEs:
* CVE-2015-8271
* CVE-2016-7543
* CVE-2016-9841
* CVE-2016-9843
* CVE-2017-1000366
* CVE-2017-2616
* CVE-2017-7507

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update cluster-proportional-autoscaler, etcd-empty-dir-cleanup, fluentd-gcp, and kube-addon-manager addons with refreshed base images containing fixes for CVE-2015-8271, CVE-2016-7543, CVE-2016-9841, CVE-2016-9843, CVE-2017-1000366, CVE-2017-2616, and CVE-2017-7507.
```
cc @timstclair @MrHohn @mbohlool @crassirostris 