### PR TITLE
fix port validating when port is string type

### DIFF
--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -574,7 +574,7 @@ func validateIngressBackend(backend *extensions.IngressBackend, fldPath *field.P
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceName"), backend.ServiceName, msg))
 		}
 	}
-	allErrs = append(allErrs, apivalidation.ValidatePortNumOrName(backend.ServicePort, fldPath.Child("servicePort"))...)
+	allErrs = append(allErrs, apivalidation.ValidatePortNum(backend.ServicePort, fldPath.Child("servicePort"))...)
 	return allErrs
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

When I investigate issue #48290, I found the type of [HTTPGetAction.Port](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/api/core/v1/types.go#L1585) is [intstr.IntOrString](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go#L34-L47), which means that *Port* can be set to a number or valid string.

However when we got below *`port: "80"`* in our YAML file,

```
        readinessProbe:
          initialDelaySeconds: 2
          httpGet:
            path: "/"
            port: "80"
```
the deployment creation would fail with error

```
Invalid value: "80": must contain at least one letter or number (a-z, 0-9)
```

**Which issue this PR fixes** : fixes #48290 

**Special notes for your reviewer**:

cc @ahmetb @kargakis I will open another PR on the document issue that you mentioned in #48290.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
