### PR TITLE
Automated cherry pick of #48129 #48132

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -40,6 +40,7 @@
                     "--v=4",
                     "--logtostderr=true",
                     "--write-status-configmap=true",
+                    "--balance-similar-node-groups=true,"
                     "{{params}}"
                 ],
                 "env": [

--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -40,7 +40,7 @@
                     "--v=4",
                     "--logtostderr=true",
                     "--write-status-configmap=true",
-                    "--balance-similar-node-groups=true,"
+                    "--balance-similar-node-groups=true",
                     "{{params}}"
                 ],
                 "env": [


### PR DESCRIPTION
Cherry pick of #48129 #48132 on release-1.7.

#48129: Set cluster-autoscaler node balancing flag
#48132: Fix typo in cluster-autoscaler config

This sets a flag in cluster-autoscaler config that was added in 0.6 version of CA. 

e2e test runs using this change on respectively single- and multi-mig cluster: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-autoscaling/4506, https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-autoscaling-migs/5100. 

This functionality was separately tested as part of cluster-autoscaler 0.6 release as described in original PR: https://github.com/kubernetes/autoscaler/pull/105#issuecomment-305830823.