### PR TITLE
Rebase hyperkube image on debian-hyperkube-base, based on debian-base.

### DIFF
--- a/build/debian-hyperkube-base/.gitignore
+++ b/build/debian-hyperkube-base/.gitignore
@@ -1,0 +1,1 @@
+/cni-tars

--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+# The samba-common, cifs-utils, and nfs-common packages depend on
+# ucf, which itself depends on /bin/bash existing.
+# It doesn't seem to actually need bash, however.
+RUN ln -s /bin/sh /bin/bash
+
+RUN echo CACHEBUST>/dev/null && clean-install \
+    iptables \
+    ebtables \
+    ethtool \
+    ca-certificates \
+    conntrack \
+    util-linux \
+    socat \
+    git \
+    jq \
+    nfs-common \
+    glusterfs-client \
+    cifs-utils \
+    ceph-common
+
+COPY cni-bin/bin /opt/cni/bin

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -1,0 +1,58 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build the hyperkube base image. This image is used to build the hyperkube image.
+#
+# Usage:
+#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push)
+
+REGISTRY?=gcr.io/google-containers
+IMAGE?=debian-hyperkube-base
+TAG=0.1
+ARCH?=amd64
+CACHEBUST?=1
+
+BASEIMAGE=gcr.io/google-containers/debian-base-$(ARCH):0.1
+CNI_RELEASE=0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
+
+TEMP_DIR:=$(shell mktemp -d)
+CNI_TARBALL=cni-$(ARCH)-$(CNI_RELEASE).tar.gz
+
+.PHONY: all build push clean
+
+all: push
+
+cni-tars/$(CNI_TARBALL):
+	mkdir -p cni-tars/
+	cd cni-tars/ && curl -sSLO --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/${CNI_TARBALL}
+
+clean:
+	rm -rf cni-tars/
+
+build: cni-tars/$(CNI_TARBALL)
+	cp Dockerfile $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+ifeq ($(CACHEBUST),1)
+	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
+endif
+
+	mkdir -p ${TEMP_DIR}/cni-bin
+	tar -xz -C ${TEMP_DIR}/cni-bin -f "cni-tars/${CNI_TARBALL}"
+
+	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	rm -rf $(TEMP_DIR)
+
+push: build
+	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)

--- a/build/debian-hyperkube-base/README.md
+++ b/build/debian-hyperkube-base/README.md
@@ -1,0 +1,33 @@
+### debian-hyperkube-base
+
+Serves as the base image for `gcr.io/google-containers/hyperkube-${ARCH}`
+images.
+
+This image is compiled for multiple architectures.
+
+#### How to release
+
+If you're editing the Dockerfile or some other thing, please bump the `TAG` in the Makefile.
+
+```console
+# Build for linux/amd64 (default)
+$ make push ARCH=amd64
+# ---> gcr.io/google-containers/debian-hyperkube-base-amd64:TAG
+
+$ make push ARCH=arm
+# ---> gcr.io/google-containers/debian-hyperkube-base-arm:TAG
+
+$ make push ARCH=arm64
+# ---> gcr.io/google-containers/debian-hyperkube-base-arm64:TAG
+
+$ make push ARCH=ppc64le
+# ---> gcr.io/google-containers/debian-hyperkube-base-ppc64le:TAG
+
+$ make push ARCH=s390x
+# ---> gcr.io/google-containers/debian-hyperkube-base-s390x:TAG
+```
+
+If you don't want to push the images, run `make build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/build/debian-hyperkube-base/README.md?pixel)]()

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -14,34 +14,6 @@
 
 FROM BASEIMAGE
 
-# If we're building for another architecture than amd64, the CROSS_BUILD_ placeholder is removed so e.g. CROSS_BUILD_COPY turns into COPY
-# If we're building normally, for amd64, CROSS_BUILD lines are removed
-CROSS_BUILD_COPY qemu-ARCH-static /usr/bin/
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get -yy -q install \
-    iptables \
-    ebtables \
-    ethtool \
-    ca-certificates \
-    conntrack \
-    util-linux \
-    socat \
-    git \
-    jq \
-    nfs-common \
-    glusterfs-client \
-    cifs-utils \
-    ceph-common \
-    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \
-    && DEBIAN_FRONTEND=noninteractive apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* # CACHEBUST
-
-RUN cp /usr/bin/nsenter /nsenter
-
-# Copy the the cni-bin folder into /opt/cni/bin
-COPY cni-bin/bin /opt/cni/bin
-
 # Create symlinks for each hyperkube server
 # Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be 
 # used instead of gcr.io/google_containers/kube-* without any modifications.

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -15,44 +15,14 @@
 # Build the hyperkube image.
 #
 # Usage:
