### PR TITLE
Automated cherry pick of #48016

### DIFF
--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -61,6 +61,9 @@ func RunApiVersions(f cmdutil.Factory, w io.Writer) error {
 		return err
 	}
 
+	// Always request fresh data from the server
+	discoveryclient.Invalidate()
+
 	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return fmt.Errorf("Couldn't get available api versions from server: %v\n", err)

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -67,6 +67,9 @@ func RunVersion(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 		return err
 	}
 
+	// Always request fresh data from the server
+	discoveryclient.Invalidate()
+
 	serverVersion, err := discoveryclient.ServerVersion()
 	if err != nil {
 		return err


### PR DESCRIPTION
Cherry pick of #48016 on release-1.6.

#48016: Fix kubectl api-versions caching