### PR TITLE
kubeadm: Allows to use versions like 1.6.4 instead v1.6.4

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	kubeReleaseBucketURL  = "https://storage.googleapis.com/kubernetes-release/release"
-	kubeReleaseRegex      = regexp.MustCompile(`^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
+	kubeReleaseRegex      = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
 	kubeReleaseLabelRegex = regexp.MustCompile(`^[[:lower:]]+(-[-\w_\.]+)?$`)
 )
 
@@ -49,7 +49,10 @@ var (
 //  latest-1.0  (and similarly 1.1, 1.2, 1.3, ...)
 func KubernetesReleaseVersion(version string) (string, error) {
 	if kubeReleaseRegex.MatchString(version) {
-		return version, nil
+		if strings.HasPrefix(version, "v") {
+			return version, nil
+		}
+		return "v" + version, nil
 	} else if kubeReleaseLabelRegex.MatchString(version) {
 		url := fmt.Sprintf("%s/%s.txt", kubeReleaseBucketURL, version)
 		resp, err := http.Get(url)

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -45,6 +45,7 @@ func TestValidVersion(t *testing.T) {
 		"v1.6.0-alpha.0.536+d60d9f3269288f",
 		"v1.5.0-alpha.0.1078+1044b6822497da-pull",
 		"v1.5.0-alpha.1.822+49b9e32fad9f32-pull-gke-gci",
+		"v1.6.1_coreos.0",
 	}
 	for _, s := range validVersions {
 		ver, err := KubernetesReleaseVersion(s)
@@ -61,8 +62,9 @@ func TestValidVersion(t *testing.T) {
 func TestInvalidVersion(t *testing.T) {
 	invalidVersions := []string{
 		"v1.3",
-		"1.4.0",
-		"1.4.5+git",
+		"1.4",
+		"b1.4.0",
+		"c1.4.5+git",
 		"something1.2",
 	}
 	for _, s := range invalidVersions {
@@ -73,6 +75,24 @@ func TestInvalidVersion(t *testing.T) {
 		}
 		if ver != "" {
 			t.Errorf("KubernetesReleaseVersion should return empty string in case of error. Returned %q for version %q", ver, s)
+		}
+	}
+}
+
+func TestValidConvenientForUserVersion(t *testing.T) {
+	validVersions := []string{
+		"1.4.0",
+		"1.4.5+git",
+		"1.6.1_coreos.0",
+	}
+	for _, s := range validVersions {
+		ver, err := KubernetesReleaseVersion(s)
+		t.Log("Valid: ", s, ver, err)
+		if err != nil {
+			t.Errorf("KubernetesReleaseVersion unexpected error for version %q: %v", s, err)
+		}
+		if ver != "v"+s {
+			t.Errorf("KubernetesReleaseVersion should return semantic version string. %q vs. %q", s, ver)
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of issue kubernetes/kubeadm#292 discussion, it
turned out that for users it is not always obvious that
version specification parameter must be in form "vX.Y.Z".
This patch allows to specify it in form "X.Y.Z" and
converts it internally to normal semantic version which
expected in the rest of the code.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- kubeadm now can accept versions like "1.6.4" where previously it strictly required "v1.6.4"
```
