### PR TITLE
Remove docs that are moved to Community repo

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/README.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/README.md)

--- a/docs/design/access.md
+++ b/docs/design/access.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/access.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/access.md)

--- a/docs/design/admission_control.md
+++ b/docs/design/admission_control.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control.md)

--- a/docs/design/admission_control_limit_range.md
+++ b/docs/design/admission_control_limit_range.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_limit_range.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_limit_range.md)

--- a/docs/design/admission_control_resource_quota.md
+++ b/docs/design/admission_control_resource_quota.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_resource_quota.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/admission_control_resource_quota.md)

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture.md)

--- a/docs/design/aws_under_the_hood.md
+++ b/docs/design/aws_under_the_hood.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/aws_under_the_hood.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/aws_under_the_hood.md)

--- a/docs/design/clustering.md
+++ b/docs/design/clustering.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/clustering.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/clustering.md)

--- a/docs/design/clustering/README.md
+++ b/docs/design/clustering/README.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/clustering/README.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/clustering/README.md)

--- a/docs/design/command_execution_port_forwarding.md
+++ b/docs/design/command_execution_port_forwarding.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/command_execution_port_forwarding.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/command_execution_port_forwarding.md)

--- a/docs/design/configmap.md
+++ b/docs/design/configmap.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/configmap.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/configmap.md)

--- a/docs/design/control-plane-resilience.md
+++ b/docs/design/control-plane-resilience.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/control-plane-resilience.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/control-plane-resilience.md)

--- a/docs/design/daemon.md
+++ b/docs/design/daemon.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/daemon.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/daemon.md)

--- a/docs/design/downward_api_resources_limits_requests.md
+++ b/docs/design/downward_api_resources_limits_requests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/downward_api_resources_limits_requests.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/downward_api_resources_limits_requests.md)

--- a/docs/design/enhance-pluggable-policy.md
+++ b/docs/design/enhance-pluggable-policy.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/enhance-pluggable-policy.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/enhance-pluggable-policy.md)

--- a/docs/design/event_compression.md
+++ b/docs/design/event_compression.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/event_compression.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/event_compression.md)

--- a/docs/design/expansion.md
+++ b/docs/design/expansion.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/expansion.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/expansion.md)

--- a/docs/design/extending-api.md
+++ b/docs/design/extending-api.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/extending-api.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/extending-api.md)

--- a/docs/design/federated-replicasets.md
+++ b/docs/design/federated-replicasets.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-replicasets.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-replicasets.md)

--- a/docs/design/federated-services.md
+++ b/docs/design/federated-services.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-services.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-services.md)

--- a/docs/design/federation-phase-1.md
+++ b/docs/design/federation-phase-1.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation-phase-1.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation-phase-1.md)

--- a/docs/design/ha_master.md
+++ b/docs/design/ha_master.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/ha_master.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/ha_master.md)

--- a/docs/design/horizontal-pod-autoscaler.md
+++ b/docs/design/horizontal-pod-autoscaler.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/horizontal-pod-autoscaler.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/horizontal-pod-autoscaler.md)

--- a/docs/design/identifiers.md
+++ b/docs/design/identifiers.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md)

--- a/docs/design/indexed-job.md
+++ b/docs/design/indexed-job.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/indexed-job.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/indexed-job.md)

--- a/docs/design/metadata-policy.md
+++ b/docs/design/metadata-policy.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/metadata-policy.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/metadata-policy.md)

--- a/docs/design/monitoring_architecture.md
+++ b/docs/design/monitoring_architecture.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/monitoring_architecture.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/monitoring_architecture.md)

--- a/docs/design/namespaces.md
+++ b/docs/design/namespaces.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/namespaces.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/namespaces.md)

--- a/docs/design/networking.md
+++ b/docs/design/networking.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/networking.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/networking.md)

--- a/docs/design/nodeaffinity.md
+++ b/docs/design/nodeaffinity.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/nodeaffinity.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/nodeaffinity.md)

--- a/docs/design/persistent-storage.md
+++ b/docs/design/persistent-storage.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/persistent-storage.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/persistent-storage.md)

--- a/docs/design/podaffinity.md
+++ b/docs/design/podaffinity.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/podaffinity.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/podaffinity.md)

--- a/docs/design/principles.md
+++ b/docs/design/principles.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/principles.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/principles.md)

