### PR TITLE
Automated cherry pick of #48182

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -107,6 +107,9 @@ spec:
         effect: "NoSchedule"
       - operator: "Exists"
         effect: "NoExecute"
+      #TODO: remove this toleration once #44445 is properly fixed.
+      - operator: "Exists"
+        effect: "NoSchedule"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
Cherry pick of #48182 on release-1.7.

#48182: Add generic NoSchedule toleration to fluentd in gcp config as

```release-note
Add generic NoSchedule toleration to fluentd in gcp
```