### PR TITLE
Move iptables logging in kubeproxy from Errorf to V(2).Infof

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1571,7 +1571,8 @@ func (proxier *Proxier) syncProxyRules() {
 	glog.V(5).Infof("Restoring iptables rules: %s", proxier.iptablesData.Bytes())
 	err = proxier.iptables.RestoreAll(proxier.iptablesData.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
-		glog.Errorf("Failed to execute iptables-restore: %v\nRules:\n%s", err, proxier.iptablesData.Bytes())
+		glog.Errorf("Failed to execute iptables-restore: %v", err)
+		glog.V(2).Infof("Rules:\n%s", proxier.iptablesData.Bytes())
 		// Revert new local ports.
 		revertPorts(replacementPortsMap, proxier.portsMap)
 		return


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/48052

This will stop fluentd from OOM'ing in reasonably large clusters with services due to kube-proxy. You'll still get iptables printed on setups which run at >= v2, but we can at least optout.
@bowei Does this look reasonable?

cc @kubernetes/sig-network-misc 

