### PR TITLE
Fix a bug that --flag=val causes completion error in zsh

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -191,14 +191,6 @@ __kubectl_compopt() {
 	true # don't do anything. Not supported by bashcompinit in zsh
 }
 
-__kubectl_declare() {
-	if [ "$1" == "-F" ]; then
-		whence -w "$@"
-	else
-		builtin declare "$@"
-	fi
-}
-
 __kubectl_ltrim_colon_completions()
 {
 	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
@@ -286,7 +278,7 @@ __kubectl_convert_bash_to_zsh() {
 	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__kubectl_ltrim_colon_completions/g" \
 	-e "s/${LWORD}compgen${RWORD}/__kubectl_compgen/g" \
 	-e "s/${LWORD}compopt${RWORD}/__kubectl_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/__kubectl_declare/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__kubectl_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR fixes a bug that flag of syntax like --flag=val causes completion error in zsh.

```
kubectl --namespace=foo g__handle_flag:25: bad math expression: operand expected at end of string
```

This problem is due to [dynamic scope](https://en.wikipedia.org/wiki/Scope_(computer_science)#Dynamic_scoping) of shell variables. If a variable is declared as local to a function, that scope remains until the function returns.

In kubectl completion zsh, `declare -A flaghash` in __start_kubectl() is replaced with `__kubectl_declare -A flaghash` by __kubectl_convert_bash_to_zsh(). As a result of it, flaghash is declared in __kubectl_declare(), and it can not access to flaghash declared in __kubectl_declare() from __handle_flag(). Therefore an error occurs in __handle_flag().

The following is the minimum reproduction code.

```sh
#!/usr/bin/env zsh

set -e

__kubectl_declare() {
    builtin declare "$@"
}

__handle_flag() {
    local flagname="--namespace="
    local flagval="kube-system"

    flaghash[${flagname}]=${flagval}

    echo "flaghash[${flagname}]=${flaghash[${flagname}]}"
}

__handle_word() {
    __handle_flag
}

__start_kubectl() {
    __kubectl_declare -A flaghash

    __handle_word
}

__start_kubectl

#
# $ zsh reproduction.zsh
# __handle_flag:4: bad math expression: operand expected at end of string
#

# __start_kubectl {
#
#     __kubectl_declare {
#
#         builtin declare -A flaghash
#
#     }
#
#     __handle_word {
#
#         __handle_flag {
#
#             # It is unable to access flaghash declared in __kubectl_declare from here
#             flaghash[${flagname}]=${flagval}
#
#         }
#
#     }
# }
```

The following is the fixed code.
```sh
#!/usr/bin/env zsh

set -e

__handle_flag() {
    local flagname="--namespace="
    local flagval="kube-system"

    flaghash[${flagname}]=${flagval}

    echo "flaghash[${flagname}]=${flaghash[${flagname}]}"
}

__handle_word() {
    __handle_flag
}

__start_kubectl() {
    builtin declare -A flaghash

    __handle_word
}

__start_kubectl

#
# $ zsh fixed.zsh
# flaghash[--namespace=]=kube-system
#

# __start_kubectl {
#
#     builtin declare -A flaghash
#
#     __handle_word {
#
#         __handle_flag {
#
#             # It is able to access flaghash declared in __start_kubectl from here :)
#             flaghash[${flagname}]=${flagval}
#
#         }
#
#     }
# }
```
https://gist.github.com/superbrothers/0ede4292f6d973f93e54368e227a4902

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes kubernetes/kubectl#42

**Special notes for your reviewer**:
@mengqiy

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
