### PR TITLE
Fix docker wait for macos

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -384,7 +384,9 @@ function kube::build::short_hash() {
 # a workaround for bug https://github.com/docker/docker/issues/3968.
 function kube::build::destroy_container() {
   "${DOCKER[@]}" kill "$1" >/dev/null 2>&1 || true
-  "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
+  if docker inspect --type=container "$1" >/dev/null 2>&1; then
+    "${DOCKER[@]}" wait "$1" >/dev/null 2>&1 || true
+  fi
   "${DOCKER[@]}" rm -f -v "$1" >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR checks if the container exist and if not don't wait for it. This allows for MacOS users to build kubernetes again. I tested it on my MacOS:
```
Darwin .... 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
```
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48342 