### PR TITLE
Automated cherry pick of #48205 #48183 #48118

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0-beta.0
+  name: heapster-v1.4.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0-beta.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0-beta.0
+      version: v1.4.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0-beta.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -65,7 +65,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: eventer
           command:
             - /eventer
@@ -103,7 +103,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -132,7 +132,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0-beta.0
+  name: heapster-v1.4.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0-beta.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0-beta.0
+      version: v1.4.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0-beta.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -66,7 +66,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: eventer
           command:
             - /eventer
@@ -104,7 +104,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -133,7 +133,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0-beta.0
+  name: heapster-v1.4.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0-beta.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0-beta.0
+      version: v1.4.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0-beta.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: eventer
           command:
             - /eventer
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -118,7 +118,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0-beta.0
+  name: heapster-v1.4.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0-beta.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0-beta.0
+      version: v1.4.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0-beta.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0-beta.0
+  name: heapster-v1.4.0
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0-beta.0
+    version: v1.4.0
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0-beta.0
+      version: v1.4.0
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0-beta.0
+        version: v1.4.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0-beta.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -80,7 +80,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0-beta.0
+            - --deployment=heapster-v1.4.0
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -447,7 +447,7 @@ func NewProxyServer(config *componentconfig.KubeProxyConfiguration, cleanupAndEx
 
 	// We omit creation of pretty much everything if we run in cleanup mode
 	if cleanupAndExit {
-		return &ProxyServer{IptInterface: iptInterface}, nil
+		return &ProxyServer{IptInterface: iptInterface, CleanupAndExit: cleanupAndExit}, nil
 	}
 
 	client, eventClient, err := createClients(config.ClientConnection, master)
@@ -627,7 +627,9 @@ func (s *ProxyServer) Run() error {
 		}
 	}
 
-	s.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: s.EventClient.Events("")})
+	if s.Broadcaster != nil && s.EventClient != nil {
+		s.Broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: s.EventClient.Events("")})
+	}
 
 	// Start up a healthz server if requested
 	if s.HealthzServer != nil {


### PR DESCRIPTION
Cherry pick of #48205 #48183 #48118 on release-1.7.

#48205: Bumped Heapster to v1.4.0
#48183: Fix kube-proxy panic when running with
#48118: Ensures node becomes schedulable at the end of tests that

``` release-note
Bumped Heapster to v1.4.0.
More details about the release https://github.com/kubernetes/heapster/releases/tag/v1.4.0
```