### PR TITLE
apiextensions-apiserver: fix build

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/doc.go
@@ -18,4 +18,4 @@ limitations under the License.
 
 // Package apiextensions is the internal version of the API.
 // +groupName=apiextensions.k8s.io
-package apiextensions // import "k8s.io/apiextension-server/pkg/apis/apiextensions"
+package apiextensions // import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
@@ -20,4 +20,4 @@ limitations under the License.
 
 // Package v1beta1 is the v1beta1 version of the API.
 // +groupName=apiextensions.k8s.io
-package v1beta1 // import "k8s.io/apiextension-server/pkg/apis/apiextensions/v1beta1"
+package v1beta1 // import "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"


### PR DESCRIPTION
Can't build CRD due to this bug. This PR will fix it.


```release-notes
Fix compilation of k8s.io/apiextensions-apiserver
```