### PR TITLE
Support completions for --serviceaccount of kubectl create clusterrolebinding

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -159,6 +159,16 @@ __kubectl_require_pod_and_container()
     return 0
 }
 
+# Print serviceaccounts across all namespaces in the format "<namespace>:<name>"
+__kubectl_get_serviceaccounts_all_namespaces()
+{
+    local template kubectl_out
+    template="{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} {{ end }}"
+    if kubectl_out=$(kubectl get -o template --template="${template}" serviceaccount --all-namespaces 2>/dev/null); then
+        COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
+    fi
+}
+
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_stop | kubectl_edit | kubectl_patch |\

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -56,6 +56,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")
+	cmd.MarkFlagCustom("serviceaccount", "__kubectl_get_serviceaccounts_all_namespaces")
 	return cmd
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR supports completion for --serviceaccount of kubectl create clusterrolebinding.
```
$ kubectl create clusterrolebinding --serviceaccount <tab>
default:default      kube-public:default  kube-system:default
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support completion for --serviceaccount of kubectl create clusterrolebinding
```
