### PR TITLE
Refactor podListEqual()

### DIFF
--- a/pkg/kubelet/preemption/preemption_test.go
+++ b/pkg/kubelet/preemption/preemption_test.go
@@ -458,21 +458,21 @@ func admissionRequirementListEqual(list1 admissionRequirementList, list2 admissi
 	return true
 }
 
-// this checks if the lists contents contain all of the same elements.
-// this is not correct if there are duplicate pods in the list.
-// for example: podListEqual([a, a, b], [a, b, b]) will return true
+// podListEqual checks if the lists contents contain all of the same elements.
 func podListEqual(list1 []*v1.Pod, list2 []*v1.Pod) bool {
 	if len(list1) != len(list2) {
 		return false
 	}
-	for _, a := range list1 {
-		contains := false
-		for _, b := range list2 {
-			if a == b {
-				contains = true
-			}
-		}
-		if !contains {
+
+	m := map[*v1.Pod]int{}
+	for _, val := range list1 {
+		m[val] = m[val] + 1
+	}
+	for _, val := range list2 {
+		m[val] = m[val] - 1
+	}
+	for _, v := range m {
+		if v != 0 {
 			return false
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
To solve the problem:
 this is not correct if there are duplicate pods in the list.
 for example: podListEqual([a, a, b], [a, b, b]) will return true

**Special notes for your reviewer**:
 the original method is O(N^2), while current method is 3* O(N).
I think it is much better.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
