### PR TITLE
kubectl: move common deploy flags to common functions

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -216,7 +216,6 @@ go_test(
         "//pkg/kubectl/util/term:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
-        "//pkg/util/i18n:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -74,18 +74,14 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		},
 	}
 
-	usage := "to use to create the resource"
-	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
+	cmdutil.AddCommonCreationFlags(cmd)
+	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, "create the resource")
 	cmd.MarkFlagRequired("filename")
 	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddPrinterFlags(cmd)
 	cmd.Flags().BoolVar(&options.EditBeforeCreate, "edit", false, "Edit the API resource before creating")
 	cmd.Flags().Bool("windows-line-endings", runtime.GOOS == "windows",
 		"Only relevant if --edit=true. Defaults to the line ending native to your platform.")
-	cmdutil.AddApplyAnnotationFlags(cmd)
-	cmdutil.AddRecordFlag(cmd)
 	cmdutil.AddDryRunFlag(cmd)
-	cmdutil.AddInclude3rdPartyFlags(cmd)
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.")
 
 	// create subcommands
@@ -106,7 +102,7 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 func ValidateArgs(cmd *cobra.Command, args []string) error {
 	if len(args) != 0 {
-		return cmdutil.UsageErrorf(cmd, "Unexpected args: %v", args)
+		return cmdutil.UsageErrorf(cmd, "Unexpected args (expected no args): %v", args)
 	}
 	return nil
 }
@@ -156,7 +152,9 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		if err != nil {
 			return err
 		}
-		if err := kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, f.JSONEncoder()); err != nil {
+
+		err = kubectl.CreateOrUpdateAnnotation(cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag), info, f.JSONEncoder())
+		if err != nil {
 			return cmdutil.AddSourceToErr("creating", info.Source, err)
 		}
 
@@ -241,7 +239,8 @@ type CreateSubcommandOptions struct {
 	// StructuredGenerator is the resource generator for the object being created
 	StructuredGenerator kubectl.StructuredGenerator
 	// DryRun is true if the command should be simulated but not run against the server
-	DryRun       bool
+	DryRun bool
+	// OutputFormat will be something like "json" or "yaml".
 	OutputFormat string
 }
 

--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -58,8 +58,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.DeploymentBasicV1Beta1GeneratorName)
-	cmd.Flags().StringSlice("image", []string{}, "Image name to run.")
-	cmd.MarkFlagRequired("image")
+	cmdutil.AddImageFlag(cmd)
 	return cmd
 }
 
