### PR TITLE
Refactor unstructured converter

### DIFF
--- a/pkg/api/unstructured_test.go
+++ b/pkg/api/unstructured_test.go
@@ -97,8 +97,7 @@ func doRoundTrip(t *testing.T, group testapi.TestGroup, kind string) {
 		return
 	}
 
-	newUnstr := make(map[string]interface{})
-	err = unstructured.DefaultConverter.ToUnstructured(item, &newUnstr)
+	newUnstr, err := unstructured.DefaultConverter.ToUnstructured(item)
 	if err != nil {
 		t.Errorf("ToUnstructured failed: %v", err)
 		return
@@ -138,8 +137,8 @@ func BenchmarkToFromUnstructured(b *testing.B) {
 	size := len(items)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		unstr := map[string]interface{}{}
-		if err := unstructured.DefaultConverter.ToUnstructured(&items[i%size], &unstr); err != nil {
+		unstr, err := unstructured.DefaultConverter.ToUnstructured(&items[i%size])
+		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
 		obj := v1.Pod{}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -482,8 +482,8 @@ func (u *Unstructured) SetInitializers(initializers *metav1.Initializers) {
 		setNestedField(u.Object, nil, "metadata", "initializers")
 		return
 	}
-	out := make(map[string]interface{})
-	if err := converter.ToUnstructured(initializers, &out); err != nil {
+	out, err := converter.ToUnstructured(initializers)
+	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to retrieve initializers for object: %v", err))
 	}
 	setNestedField(u.Object, out, "metadata", "initializers")

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter_test.go
@@ -121,8 +121,7 @@ func doRoundTrip(t *testing.T, item runtime.Object) {
 		return
 	}
 
-	newUnstr := make(map[string]interface{})
-	err = DefaultConverter.ToUnstructured(item, &newUnstr)
+	newUnstr, err := DefaultConverter.ToUnstructured(item)
 	if err != nil {
 		t.Errorf("ToUnstructured failed: %v", err)
 		return

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -87,8 +87,8 @@ func strategicPatchObject(
 	objToUpdate runtime.Object,
 	versionedObj runtime.Object,
 ) error {
-	originalObjMap := make(map[string]interface{})
-	if err := unstructured.DefaultConverter.ToUnstructured(originalObject, &originalObjMap); err != nil {
+	originalObjMap, err := unstructured.DefaultConverter.ToUnstructured(originalObject)
+	if err != nil {
 		return err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -694,8 +694,8 @@ func patchResource(
 					return nil, err
 				}
 				// Capture the original object map and patch for possible retries.
-				originalMap := make(map[string]interface{})
-				if err := unstructured.DefaultConverter.ToUnstructured(currentVersionedObject, &originalMap); err != nil {
+				originalMap, err := unstructured.DefaultConverter.ToUnstructured(currentVersionedObject)
+				if err != nil {
 					return nil, err
 				}
 				if err := strategicPatchObject(codec, defaulter, currentVersionedObject, patchJS, versionedObjToUpdate, versionedObj); err != nil {
@@ -734,15 +734,14 @@ func patchResource(
 			// 3. ensure no conflicts between the two patches
 			// 4. apply the #1 patch to the currentJS object
 
-			currentObjMap := make(map[string]interface{})
-
 			// Since the patch is applied on versioned objects, we need to convert the
 			// current object to versioned representation first.
 			currentVersionedObject, err := unsafeConvertor.ConvertToVersion(currentObject, kind.GroupVersion())
 			if err != nil {
 				return nil, err
 			}
-			if err := unstructured.DefaultConverter.ToUnstructured(currentVersionedObject, &currentObjMap); err != nil {
+			currentObjMap, err := unstructured.DefaultConverter.ToUnstructured(currentVersionedObject)
+			if err != nil {
 				return nil, err
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
See #48039. Makes it impossible to misuse unstructured converter.

**Which issue this PR fixes**:
Fixes #48039

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig api-machinery