### PR TITLE
Add node-name flag to `join` phase

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -93,6 +93,7 @@ type NodeConfiguration struct {
 	DiscoveryToken string
 	// Currently we only pay attention to one api server but hope to support >1 in the future
 	DiscoveryTokenAPIServers []string
+	NodeName                 string
 	TLSBootstrapToken        string
 	Token                    string
 }

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -85,6 +85,7 @@ type NodeConfiguration struct {
 	DiscoveryFile            string   `json:"discoveryFile"`
 	DiscoveryToken           string   `json:"discoveryToken"`
 	DiscoveryTokenAPIServers []string `json:"discoveryTokenAPIServers"`
+	NodeName                 string   `json:"nodeName"`
 	TLSBootstrapToken        string   `json:"tlsBootstrapToken"`
 	Token                    string   `json:"token"`
 }

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -113,6 +113,9 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 		&cfg.DiscoveryToken, "discovery-token", "",
 		"A token used to validate cluster information fetched from the master")
 	cmd.PersistentFlags().StringVar(
+		&cfg.NodeName, "node-name", "",
+		"Specify the node name")
+	cmd.PersistentFlags().StringVar(
 		&cfg.TLSBootstrapToken, "tls-bootstrap-token", "",
 		"A token used for TLS bootstrapping")
 	cmd.PersistentFlags().StringVar(
@@ -175,9 +178,12 @@ func (j *Join) Run(out io.Writer) error {
 		return err
 	}
 
-	hostname, err := os.Hostname()
-	if err != nil {
-		return err
+	hostname := j.cfg.NodeName
+	if hostname == "" {
+		hostname, err = os.Hostname()
+		if err != nil {
+			return err
+		}
 	}
 	client, err := kubeconfigutil.KubeConfigToClientSet(cfg)
 	if err != nil {

--- a/cmd/kubeadm/test/cmd/join_test.go
+++ b/cmd/kubeadm/test/cmd/join_test.go
@@ -105,6 +105,34 @@ func TestCmdJoinDiscoveryToken(t *testing.T) {
 	}
 }
 
+func TestCmdJoinNodeName(t *testing.T) {
+	if *kubeadmCmdSkip {
+		t.Log("kubeadm cmd tests being skipped")
+		t.Skip()
+	}
+
+	var initTest = []struct {
+		args     string
+		expected bool
+	}{
+		{"--node-name=foobar", false},
+	}
+
+	for _, rt := range initTest {
+		_, _, actual := RunCmd(*kubeadmPath, "join", rt.args, "--skip-preflight-checks")
+		if (actual == nil) != rt.expected {
+			t.Errorf(
+				"failed CmdJoinNodeName running 'kubeadm join %s' with an error: %v\n\texpected: %t\n\t  actual: %t",
+				rt.args,
+				actual,
+				rt.expected,
+				(actual == nil),
+			)
+		}
+		kubeadmReset()
+	}
+}
+
 func TestCmdJoinTLSBootstrapToken(t *testing.T) {
 	if *kubeadmCmdSkip {
 		t.Log("kubeadm cmd tests being skipped")


### PR DESCRIPTION
**What this PR does / why we need it**: Allow to specify a node-name instead of relaying in `os.Hostname()`
This is useful where kubelet use the name given by the cloud-provider to
register the node.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: partially fixes kubernetes/kubeadm#64

**Special notes for your reviewer**:

**Release note**:
```release-note
Added new flag to `kubeadm join`: --node-name, that lets you specify the name of the Node object that's gonna be created
```
