### PR TITLE
Automated cherry pick of #48016

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -55,6 +55,9 @@ func RunApiVersions(f cmdutil.Factory, w io.Writer) error {
 		return err
 	}
 
+	// Always request fresh data from the server
+	discoveryclient.Invalidate()
+
 	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -116,10 +116,12 @@ func RunVersion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 
 func retrieveServerVersion(f cmdutil.Factory) (*apimachineryversion.Info, error) {
 	discoveryClient, err := f.DiscoveryClient()
-
 	if err != nil {
 		return nil, err
 	}
+
+	// Always request fresh data from the server
+	discoveryClient.Invalidate()
 
 	serverVersion, err := discoveryClient.ServerVersion()
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #48016 on release-1.7.

#48016: Fix kubectl api-versions caching