### PR TITLE
Fix share name generation in azure file provisioner.

### DIFF
--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -134,7 +134,9 @@ var _ volume.Provisioner = &azureFileProvisioner{}
 func (a *azureFileProvisioner) Provision() (*v1.PersistentVolume, error) {
 	var sku, location, account string
 
-	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 75)
+	// File share name has a length limit of 63, and it cannot contain two consecutive '-'s.
+	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 63)
+	name = strings.Replace(name, "--", "-", -1)
 	capacity := a.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestBytes := capacity.Value()
 	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure file share name has a length limit of 63, but currently the code is using data volume's limit 75.

**Which issue this PR fixes**
With current implementation, when the cluster name is long, the resulting file share name could have a length of 75.

Also function `GenerateVolumeName` would produce double '-' when clusterName containing '-' is to be truncated.

In both cases, service would reject the creating file share request.

**Special notes for your reviewer**:
Please refer to:
https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata#share-names

- Share names must be from 3 through 63 characters long.
- The name cannot contain two consecutive hyphens.

@rootfs @colemickens 

**Release note**:


