### PR TITLE
Fix cascading delete

### DIFF
--- a/federation/pkg/federatedtypes/crudtester/crudtester.go
+++ b/federation/pkg/federatedtypes/crudtester/crudtester.go
@@ -155,7 +155,7 @@ func (c *FederatedTypeCRUDTester) CheckDelete(obj pkgruntime.Object, orphanDepen
 		return false, err
 	})
 	if err != nil {
-		c.tl.Fatalf("Error deleting federated %s %q: %v", c.kind, qualifiedName, err)
+		c.tl.Fatalf("Error deleting federated %s %q in %s: %v", c.kind, qualifiedName, waitTimeout, err)
 	}
 
 	var stateMsg string = "present"

--- a/federation/pkg/federation-controller/ingress/ingress_controller.go
+++ b/federation/pkg/federation-controller/ingress/ingress_controller.go
@@ -256,8 +256,10 @@ func NewIngressController(client federationclientset.Interface) *IngressControll
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			ingress := obj.(*extensionsv1beta1.Ingress)
 			glog.V(4).Infof("Attempting to delete Ingress: %v", ingress)
-			orphanDependents := false
-			err := client.Extensions().Ingresses(ingress.Namespace).Delete(ingress.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+			propagationPolicy := metav1.DeletePropagationForeground
+			err := client.Extensions().Ingresses(ingress.Namespace).Delete(ingress.Name, &metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -177,8 +177,10 @@ func New(federationClient fedclientset.Interface) *ServiceController {
 		},
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			svc := obj.(*v1.Service)
-			orphanDependents := false
-			err := client.Core().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+			propagationPolicy := metav1.DeletePropagationForeground
+			err := client.Core().Services(svc.Namespace).Delete(svc.Name, &metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/sync/controller.go
+++ b/federation/pkg/federation-controller/sync/controller.go
@@ -189,8 +189,12 @@ func newFederationSyncController(client federationclientset.Interface, adapter f
 		},
 		func(client kubeclientset.Interface, obj pkgruntime.Object) error {
 			qualifiedName := adapter.QualifiedName(obj)
-			orphanDependents := false
-			err := adapter.ClusterDelete(client, qualifiedName, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+			// set PropagationPolicy default to Foreground
+			// TODO: make DeleteOptions optional, and support Background
+			propagationPolicy := metav1.DeletePropagationForeground
+			err := adapter.ClusterDelete(client, qualifiedName, &metav1.DeleteOptions{
+				PropagationPolicy: &propagationPolicy,
+			})
 			return err
 		})
 

--- a/federation/pkg/federation-controller/util/deletionhelper/deletion_helper.go
+++ b/federation/pkg/federation-controller/util/deletionhelper/deletion_helper.go
@@ -67,9 +67,11 @@ func NewDeletionHelper(
 // Ensures that the given object has both FinalizerDeleteFromUnderlyingClusters
 // and FinalizerOrphan finalizers.
 // We do this so that the controller is always notified when a federation resource is deleted.
-// If user deletes the resource with nil DeleteOptions or
-// DeletionOptions.OrphanDependents = true then the apiserver removes the orphan finalizer
-// and deletion helper does a cascading deletion.
+// If user deletes the resource with nil DeleteOptions or DeletionOptions.OrphanDependents = true,
+// then the federation controller manager just deletes federation resource.
+// if user deletes the resource with DeletionOptions.OrphanDependents = false,
+// then the federation apiserver removes the orphan finalizer and deletion helper
+// does a cascading deletion(deletes federation resource and cluster resources).
 // Otherwise, deletion helper just removes the federation resource and orphans
 // the corresponding resources in underlying clusters.
 // This method should be called before creating objects in underlying clusters.

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -240,8 +240,10 @@ func updateConfigMapFromCluster(hostClientset, unjoiningClusterClientset interna
 // deleteSecret deletes the secret with the given name from the host
 // cluster.
 func deleteSecret(clientset internalclientset.Interface, name, namespace string) error {
-	orphanDependents := false
-	return clientset.Core().Secrets(namespace).Delete(name, &metav1.DeleteOptions{OrphanDependents: &orphanDependents})
+	propagationPolicy := metav1.DeletePropagationForeground
+	return clientset.Core().Secrets(namespace).Delete(name, &metav1.DeleteOptions{
+		PropagationPolicy: &propagationPolicy,
+	})
 }
 
 // isNotFound checks if the given error is a NotFound status error.

--- a/test/integration/federation/framework/crudtester.go
+++ b/test/integration/federation/framework/crudtester.go
@@ -18,12 +18,14 @@ package framework
 
 import (
 	"testing"
+	"time"
 
-	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/federation/pkg/federatedtypes"
 	"k8s.io/kubernetes/federation/pkg/federatedtypes/crudtester"
 )
+
+const FederatedDefaultTestTimeout = 10 * time.Minute
 
 type IntegrationLogger struct {
 	t *testing.T
@@ -43,5 +45,5 @@ func (l *IntegrationLogger) Fatal(msg string) {
 
 func NewFederatedTypeCRUDTester(t *testing.T, adapter federatedtypes.FederatedTypeAdapter, clusterClients []clientset.Interface) *crudtester.FederatedTypeCRUDTester {
 	logger := &IntegrationLogger{t}
-	return crudtester.NewFederatedTypeCRUDTester(logger, adapter, clusterClients, DefaultWaitInterval, wait.ForeverTestTimeout)
+	return crudtester.NewFederatedTypeCRUDTester(logger, adapter, clusterClients, DefaultWaitInterval, FederatedDefaultTestTimeout)
 }


### PR DESCRIPTION
Kubernetes 1.6 adds a PropagationPolicy to the delete options,
obsoleting the previous OrphanDependents boolean. This PR sets
PropagationPolicy=foreground instead of OrphanDependents=false
when federation controller manager delete cluster resource.

@caesarxuchao ptal

**Release note**:
```release-note
NONE
```
