### PR TITLE
Fix IntOrStr JSON Schema type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -124,8 +124,7 @@ func (_ IntOrString) OpenAPIDefinition() openapi.OpenAPIDefinition {
 	return openapi.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type:   []string{"string"},
-				Format: "int-or-string",
+				Type: []string{"integer", "string"},
 			},
 		},
 	}


### PR DESCRIPTION
Sum types can be expressed in JSON schema either via the type array or
with the anyOf construct. This change chooses the former to give the type
the correct schema.
