### PR TITLE
Fix error message for rbac

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -234,7 +234,7 @@ func (r *PolicyRuleBuilder) Rule() (PolicyRule, error) {
 				}
 			}
 			if len(illegalVerbs) > 0 {
-				return PolicyRule{}, fmt.Errorf("verbs %v do not have names available: %#v", illegalVerbs, r.PolicyRule)
+				return PolicyRule{}, fmt.Errorf("verbs %v do not support resource name: %#v", illegalVerbs, r.PolicyRule)
 			}
 		}
 


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
@liggitt 
