### PR TITLE
Automated cherry pick of #48074

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.0-beta1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #48074 on release-1.7.

#48074: Bump Cluster Autoscaler to 0.6.0

This is basically just an image name change. Nothing new went in comparing to 0.6.0-beta2 that was tested over the weekend in HEAD.