### PR TITLE
start cadvisor manager after initialization

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -115,10 +115,15 @@ func New(address string, port uint, runtime string, rootPath string) (Interface,
 	if err != nil {
 		return nil, err
 	}
+	err = cadvisorClient.Start()
+	if err != nil {
+		return nil, err
+	}
 	return cadvisorClient, nil
 }
 
 func (cc *cadvisorClient) Start() error {
+	glog.Infoln("starting cadvisor manager ...")
 	return cc.Manager.Start()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

The cadvisor manager did not get started after initialization. So `obj.manager.memoryCache` kept nil.

**Which issue this PR fixes** : fixes #48452 

**Special notes for your reviewer**:

cc @feiskyer @k82cn 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
