### PR TITLE
allow heapster clusterrole to see deployments

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -243,6 +243,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:heapster"},
 			Rules: []rbac.PolicyRule{
 				rbac.NewRule(Read...).Groups(legacyGroup).Resources("events", "pods", "nodes", "namespaces").RuleOrDie(),
+				rbac.NewRule(Read...).Groups(extensionsGroup).Resources("deployments").RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -404,6 +404,14 @@ items:
     - get
     - list
     - watch
+  - apiGroups:
+    - extensions
+    resources:
+    - deployments
+    verbs:
+    - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the default `system:heapster` ClusterRole does not allow access to the `deployment.extensions`. This limits metric collection and results in `DENY` messages in the kube-api logs like these:

```
[kube-apiserver-ip-10-0-10-12.us-west-2.compute.internal] I0630 19:22:16.088301       1 rbac.go:87] RBAC DENY: user "system:serviceaccount:kube-system:heapster" groups [system:serviceaccounts system:serviceaccounts:kube-system system:authenticated] cannot "get" resource "deployments.extensions" named "heapster-v1.4.0" in namespace "kube-system"
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #  https://github.com/kubernetes/heapster/issues/1710

**Special notes for your reviewer**: NONE

**Release note**:

```release-note
Allow the system:heapster ClusterRole read access to deployments
```
