### PR TITLE
Fix Unstructured field accessor

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -69,7 +69,8 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	// Removing the finalizers to allow the following delete remove the object.
-	// This step will fail if previous delete wrongly removed the object.
+	// This step will fail if previous delete wrongly removed the object. The
+	// object will be deleted as part of the finalizer update.
 	for {
 		gottenNoxuInstance.SetFinalizers(nil)
 		_, err = noxuResourceClient.Update(gottenNoxuInstance)
@@ -82,14 +83,6 @@ func TestFinalization(t *testing.T) {
 		gottenNoxuInstance, err = noxuResourceClient.Get(name, metav1.GetOptions{})
 		require.NoError(t, err)
 	}
-
-	// Now when finalizer is not there it should be possible to actually remove the object from the server.
-	err = noxuResourceClient.Delete(name, &metav1.DeleteOptions{
-		Preconditions: &metav1.Preconditions{
-			UID: &uid,
-		},
-	})
-	require.NoError(t, err)
 
 	// Check that the object is actually gone.
 	_, err = noxuResourceClient.Get(name, metav1.GetOptions{})

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -136,10 +136,15 @@ func getNestedInt64(obj map[string]interface{}, fields ...string) int64 {
 }
 
 func getNestedInt64Pointer(obj map[string]interface{}, fields ...string) *int64 {
-	if str, ok := getNestedField(obj, fields...).(*int64); ok {
-		return str
+	nested := getNestedField(obj, fields...)
+	switch n := nested.(type) {
+	case int64:
+		return &n
+	case *int64:
+		return n
+	default:
+		return nil
 	}
-	return nil
 }
 
 func getNestedSlice(obj map[string]interface{}, fields ...string) []string {
@@ -470,6 +475,9 @@ func (u *Unstructured) GetInitializers() *metav1.Initializers {
 }
 
 func (u *Unstructured) SetInitializers(initializers *metav1.Initializers) {
+	if u.Object == nil {
+		u.Object = make(map[string]interface{})
+	}
 	if initializers == nil {
 		setNestedField(u.Object, nil, "metadata", "initializers")
 		return


### PR DESCRIPTION
Fix the Unstructured GetDeletionGracePeriodSeconds accessor which was
always returning nil regardless of the underlying stored value. The
field value always appearing nil prevents Custom Resource instances
from being deleted when garbage collection is enabled for CRs and
when DeletePropagationOrphan is used. More generally, this fix means that
delete-on-update now works for CR instances.

Add some test coverage for Unstructured metadata deserialization.

The Unstructured DeletionGracePeriodSeconds field marshals as a value
type from JSON and as a pointer type via SetDeletionGracePeriodSeconds.
The GetDeletionGracePeriodSeconds method now supports handling both
int64 and *int64 values so that either underlying value can be returned.

Add a reflection-based unit test which attempts to exercise all the
Object Get/Set methods for nil handling.

```release-note
Registries backed by the generic Store's `Update` implementation support delete-on-update, which allows resources to be automatically deleted during an update provided:

* Garbage collection is enabled for the Store
* The resource being updated has no finalizers
* The resource being updated has a non-nil DeletionGracePeriodSeconds equal to 0

With this fix, Custom Resource instances now also support delete-on-update behavior under the same circumstances.
```
