### PR TITLE
Set NODE_OS_DISTRIBUTION to "gci" in GKE test config.

### DIFF
--- a/cluster/gke/config-test.sh
+++ b/cluster/gke/config-test.sh
@@ -18,10 +18,24 @@
 CLUSTER_NAME="${CLUSTER_NAME:-${USER}-gke-e2e}"
 NETWORK=${KUBE_GKE_NETWORK:-e2e}
 NODE_TAG="k8s-${CLUSTER_NAME}-node"
-IMAGE_TYPE="${KUBE_GKE_IMAGE_TYPE:-container_vm}"
+IMAGE_TYPE="${KUBE_GKE_IMAGE_TYPE:-cos}"
 ENABLE_KUBERNETES_ALPHA="${KUBE_GKE_ENABLE_KUBERNETES_ALPHA:-}"
 
 KUBE_DELETE_NETWORK=${KUBE_DELETE_NETWORK:-true}
+
+# Set e2e test context through NODE_OS_DISTRIBUTION.
+case $(kubectl get node -o=jsonpath='{.items[0].status.nodeInfo.osImage}') in
+*"Debian"*)
+	NODE_OS_DISTRIBUTION="debian"
+	;;
+"ubuntu")
+	NODE_OS_DISTRIBUTION="ubuntu"
+	;;
+*)
+	NODE_OS_DISTRIBUTION="gci"
+	;;
+esac
+echo "Setting NODE_OS_DISTRIBUTION=${NODE_OS_DISTRIBUTION-}"
 
 # For ease of maintenance, extract any pieces that do not vary between default
 # and test in a common config.


### PR DESCRIPTION
**What this PR does / why we need it**:
E2E tests access `framework.TestContext.NodeOSDistro` to determine the OS of the node they're operating in, which implies the availability of specific dependencies.

`framework.TestContext.NodeOSDistro` is set by parsing options to the e2e binary (`--node-os-distro`).  If unset/null, `framework.TestContext.NodeOSDistro` defaults to debian.  However, on GKE clusters, the default os image is `gci`. When deploying on GKE, a user/developer will get `gci` nodes, but the e2e test will register them as `debian`.

This can lead to tests that require `gci` skipping, thinking that the os distro is `debian`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48156

**Special notes for your reviewer**:
This fix is only relevant to GKE.  On GCE, in order to deploy `gci` nodes, the user must set `KUBE_NODE_OS_DISTRIBUTION=gci`, which is passed through the `--node-os-distro` option to `framework.TestContext.NodeOSDistro`.  Otherwise, cluster deployment scripts and `framework.TestContext.NodeOSDistro` default to `debian`, as expected.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
cc @jeffvance @msau42 
