### PR TITLE
Do not fail on error when deleting ingress

### DIFF
--- a/test/e2e/framework/ingress_utils.go
+++ b/test/e2e/framework/ingress_utils.go
@@ -882,9 +882,12 @@ func (j *IngressTestJig) GetRootCA(secretName string) (rootCA []byte) {
 	return
 }
 
-// DeleteIngress deletes the ingress resource
-func (j *IngressTestJig) DeleteIngress() {
-	ExpectNoError(j.Client.Extensions().Ingresses(j.Ingress.Namespace).Delete(j.Ingress.Name, nil))
+// TryDeleteIngress attempts to delete the ingress resource and logs errors if they occur.
+func (j *IngressTestJig) TryDeleteIngress() {
+	err := j.Client.Extensions().Ingresses(j.Ingress.Namespace).Delete(j.Ingress.Name, nil)
+	if err != nil {
+		Logf("Error while deleting the ingress %v/%v: %v", j.Ingress.Namespace, j.Ingress.Name, err)
+	}
 }
 
 // WaitForIngress waits till the ingress acquires an IP, then waits for its

--- a/test/e2e/ingress.go
+++ b/test/e2e/ingress.go
@@ -89,7 +89,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 				return
 			}
 			By("Deleting ingress")
-			jig.DeleteIngress()
+			jig.TryDeleteIngress()
 
 			By("Cleaning up cloud resources")
 			framework.CleanupGCEIngressController(gceController)
@@ -179,7 +179,7 @@ var _ = framework.KubeDescribe("Loadbalancing: L7", func() {
 				return
 			}
 			By("Deleting ingress")
-			jig.DeleteIngress()
+			jig.TryDeleteIngress()
 		})
 
 		It("should conform to Ingress spec", func() {

--- a/test/e2e/upgrades/ingress.go
+++ b/test/e2e/upgrades/ingress.go
@@ -101,7 +101,7 @@ func (t *IngressUpgradeTest) Teardown(f *framework.Framework) {
 	}
 	if t.jig.Ingress != nil {
 		By("Deleting ingress")
-		t.jig.DeleteIngress()
+		t.jig.TryDeleteIngress()
 	} else {
 		By("No ingress created, no cleanup necessary")
 	}


### PR DESCRIPTION
Fixes #48239

If the api server or master is unavailable, the test should manually teardown load balancer resources. 

**Release note**:
```release-note
NONE
```
