### PR TITLE
Rev Calico's Typha daemon to v0.2.3 in add-on deployment.

### DIFF
--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: calico/typha:v0.2.2
+      - image: calico/typha:v0.2.3
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR revs the version of Calico's Typha daemon used in the calico-policy-controller add-on to the latest bug-fix release, which incorporates a [critical bug fix](https://github.com/projectcalico/typha/issues/28).

**Which issue this PR fixes**

fixes #49473

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Rev version of Calico's Typha daemon used in add-on to v0.2.3 to pull in bug-fixes.
```