-#   [ARCH=amd64] [REGISTRY="gcr.io/google_containers"] make (build|push) VERSION={some_released_version_of_kubernetes}
+#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push) VERSION={some_released_version_of_kubernetes}
 
-REGISTRY?=gcr.io/google_containers
+REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
+HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
+
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.1
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
-CNI_RELEASE=0799f5732f2a11b329d9e3d51b9c8f2e3759f2ff
-CACHEBUST?=1
-QEMUVERSION=v2.7.0
-HYPERKUBE_BIN?=_output/dockerized/bin/linux/${ARCH}/hyperkube
-HOSTARCH?=amd64
-
-UNAME_S:=$(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	SED_CMD?=sed -i ""
-endif
-ifeq ($(UNAME_S),Linux)
-	SED_CMD?=sed -i
-endif
-
-ifeq ($(ARCH),amd64)
-	BASEIMAGE?=debian:jessie
-endif
-ifeq ($(ARCH),arm)
-	BASEIMAGE?=armhf/debian:jessie
-	QEMUARCH=arm
-endif
-ifeq ($(ARCH),arm64)
-	BASEIMAGE?=aarch64/debian:jessie
-	QEMUARCH=aarch64
-endif
-ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/debian:jessie
-	QEMUARCH=ppc64le
-endif
-ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/debian:jessie
-	QEMUARCH=s390x
-endif
 
 all: build
 
@@ -62,31 +32,11 @@ ifndef VERSION
     $(error VERSION is undefined)
 endif
 	cp -r ./* ${TEMP_DIR}
-	mkdir -p ${TEMP_DIR}/cni-bin
-
 	cp ../../../${HYPERKUBE_BIN} ${TEMP_DIR}
 
 	chmod a+rx ${TEMP_DIR}/hyperkube
 
-	cd ${TEMP_DIR} && sed -i.back "s|ARCH|${QEMUARCH}|g" Dockerfile
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
-ifeq ($(CACHEBUST),1)
-	cd ${TEMP_DIR} && sed -i.back "s|CACHEBUST|$(shell uuidgen)|g" Dockerfile
-endif
-
-ifeq ($(ARCH),$(HOSTARCH))
-	# When building "normally", remove the whole line, it has no part in the image
-	cd ${TEMP_DIR} && ${SED_CMD} "/CROSS_BUILD_/d" Dockerfile
-else
-	cd ${TEMP_DIR} && ${SED_CMD} "s/CROSS_BUILD_//g" Dockerfile
-
-	# When cross-building, only the placeholder "CROSS_BUILD_" should be removed
-	# Register /usr/bin/qemu-ARCH-static as the handler for ARM binaries in the kernel
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	curl -sSL --retry 5 https://github.com/multiarch/qemu-user-static/releases/download/$(QEMUVERSION)/x86_64_qemu-${QEMUARCH}-static.tar.gz | tar -xz -C ${TEMP_DIR}
-endif
-	# Download CNI
-	curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/cni-${ARCH}-${CNI_RELEASE}.tar.gz | tar -xz -C ${TEMP_DIR}/cni-bin
 
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
@@ -99,4 +49,4 @@ ifeq ($(ARCH),amd64)
 	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
-.PHONY: all
+.PHONY: build push all


### PR DESCRIPTION
**What this PR does / why we need it**: saves all of the hyperkube image dependencies in a cacheable base image, rather than downloading them for every build (which is slow and flaky).

This way, at build time, we only need to pull down the hyperkube base image and add the hyperkube binary.

I've additionally based the base image on `debian-base` instead of `debian`, though we amusing end up reinstalling a bunch of the things we removed in `debian-base`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #35058, at least partially

**Special notes for your reviewer**: I'm increasingly convinced that the hyperkube image is a bad pattern, as this image carries the superset of dependencies anyone might need, rather than the limited set of dependencies one needs. hyperkube really needs a proper owner.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/assign @timstclair @luxas @philips @nikhiljindal 
cc @kubernetes/sig-release-pr-reviews 