### PR TITLE
client-go support IPv6 addresses for PortForwarder getListener()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -207,7 +207,7 @@ func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol st
 // getListener creates a listener on the interface targeted by the given hostname on the given port with
 // the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
 func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
-	listener, err := net.Listen(protocol, fmt.Sprintf("%s:%d", hostname, port.Local))
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create listener: Error %s", err)
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -134,24 +134,18 @@ func TestGetListener(t *testing.T) {
 			ExpectedListenerAddress: "127.0.0.1",
 		},
 		{
-			Hostname:                "[::1]",
+			Hostname:                "::1",
 			Protocol:                "tcp6",
 			ShouldRaiseError:        false,
 			ExpectedListenerAddress: "::1",
 		},
 		{
-			Hostname:         "[::1]",
+			Hostname:         "::1",
 			Protocol:         "tcp4",
 			ShouldRaiseError: true,
 		},
 		{
 			Hostname:         "127.0.0.1",
-			Protocol:         "tcp6",
-			ShouldRaiseError: true,
-		},
-		{
-			// IPv6 address must be put into brackets. This test reveals this.
-			Hostname:         "::1",
 			Protocol:         "tcp6",
 			ShouldRaiseError: true,
 		},
@@ -182,7 +176,7 @@ func TestGetListener(t *testing.T) {
 		host, port, _ := net.SplitHostPort(listener.Addr().String())
 		t.Logf("Asked a %s forward for: %s:%v, got listener %s:%s, expected: %s", testCase.Protocol, testCase.Hostname, 12345, host, port, expectedListenerPort)
 		if host != testCase.ExpectedListenerAddress {
-			t.Errorf("Test case #%d failed: Listener does not listen on exepected address: asked %v got %v", i, testCase.ExpectedListenerAddress, host)
+			t.Errorf("Test case #%d failed: Listener does not listen on expected address: asked '%v' got '%v'", i, testCase.ExpectedListenerAddress, host)
 		}
 		if port != expectedListenerPort {
 			t.Errorf("Test case #%d failed: Listener does not listen on exepected port: asked %v got %v", i, expectedListenerPort, port)


### PR DESCRIPTION
Currently, client-go requires that an IPv6 address string for hostname has
square brackets surrounding, so that it can be used with address:port in
an API request.

This change, removes that requirement, and has getListener() add the
square brackets, if needed. If the hostname is a name, an IPv4 address
string, or an IPv6 address already with square brackets, no change is made.

Decided to change here, rather than everywhere client-go is used (thinking
that there may be places where we DON'T want the square brackets applied).

This issue was found in kubelet, which, at startup, creates a listener for
services and nodes. If an IPv6 address is used, the URI was malformed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Ensures that client-go will handle IPv6 addresses as hostnames, without any special encoding by caller.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48225 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
