### PR TITLE
Configurable CGO_ENABLED variable

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -17,6 +17,7 @@
 # The golang package that we are building.
 readonly KUBE_GO_PACKAGE=k8s.io/kubernetes
 readonly KUBE_GOPATH="${KUBE_OUTPUT}/go"
+CGO_ENABLED=${CGO_ENABLED:-0}
 
 # The set of server targets that we are only building for Linux
 # If you update this list, please also update build/BUILD.
@@ -502,7 +503,7 @@ kube::golang::build_binaries_for_platform() {
     kube::log::progress "    "
     for binary in "${statics[@]:+${statics[@]}}"; do
       local outfile=$(kube::golang::output_filename_for_binary "${binary}" "${platform}")
-      CGO_ENABLED=0 go build -o "${outfile}" \
+      CGO_ENABLED=${CGO_ENABLED} go build -o "${outfile}" \
         "${goflags[@]:+${goflags[@]}}" \
         -gcflags "${gogcflags}" \
         -ldflags "${goldflags}" \
@@ -528,7 +529,7 @@ kube::golang::build_binaries_for_platform() {
         "${nonstatics[@]:+${nonstatics[@]}}"
     fi
     if [[ "${#statics[@]}" != 0 ]]; then
-      CGO_ENABLED=0 go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
+      CGO_ENABLED=${CGO_ENABLED} go install -installsuffix cgo "${goflags[@]:+${goflags[@]}}" \
         -gcflags "${gogcflags}" \
         -ldflags "${goldflags}" \
         "${statics[@]:+${statics[@]}}"


### PR DESCRIPTION
This PR will fix the issue: #48420 . The default value of `CGO_ENABLED` is 0, it is configurable. We can set it via environment variable, the same as the `go env` shows(as the below). Hence, the will support the code of `cgo` compiling by modify the environment variable.
I think this will be more convenient and reasonable for ordinary users.
```
root@test1:/home/zhangjian/src/k8s.io/kubernetes# go env
GOARCH="amd64"
GOBIN="/usr/local/go/bin"
GOEXE=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/home/zhangjian"
GORACE=""
GOROOT="/usr/local/go"
GOTOOLDIR="/usr/local/go/pkg/tool/linux_amd64"
CC="gcc"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build959694934=/tmp/go-build -gno-record-gcc-switches"
CXX="g++"
CGO_ENABLED="1"
```