### PR TITLE
remove useless check from impersonation filter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go
@@ -118,18 +118,8 @@ func WithImpersonation(handler http.Handler, requestContextMapper request.Reques
 
 		if !groupsSpecified && username != user.Anonymous {
 			// When impersonating a non-anonymous user, if no groups were specified
-			// if neither the system:authenticated nor system:unauthenticated groups are explicitly included,
 			// include the system:authenticated group in the impersonated user info
-			found := false
-			for _, group := range groups {
-				if group == user.AllAuthenticated || group == user.AllUnauthenticated {
-					found = true
-					break
-				}
-			}
-			if !found {
-				groups = append(groups, user.AllAuthenticated)
-			}
+			groups = append(groups, user.AllAuthenticated)
 		}
 
 		newUser := &user.DefaultInfo{


### PR DESCRIPTION
When groupsSpecified is false, that means no other groups are added
rather than the service account groups. So this check doesn't make
any sense.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