--- a/docs/design/resource-qos.md
+++ b/docs/design/resource-qos.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-qos.md)

--- a/docs/design/resources.md
+++ b/docs/design/resources.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resources.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resources.md)

--- a/docs/design/scheduler_extender.md
+++ b/docs/design/scheduler_extender.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduler_extender.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduler_extender.md)

--- a/docs/design/seccomp.md
+++ b/docs/design/seccomp.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/seccomp.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/seccomp.md)

--- a/docs/design/secrets.md
+++ b/docs/design/secrets.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/secrets.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/secrets.md)

--- a/docs/design/security.md
+++ b/docs/design/security.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security.md)

--- a/docs/design/security_context.md
+++ b/docs/design/security_context.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security_context.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security_context.md)

--- a/docs/design/selector-generation.md
+++ b/docs/design/selector-generation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selector-generation.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selector-generation.md)

--- a/docs/design/selinux.md
+++ b/docs/design/selinux.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selinux.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selinux.md)

--- a/docs/design/service_accounts.md
+++ b/docs/design/service_accounts.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service_accounts.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service_accounts.md)

--- a/docs/design/simple-rolling-update.md
+++ b/docs/design/simple-rolling-update.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/simple-rolling-update.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/simple-rolling-update.md)

--- a/docs/design/taint-toleration-dedicated.md
+++ b/docs/design/taint-toleration-dedicated.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/taint-toleration-dedicated.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/taint-toleration-dedicated.md)

--- a/docs/design/versioning.md
+++ b/docs/design/versioning.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/versioning.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/versioning.md)

--- a/docs/design/volume-snapshotting.md
+++ b/docs/design/volume-snapshotting.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-snapshotting.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-snapshotting.md)

--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/README.md](https://github.com/kubernetes/community/blob/master/contributors/devel/README.md)

--- a/docs/devel/adding-an-APIGroup.md
+++ b/docs/devel/adding-an-APIGroup.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/adding-an-APIGroup.md](https://github.com/kubernetes/community/blob/master/contributors/devel/adding-an-APIGroup.md)

--- a/docs/devel/api-conventions.md
+++ b/docs/devel/api-conventions.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md](https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md)

--- a/docs/devel/api_changes.md
+++ b/docs/devel/api_changes.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md](https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md)

--- a/docs/devel/automation.md
+++ b/docs/devel/automation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/automation.md](https://github.com/kubernetes/community/blob/master/contributors/devel/automation.md)

--- a/docs/devel/bazel.md
+++ b/docs/devel/bazel.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/bazel.md](https://github.com/kubernetes/community/blob/master/contributors/devel/bazel.md)

--- a/docs/devel/cherry-picks.md
+++ b/docs/devel/cherry-picks.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md](https://github.com/kubernetes/community/blob/master/contributors/devel/cherry-picks.md)

--- a/docs/devel/cli-roadmap.md
+++ b/docs/devel/cli-roadmap.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/cli-roadmap.md](https://github.com/kubernetes/community/blob/master/contributors/devel/cli-roadmap.md)

--- a/docs/devel/client-libraries.md
+++ b/docs/devel/client-libraries.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/client-libraries.md](https://github.com/kubernetes/community/blob/master/contributors/devel/client-libraries.md)

--- a/docs/devel/coding-conventions.md
+++ b/docs/devel/coding-conventions.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/coding-conventions.md](https://github.com/kubernetes/community/blob/master/contributors/devel/coding-conventions.md)

--- a/docs/devel/collab.md
+++ b/docs/devel/collab.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/collab.md](https://github.com/kubernetes/community/blob/master/contributors/devel/collab.md)

--- a/docs/devel/community-expectations.md
+++ b/docs/devel/community-expectations.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/community-expectations.md](https://github.com/kubernetes/community/blob/master/contributors/devel/community-expectations.md)

--- a/docs/devel/container-runtime-interface.md
+++ b/docs/devel/container-runtime-interface.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md)

--- a/docs/devel/controllers.md
+++ b/docs/devel/controllers.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md](https://github.com/kubernetes/community/blob/master/contributors/devel/controllers.md)

--- a/docs/devel/developer-guides/vagrant.md
+++ b/docs/devel/developer-guides/vagrant.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/developer-guides/vagrant.md](https://github.com/kubernetes/community/blob/master/contributors/devel/developer-guides/vagrant.md)

--- a/docs/devel/development.md
+++ b/docs/devel/development.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/development.md](https://github.com/kubernetes/community/blob/master/contributors/devel/development.md)

--- a/docs/devel/e2e-node-tests.md
+++ b/docs/devel/e2e-node-tests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-node-tests.md](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-node-tests.md)

