### PR TITLE
Automated cherry pick of #48077

### DIFF
--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor:k8s.io/apimachinery/pkg/apis/meta/v1",
         "//vendor:k8s.io/apimachinery/pkg/runtime/schema",
         "//vendor:k8s.io/apimachinery/pkg/util/net",
+        "//vendor:k8s.io/client-go/discovery",
         "//vendor:k8s.io/client-go/rest",
         "//vendor:k8s.io/client-go/tools/clientcmd",
         "//vendor:k8s.io/client-go/tools/clientcmd/api",

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -232,6 +233,21 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 	if err != nil {
 		return nil, err
 	}
+
+	rbacVersion, err := getRBACVersion(discoveryclient)
+	if err != nil && !discoveryclient.Fresh() {
+		discoveryclient.Invalidate()
+		rbacVersion, err = getRBACVersion(discoveryclient)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return hostFactory.ClientSetForVersion(rbacVersion)
+}
+
+func getRBACVersion(discoveryclient discovery.CachedDiscoveryInterface) (*schema.GroupVersion, error) {
+
 	groupList, err := discoveryclient.ServerGroups()
 	if err != nil {
 		return nil, fmt.Errorf("Couldn't get clientset to create RBAC roles in the host cluster: %v", err)
@@ -244,7 +260,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 				if err != nil {
 					return nil, err
 				}
-				return hostFactory.ClientSetForVersion(&gv)
+				return &gv, nil
 			}
 			for i := 0; i < len(g.Versions); i++ {
 				if g.Versions[i].GroupVersion != "" {
@@ -252,7 +268,7 @@ func GetVersionedClientForRBACOrFail(hostFactory cmdutil.Factory) (client.Interf
 					if err != nil {
 						return nil, err
 					}
-					return hostFactory.ClientSetForVersion(&gv)
+					return &gv, nil
 				}
 			}
 		}


### PR DESCRIPTION
Cherry pick of #48077 on release-1.6.

#48077: Retry finding RBAC version if not found in discovery cache