### PR TITLE
Support completions for --clusterrole of kubectl create clusterrolebinding

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -130,6 +130,11 @@ __kubectl_get_resource_node()
     __kubectl_parse_get "node"
 }
 
+__kubectl_get_resource_clusterrole()
+{
+    __kubectl_parse_get "clusterrole"
+}
+
 # $1 is the name of the pod we want to get the list of containers inside
 __kubectl_get_containers()
 {

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -53,6 +53,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ClusterRoleBindingV1GeneratorName)
 	cmd.Flags().String("clusterrole", "", i18n.T("ClusterRole this ClusterRoleBinding should reference"))
+	cmd.MarkFlagCustom("clusterrole", "__kubectl_get_resource_clusterrole")
 	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/
Support completions for --clusterrole of kubectl create clusterrolebindingcommunity/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR supports completion for --clusterrole of kubectl create clusterrolebinding.
```
$ kubectl create clusterrolebinding hoge --clusterrole <tab>
admin                                         system:controller:daemon-set-controller       system:controller:node-controller             system:controller:service-controller          system:kube-scheduler
cluster-admin                                 system:controller:deployment-controller       system:controller:persistent-volume-binder    system:controller:statefulset-controller      system:node
edit                                          system:controller:disruption-controller       system:controller:pod-garbage-collector       system:controller:ttl-controller              system:node-bootstrapper
system:auth-delegator                         system:controller:endpoint-controller         system:controller:replicaset-controller       system:discovery                              system:node-problem-detector
system:basic-user                             system:controller:generic-garbage-collector   system:controller:replication-controller      system:heapster                               system:node-proxier
system:controller:attachdetach-controller     system:controller:horizontal-pod-autoscaler   system:controller:resourcequota-controller    system:kube-aggregator                        system:persistent-volume-provisioner
system:controller:certificate-controller      system:controller:job-controller              system:controller:route-controller            system:kube-controller-manager                view
system:controller:cronjob-controller          system:controller:namespace-controller        system:controller:service-account-controller  system:kube-dns
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I feel that it is better to except system clusterroles from completion candidates. What do you think about it?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support completion for --clusterrole of kubectl create clusterrolebinding
```
