### PR TITLE
fixes to two pkg/util unit tests

### DIFF
--- a/pkg/util/ebtables/ebtables_test.go
+++ b/pkg/util/ebtables/ebtables_test.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/exec"
 )
 
-func testEnsureChain(t *testing.T) {
+func TestEnsureChain(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// Does not Exists
@@ -75,7 +75,7 @@ func testEnsureChain(t *testing.T) {
 	}
 }
 
-func testEnsureRule(t *testing.T) {
+func TestEnsureRule(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// Exists
@@ -118,7 +118,7 @@ Bridge chain: TEST, entries: 0, policy: ACCEPT`), nil
 	if exists {
 		t.Errorf("expected exists = false")
 	}
-	errStr := "Failed to ensure rule: exist 2, output: "
+	errStr := "Failed to ensure rule: exit 2, output: "
 	if err == nil || err.Error() != errStr {
 		t.Errorf("expected error: %q", errStr)
 	}

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -333,7 +333,7 @@ func TestEnsureRuleErrorCreating(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleAlreadyExists(t *testing.T) {
+func TestDeleteRuleDoesNotExist(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check
@@ -368,7 +368,7 @@ func TestDeleteRuleAlreadyExists(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleNew(t *testing.T) {
+func TestDeleteRuleExists(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check
@@ -438,7 +438,7 @@ func TestDeleteRuleErrorChecking(t *testing.T) {
 	}
 }
 
-func TestDeleteRuleErrorCreating(t *testing.T) {
+func TestDeleteRuleErrorDeleting(t *testing.T) {
 	fcmd := exec.FakeCmd{
 		CombinedOutputScript: []exec.FakeCombinedOutputAction{
 			// iptables version check


### PR DESCRIPTION
Spun out from #46537. Trivial unit test fixes:
- `pkg/util/ebtables/ebtables_test.go`'s tests are incorrectly named and so weren't getting run by "go test". (And one of them had a typo in it so it failed after the name was fixed)
- In `pkg/util/iptables/iptables_test.go`, the deletion tests were apparently written by copying+pasting+editing the creation tests, but they forgot to change the names of the tests to match the behavior that was being tested in the new version