--- a/docs/devel/e2e-tests.md
+++ b/docs/devel/e2e-tests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md](https://github.com/kubernetes/community/blob/master/contributors/devel/e2e-tests.md)

--- a/docs/devel/faster_reviews.md
+++ b/docs/devel/faster_reviews.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md](https://github.com/kubernetes/community/blob/master/contributors/devel/faster_reviews.md)

--- a/docs/devel/flaky-tests.md
+++ b/docs/devel/flaky-tests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md](https://github.com/kubernetes/community/blob/master/contributors/devel/flaky-tests.md)

--- a/docs/devel/generating-clientset.md
+++ b/docs/devel/generating-clientset.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/generating-clientset.md](https://github.com/kubernetes/community/blob/master/contributors/devel/generating-clientset.md)

--- a/docs/devel/getting-builds.md
+++ b/docs/devel/getting-builds.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/getting-builds.md](https://github.com/kubernetes/community/blob/master/contributors/devel/getting-builds.md)

--- a/docs/devel/go-code.md
+++ b/docs/devel/go-code.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/go-code.md](https://github.com/kubernetes/community/blob/master/contributors/devel/go-code.md)

--- a/docs/devel/godep.md
+++ b/docs/devel/godep.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/godep.md](https://github.com/kubernetes/community/blob/master/contributors/devel/godep.md)

--- a/docs/devel/gubernator.md
+++ b/docs/devel/gubernator.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/gubernator.md](https://github.com/kubernetes/community/blob/master/contributors/devel/gubernator.md)

--- a/docs/devel/how-to-doc.md
+++ b/docs/devel/how-to-doc.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/how-to-doc.md](https://github.com/kubernetes/community/blob/master/contributors/devel/how-to-doc.md)

--- a/docs/devel/instrumentation.md
+++ b/docs/devel/instrumentation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md](https://github.com/kubernetes/community/blob/master/contributors/devel/instrumentation.md)

--- a/docs/devel/issues.md
+++ b/docs/devel/issues.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/issues.md](https://github.com/kubernetes/community/blob/master/contributors/devel/issues.md)

--- a/docs/devel/kubectl-conventions.md
+++ b/docs/devel/kubectl-conventions.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/kubectl-conventions.md](https://github.com/kubernetes/community/blob/master/contributors/devel/kubectl-conventions.md)

--- a/docs/devel/kubemark-guide.md
+++ b/docs/devel/kubemark-guide.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/kubemark-guide.md](https://github.com/kubernetes/community/blob/master/contributors/devel/kubemark-guide.md)

--- a/docs/devel/local-cluster/docker.md
+++ b/docs/devel/local-cluster/docker.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md)

--- a/docs/devel/local-cluster/local.md
+++ b/docs/devel/local-cluster/local.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/local.md](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/local.md)

--- a/docs/devel/local-cluster/vagrant.md
+++ b/docs/devel/local-cluster/vagrant.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/vagrant.md](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/vagrant.md)

--- a/docs/devel/logging.md
+++ b/docs/devel/logging.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md](https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md)

--- a/docs/devel/mesos-style.md
+++ b/docs/devel/mesos-style.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/mesos-style.md](https://github.com/kubernetes/community/blob/master/contributors/devel/mesos-style.md)

--- a/docs/devel/node-performance-testing.md
+++ b/docs/devel/node-performance-testing.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/node-performance-testing.md](https://github.com/kubernetes/community/blob/master/contributors/devel/node-performance-testing.md)

--- a/docs/devel/on-call-build-cop.md
+++ b/docs/devel/on-call-build-cop.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-build-cop.md](https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-build-cop.md)

--- a/docs/devel/on-call-rotations.md
+++ b/docs/devel/on-call-rotations.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-rotations.md](https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-rotations.md)

--- a/docs/devel/on-call-user-support.md
+++ b/docs/devel/on-call-user-support.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-user-support.md](https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-user-support.md)

--- a/docs/devel/owners.md
+++ b/docs/devel/owners.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md](https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md)

