### PR TITLE
Fix tls config copy in dial test

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/golang.org/x/net/websocket:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
     ],


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/kubernetes/kubernetes/commit/0d42da1b9345e2a649f298ac4f77807143e7befa#diff-1748ffb7995a87b1f6bfd534dc5a51abL99 that broke the mutation test check (it was checking an object against itself)