### PR TITLE
Modify chaos-chance conditional

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -856,7 +856,7 @@ func CreateAPIServerClientConfig(s *options.KubeletServer) (*restclient.Config, 
 
 // addChaosToClientConfig injects random errors into client connections if configured.
 func addChaosToClientConfig(s *options.KubeletServer, config *restclient.Config) {
-	if s.ChaosChance != 0.0 {
+	if s.ChaosChance > 0.0 {
 		config.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 			seed := chaosclient.NewSeed(1)
 			// TODO: introduce a standard chaos package with more tunables - this is just a proof of concept


### PR DESCRIPTION
About --chaos-chance parameter help information is described here:

```
--chaos-chance float                                      If > 0.0, introduce random client errors and latency. Intended for testing.
```
But the code condition judgment and description information are inconsistent.

**Release note**:
```release-note
NONE
```