--- a/docs/devel/profiling.md
+++ b/docs/devel/profiling.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md](https://github.com/kubernetes/community/blob/master/contributors/devel/profiling.md)

--- a/docs/devel/pull-requests.md
+++ b/docs/devel/pull-requests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md](https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#pull-request-process)

--- a/docs/devel/running-locally.md
+++ b/docs/devel/running-locally.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md](https://github.com/kubernetes/community/blob/master/contributors/devel/running-locally.md)

--- a/docs/devel/scheduler.md
+++ b/docs/devel/scheduler.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler.md](https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler.md)

--- a/docs/devel/scheduler_algorithm.md
+++ b/docs/devel/scheduler_algorithm.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler_algorithm.md](https://github.com/kubernetes/community/blob/master/contributors/devel/scheduler_algorithm.md)

--- a/docs/devel/testing.md
+++ b/docs/devel/testing.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/testing.md](https://github.com/kubernetes/community/blob/master/contributors/devel/testing.md)

--- a/docs/devel/update-release-docs.md
+++ b/docs/devel/update-release-docs.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/update-release-docs.md](https://github.com/kubernetes/community/blob/master/contributors/devel/update-release-docs.md)

--- a/docs/devel/updating-docs-for-feature-changes.md
+++ b/docs/devel/updating-docs-for-feature-changes.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/updating-docs-for-feature-changes.md](https://github.com/kubernetes/community/blob/master/contributors/devel/updating-docs-for-feature-changes.md)

--- a/docs/devel/writing-a-getting-started-guide.md
+++ b/docs/devel/writing-a-getting-started-guide.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/writing-a-getting-started-guide.md](https://github.com/kubernetes/community/blob/master/contributors/devel/writing-a-getting-started-guide.md)

--- a/docs/devel/writing-good-e2e-tests.md
+++ b/docs/devel/writing-good-e2e-tests.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/writing-good-e2e-tests.md](https://github.com/kubernetes/community/blob/master/contributors/devel/writing-good-e2e-tests.md)

--- a/docs/getting-started-guides/docker.md
+++ b/docs/getting-started-guides/docker.md
@@ -1,6 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md](https://github.com/kubernetes/community/blob/master/contributors/devel/local-cluster/docker.md)
-
-
-<!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
-[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/docs/getting-started-guides/docker.md?pixel)]()
-<!-- END MUNGE: GENERATED_ANALYTICS -->

--- a/docs/proposals/api-group.md
+++ b/docs/proposals/api-group.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-group.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/api-group.md)

--- a/docs/proposals/apiserver-watch.md
+++ b/docs/proposals/apiserver-watch.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apiserver-watch.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apiserver-watch.md)

--- a/docs/proposals/apparmor.md
+++ b/docs/proposals/apparmor.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apparmor.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/apparmor.md)

--- a/docs/proposals/client-package-structure.md
+++ b/docs/proposals/client-package-structure.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/client-package-structure.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/client-package-structure.md)

--- a/docs/proposals/cluster-deployment.md
+++ b/docs/proposals/cluster-deployment.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-deployment.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cluster-deployment.md)

--- a/docs/proposals/container-init.md
+++ b/docs/proposals/container-init.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-init.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-init.md)

--- a/docs/proposals/container-runtime-interface-v1.md
+++ b/docs/proposals/container-runtime-interface-v1.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-runtime-interface-v1.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/container-runtime-interface-v1.md)

--- a/docs/proposals/controller-ref.md
+++ b/docs/proposals/controller-ref.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md)

--- a/docs/proposals/deploy.md
+++ b/docs/proposals/deploy.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/deploy.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/deploy.md)

--- a/docs/proposals/deployment.md
+++ b/docs/proposals/deployment.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/deployment.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/deployment.md)

--- a/docs/proposals/disk-accounting.md
+++ b/docs/proposals/disk-accounting.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/disk-accounting.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/disk-accounting.md)

--- a/docs/proposals/dramatically-simplify-cluster-creation.md
+++ b/docs/proposals/dramatically-simplify-cluster-creation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/dramatically-simplify-cluster-creation.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/dramatically-simplify-cluster-creation.md)

--- a/docs/proposals/external-lb-source-ip-preservation.md
+++ b/docs/proposals/external-lb-source-ip-preservation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/external-lb-source-ip-preservation.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/external-lb-source-ip-preservation.md)

--- a/docs/proposals/federated-api-servers.md
+++ b/docs/proposals/federated-api-servers.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-api-servers.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-api-servers.md)

