### PR TITLE
Use the azure certificate password when decoding the certificate

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -159,7 +159,7 @@ func newServicePrincipalToken(az *Cloud) (*azure.ServicePrincipalToken, error) {
 		if err != nil {
 			return nil, fmt.Errorf("reading the client certificate from file %s: %v", az.AADClientCertPath, err)
 		}
-		certificate, privateKey, err := decodePkcs12(certData, az.AADClientSecret)
+		certificate, privateKey, err := decodePkcs12(certData, az.AADClientCertPassword)
 		if err != nil {
 			return nil, fmt.Errorf("decoding the client certificate: %v", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use the correct password when decoding the azure client certificate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47286

cc @colemickens 
