### PR TITLE
Non-leaders overwrite local keys with what the leader has

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -247,7 +247,9 @@ def setup_non_leader_authentication():
     known_tokens = '/root/cdk/known_tokens.csv'
 
     keys = [service_key, basic_auth, known_tokens]
-    if not get_keys_from_leader(keys):
+    # The source of truth for non-leaders is the leader.
+    # Therefore we overwrite_local with whatever the leader has.
+    if not get_keys_from_leader(keys, overwrite_local=True):
         # the keys were not retrieved. Non-leaders have to retry.
         return
 
@@ -268,7 +270,7 @@ def setup_non_leader_authentication():
     set_state('authentication.setup')
 
 
-def get_keys_from_leader(keys):
+def get_keys_from_leader(keys, overwrite_local=False):
     """
     Gets the broadcasted keys from the leader and stores them in
     the corresponding files.
@@ -285,7 +287,7 @@ def get_keys_from_leader(keys):
 
     for k in keys:
         # If the path does not exist, assume we need it
-        if not os.path.exists(k):
+        if not os.path.exists(k) or overwrite_local:
             # Fetch data from leadership broadcast
             contents = charms.leadership.leader_get(k)
             # Default to logging the warning and wait for leader data to be set


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Non-leaders juju master units do not update their auth keys.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48434

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
