### PR TITLE
Fix error in local-cluster-up

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -149,7 +149,7 @@ do
             ;;
         O)
             GO_OUT=$(guess_built_binary_path)
-            if [ $GO_OUT == "" ]; then
+            if [ "$GO_OUT" == "" ]; then
                 echo "Could not guess the correct output directory to use."
                 exit 1
             fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

When $GO_OUT is not set, line 152 outputs an error.

```
./hack/local-up-cluster.sh: line 152: [: ==: unary operator expected
```
This occurs because the if condition expands as `if [  == "" ]`. This results in an error because == is a binary operator and expects something on the LHS.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

cc @sttts 

FYI @Gouthamve