### PR TITLE
Fix kubectl api-versions caching

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -55,6 +55,9 @@ func RunApiVersions(f cmdutil.Factory, w io.Writer) error {
 		return err
 	}
 
+	// Always request fresh data from the server
+	discoveryclient.Invalidate()
+
 	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -116,10 +116,12 @@ func RunVersion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 
 func retrieveServerVersion(f cmdutil.Factory) (*apimachineryversion.Info, error) {
 	discoveryClient, err := f.DiscoveryClient()
-
 	if err != nil {
 		return nil, err
 	}
+
+	// Always request fresh data from the server
+	discoveryClient.Invalidate()
 
 	serverVersion, err := discoveryClient.ServerVersion()
 	if err != nil {


### PR DESCRIPTION
xref https://github.com/kubernetes/kubectl/issues/41 https://github.com/kubernetes/kubernetes/issues/47977

The point of the `api-versions` and `version` commands is to ask the server for its API groups or versions, so we don't want to use cached data

```release-note
`kubectl api-versions` now always fetches information about enabled API groups and versions instead of using the local cache.
```