### PR TITLE
Add IPv6 support to iptables proxier

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -56,6 +56,52 @@ func checkAllLines(t *testing.T, table utiliptables.Table, save []byte, expected
 	}
 }
 
+func TestIpPart(t *testing.T) {
+	const noError = ""
+
+	testCases := []struct {
+		endpoint      string
+		expectedIP    string
+		expectedError string
+	}{
+		{"1.2.3.4", "1.2.3.4", noError},
+		{"1.2.3.4:9999", "1.2.3.4", noError},
+		{"2001:db8::1:1", "2001:db8::1:1", noError},
+		{"[2001:db8::2:2]:9999", "2001:db8::2:2", noError},
+		{"1.2.3.4::9999", "", "too many colons"},
+		{"1.2.3.4:[0]", "", "unexpected '[' in address"},
+	}
+
+	for _, tc := range testCases {
+		ip := ipPart(tc.endpoint)
+		if tc.expectedError == noError {
+			if ip != tc.expectedIP {
+				t.Errorf("Unexpected IP for %s: Expected: %s, Got %s", tc.endpoint, tc.expectedIP, ip)
+			}
+		} else if ip != "" {
+			t.Errorf("Error did not occur for %s, expected: '%s' error", tc.endpoint, tc.expectedError)
+		}
+	}
+}
+
+func TestHostAddress(t *testing.T) {
+	testCases := []struct {
+		ip           string
+		expectedAddr string
+	}{
+		{"1.2.3.4", "1.2.3.4/32"},
+		{"2001:db8::1:1", "2001:db8::1:1/128"},
+	}
+
+	for _, tc := range testCases {
+		ip := net.ParseIP(tc.ip)
+		addr := hostAddress(ip)
+		if addr != tc.expectedAddr {
+			t.Errorf("Unexpected host address for %s: Expected: %s, Got %s", tc.ip, tc.expectedAddr, addr)
+		}
+	}
+}
+
 func TestReadLinesFromByteBuffer(t *testing.T) {
 	testFn := func(byteArray []byte, expected []string) {
 		index := 0

--- a/pkg/proxy/util/port.go
+++ b/pkg/proxy/util/port.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"fmt"
+	"net"
+	"strconv"
 
 	"github.com/golang/glog"
 )
@@ -37,7 +39,8 @@ type LocalPort struct {
 }
 
 func (lp *LocalPort) String() string {
-	return fmt.Sprintf("%q (%s:%d/%s)", lp.Description, lp.IP, lp.Port, lp.Protocol)
+	ipPort := net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port))
+	return fmt.Sprintf("%q (%s/%s)", lp.Description, ipPort, lp.Protocol)
 }
 
 // Closeable is an interface around closing an port.

--- a/pkg/proxy/util/port_test.go
+++ b/pkg/proxy/util/port_test.go
@@ -27,6 +27,33 @@ func (c *fakeClosable) Close() error {
 	return nil
 }
 
+func TestLocalPortString(t *testing.T) {
+	testCases := []struct {
+		description string
+		ip          string
+		port        int
+		protocol    string
+		expectedStr string
+	}{
+		{"IPv4 UDP", "1.2.3.4", 9999, "udp", "\"IPv4 UDP\" (1.2.3.4:9999/udp)"},
+		{"IPv4 TCP", "5.6.7.8", 1053, "tcp", "\"IPv4 TCP\" (5.6.7.8:1053/tcp)"},
+		{"IPv6 TCP", "2001:db8::1", 80, "tcp", "\"IPv6 TCP\" ([2001:db8::1]:80/tcp)"},
+	}
+
+	for _, tc := range testCases {
+		lp := &LocalPort{
+			Description: tc.description,
+			IP:          tc.ip,
+			Port:        tc.port,
+			Protocol:    tc.protocol,
+		}
+		str := lp.String()
+		if str != tc.expectedStr {
+			t.Errorf("Unexpected output for %s, expected: %s, got: %s", tc.description, tc.expectedStr, str)
+		}
+	}
+}
+
 func TestRevertPorts(t *testing.T) {
 	testCases := []struct {
 		replacementPorts []LocalPort


### PR DESCRIPTION
Add IPv6 support to iptables proxier

The following changes are proposed for the iptables proxier:

- There are three places where a string specifying IP:port is parsed
  using something like this:
      if index := strings.Index(e.endpoint, ":"); index != -1 {
  This will fail for IPv6 since V6 addresses contain colons. Also,
  the V6 address is expected to be surrounded by square brackets
  (i.e. [<ipv6-addr>]:<port>). Fix this by replacing call to Index with
  call to LastIndex() and stripping out square brackets.
- The String() method for the localPort struct should put square brackets
  around IPv6 addresses.
- The logging in the merge() method for proxyServiceMap should put brackets
  around IPv6 addresses.
- There are several places where filterRules destination is hardcoded to
  <clusterIP>/32. This should be a /128 for IPv6 case.
- Add IPv6 unit test cases

Note: I've left out most of the UT test cases that I had included in my original version of this
PR because the number of lines of code change were much too large for a single review.
I'm including a minimum of UT with this current version of the PR.

fixes #48550

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR addresses several issues in the iptables proxier for handling IPv6 addresses
that were found via visual code inspection, including:
- There are three places where a string specifying IP:port using something like the following:
       if index := strings.Index(e.endpoint, ":"); index != -1 {
  This will fail for IPv6 since V6 addresses contains many colons, and the V6 address is expected
  to be enclosed in square brackets when followed by :<port>.
- The String() method for the localPort struct should put square brackets around IPv6 addresses.
- The logging in the merge() method for proxyServiceMap should put brackets around IPv6
  addresses.
- There are several places where filterRules destination is hardcoded to /32.
  Should be a /128 for IPv6 case.
- More IPv6 unit test cases are needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48550

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