--- a/docs/proposals/federated-ingress.md
+++ b/docs/proposals/federated-ingress.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-ingress.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federated-ingress.md)

--- a/docs/proposals/federation-lite.md
+++ b/docs/proposals/federation-lite.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation-lite.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation-lite.md)

--- a/docs/proposals/federation.md
+++ b/docs/proposals/federation.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/federation.md)

--- a/docs/proposals/flannel-integration.md
+++ b/docs/proposals/flannel-integration.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/flannel-integration.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/flannel-integration.md)

--- a/docs/proposals/garbage-collection.md
+++ b/docs/proposals/garbage-collection.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/garbage-collection.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/garbage-collection.md)

--- a/docs/proposals/gpu-support.md
+++ b/docs/proposals/gpu-support.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/gpu-support.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/gpu-support.md)

--- a/docs/proposals/high-availability.md
+++ b/docs/proposals/high-availability.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/high-availability.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/high-availability.md)

--- a/docs/proposals/image-provenance.md
+++ b/docs/proposals/image-provenance.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/image-provenance.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/image-provenance.md)

--- a/docs/proposals/initial-resources.md
+++ b/docs/proposals/initial-resources.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/initial-resources.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/initial-resources.md)

--- a/docs/proposals/job.md
+++ b/docs/proposals/job.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/job.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/job.md)

--- a/docs/proposals/kubectl-login.md
+++ b/docs/proposals/kubectl-login.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubectl-login.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubectl-login.md)

--- a/docs/proposals/kubelet-auth.md
+++ b/docs/proposals/kubelet-auth.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-auth.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-auth.md)

--- a/docs/proposals/kubelet-cri-logging.md
+++ b/docs/proposals/kubelet-cri-logging.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-cri-logging.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-cri-logging.md)

--- a/docs/proposals/kubelet-eviction.md
+++ b/docs/proposals/kubelet-eviction.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-eviction.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-eviction.md)

--- a/docs/proposals/kubelet-hypercontainer-runtime.md
+++ b/docs/proposals/kubelet-hypercontainer-runtime.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-hypercontainer-runtime.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-hypercontainer-runtime.md)

--- a/docs/proposals/kubelet-rkt-runtime.md
+++ b/docs/proposals/kubelet-rkt-runtime.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-rkt-runtime.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-rkt-runtime.md)

--- a/docs/proposals/kubelet-systemd.md
+++ b/docs/proposals/kubelet-systemd.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-systemd.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-systemd.md)

--- a/docs/proposals/kubelet-tls-bootstrap.md
+++ b/docs/proposals/kubelet-tls-bootstrap.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-tls-bootstrap.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubelet-tls-bootstrap.md)

--- a/docs/proposals/kubemark.md
+++ b/docs/proposals/kubemark.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubemark.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/kubemark.md)

--- a/docs/proposals/local-cluster-ux.md
+++ b/docs/proposals/local-cluster-ux.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/local-cluster-ux.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/local-cluster-ux.md)

--- a/docs/proposals/multi-platform.md
+++ b/docs/proposals/multi-platform.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multi-platform.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multi-platform.md)

--- a/docs/proposals/multiple-schedulers.md
+++ b/docs/proposals/multiple-schedulers.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multiple-schedulers.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/multiple-schedulers.md)

--- a/docs/proposals/network-policy.md
+++ b/docs/proposals/network-policy.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/network-policy.md)

--- a/docs/proposals/node-allocatable.md
+++ b/docs/proposals/node-allocatable.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node-allocatable.md)

--- a/docs/proposals/performance-related-monitoring.md
+++ b/docs/proposals/performance-related-monitoring.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/performance-related-monitoring.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/performance-related-monitoring.md)

--- a/docs/proposals/pod-lifecycle-event-generator.md
+++ b/docs/proposals/pod-lifecycle-event-generator.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-lifecycle-event-generator.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-lifecycle-event-generator.md)

--- a/docs/proposals/pod-resource-management.md
+++ b/docs/proposals/pod-resource-management.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-resource-management.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-resource-management.md)

--- a/docs/proposals/pod-security-context.md
+++ b/docs/proposals/pod-security-context.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-security-context.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/pod-security-context.md)

--- a/docs/proposals/protobuf.md
+++ b/docs/proposals/protobuf.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/protobuf.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/protobuf.md)