@@ -79,9 +78,7 @@ func fallbackGeneratorNameIfNecessary(
 		!contains(resourcesList, appsv1beta1.SchemeGroupVersion.WithResource("deployments")) {
 
 		fmt.Fprintf(cmdErr,
-			"WARNING: New deployments generator %q specified, "+
-				"but apps/v1beta1.Deployments are not available. "+
-				"Falling back to %q.\n",
+			"WARNING: New deployments generator %q specified, but apps/v1beta1.Deployments are not available. Falling back to %q.\n",
 			cmdutil.DeploymentBasicAppsV1Beta1GeneratorName,
 			cmdutil.DeploymentBasicV1Beta1GeneratorName,
 		)

--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -54,11 +54,13 @@ func NewCmdCreateDeployment(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.
 			cmdutil.CheckErr(err)
 		},
 	}
-	cmdutil.AddApplyAnnotationFlags(cmd)
-	cmdutil.AddValidateFlags(cmd)
-	cmdutil.AddPrinterFlags(cmd)
-	cmdutil.AddGeneratorFlags(cmd, cmdutil.DeploymentBasicV1Beta1GeneratorName)
-	cmdutil.AddImageFlag(cmd)
+
+	cmdutil.AddCommonCreationFlags(cmd)
+
+	// all the other flags we need already exist in our parent command
+	// "kubectl create"
+	cmdutil.AddDeploymentFlags(cmd, cmdutil.DeploymentBasicV1Beta1GeneratorName)
+
 	return cmd
 }
 

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -107,33 +107,35 @@ func addRunFlags(cmd *cobra.Command) {
 	// Flags that are common enough we share the definition with other
 	// commands.
 	// For example, "kubectl create" also supports "pod-running-timeout"
-	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
-	cmdutil.AddGeneratorFlags(cmd, "")
 	cmdutil.AddCommonCreationFlags(cmd)
-	cmdutil.AddImageFlag(cmd)
+	cmdutil.AddDeploymentFlags(cmd, "")
 
-	// Flags that are (supposed to be) specific to "kubectl run".
-	cmd.Flags().String("image-pull-policy", "", i18n.T("The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server"))
-	cmd.Flags().IntP("replicas", "r", 1, "Number of replicas to create for this container. Default is 1.")
+	// These are sort of specific to `kubectl run` but some of them are used
+	// in different configurations by other commands.
+	cmdutil.AddPodRunningTimeoutFlag(cmd, defaultPodAttachTimeout)
+
+	// These flags correspond to the flags from the Generator.
 	cmd.Flags().Bool("rm", false, "If true, delete resources created in this command for attached containers.")
 	cmd.Flags().String("overrides", "", i18n.T("An inline JSON override for the generated object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field."))
-	cmd.Flags().StringSlice("env", []string{}, "Environment variables to set in the container")
-	cmd.Flags().String("port", "", i18n.T("The port that this container exposes.  If --expose is true, this is also the port used by the service that is created."))
-	cmd.Flags().Int("hostport", -1, "The host port mapping for the container port. To demonstrate a single-machine container.")
-	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the pod(s).")
-	cmd.Flags().BoolP("stdin", "i", false, "Keep stdin open on the container(s) in the pod, even if nothing is attached.")
-	cmd.Flags().BoolP("tty", "t", false, "Allocated a TTY for each container in the pod.")
 	cmd.Flags().Bool("attach", false, "If true, wait for the Pod to start running, and then attach to the Pod as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true. With '--restart=Never' the exit code of the container process is returned.")
 	cmd.Flags().Bool("leave-stdin-open", false, "If the pod is started in interactive mode or with stdin, leave stdin open after the first attach completes. By default, stdin will be closed after the first attach completes.")
 	cmd.Flags().String("restart", "Always", i18n.T("The restart policy for this Pod.  Legal values [Always, OnFailure, Never].  If set to 'Always' a deployment is created, if set to 'OnFailure' a job is created, if set to 'Never', a regular pod is created. For the latter two --replicas must be 1.  Default 'Always', for CronJobs `Never`."))
-	cmd.Flags().Bool("command", false, "If true and extra arguments are present, use them as the 'command' field in the container, rather than the 'args' field which is the default.")
-	cmd.Flags().String("requests", "", i18n.T("The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges."))
-	cmd.Flags().String("limits", "", i18n.T("The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'.  Note that server side components may assign limits depending on the server configuration, such as limit ranges."))
 	cmd.Flags().Bool("expose", false, "If true, a public, external service is created for the container(s) which are run")
 	cmd.Flags().String("service-generator", "service/v2", i18n.T("The name of the generator to use for creating a service.  Only used if --expose is true"))
 	cmd.Flags().String("service-overrides", "", i18n.T("An inline JSON override for the generated service object. If this is non-empty, it is used to override the generated object. Requires that the object supply a valid apiVersion field.  Only used if --expose is true."))
 	cmd.Flags().Bool("quiet", false, "If true, suppress prompt messages.")
 	cmd.Flags().String("schedule", "", i18n.T("A schedule in the Cron format the job should be run with."))
+	cmd.Flags().StringP("labels", "l", "", "Labels to apply to the pod(s).")
+	cmd.Flags().String("image-pull-policy", "", i18n.T("The image pull policy for the container. If left empty, this value will not be specified by the client and defaulted by the server"))
+	cmd.Flags().IntP("replicas", "r", 1, "Number of replicas to create for this container. Default is 1.")
+	cmd.Flags().String("port", "", i18n.T("The port that this container exposes.  If --expose is true, this is also the port used by the service that is created."))
+	cmd.Flags().Int("hostport", -1, "The host port mapping for the container port. To demonstrate a single-machine container.")
+	cmd.Flags().BoolP("tty", "t", false, "Allocated a TTY for each container in the pod.")
+	cmd.Flags().BoolP("stdin", "i", false, "Keep stdin open on the container(s) in the pod, even if nothing is attached.")
+	cmd.Flags().Bool("command", false, "If true and extra arguments are present, use them as the 'command' field in the container, rather than the 'args' field which is the default.")
+	cmd.Flags().StringSlice("env", []string{}, "Environment variables to set in the container")
+	cmd.Flags().String("requests", "", i18n.T("The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges."))
+	cmd.Flags().String("limits", "", i18n.T("The resource requirement limits for this container.  For example, 'cpu=200m,memory=512Mi'.  Note that server side components may assign limits depending on the server configuration, such as limit ranges."))
 }
 
 func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *cobra.Command, args []string, argsLenAtDash int) error {

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -147,11 +147,17 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 		return cmdutil.UsageErrorf(cmd, "%v", err)
 	}
 
