### PR TITLE
refactor auth provider

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -205,6 +205,16 @@ func (n *fakeNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, 
 	return &fakeCodec{}
 }
 
+type fakeBearerTokenSource struct{}
+
+func (t *fakeBearerTokenSource) Token() (string, error) {
+	return "token", nil
+}
+
+func (t *fakeBearerTokenSource) Refresh() (bool, error) {
+	return true, nil
+}
+
 func TestAnonymousConfig(t *testing.T) {
 	f := fuzz.New().NilChance(0.0).NumElements(1, 1)
 	f.Funcs(
@@ -235,6 +245,11 @@ func TestAnonymousConfig(t *testing.T) {
 		func(r *AuthProviderConfigPersister, f fuzz.Continue) {},
 		func(r *clientcmdapi.AuthProviderConfig, f fuzz.Continue) {
 			r.Config = map[string]string{}
+		},
+		func(t *BearerTokenSource, f fuzz.Continue) {
+			tokenSource := &fakeBearerTokenSource{}
+			f.Fuzz(tokenSource)
+			*t = tokenSource
 		},
 	)
 	for i := 0; i < 20; i++ {

--- a/staging/src/k8s.io/client-go/rest/plugin.go
+++ b/staging/src/k8s.io/client-go/rest/plugin.go
@@ -33,6 +33,9 @@ type AuthProvider interface {
 	// Login allows the plugin to initialize its configuration. It must not
 	// require direct user interaction.
 	Login() error
+
+	// BearerTokenSource will return a BearerTokenSource from AuthProvider
+	BearerTokenSource() BearerTokenSource
 }
 
 // Factory generates an AuthProvider plugin.

--- a/staging/src/k8s.io/client-go/rest/plugin_test.go
+++ b/staging/src/k8s.io/client-go/rest/plugin_test.go
@@ -218,6 +218,8 @@ func (*pluginA) WrapTransport(rt http.RoundTripper) http.RoundTripper {
 
 func (*pluginA) Login() error { return nil }
 
+func (*pluginA) BearerTokenSource() BearerTokenSource { return nil }
+
 func pluginAProvider(string, map[string]string, AuthProviderConfigPersister) (AuthProvider, error) {
 	return &pluginA{}, nil
 }
@@ -237,6 +239,8 @@ func (w *wrapTransportB) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 type pluginB struct{}
+
+func (*pluginB) BearerTokenSource() BearerTokenSource { return nil }
 
 func (*pluginB) WrapTransport(rt http.RoundTripper) http.RoundTripper {
 	return &wrapTransportB{rt}
@@ -306,6 +310,9 @@ func (p *pluginPersist) Login() error {
 	return nil
 }
 
+func (p *pluginPersist) BearerTokenSource() BearerTokenSource {
+	return nil
+}
 func pluginPersistProvider(_ string, config map[string]string, persister AuthProviderConfigPersister) (AuthProvider, error) {
 	return &pluginPersist{config, persister}, nil
 }

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -58,7 +58,9 @@ func HTTPWrappersForConfig(config *Config, rt http.RoundTripper) (http.RoundTrip
 
 // TransportConfig converts a client config to an appropriate transport config.
 func (c *Config) TransportConfig() (*transport.Config, error) {
+	bearerTokenSource := c.BearerTokenSource
 	wt := c.WrapTransport
+
 	if c.AuthProvider != nil {
 		provider, err := GetAuthProvider(c.Host, c.AuthProvider, c.AuthConfigPersister)
 		if err != nil {
@@ -71,6 +73,9 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			}
 		} else {
 			wt = provider.WrapTransport
+		}
+		if bearerTokenSource == nil {
+			bearerTokenSource = provider.BearerTokenSource()
 		}
 	}
 	return &transport.Config{
@@ -95,5 +100,6 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
+		BearerTokenSource: bearerTokenSource,
 	}, nil
 }

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -48,6 +48,21 @@ type Config struct {
 	// config may layer other RoundTrippers on top of the returned
 	// RoundTripper.
 	WrapTransport func(rt http.RoundTripper) http.RoundTripper
+
+	// BearerTokenSource will be used to get a token and refresh a new token.
+	BearerTokenSource BearerTokenSource
+}
+
+// BearerTokenSource will be used to get a token and refresh a new token
+type BearerTokenSource interface {
+
+	// Token returns a bearer token for HTTP requests.
+	Token() (string, error)
+
+	// This will try to refresh a new token and bust the cache.
+	// Refresh can be called when the REST client experiences a
+	// 401, which implies that the token is invalid or has expired.
+	Refresh() (result bool, err error)
 }
 
 // ImpersonationConfig has all the available impersonation options

--- a/staging/src/k8s.io/client-go/transport/round_trippers.go
+++ b/staging/src/k8s.io/client-go/transport/round_trippers.go
@@ -275,10 +275,6 @@ func NewBearerAuthRoundTripper(bearer string, rt http.RoundTripper) http.RoundTr
 }
 
 func (rt *bearerAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	if len(req.Header.Get("Authorization")) != 0 {
-		return rt.rt.RoundTrip(req)
-	}
-
 	req = utilnet.CloneRequest(req)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", rt.bearer))
 	return rt.rt.RoundTrip(req)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Abstract BearerTokenSource interface, `Token()` will generate a token, maybe cached or not, `Refresh()` will renew a token using refresh code and cached them, so next time invoke `Token()`, new token can be returned.
2. AuthProvider will generate a BearerTokenSource , so that client side can refresh tokens dynamically.
3. Keep the WrapTrasport() func in AuthProvider interface in case of the auth provider want to wrap something except the bearer token, like gce provider are clean the cache when 401.
4. And the BearerTokenSource param to rest config, so, if user can use it's own generated BeaerTokenSource instead of the one generate by authPrivider config.
5. And BearerTokenSource param to client config, so when use make rest request, they can decide whether to refresh the token dynamically
```

// BearerTokenSource will be used to get a token and refresh a new token
type BearerTokenSource interface {

	// Token returns a bearer token for HTTP requests.
	Token() (string, error)

	// This will try to refresh a new token and bust the cache.
	// Refresh can be called when the REST client experiences a
	// 401, which implies that the token is invalid or has expired.
	Refresh() (result bool, err error)
}

type AuthProvider interface {
	// WrapTransport allows the plugin to create a modified RoundTripper that
	// attaches authorization headers (or other info) to requests.
	WrapTransport(http.RoundTripper) http.RoundTripper
	// Login allows the plugin to initialize its configuration. It must not
	// require direct user interaction.
	Login() error

	// BearerTokenSource will return a BearerTokenSource from AuthProvider
	BearerTokenSource() BearerTokenSource
}
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```
Abstract a BearerTokenSource interface, so user can refresh the token dynamically.
```
