### PR TITLE
allow impersonate serviceaccount in cli

### DIFF
--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -79,6 +79,10 @@ var (
 			},
 			{
 				Group:    "",
+				Resource: "serviceaccounts",
+			},
+			{
+				Group:    "",
 				Resource: "groups",
 			},
 			{


### PR DESCRIPTION
We can impersonate four kinds of resources according to the code:
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go#L83

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
allow impersonate serviceaccount in cli
```
Fixes: https://github.com/kubernetes/kubernetes/issues/48260