### PR TITLE
Retry finding RBAC version if not found in discovery cache

### DIFF
--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -263,6 +264,21 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 	if err != nil {
 		return nil, err
 	}
+
+	rbacVersion, err := getRBACVersion(discoveryclient)
+	if err != nil && !discoveryclient.Fresh() {
+		discoveryclient.Invalidate()
+		rbacVersion, err = getRBACVersion(discoveryclient)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return hostFactory.ClientSetForVersion(rbacVersion)
+}
+
+func getRBACVersion(discoveryclient discovery.CachedDiscoveryInterface) (*schema.GroupVersion, error) {
+
 	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get clientset to create RBAC roles in the host cluster: %v", err)
@@ -275,7 +291,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 				if err != nil {
 					return nil, err
 				}
-				return hostFactory.ClientSetForVersion(&gv)
+				return &gv, nil
 			}
 			for _, version := range g.Versions {
 				if version.GroupVersion != "" {
@@ -283,7 +299,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 					if err != nil {
 						return nil, err
 					}
-					return hostFactory.ClientSetForVersion(&gv)
+					return &gv, nil
 				}
 			}
 		}


### PR DESCRIPTION
Alternate to https://github.com/kubernetes/kubernetes/pull/47995

xref #47977

The caching discovery client can indicate whether it used fresh discovery data. `kubefed init` should invalidate and recheck if it doesn't find an RBAC API group

```release-note
`kubefed init` correctly checks for RBAC API enablement.
```