### PR TITLE
 modify the meassage in kubectl secret command when the envFile path is not an file path

### DIFF
--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -217,7 +217,7 @@ func handleFromEnvFileSource(secret *api.Secret, envFileSource string) error {
 		}
 	}
 	if info.IsDir() {
-		return fmt.Errorf("must be a file")
+		return fmt.Errorf("env secret file cannot be a directory")
 	}
 
 	return addFromEnvFile(envFileSource, func(key, value string) error {


### PR DESCRIPTION
What this PR does / why we need it:
We found that the error message of kubectl secret command when the the envFile path is not an file path
is inaccurate and the style is different with which in  kubectl configmap command. We modified “must be a file” to "env secret file cannot be a directory" 
Special notes for your reviewer:
None