### PR TITLE
Fix fluentd-gcp configuration to facilitate JSON parsing

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -314,7 +314,7 @@ data:
 
     # This filter is used to convert process start timestamp to integer
     # value for correct ingestion in the prometheus output plugin.
-    <filter>
+    <filter process_start>
       @type record_transformer
       enable_ruby true
       auto_typecast true
@@ -415,7 +415,7 @@ data:
       </store>
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.0
+  name: fluentd-gcp-config-v1.1
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -120,7 +120,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.0
+          name: fluentd-gcp-config-v1.1
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs


### PR DESCRIPTION
There's a bug in https://github.com/kubernetes/kubernetes/pull/45734, because of which each records gets additional field and google-cloud plugin thinks it's not JSON (https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/master/lib/fluent/plugin/out_google_cloud.rb#L569)

Fixes https://github.com/kubernetes/kubernetes/issues/48108

/cc @piosz @fgrzadkowski 