### PR TITLE
Automated cherry pick of #47986 #47152 #47860 #47945 #47961 #47986 #47993 #48012 #48085

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0
+  name: heapster-v1.4.0-beta.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.4.0-beta.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0
+      version: v1.4.0-beta.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0
+        version: v1.4.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -65,7 +65,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: eventer
           command:
             - /eventer
@@ -103,7 +103,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -132,7 +132,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0
+  name: heapster-v1.4.0-beta.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.4.0-beta.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0
+      version: v1.4.0-beta.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0
+        version: v1.4.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -66,7 +66,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: eventer
           command:
             - /eventer
@@ -104,7 +104,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -133,7 +133,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0
+  name: heapster-v1.4.0-beta.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.4.0-beta.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0
+      version: v1.4.0-beta.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0
+        version: v1.4.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: eventer
           command:
             - /eventer
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -118,7 +118,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0
+  name: heapster-v1.4.0-beta.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.4.0-beta.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0
+      version: v1.4.0-beta.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0
+        version: v1.4.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.3.0
+  name: heapster-v1.4.0-beta.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.4.0-beta.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.3.0
+      version: v1.4.0-beta.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.3.0
+        version: v1.4.0-beta.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.3.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -80,7 +80,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.3.0
+            - --deployment=heapster-v1.4.0-beta.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -27,7 +27,10 @@ spec:
         command:
           - '/bin/sh'
           - '-c'
-          - '/usr/sbin/td-agent 2>&1 >> /var/log/fluentd.log'
+          - '/usr/sbin/td-agent $FLUENTD_ARGS'
+        env:
+        - name: FLUENTD_AGRS
+          value: -q
         resources:
           limits:
             memory: 200Mi

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -36,10 +36,10 @@ spec:
         command:
           - '/bin/sh'
           - '-c'
-          - '/run.sh $FLUENTD_ARGS 2>&1 >>/var/log/fluentd.log'
+          - '/run.sh $FLUENTD_ARGS'
         env:
         - name: FLUENTD_ARGS
-          value: --no-supervisor
+          value: --no-supervisor -q
         resources:
           limits:
             memory: 300Mi

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1710,7 +1710,7 @@ function start-kube-addons {
   if [[ "${ENABLE_DEFAULT_STORAGE_CLASS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "storage-class/gce"
   fi
-  if [[ "${NON_MASQUERADE_CIDR:-}" == "0.0.0.0/0" ]]; then
+  if [[ "${ENABLE_IP_MASQ_AGENT:-}" == "true" ]]; then
     setup-addon-manifests "addons" "ip-masq-agent"
   fi
   if [[ "${ENABLE_METADATA_PROXY:-}" == "simple" ]]; then

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -422,7 +422,10 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		glog.V(2).Infof("Using node IP: %q", kl.nodeIP.String())
 	}
 
-	if kl.cloud != nil {
+	if kl.externalCloudProvider {
+		// We rely on the external cloud provider to supply the addresses.
+		return nil
+	} else if kl.cloud != nil {
 		instances, ok := kl.cloud.Instances()
 		if !ok {
 			return fmt.Errorf("failed to get instances from cloud provider")

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1571,7 +1571,8 @@ func (proxier *Proxier) syncProxyRules() {
 	glog.V(5).Infof("Restoring iptables rules: %s", proxier.iptablesData.Bytes())
 	err = proxier.iptables.RestoreAll(proxier.iptablesData.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
-		glog.Errorf("Failed to execute iptables-restore: %v\nRules:\n%s", err, proxier.iptablesData.Bytes())
+		glog.Errorf("Failed to execute iptables-restore: %v", err)
+		glog.V(2).Infof("Rules:\n%s", proxier.iptablesData.Bytes())
 		// Revert new local ports.
 		revertPorts(replacementPortsMap, proxier.portsMap)
 		return

--- a/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
@@ -49,6 +49,6 @@ func InitFlags() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.Parse()
 	pflag.VisitAll(func(flag *pflag.Flag) {
-		glog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+		glog.V(4).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
 }

--- a/test/e2e/monitoring.go
+++ b/test/e2e/monitoring.go
@@ -48,8 +48,8 @@ var _ = framework.KubeDescribe("Monitoring", func() {
 const (
 	influxdbService       = "monitoring-influxdb"
 	influxdbDatabaseName  = "k8s"
-	podlistQuery          = "show tag values from \"cpu/usage\" with key = pod_id"
-	nodelistQuery         = "show tag values from \"cpu/usage\" with key = hostname"
+	podlistQuery          = "show tag values from \"cpu/usage\" with key = pod_name"
+	nodelistQuery         = "show tag values from \"cpu/usage\" with key = nodename"
 	sleepBetweenAttempts  = 5 * time.Second
 	testTimeout           = 5 * time.Minute
 	initializationTimeout = 5 * time.Minute
@@ -161,7 +161,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c clientset.Interface) ([]string, 
 				if pod.DeletionTimestamp != nil {
 					continue
 				}
-				expectedPods = append(expectedPods, string(pod.UID))
+				expectedPods = append(expectedPods, pod.Name)
 			}
 		}
 		// Do the same for all deployments.
@@ -176,7 +176,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c clientset.Interface) ([]string, 
 				if pod.DeletionTimestamp != nil {
 					continue
 				}
-				expectedPods = append(expectedPods, string(pod.UID))
+				expectedPods = append(expectedPods, pod.Name)
 			}
 		}
 		// And for pet sets.
@@ -191,7 +191,7 @@ func verifyExpectedRcsExistAndGetExpectedPods(c clientset.Interface) ([]string, 
 				if pod.DeletionTimestamp != nil {
 					continue
 				}
-				expectedPods = append(expectedPods, string(pod.UID))
+				expectedPods = append(expectedPods, pod.Name)
 			}
 		}
 	}

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -43,7 +43,7 @@ import (
 const (
 	gcePDDetachTimeout  = 10 * time.Minute
 	gcePDDetachPollTime = 10 * time.Second
-	nodeStatusTimeout   = 5 * time.Minute
+	nodeStatusTimeout   = 10 * time.Minute
 	nodeStatusPollTime  = 1 * time.Second
 	maxReadRetry        = 3
 )


### PR DESCRIPTION
Cherry pick of #47986 #47152 #47860 #47945 #47961 #47986 #47993 #48012 #48085 on release-1.7.

#47986: Change service port to avoid collision
#47152: Kubelet doesn't override addrs from Cloud provider
#47860: Make fluentd log to stdio instead of a dedicated file
#47945: add level for print flags
#47961: Bumped Heapster to v1.4.0-beta.0
#47986: Change service port to avoid collision
#47993: Use a different env var to enable the ip-masq-agent addon. We
#48012: Extending timeout waiting for delete node to become ready
#48085: Move iptables logging in kubeproxy from Errorf to V(2).Infof