### PR TITLE
forget pod first after binding failed

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -220,9 +220,6 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 	// If binding succeeded then PodScheduled condition will be updated in apiserver so that
 	// it's atomic with setting host.
 	err := sched.config.Binder.Bind(b)
-	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
-		return fmt.Errorf("scheduler cache FinishBinding failed: %v", err)
-	}
 	if err != nil {
 		glog.V(1).Infof("Failed to bind pod: %v/%v", assumed.Namespace, assumed.Name)
 		if err := sched.config.SchedulerCache.ForgetPod(assumed); err != nil {
@@ -237,6 +234,11 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 		})
 		return err
 	}
+
+	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
+		return fmt.Errorf("scheduler cache FinishBinding failed: %v", err)
+	}
+
 	metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
 	sched.config.Recorder.Eventf(assumed, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v to %v", assumed.Name, b.Target.Name)
 	return nil


### PR DESCRIPTION
Signed-off-by: sakeven <jc5930@sina.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In the implementation of scheduler cache, `FinishBinding` marks Pod expired, and then pod would be cleaned in ttl seconds. While `ForgetPod` checks Pod whether assumed,  if not, it reports an error.

So if binding failed and ttl(now 30s) is too short,  the error will occur when `ForgetPod`, thus we won't record `BindingRejected` event.

Although it's rare, we shouldn't depend on the value of ttl.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
