### PR TITLE
Fix: namespace-create have kubectl in path

### DIFF
--- a/cluster/juju/layers/kubernetes-master/actions/namespace-create
+++ b/cluster/juju/layers/kubernetes-master/actions/namespace-create
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import os
 from yaml import safe_load as load
 from charmhelpers.core.hookenv import (
     action_get,
@@ -9,6 +9,9 @@ from charmhelpers.core.hookenv import (
 )
 from charms.templating.jinja2 import render
 from subprocess import check_output
+
+
+os.environ['PATH'] += os.pathsep + os.path.join(os.sep, 'snap', 'bin')
 
 
 def kubectl(args):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: In juju deployed clusters namespace-create action is failing

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/326

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Fix: namespace-create action on Juju deployed clusters
```
