### PR TITLE
apiextensions: add cleanup section to client-go

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/README.md
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/README.md
@@ -44,3 +44,9 @@ type User struct {
 	Password string `json:"password"`
 }
 ```
+
+## Cleanup
+
+Successfully running this program will clean the created artifacts. If you terminate the program without completing, you can clean up the created CustomResourceDefinition with:
+
+    kubectl delete crd examples.cr.client-go.k8s.io

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
@@ -110,7 +110,7 @@ func main() {
 	}
 	fmt.Print("PROCESSED\n")
 
-	// Fetch a list of our TPRs
+	// Fetch a list of our CRs
 	exampleList := crv1.ExampleList{}
 	err = exampleClient.Get().Resource(crv1.ExampleResourcePlural).Do().Into(&exampleList)
 	if err != nil {


### PR DESCRIPTION
Adds a `Cleanup` section to be consistent with other client-go tutorials.

Fixes https://github.com/kubernetes/apiextensions-apiserver/issues/1

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
