### PR TITLE
Fix Audit-ID header key

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/request.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/request.go
@@ -50,9 +50,9 @@ func NewEventFromRequest(req *http.Request, level auditinternal.Level, attribs a
 
 	// prefer the id from the headers. If not available, create a new one.
 	// TODO(audit): do we want to forbid the header for non-front-proxy users?
-	ids := req.Header[auditinternal.HeaderAuditID]
-	if len(ids) > 0 {
-		ev.AuditID = types.UID(ids[0])
+	ids := req.Header.Get(auditinternal.HeaderAuditID)
+	if ids != "" {
+		ev.AuditID = types.UID(ids)
 	} else {
 		ev.AuditID = types.UID(uuid.NewRandom().String())
 	}


### PR DESCRIPTION
Now http header key "Audit-ID" doesn't have effect, because golang
automaticly transforms "Audit-ID" into "Audit-Id". This change use
http.Header.Get() function to canonicalize "Audit-ID" to "Audit-Id".


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
