### PR TITLE
Fix completions for --namespace to override kubectl flags

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -69,11 +69,7 @@ __kubectl_override_flags()
 
 __kubectl_get_namespaces()
 {
-    local template kubectl_out
-    template="{{ range .items  }}{{ .metadata.name }} {{ end }}"
-    if kubectl_out=$(kubectl get -o template --template="${template}" namespace 2>/dev/null); then
-        COMPREPLY=( $( compgen -W "${kubectl_out[*]}" -- "$cur" ) )
-    fi
+    __kubectl_parse_get "namespace"
 }
 
 __kubectl_config_get_contexts()

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -67,11 +67,6 @@ __kubectl_override_flags()
     done
 }
 
-__kubectl_get_namespaces()
-{
-    __kubectl_parse_get "namespace"
-}
-
 __kubectl_config_get_contexts()
 {
     __kubectl_parse_config "contexts"
@@ -113,6 +108,11 @@ __kubectl_get_resource()
         return 1
     fi
     __kubectl_parse_get "${nouns[${#nouns[@]} -1]}"
+}
+
+__kubectl_get_resource_namespace()
+{
+    __kubectl_parse_get "namespace"
 }
 
 __kubectl_get_resource_pod()
@@ -240,7 +240,7 @@ __custom_func() {
 
 var (
 	bash_completion_flags = map[string]string{
-		"namespace": "__kubectl_get_namespaces",
+		"namespace": "__kubectl_get_resource_namespace",
 		"context":   "__kubectl_config_get_contexts",
 		"cluster":   "__kubectl_config_get_clusters",
 		"user":      "__kubectl_config_get_users",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR fixes completions for --namespace to override kubectl flags. Due to not using __kubectl_parse_get, __kubectl_get_namespaces doesn't support to override kubectl flags.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