-	// validate image name
-	imageName := cmdutil.GetFlagString(cmd, "image")
-	validImageRef := reference.ReferenceRegexp.MatchString(imageName)
-	if !validImageRef {
-		return fmt.Errorf("Invalid image name %q: %v", imageName, reference.ErrReferenceInvalidFormat)
+	// Validate image name.
+	// TODO(github.com/alexandercampbell): support multiple images here in
+	// "run", just as we do in "create deployment".
+	imageNames := cmdutil.GetFlagStringSlice(cmd, "image")
+	if len(imageNames) != 1 {
+		return fmt.Errorf("Exactly one image name is required")
+	}
+	imageName := imageNames[0]
+	if !reference.ReferenceRegexp.MatchString(imageName) {
+		return fmt.Errorf("Invalid image name %q: %v",
+			imageName, reference.ErrReferenceInvalidFormat)
 	}
 
 	interactive := cmdutil.GetFlagBool(cmd, "stdin")

--- a/pkg/kubectl/cmd/run_test.go
+++ b/pkg/kubectl/cmd/run_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	"k8s.io/kubernetes/pkg/util/i18n"
 )
 
 func TestGetRestartPolicy(t *testing.T) {
@@ -82,7 +81,7 @@ func TestGetRestartPolicy(t *testing.T) {
 	}
 	for _, test := range tests {
 		cmd := &cobra.Command{}
-		cmd.Flags().String("restart", "", i18n.T("dummy restart flag)"))
+		cmd.Flags().String("restart", "", "dummy restart flag")
 		cmd.Flags().Lookup("restart").Value.Set(test.input)
 		policy, err := getRestartPolicy(cmd, test.interactive)
 		if test.expectErr && err == nil {
@@ -320,10 +319,6 @@ func TestGenerateService(t *testing.T) {
 			}),
 		}
 		cmd := &cobra.Command{}
-		cmd.Flags().Bool(cmdutil.ApplyAnnotationsFlag, false, "")
-		cmd.Flags().Bool("record", false, "Record current kubectl command in the resource annotation. If set to false, do not record the command. If set to true, record the command. If not set, default to updating the existing annotation value only if one already exists.")
-		cmdutil.AddPrinterFlags(cmd)
-		cmdutil.AddInclude3rdPartyFlags(cmd)
 		addRunFlags(cmd)
 
 		if !test.expectPOST {

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/util/exec:go_default_library",
+        "//pkg/util/i18n:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/emicklei/go-restful-swagger12:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/util/exec:go_default_library",
-        "//pkg/util/i18n:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/emicklei/go-restful-swagger12:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -824,8 +824,9 @@ func ManualStrip(file []byte) []byte {
 	return stripped
 }
 
-// These are flags shared by the creation commands. For instance, all creation
-// commands need to be able to record to the resource annotation.
+// AddCommonCreationFlags adds flags shared by the creation commands. For
+// instance, all creation commands need to be able to record to the resource
+// annotation.
 func AddCommonCreationFlags(cmd *cobra.Command) {
 	AddPrinterFlags(cmd)
 	AddApplyAnnotationFlags(cmd)
@@ -833,8 +834,11 @@ func AddCommonCreationFlags(cmd *cobra.Command) {
 	AddInclude3rdPartyFlags(cmd)
 }
 
-// Add the required StringSlice flag "--image".
-func AddImageFlag(cmd *cobra.Command) {
+// AddDeploymentFlags adds the flags that are specific to "kubectl create
+// deployment" and "kubectl run". Flags shared between "kubectl create" and
+// "kubectl run" are kept in AddCommonCreationFlags.
+func AddDeploymentFlags(cmd *cobra.Command, defaultGeneratorName string) {
 	cmd.Flags().StringSlice("image", []string{}, i18n.T("The image(s) for the container to run."))
 	cmd.MarkFlagRequired("image")
+	AddGeneratorFlags(cmd, defaultGeneratorName)
 }

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -835,6 +835,6 @@ func AddCommonCreationFlags(cmd *cobra.Command) {
 
 // Add the required StringSlice flag "--image".
 func AddImageFlag(cmd *cobra.Command) {
-	cmd.Flags().String("image", "", i18n.T("The image for the container to run."))
+	cmd.Flags().StringSlice("image", []string{}, i18n.T("The image(s) for the container to run."))
 	cmd.MarkFlagRequired("image")
 }


### PR DESCRIPTION
**What this PR does**:

- [x] Move flags that were defined multiple times into common functions.
- [x] Change `kubectl run` to take a string-slice of images instead of a single image (to match `kubectl create deployment`). The execution function returns an error if multiple images are provided to ensure no untested behavior is performed. This is temporary since "kubectl run" will shortly support the images as requested.
- [x] Restructure the definition of the "kubectl run", "kubectl create", and "kubectl create deployment" commands to use helper functions with clear purposes and docstrings.
    - Examples: the function "AddCommonCreationFlags" which is shared by all three of the above commands and the function "AddDeploymentFlags" which is shared by "kubectl run" and "kubectl create deployment".
- [x] Add 58 lines worth of docstrings. The most prominent addition is my docstring for `RunRun()` which gives a careful explanation of its responsibilities.

**Which issue this PR fixes**: Progress towards kubernetes/kubectl#11

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
