### PR TITLE
E2E Volumes: Reinstate GlusterFS volume test where GCI is the node distro.

### DIFF
--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -138,10 +138,13 @@ var _ = SIGDescribe("Volumes", func() {
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
 
-	SIGDescribe("GlusterFS [Feature:Volumes]", func() {
+	framework.KubeDescribe("GlusterFS", func() {
 		It("should be mountable", func() {
-			//TODO (copejon) GFS is not supported on debian image.
-			framework.SkipUnlessNodeOSDistroIs("gci")
+			framework.SkipUnlessProviderIs("gke", "gce")
+			if framework.TestContext.Provider == "gce" {
+				// GKE Node Distro registers as debian (underlying VM) but nodes are GCI images.
+				framework.SkipUnlessNodeOSDistroIs("gci")
+			}
 
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Removes the `[Feature:Volumes]` tag from the GlusterFS test to reenable it under certain conditions in the CI.  GlusterFS is supported on nodes running the Google Container Image in both GKE and GCE.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
On GKE, `framework.TestContext.NodeOSDistro` registers as debian because that is the OS of the underlying VM.  The containerized node is GCI.  So it is only necessary to `SkipUnlessNodeDistroIs("gci")` when the provider is "GCE".
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
