### PR TITLE
Automated cherry pick of #47875 #48050 #48261

### DIFF
--- a/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
+++ b/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
@@ -105,7 +105,7 @@ func createRoles(clientset *clientset.Clientset) error {
 				Namespace: metav1.NamespacePublic,
 			},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("get").Groups("").Resources("configmaps").RuleOrDie(),
+				rbac.NewRule("get").Groups("").Resources("configmaps").Names("cluster-info").RuleOrDie(),
 			},
 		},
 	}

--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -115,7 +115,7 @@ func (gc *GarbageCollector) removeFinalizer(owner *node, targetFinalizer string)
 		for _, f := range finalizers {
 			if f == targetFinalizer {
 				found = true
-				break
+				continue
 			}
 			newFinalizers = append(newFinalizers, f)
 		}

--- a/test/e2e/cluster-logging/BUILD
+++ b/test/e2e/cluster-logging/BUILD
@@ -13,6 +13,7 @@ go_library(
         "es.go",
         "es_utils.go",
         "sd.go",
+        "sd_events.go",
         "sd_load.go",
         "sd_utils.go",
         "utils.go",

--- a/test/e2e/cluster-logging/sd_events.go
+++ b/test/e2e/cluster-logging/sd_events.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"time"
+
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	. "github.com/onsi/ginkgo"
+)
+
+const (
+	// eventsIngestionTimeout is the amount of time to wait until some
+	// events are ingested.
+	eventsIngestionTimeout = 10 * time.Minute
+
+	// eventPollingInterval is the delay between attempts to read events
+	// from the logs provider.
+	eventPollingInterval = 1 * time.Second
+
+	// eventCreationInterval is the minimal delay between two events
+	// created for testing purposes.
+	eventCreationInterval = 10 * time.Second
+)
+
+var _ = framework.KubeDescribe("Cluster level logging using GCL", func() {
+	f := framework.NewDefaultFramework("gcl-logging-events")
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("gce", "gke")
+	})
+
+	It("should ingest events", func() {
+		gclLogsProvider, err := newGclLogsProvider(f)
+		framework.ExpectNoError(err, "Failed to create GCL logs provider")
+
+		err = gclLogsProvider.Init()
+		defer gclLogsProvider.Cleanup()
+		framework.ExpectNoError(err, "Failed to init GCL logs provider")
+
+		stopCh := make(chan struct{})
+		successCh := make(chan struct{})
+		go func() {
+			wait.Poll(eventPollingInterval, eventsIngestionTimeout, func() (bool, error) {
+				events := gclLogsProvider.ReadEvents()
+				if len(events) > 0 {
+					framework.Logf("Some events are ingested, sample event: %v", events[0])
+					close(successCh)
+					return true, nil
+				}
+				return false, nil
+			})
+			close(stopCh)
+		}()
+
+		By("Running pods to generate events while waiting for some of them to be ingested")
+		wait.PollUntil(eventCreationInterval, func() (bool, error) {
+			podName := "synthlogger"
+			createLoggingPod(f, podName, "", 1, 1*time.Second)
+			defer f.PodClient().Delete(podName, &meta_v1.DeleteOptions{})
+			err = framework.WaitForPodSuccessInNamespace(f.ClientSet, podName, f.Namespace.Name)
+			if err != nil {
+				framework.Logf("Failed to wait pod %s to successfully complete due to %v", podName, err)
+			}
+
+			return false, nil
+		}, stopCh)
+
+		select {
+		case <-successCh:
+			break
+		default:
+			framework.Failf("No events are present in Stackdriver after %v", eventsIngestionTimeout)
+		}
+	})
+})


### PR DESCRIPTION
Cherry pick of #47875 #48050 #48261 on release-1.7.

#47875: Implement e2e test for Stackdriver event exporter
#48050: kubeadm: Expose only the cluster-info ConfigMap in the
#48261: Fix removing finalizer for garbage collector