### PR TITLE
Add e2e tests for CA scale up when pending pod requests volume

### DIFF
--- a/test/e2e/autoscaling/BUILD
+++ b/test/e2e/autoscaling/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",


### PR DESCRIPTION
Test verifying pending pods with PVC don't interfere with scale up, issue: kubernetes/autoscaler#22