### PR TITLE
Make cluster IP range an argument to ginkgo to fix firewall test

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -157,6 +157,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   ${MASTER_OS_DISTRIBUTION:+"--master-os-distro=${MASTER_OS_DISTRIBUTION}"} \
   ${NODE_OS_DISTRIBUTION:+"--node-os-distro=${NODE_OS_DISTRIBUTION}"} \
   ${NUM_NODES:+"--num-nodes=${NUM_NODES}"} \
+  ${CLUSTER_IP_RANGE:+"--cluster-ip-range=${CLUSTER_IP_RANGE}"} \
   ${E2E_CLEAN_START:+"--clean-start=true"} \
   ${E2E_MIN_STARTUP_PODS:+"--minStartupPods=${E2E_MIN_STARTUP_PODS}"} \
   ${E2E_REPORT_DIR:+"--report-dir=${E2E_REPORT_DIR}"} \

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -105,6 +105,7 @@ cluster-context
 cluster-dns
 cluster-domain
 cluster-ip
+cluster-ip-range
 cluster-monitor-period
 cluster-name
 cluster-signing-cert-file

--- a/test/e2e/firewall.go
+++ b/test/e2e/firewall.go
@@ -160,7 +160,7 @@ var _ = framework.KubeDescribe("Firewall rule", func() {
 		}
 
 		By("Checking if e2e firewall rules are correct")
-		for _, expFw := range framework.GetE2eFirewalls(cloudConfig.MasterName, cloudConfig.MasterTag, cloudConfig.NodeTag, cloudConfig.Network) {
+		for _, expFw := range framework.GetE2eFirewalls(cloudConfig.MasterName, cloudConfig.MasterTag, cloudConfig.NodeTag, cloudConfig.Network, cloudConfig.ClusterIPRange) {
 			fw, err := gceCloud.GetFirewall(expFw.Name)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(framework.VerifyFirewallRule(fw, expFw, cloudConfig.Network, false)).NotTo(HaveOccurred())

--- a/test/e2e/framework/firewall_util.go
+++ b/test/e2e/framework/firewall_util.go
@@ -141,21 +141,12 @@ func GetClusterName(instancePrefix string) string {
 	return instancePrefix
 }
 
-// GetClusterIpRange returns the CLUSTER_IP_RANGE env we set for e2e cluster.
-//
-// Warning: this MUST be consistent with the CLUSTER_IP_RANGE set in
-// gce/config-test.sh.
-func GetClusterIpRange() string {
-	return "10.100.0.0/14"
-}
-
 // GetE2eFirewalls returns all firewall rules we create for an e2e cluster.
 // From cluster/gce/util.sh, all firewall rules should be consistent with the ones created by startup scripts.
-func GetE2eFirewalls(masterName, masterTag, nodeTag, network string) []*compute.Firewall {
+func GetE2eFirewalls(masterName, masterTag, nodeTag, network, clusterIpRange string) []*compute.Firewall {
 	instancePrefix, err := GetInstancePrefix(masterName)
 	Expect(err).NotTo(HaveOccurred())
 	clusterName := GetClusterName(instancePrefix)
-	clusterIpRange := GetClusterIpRange()
 
 	fws := []*compute.Firewall{}
 	fws = append(fws, &compute.Firewall{

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -140,6 +140,7 @@ type CloudConfig struct {
 	MasterName        string
 	NodeInstanceGroup string // comma-delimited list of groups' names
 	NumNodes          int
+	ClusterIPRange    string
 	ClusterTag        string
 	Network           string
 	ConfigFile        string // for azure and openstack
@@ -212,6 +213,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws. If there is more than one group: comma separated list of groups.")
 	flag.StringVar(&cloudConfig.Network, "network", "e2e", "The cloud provider network for this e2e cluster.")
 	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
+	flag.StringVar(&cloudConfig.ClusterIPRange, "cluster-ip-range", "10.100.0.0/14", "A CIDR notation IP range from which to assign IPs in the cluster.")
 	flag.StringVar(&cloudConfig.NodeTag, "node-tag", "", "Network tags used on node instances. Valid only for gce, gke")
 	flag.StringVar(&cloudConfig.MasterTag, "master-tag", "", "Network tags used on master instances. Valid only for gce, gke")
 


### PR DESCRIPTION
This should fix the failing "Firewall rule should have correct firewall rules for e2e cluster" test when using a non-default cluster IP range.
(Ref: https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-enormous-cluster/13#k8sio-firewall-rule-should-have-correct-firewall-rules-for-e2e-cluster)

/cc @kubernetes/sig-network-pr-reviews @gmarek 