### PR TITLE
[Federation] Make arguments to scheduling type adapter methods generic

### DIFF
--- a/federation/pkg/federatedtypes/deployment.go
+++ b/federation/pkg/federatedtypes/deployment.go
@@ -47,15 +47,16 @@ type DeploymentAdapter struct {
 func NewDeploymentAdapter(client federationclientset.Interface, config *restclient.Config) FederatedTypeAdapter {
 	schedulingAdapter := schedulingAdapter{
 		preferencesAnnotationName: FedDeploymentPreferencesAnnotation,
-		updateStatusFunc: func(obj pkgruntime.Object, status SchedulingStatus) error {
+		updateStatusFunc: func(obj pkgruntime.Object, status interface{}) error {
 			deployment := obj.(*extensionsv1.Deployment)
-			if status.Replicas != deployment.Status.Replicas || status.UpdatedReplicas != deployment.Status.UpdatedReplicas ||
-				status.ReadyReplicas != deployment.Status.ReadyReplicas || status.AvailableReplicas != deployment.Status.AvailableReplicas {
+			typedStatus := status.(ReplicaSchedulingStatus)
+			if typedStatus.Replicas != deployment.Status.Replicas || typedStatus.UpdatedReplicas != deployment.Status.UpdatedReplicas ||
+				typedStatus.ReadyReplicas != deployment.Status.ReadyReplicas || typedStatus.AvailableReplicas != deployment.Status.AvailableReplicas {
 				deployment.Status = extensionsv1.DeploymentStatus{
-					Replicas:          status.Replicas,
-					UpdatedReplicas:   status.UpdatedReplicas,
-					ReadyReplicas:     status.ReadyReplicas,
-					AvailableReplicas: status.AvailableReplicas,
+					Replicas:          typedStatus.Replicas,
+					UpdatedReplicas:   typedStatus.UpdatedReplicas,
+					ReadyReplicas:     typedStatus.ReadyReplicas,
+					AvailableReplicas: typedStatus.AvailableReplicas,
 				}
 				_, err := client.Extensions().Deployments(deployment.Namespace).UpdateStatus(deployment)
 				return err

--- a/federation/pkg/federatedtypes/replicaset.go
+++ b/federation/pkg/federatedtypes/replicaset.go
@@ -47,15 +47,16 @@ type ReplicaSetAdapter struct {
 func NewReplicaSetAdapter(client federationclientset.Interface, config *restclient.Config) FederatedTypeAdapter {
 	schedulingAdapter := schedulingAdapter{
 		preferencesAnnotationName: FedReplicaSetPreferencesAnnotation,
-		updateStatusFunc: func(obj pkgruntime.Object, status SchedulingStatus) error {
+		updateStatusFunc: func(obj pkgruntime.Object, status interface{}) error {
 			rs := obj.(*extensionsv1.ReplicaSet)
-			if status.Replicas != rs.Status.Replicas || status.FullyLabeledReplicas != rs.Status.FullyLabeledReplicas ||
-				status.ReadyReplicas != rs.Status.ReadyReplicas || status.AvailableReplicas != rs.Status.AvailableReplicas {
+			typedStatus := status.(ReplicaSchedulingStatus)
+			if typedStatus.Replicas != rs.Status.Replicas || typedStatus.FullyLabeledReplicas != rs.Status.FullyLabeledReplicas ||
+				typedStatus.ReadyReplicas != rs.Status.ReadyReplicas || typedStatus.AvailableReplicas != rs.Status.AvailableReplicas {
 				rs.Status = extensionsv1.ReplicaSetStatus{
-					Replicas:             status.Replicas,
-					FullyLabeledReplicas: status.Replicas,
-					ReadyReplicas:        status.ReadyReplicas,
-					AvailableReplicas:    status.AvailableReplicas,
+					Replicas:             typedStatus.Replicas,
+					FullyLabeledReplicas: typedStatus.Replicas,
+					ReadyReplicas:        typedStatus.ReadyReplicas,
+					AvailableReplicas:    typedStatus.AvailableReplicas,
 				}
 				_, err := client.Extensions().ReplicaSets(rs.Namespace).UpdateStatus(rs)
 				return err

--- a/federation/pkg/federation-controller/sync/controller_test.go
+++ b/federation/pkg/federation-controller/sync/controller_test.go
@@ -75,7 +75,7 @@ func TestSyncToClusters(t *testing.T) {
 					}
 					return nil, nil
 				},
-				func(federatedtypes.FederatedTypeAdapter, []*federationapi.Cluster, []*federationapi.Cluster, pkgruntime.Object, *federatedtypes.SchedulingInfo) ([]util.FederatedOperation, error) {
+				func(federatedtypes.FederatedTypeAdapter, []*federationapi.Cluster, []*federationapi.Cluster, pkgruntime.Object, interface{}) ([]util.FederatedOperation, error) {
 					if testCase.operationsError {
 						return nil, awfulError
 					}


### PR DESCRIPTION
This is in the process of trying to rebase https://github.com/kubernetes/kubernetes/pull/45993 on latest.
cc @marun @perotinus 
@kubernetes/sig-federation-misc 
Hoping I get some attention to this and later PRs soon.

Associated issue https://github.com/kubernetes/kubernetes/issues/49181

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```