### PR TITLE
audit newest impersonated user info in the ResponseStarted, ResponseComplete audit stage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -31,6 +30,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -28,7 +27,6 @@ import (
 
 	"reflect"
 
-	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,6 +34,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/apis/audit"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -73,24 +72,6 @@ func NewEventFromRequest(req *http.Request, level auditinternal.Level, attribs a
 		ev.User.UID = user.GetUID()
 	}
 
-	if asuser := req.Header.Get(authenticationv1.ImpersonateUserHeader); len(asuser) > 0 {
-		ev.ImpersonatedUser = &auditinternal.UserInfo{
-			Username: asuser,
-		}
-		if requestedGroups := req.Header[authenticationv1.ImpersonateGroupHeader]; len(requestedGroups) > 0 {
-			ev.ImpersonatedUser.Groups = requestedGroups
-		}
-
-		ev.ImpersonatedUser.Extra = map[string]auditinternal.ExtraValue{}
-		for k, v := range req.Header {
-			if !strings.HasPrefix(k, authenticationv1.ImpersonateUserExtraHeaderPrefix) {
-				continue
-			}
-			k = k[len(authenticationv1.ImpersonateUserExtraHeaderPrefix):]
-			ev.ImpersonatedUser.Extra[k] = auditinternal.ExtraValue(v)
-		}
-	}
-
 	if attribs.IsResourceRequest() {
 		ev.ObjectRef = &auditinternal.ObjectReference{
 			Namespace:   attribs.GetNamespace(),
@@ -102,6 +83,22 @@ func NewEventFromRequest(req *http.Request, level auditinternal.Level, attribs a
 	}
 
 	return ev, nil
+}
+
+// LogImpersonatedUser fills in the impersonated user attributes into an audit event.
+func LogImpersonatedUser(ae *auditinternal.Event, user user.Info) {
+	if ae == nil || ae.Level.Less(audit.LevelMetadata) {
+		return
+	}
+	ae.ImpersonatedUser = &auditinternal.UserInfo{
+		Username: user.GetName(),
+	}
+	ae.ImpersonatedUser.Groups = user.GetGroups()
+	ae.ImpersonatedUser.UID = user.GetUID()
+	ae.ImpersonatedUser.Extra = map[string]auditinternal.ExtraValue{}
+	for k, v := range user.GetExtra() {
+		ae.ImpersonatedUser.Extra[k] = auditinternal.ExtraValue(v)
+	}
 }
 
 // LogRequestObject fills in the request object into an audit event. The passed runtime.Object

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -27,6 +27,7 @@ import (
 	authenticationv1 "k8s.io/api/authentication/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -132,6 +133,9 @@ func WithImpersonation(handler http.Handler, requestContextMapper request.Reques
 
 		oldUser, _ := request.UserFrom(ctx)
 		httplog.LogOf(req, w).Addf("%v is acting as %v", oldUser, newUser)
+
+		ae := request.AuditEventFrom(ctx)
+		audit.LogImpersonatedUser(ae, newUser)
 
 		// clear all the impersonation headers from the request
 		req.Header.Del(authenticationv1.ImpersonateUserHeader)


### PR DESCRIPTION
Impersonation will automatically add system:authenticated, system:serviceaccounts group to the impersonated user info. This pr use the newest impersonated user info in the second audit event. This will help users to debug rbac problems.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
[advanced audit] audit newest impersonated user info in the ResponseStarted, ResponseComplete audit stage
```
@liggitt @sttts 