### PR TITLE
Add Containers and InitContainers to PodPresets, #43874

### DIFF
--- a/pkg/apis/settings/types.go
+++ b/pkg/apis/settings/types.go
@@ -51,6 +51,12 @@ type PodPresetSpec struct {
 	// VolumeMounts defines the collection of VolumeMount to inject into containers.
 	// +optional
 	VolumeMounts []api.VolumeMount
+	// Containers defines the collection of Container to inject into the Pod
+	// +optional
+	Containers []api.Container
+	// InitContainers defines the collection of Containers to inject into the Pods InitContainers
+	// +optional
+	InitContainers []api.Container
 }
 
 // PodPresetList is a list of PodPreset objects.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Adds Containers and InitContainers to PodPresets. One use case would be Istio were a sidecar proxy is injected into every pod
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #43874
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds ability to define Containers and InitContainers inside PodPresets
```
