### PR TITLE
Add an option for VNet resource group in azure configuration

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -66,6 +66,8 @@ type Config struct {
 	Location string `json:"location" yaml:"location"`
 	// The name of the VNet that the cluster is deployed in
 	VnetName string `json:"vnetName" yaml:"vnetName"`
+	// The name of the resource group where the VNet is created, if empty will use the cluster resource group
+	VnetResourceGroup string `json:"vnetResourceGroup" yaml:"vnetResourceGroup"`
 	// The name of the subnet that the cluster is deployed in
 	SubnetName string `json:"subnetName" yaml:"subnetName"`
 	// The name of the security group attached to the cluster's subnet

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -592,6 +592,7 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"subnetName": "--subnet-name--",
 		"securityGroupName": "--security-group-name--",
 		"vnetName": "--vnet-name--",
+		"vnetResourceGroup": "--vnet-resource-group--",
 		"routeTableName": "--route-table-name--",
 		"primaryAvailabilitySetName": "--primary-availability-set-name--",
 		"cloudProviderBackoff": true,
@@ -639,6 +640,7 @@ location: --location--
 subnetName: --subnet-name--
 securityGroupName: --security-group-name--
 vnetName: --vnet-name--
+vnetResourceGroup: --vnet-resource-group--
 routeTableName: --route-table-name--
 primaryAvailabilitySetName: --primary-availability-set-name--
 cloudProviderBackoff: true
@@ -688,6 +690,9 @@ func validateConfig(t *testing.T, config string) {
 	}
 	if azureCloud.VnetName != "--vnet-name--" {
 		t.Errorf("got incorrect value for VnetName")
+	}
+	if azureCloud.VnetResourceGroup != "--vnet-resource-group--" {
+		t.Errorf("got incorrect value for VnetResourceGroup")
 	}
 	if azureCloud.RouteTableName != "--route-table-name--" {
 		t.Errorf("got incorrect value for RouteTableName")

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -132,9 +132,12 @@ func (az *Cloud) getPublicIPAddress(name string) (pip network.PublicIPAddress, e
 
 func (az *Cloud) getSubnet(virtualNetworkName string, subnetName string) (subnet network.Subnet, exists bool, err error) {
 	var realErr error
-
+	resourceGroup := az.ResourceGroup
+	if len(az.VnetResourceGroup) > 0 {
+		resourceGroup = az.VnetResourceGroup
+	}
 	az.operationPollRateLimiter.Accept()
-	subnet, err = az.SubnetsClient.Get(az.ResourceGroup, virtualNetworkName, subnetName, "")
+	subnet, err = az.SubnetsClient.Get(resourceGroup, virtualNetworkName, subnetName, "")
 
 	exists, realErr = checkResourceExistsFromError(err)
 	if realErr != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds an option for VNet resource group in azure configuration. This will allow a VNet deployed in a different resource group than the cluster resource group. The cluster resource group will be used in case of an empty VNet resource group.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47913

cc @brendandburns 
