### PR TITLE
update events' ResponseStatus at Metadata level

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -100,8 +100,8 @@ type Event struct {
 	// +optional
 	ObjectRef *ObjectReference
 	// The response status, populated even when the ResponseObject is not a Status type.
-	// For successful responses, this will only include the Code and StatusSuccess.
-	// For non-status type error responses, this will be auto-populated with the error Message.
+	// For successful responses, this will only include the Code. For non-status type
+	// error responses, this will be auto-populated with the error Message.
 	// +optional
 	ResponseStatus *metav1.Status
 

--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -170,14 +170,16 @@ func LogRequestPatch(ae *audit.Event, patch []byte) {
 // LogResponseObject fills in the response object into an audit event. The passed runtime.Object
 // will be converted to the given gv.
 func LogResponseObject(ae *audit.Event, obj runtime.Object, gv schema.GroupVersion, s runtime.NegotiatedSerializer) {
-	if ae == nil || ae.Level.Less(audit.LevelRequestResponse) {
+	if ae == nil || ae.Level.Less(audit.LevelMetadata) {
 		return
 	}
-
 	if status, ok := obj.(*metav1.Status); ok {
 		ae.ResponseStatus = status
 	}
 
+	if ae.Level.Less(audit.LevelRequestResponse) {
+		return
+	}
 	// TODO(audit): hook into the serializer to avoid double conversion
 	var err error
 	ae.ResponseObject, err = encodeObject(obj, gv, s)


### PR DESCRIPTION
ResponseStatus is populated in MetadataLevel, so we also update it in
MetadataLevel.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
