### PR TITLE
Set cluster-autoscaler node balancing flag

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -40,6 +40,7 @@
                     "--v=4",
                     "--logtostderr=true",
                     "--write-status-configmap=true",
+                    "--balance-similar-node-groups=true,"
                     "{{params}}"
                 ],
                 "env": [


### PR DESCRIPTION
Ref: https://github.com/kubernetes/autoscaler/issues/47

Enable cluster-autoscaler node balancing functionality provided in CA 0.6.