### PR TITLE
scheduler: fix validation test

### DIFF
--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -17,70 +17,60 @@ limitations under the License.
 package validation
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
 
-func TestValidatePriorityWithNoWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority"}}}
-	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight not being positive")
-	}
-}
-
-func TestValidatePriorityWithZeroWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}}
-	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight not being positive")
-	}
-}
-
-func TestValidatePriorityWithNonZeroWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}}
-	errs := ValidatePolicy(policy)
-	if errs != nil {
-		t.Errorf("Unexpected errors %v", errs)
-	}
-}
-
-func TestValidatePriorityWithNegativeWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}}
-	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight not being positive")
-	}
-}
-
-func TestValidatePriorityWithOverFlowWeight(t *testing.T) {
-	policy := api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: api.MaxWeight}}}
-	if ValidatePolicy(policy) == nil {
-		t.Errorf("Expected error about priority weight not being overflown.")
-	}
-}
-
-func TestValidateExtenderWithNonNegativeWeight(t *testing.T) {
-	extenderPolicy := api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: 2}}}
-	errs := ValidatePolicy(extenderPolicy)
-	if errs != nil {
-		t.Errorf("Unexpected errors %v", errs)
-	}
-}
-
-func TestValidateExtenderWithNegativeWeight(t *testing.T) {
-	extenderPolicy := api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: -2}}}
-	if ValidatePolicy(extenderPolicy) == nil {
-		t.Errorf("Expected error about priority weight for extender not being positive")
-	}
-}
-
-func TestValidateMultipleExtendersWithBind(t *testing.T) {
-	extenderPolicy := api.Policy{
-		ExtenderConfigs: []api.ExtenderConfig{
-			{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind"},
-			{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind"},
+func TestValidatePolicy(t *testing.T) {
+	tests := []struct {
+		policy   api.Policy
+		expected error
+	}{
+		{
+			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority"}}},
+			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
+		},
+		{
+			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "NoWeightPriority", Weight: 0}}},
+			expected: errors.New("Priority NoWeightPriority should have a positive weight applied to it or it has overflown"),
+		},
+		{
+			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: 2}}},
+			expected: nil,
+		},
+		{
+			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: -2}}},
+			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
+		},
+		{
+			policy:   api.Policy{Priorities: []api.PriorityPolicy{{Name: "WeightPriority", Weight: api.MaxWeight}}},
+			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
+		},
+		{
+			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: 2}}},
+			expected: nil,
+		},
+		{
+			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: -2}}},
+			expected: errors.New("Priority for extender http://127.0.0.1:8081/extender should have a positive weight applied to it"),
+		},
+		{
+			policy: api.Policy{
+				ExtenderConfigs: []api.ExtenderConfig{
+					{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind", Weight: 2},
+					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind", Weight: 2},
+				}},
+			expected: errors.New("Only one extender can implement bind, found 2"),
 		},
 	}
-	if ValidatePolicy(extenderPolicy) == nil {
-		t.Errorf("Expected failure when multiple extenders with bind")
+
+	for _, test := range tests {
+		actual := ValidatePolicy(test.policy)
+		if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
+			t.Errorf("expected: %s, actual: %s", test.expected, actual)
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: sakeven <jc5930@sina.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Without setting `Weight`, `ValidatePolicy` will report
```
Priority for extender http://127.0.0.1:8081/extender should have a positive weight applied to it
```

**Besides**, it seems it's not a good way to test ValidatePolicy by```if ValidatePolicy(extenderPolicy) == nil```, because we can't determine specific reason which causes error.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