--- a/docs/proposals/release-notes.md
+++ b/docs/proposals/release-notes.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release-notes.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release-notes.md)

--- a/docs/proposals/rescheduler.md
+++ b/docs/proposals/rescheduler.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduler.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduler.md)

--- a/docs/proposals/rescheduling-for-critical-pods.md
+++ b/docs/proposals/rescheduling-for-critical-pods.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduling-for-critical-pods.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduling-for-critical-pods.md)

--- a/docs/proposals/rescheduling.md
+++ b/docs/proposals/rescheduling.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduling.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/rescheduling.md)

--- a/docs/proposals/resource-metrics-api.md
+++ b/docs/proposals/resource-metrics-api.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-metrics-api.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-metrics-api.md)

--- a/docs/proposals/resource-quota-scoping.md
+++ b/docs/proposals/resource-quota-scoping.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-quota-scoping.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/resource-quota-scoping.md)

--- a/docs/proposals/runtime-client-server.md
+++ b/docs/proposals/runtime-client-server.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtime-client-server.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtime-client-server.md)

--- a/docs/proposals/runtime-pod-cache.md
+++ b/docs/proposals/runtime-pod-cache.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtime-pod-cache.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtime-pod-cache.md)

--- a/docs/proposals/runtimeconfig.md
+++ b/docs/proposals/runtimeconfig.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtimeconfig.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/runtimeconfig.md)

--- a/docs/proposals/scalability-testing.md
+++ b/docs/proposals/scalability-testing.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scalability-testing.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scalability-testing.md)

--- a/docs/proposals/scheduledjob.md
+++ b/docs/proposals/scheduledjob.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cronjob.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/cronjob.md)

--- a/docs/proposals/secret-configmap-downwarapi-file-mode.md
+++ b/docs/proposals/secret-configmap-downwarapi-file-mode.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/secret-configmap-downwarapi-file-mode.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/secret-configmap-downwarapi-file-mode.md)

--- a/docs/proposals/security-context-constraints.md
+++ b/docs/proposals/security-context-constraints.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security-context-constraints.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/security-context-constraints.md)

--- a/docs/proposals/self-hosted-kubelet.md
+++ b/docs/proposals/self-hosted-kubelet.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/self-hosted-kubelet.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/self-hosted-kubelet.md)

--- a/docs/proposals/selinux-enhancements.md
+++ b/docs/proposals/selinux-enhancements.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selinux-enhancements.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/selinux-enhancements.md)

--- a/docs/proposals/service-discovery.md
+++ b/docs/proposals/service-discovery.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service-discovery.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service-discovery.md)

--- a/docs/proposals/service-external-name.md
+++ b/docs/proposals/service-external-name.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service-external-name.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/service-external-name.md)

--- a/docs/proposals/stateful-apps.md
+++ b/docs/proposals/stateful-apps.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/stateful-apps.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/stateful-apps.md)

--- a/docs/proposals/synchronous-garbage-collection.md
+++ b/docs/proposals/synchronous-garbage-collection.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/synchronous-garbage-collection.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/synchronous-garbage-collection.md)

--- a/docs/proposals/templates.md
+++ b/docs/proposals/templates.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/templates.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/templates.md)

--- a/docs/proposals/volume-hostpath-qualifiers.md
+++ b/docs/proposals/volume-hostpath-qualifiers.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-hostpath-qualifiers.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-hostpath-qualifiers.md)

--- a/docs/proposals/volume-ownership-management.md
+++ b/docs/proposals/volume-ownership-management.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-ownership-management.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-ownership-management.md)

--- a/docs/proposals/volume-provisioning.md
+++ b/docs/proposals/volume-provisioning.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-provisioning.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-provisioning.md)

--- a/docs/proposals/volume-selectors.md
+++ b/docs/proposals/volume-selectors.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-selectors.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volume-selectors.md)

--- a/docs/proposals/volumes.md
+++ b/docs/proposals/volumes.md
@@ -1,1 +1,0 @@
-This file has moved to [https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volumes.md](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/volumes.md)


### PR DESCRIPTION
We are working on cleaning the docs directory. Per the discussion with Doc SIG
and more under https://github.com/kubernetes/kubernetes/issues/47361 we will
be working on moving the generated code and content to a different repo. This
PR is to clean up docs content which is already moved to Community repo and
not needed here.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
