### PR TITLE
Use Container-Optimized OS by default for nodes

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -63,15 +63,16 @@ if [[ "${NODE_OS_DISTRIBUTION}" == "debian" ]]; then
     NODE_ACCELERATORS=""
 fi
 
-# By default a cluster will be started with the master on GCI and nodes on
-# containervm. If you are updating the containervm version, update this
-# variable. Also please update corresponding image for node e2e at:
+# By default a cluster will be started with the master and nodes
+# on Container-optimized OS (cos, previously known as gci). If
+# you are updating the os image versions, update this variable.
+# Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
 CVM_VERSION=${CVM_VERSION:-container-vm-v20170627}
 GCI_VERSION=${KUBE_GCI_VERSION:-cos-stable-59-9460-64-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
-NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${CVM_VERSION}}
+NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}
 NODE_IMAGE_PROJECT=${KUBE_GCE_NODE_PROJECT:-cos-cloud}
 CONTAINER_RUNTIME=${KUBE_CONTAINER_RUNTIME:-docker}
 RKT_VERSION=${KUBE_RKT_VERSION:-1.23.0}

--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -188,7 +188,7 @@ func LogClusterImageSources() {
 	}
 
 	outputBytes, _ := json.MarshalIndent(images, "", "  ")
-	filePath := filepath.Join(TestContext.OutputDir, "images.json")
+	filePath := filepath.Join(TestContext.ReportDir, "images.json")
 	if err := ioutil.WriteFile(filePath, outputBytes, 0644); err != nil {
 		Logf("cluster images sources, could not write to %q: %v", filePath, err)
 	}


### PR DESCRIPTION
This is part of the deprecation of ContainerVM (the debian based distribution we've been using for kubernetes nodes)

/assign @timstclair @mtaufen - are there any wider implications of this change ?