### PR TITLE
Fix removing finalizer for garbage collector

### DIFF
--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -115,7 +115,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 		for _, f := range finalizers {
 			if f == targetFinalizer {
 				found = true
-				break
+				continue
 			}
 			newFinalizers = append(newFinalizers, f)
 		}


### PR DESCRIPTION
The loop should use 'continue' not 'break', otherwise removeFinalizer()
not only removes "orphaningFinalizer" from its finalizers list but
also removes others.

Fix #48363

**Release note**:
```release-note
NONE
```
