### PR TITLE
Automated cherry pick of #48139 #48049 #48042

### DIFF
--- a/build/debs/kubeadm-10.conf
+++ b/build/debs/kubeadm-10.conf
@@ -3,5 +3,7 @@ Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf -
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
+Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
+Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
 ExecStart=
-ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_EXTRA_ARGS

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -314,7 +314,7 @@ data:
 
     # This filter is used to convert process start timestamp to integer
     # value for correct ingestion in the prometheus output plugin.
-    <filter>
+    <filter process_start>
       @type record_transformer
       enable_ruby true
       auto_typecast true
@@ -415,7 +415,7 @@ data:
       </store>
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.0
+  name: fluentd-gcp-config-v1.1
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -120,7 +120,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.0
+          name: fluentd-gcp-config-v1.1
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -59,6 +59,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-proxy
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Cherry pick of #48139 #48049 #48042 on release-1.7.

#48139: Fix fluentd-gcp configuration to facilitate JSON parsing
#48049: kubeadm: Make kube-proxy RollingUpgradeable
#48042: Reflect kubeadm-specific kubelet changes in the bazel debs