### PR TITLE
Disable Requesting Compression by default on restclient

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -110,6 +110,12 @@ type Config struct {
 	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
 	Timeout time.Duration
 
+	// EnableCompression, if true the Transport will
+	// request compression with an "Accept-Encoding: gzip"
+	// request header when the Request contains no existing
+	// Accept-Encoding value.
+	EnableCompression bool
+
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
@@ -406,12 +412,13 @@ func AnonymousClientConfig(config *Config) *Config {
 			CAFile:     config.TLSClientConfig.CAFile,
 			CAData:     config.TLSClientConfig.CAData,
 		},
-		RateLimiter:   config.RateLimiter,
-		UserAgent:     config.UserAgent,
-		Transport:     config.Transport,
-		WrapTransport: config.WrapTransport,
-		QPS:           config.QPS,
-		Burst:         config.Burst,
-		Timeout:       config.Timeout,
+		RateLimiter:       config.RateLimiter,
+		UserAgent:         config.UserAgent,
+		Transport:         config.Transport,
+		WrapTransport:     config.WrapTransport,
+		QPS:               config.QPS,
+		Burst:             config.Burst,
+		Timeout:           config.Timeout,
+		EnableCompression: config.EnableCompression,
 	}
 }

--- a/staging/src/k8s.io/client-go/rest/transport.go
+++ b/staging/src/k8s.io/client-go/rest/transport.go
@@ -95,5 +95,6 @@ func (c *Config) TransportConfig() (*transport.Config, error) {
 			Groups:   c.Impersonate.Groups,
 			Extra:    c.Impersonate.Extra,
 		},
