### PR TITLE
Accept variations of true/false for is-default-class

### DIFF
--- a/pkg/apis/storage/util/helpers.go
+++ b/pkg/apis/storage/util/helpers.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package util
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
@@ -28,10 +32,10 @@ const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
 
@@ -42,10 +46,10 @@ func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
 

--- a/pkg/apis/storage/v1/util/helpers.go
+++ b/pkg/apis/storage/v1/util/helpers.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package util
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
@@ -28,10 +32,10 @@ const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
 
@@ -42,10 +46,10 @@ func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
 

--- a/pkg/apis/storage/v1beta1/util/helpers.go
+++ b/pkg/apis/storage/v1beta1/util/helpers.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package util
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"strconv"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // IsDefaultStorageClassAnnotation represents a StorageClass annotation that
 // marks a class as the default StorageClass
@@ -28,10 +32,10 @@ const BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return "Yes"
 	}
 
@@ -42,10 +46,10 @@ func IsDefaultAnnotationText(obj metav1.ObjectMeta) string {
 // the annotation is set
 // TODO: remove Beta when no longer needed
 func IsDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[IsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if ret, _ := strconv.ParseBool(obj.Annotations[BetaIsDefaultStorageClassAnnotation]); ret == true {
 		return true
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Use strconv.ParseBool to accept strings with 1, t, T, TRUE, true, True,
0, f, F, FALSE, false, False etc as valid options to set the value of
is-default-class. Currently we just allow "true", everything else is
treated as false.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #48350

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
In addition to "true", storageclass.kubernetes.io/is-default-class can be set to "TRUE", "True", "1", "t", "T" to mean the same.
```
