### PR TITLE
Allow TransformFuncs for atomic configmap updates (for use with encryption providers)

### DIFF
--- a/pkg/registry/core/configmap/registry.go
+++ b/pkg/registry/core/configmap/registry.go
@@ -31,7 +31,7 @@ type Registry interface {
 	WatchConfigMaps(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (watch.Interface, error)
 	GetConfigMap(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (*api.ConfigMap, error)
 	CreateConfigMap(ctx genericapirequest.Context, cfg *api.ConfigMap) (*api.ConfigMap, error)
-	UpdateConfigMap(ctx genericapirequest.Context, cfg *api.ConfigMap) (*api.ConfigMap, error)
+	UpdateConfigMap(ctx genericapirequest.Context, cfg *api.ConfigMap, transformFuncs ...rest.TransformFunc) (*api.ConfigMap, error)
 	DeleteConfigMap(ctx genericapirequest.Context, name string) error
 }
 
@@ -77,8 +77,8 @@ func (s *storage) CreateConfigMap(ctx genericapirequest.Context, cfg *api.Config
 	return obj.(*api.ConfigMap), nil
 }
 
-func (s *storage) UpdateConfigMap(ctx genericapirequest.Context, cfg *api.ConfigMap) (*api.ConfigMap, error) {
-	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg, api.Scheme))
+func (s *storage) UpdateConfigMap(ctx genericapirequest.Context, cfg *api.ConfigMap, transformFuncs ...rest.TransformFunc) (*api.ConfigMap, error) {
+	obj, _, err := s.Update(ctx, cfg.Name, rest.DefaultUpdatedObjectInfo(cfg, api.Scheme, transformFuncs...))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To allow using configmap API for storing information for use in encrypting the secrets in etcd at rest using KMS. Since the Update function on rest already supported varargs, there would be no change in other places.

Context: 
* [Main proposal on secrets in k8s](https://github.com/destijl/community/blob/e2c73db992f30e2a8d2bd974f89e9855b3293df8/contributors/design-proposals/encryption.md)
* [Temporary PR](https://github.com/sakshamsharma/kubernetes/pull/3) on my own fork to hold the KMS encryption feature until it gets to master.

We plan to use configmap API for storing a certain number of maps into storage, on a different location (not `/configmaps`), and use configmap simply as an API for reading and writing. The specific use-case requires an atomic read+write, or an optimistic lock. The plan is to use it in the following way:
* Keys are DEKs (Data-Encryption-Keys)
* Keep a map of keys (indexed by their names) to use for encrypting and decrypting secrets.
* Primary encryption key (the one to be used for writing to disk) has a prefix "-" at the beginning, to allow adding a key and updating the primary key atomically.
* To add a new key, fetch previous keys, and generate a unique name for the new key.
* Then add that new key to the map, and write that map to disk, while checking the version of the object being overwritten is the same as the one that was read.

Snippet from proposed usage of this addition:
```
    // Provide a function which can read the object and update it safely
    // Type: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go#L124
    // TODO: Not sure what purpose the 2nd argument (newObj) serves
	updater := func(ctx genericapirequest.Context, _ runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
		newDEKs := map[string]string{}
		// Re-create the map because unsafe to modify map while iterating over it
		for dekname, dek := range oldObj.(*api.ConfigMap).Data {
			// Remove the identifying prefix in front of the primary key.
			if strings.HasPrefix(dekname, "-") {
				dekname = dekname[1:]
			}
			newDEKs[dekname] = dek
		}

		// Get a new and unique name
		// GenerateName will generate a random alphanumeric string,
		// which does not exist in the newDEKs map.
		newDEKname := GenerateName(newDEKs)

		newDEKs["-"+newDEKname] = encDEK
		oldObj.(*api.ConfigMap).Data = newDEKs
		return oldObj, nil
	}

	_, err = p.configmaps.UpdateConfigMap(ctx, cfg, updater)
```
The above code can be seen inplace [here](https://github.com/sakshamsharma/kubernetes/blob/kmstransformer/staging/src/k8s.io/apiserver/pkg/storage/value/transformhelpers/key_store.go#L98)

Link to code which allows using transform functions with the Update method on APIs:
* [rest.DefaultUpdatedObjectInfo](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go#L142): The object which is passed to the Update function, which I modified.
* [UpdatedObject method](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go#L182) on DefaultUpdatedObjectInfo
* [GuaranteedUpdate](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go#L290) method on storage which does an optimistic lock.

I have not been able to test that this will be enough to prevent any race conditions during updates, but looking at the code makes it seem that it should be enough.
Expected race condition which we need to prevent: Two different apiservers try to add a key at the same time. One of the keys gets lost if there is no optimistic locking.

Comments are requested on whether the above usage is correct, and whether this race condition is already tested for the Update function.