+		EnableCompression: c.EnableCompression,
 	}, nil
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -132,6 +132,8 @@ func (config *DirectClientConfig) ClientConfig() (*restclient.Config, error) {
 	clientConfig := &restclient.Config{}
 	clientConfig.Host = configClusterInfo.Server
 
+	clientConfig.EnableCompression = config.overrides.EnableCompression
+
 	if len(config.overrides.Timeout) > 0 {
 		timeout, err := ParseTimeout(config.overrides.Timeout)
 		if err != nil {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -29,11 +29,12 @@ import (
 type ConfigOverrides struct {
 	AuthInfo clientcmdapi.AuthInfo
 	// ClusterDefaults are applied before the configured cluster info is loaded.
-	ClusterDefaults clientcmdapi.Cluster
-	ClusterInfo     clientcmdapi.Cluster
-	Context         clientcmdapi.Context
-	CurrentContext  string
-	Timeout         string
+	ClusterDefaults   clientcmdapi.Cluster
+	ClusterInfo       clientcmdapi.Cluster
+	Context           clientcmdapi.Context
+	CurrentContext    string
+	Timeout           string
+	EnableCompression bool
 }
 
 // ConfigOverrideFlags holds the flag names to be used for binding command line flags.  Notice that this structure tightly
@@ -43,6 +44,7 @@ type ConfigOverrideFlags struct {
 	ClusterOverrideFlags ClusterOverrideFlags
 	ContextOverrideFlags ContextOverrideFlags
 	CurrentContext       FlagInfo
+	EnableCompression    FlagInfo
 	Timeout              FlagInfo
 }
 
@@ -130,22 +132,23 @@ func (f FlagInfo) BindBoolFlag(flags *pflag.FlagSet, target *bool) FlagInfo {
 }
 
 const (
-	FlagClusterName      = "cluster"
-	FlagAuthInfoName     = "user"
-	FlagContext          = "context"
-	FlagNamespace        = "namespace"
-	FlagAPIServer        = "server"
-	FlagInsecure         = "insecure-skip-tls-verify"
-	FlagCertFile         = "client-certificate"
-	FlagKeyFile          = "client-key"
-	FlagCAFile           = "certificate-authority"
-	FlagEmbedCerts       = "embed-certs"
-	FlagBearerToken      = "token"
-	FlagImpersonate      = "as"
-	FlagImpersonateGroup = "as-group"
-	FlagUsername         = "username"
-	FlagPassword         = "password"
-	FlagTimeout          = "request-timeout"
+	FlagClusterName       = "cluster"
+	FlagAuthInfoName      = "user"
+	FlagContext           = "context"
+	FlagNamespace         = "namespace"
+	FlagAPIServer         = "server"
+	FlagInsecure          = "insecure-skip-tls-verify"
+	FlagCertFile          = "client-certificate"
+	FlagKeyFile           = "client-key"
+	FlagCAFile            = "certificate-authority"
+	FlagEmbedCerts        = "embed-certs"
+	FlagBearerToken       = "token"
+	FlagImpersonate       = "as"
+	FlagImpersonateGroup  = "as-group"
+	FlagUsername          = "username"
+	FlagPassword          = "password"
+	FlagTimeout           = "request-timeout"
+	FlagEnableCompression = "enable-compression"
 )
 
 // RecommendedConfigOverrideFlags is a convenience method to return recommended flag names prefixed with a string of your choosing
@@ -155,8 +158,9 @@ func RecommendedConfigOverrideFlags(prefix string) ConfigOverrideFlags {
 		ClusterOverrideFlags: RecommendedClusterOverrideFlags(prefix),
 		ContextOverrideFlags: RecommendedContextOverrideFlags(prefix),
 
-		CurrentContext: FlagInfo{prefix + FlagContext, "", "", "The name of the kubeconfig context to use"},
-		Timeout:        FlagInfo{prefix + FlagTimeout, "", "0", "The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests."},
+		CurrentContext:    FlagInfo{prefix + FlagContext, "", "", "The name of the kubeconfig context to use"},
+		Timeout:           FlagInfo{prefix + FlagTimeout, "", "0", "The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests."},
+		EnableCompression: FlagInfo{prefix + FlagEnableCompression, "", "false", "Enable HTTP client to request compressed responses from server"},
 	}
 }
 
@@ -197,6 +201,7 @@ func BindOverrideFlags(overrides *ConfigOverrides, flags *pflag.FlagSet, flagNam
 	BindClusterFlags(&overrides.ClusterInfo, flags, flagNames.ClusterOverrideFlags)
 	BindContextFlags(&overrides.Context, flags, flagNames.ContextOverrideFlags)
 	flagNames.CurrentContext.BindStringFlag(flags, &overrides.CurrentContext)
+	flagNames.EnableCompression.BindBoolFlag(flags, &overrides.EnableCompression)
 	flagNames.Timeout.BindStringFlag(flags, &overrides.Timeout)
 }
 

--- a/staging/src/k8s.io/client-go/transport/config.go
+++ b/staging/src/k8s.io/client-go/transport/config.go
@@ -34,6 +34,12 @@ type Config struct {
 	// Bearer token for authentication
 	BearerToken string
 
+	// EnableCompression, if true the Transport will
+	// request compression with an "Accept-Encoding: gzip"
+	// request header when the Request contains no existing
+	// Accept-Encoding value.
+	EnableCompression bool
+
 	// Impersonate is the config that this Config will impersonate using
 	Impersonate ImpersonationConfig
 

--- a/staging/src/k8s.io/client-go/transport/transport_test.go
+++ b/staging/src/k8s.io/client-go/transport/transport_test.go
@@ -18,6 +18,7 @@ package transport
 
 import (
 	"net/http"
+	"reflect"
 	"testing"
 )
 
@@ -181,8 +182,22 @@ func TestNew(t *testing.T) {
 		}
 
 		switch {
-		case testCase.Default && transport != http.DefaultTransport:
-			t.Errorf("%s: expected the default transport, got %#v", k, transport)
+		case testCase.Default:
+			defaulTransport := http.DefaultTransport.(*http.Transport)
+			httpTransport, ok := transport.(*http.Transport)
+			if !ok {
+				t.Errorf("%s: expected transport did not match the default transport, got %#v", k, transport)
+			}
+			match := reflect.ValueOf(httpTransport.Proxy).Pointer() == reflect.ValueOf(defaulTransport.Proxy).Pointer() &&
+				reflect.ValueOf(httpTransport.DialContext).Pointer() == reflect.ValueOf(defaulTransport.DialContext).Pointer() &&
+				httpTransport.MaxIdleConns == defaulTransport.MaxIdleConns &&
+				httpTransport.IdleConnTimeout == defaulTransport.IdleConnTimeout &&
+				httpTransport.TLSHandshakeTimeout == defaulTransport.TLSHandshakeTimeout &&
+				httpTransport.ExpectContinueTimeout == defaulTransport.ExpectContinueTimeout
+
+			if !match {
+				t.Errorf("%s: expected transport did not match the default transport, got %#v", k, transport)
+			}
 			continue
 		case !testCase.Default && transport == http.DefaultTransport:
 			t.Errorf("%s: expected non-default transport, got %#v", k, transport)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**Background:**
The HTTP2 Transport used by internal HTTP Clients in Kubernetes by default adds the header `Accept-Encoding: gzip` to all HTTP requests (and then attempts to decompress responses that contain the header `Content-Encoding: gzip`) in a way that is transparent to the caller. This behavior can be disabled using the [`DisableCompression` field of the `http.Transport`](https://github.com/kubernetes/kubernetes/blob/master/vendor/golang.org/x/net/http2/transport.go#L81). Since #46966 the kube apiserver now supports gzipping HTTP responses as per client request. Enabling this feature causes increased CPU usage as all internal clients are consuming it by default.

**What this PR does / why we need it**:
This PR exposes `DisableCompression` and makes it configurable via the new field `*restclient.Config.DisableCompression` (which is set to `true` by default). This should have the benefit of enabling API Compression support (e.g. for external clients) without causing unwanted CPU overhead. Internal clients that wish to request compression should be made to do so explicitly.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
