### PR TITLE
Automated cherry pick of #48050

### DIFF
--- a/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
+++ b/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
@@ -95,7 +95,7 @@ func CreateRoles(clientset *clientset.Clientset) error {
 				Namespace: metav1.NamespacePublic,
 			},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("get").Groups("").Resources("configmaps").RuleOrDie(),
+				rbac.NewRule("get").Groups("").Resources("configmaps").Names("cluster-info").RuleOrDie(),
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #48050 on release-1.6.

#48050: kubeadm: Expose only the cluster-info ConfigMap in the