### PR TITLE
Use $(location) to find generated output paths.

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -7,9 +7,9 @@ http_archive(
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "a9fb7027f060b868cdbd235a0de0971b557b9d26f9c89e422feb80f48d8c0e90",
-    strip_prefix = "repo-infra-9dedd5f4093884c133ad5ea73695b28338b954ab",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/9dedd5f4093884c133ad5ea73695b28338b954ab.tar.gz"],
+    sha256 = "2555f94944df8547066471377e7b30215abd9831c46647062f83abbc4a0e80d2",
+    strip_prefix = "repo-infra-4291717be0a0f9e789c800c295f2a4067de15bef",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/4291717be0a0f9e789c800c295f2a4067de15bef.tar.gz"],
 )
 
 ETCD_VERSION = "3.0.17"

--- a/pkg/generated/openapi/def.bzl
+++ b/pkg/generated/openapi/def.bzl
@@ -24,7 +24,7 @@ def openapi_library(name, tags, srcs, openapi_targets=[], vendor_targets=[]):
         "--output-file-base zz_generated.openapi",
         "--output-package k8s.io/kubernetes/pkg/generated/openapi",
         "--input-dirs " + ",".join(["k8s.io/kubernetes/" + target for target in openapi_targets] + ["k8s.io/kubernetes/vendor/" + target for target in vendor_targets]),
-        "&& cp pkg/generated/openapi/zz_generated.openapi.go $(GENDIR)/pkg/generated/openapi",
+        "&& cp pkg/generated/openapi/zz_generated.openapi.go $(location :zz_generated.openapi.go)",
       ]),
       go_deps = deps,
       tools = ["//cmd/libs/go2idl/openapi-gen"],

--- a/staging/src/k8s.io/apimachinery/pkg/util/sets/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/sets/BUILD
@@ -38,7 +38,7 @@ go_genrule(
     cmd = """
 $(location //cmd/libs/go2idl/set-gen) \
     --input-dirs ./vendor/k8s.io/apimachinery/pkg/util/sets/types \
-    --output-base $(GENDIR)/vendor/k8s.io/apimachinery/pkg/util \
+    --output-base $$(dirname $$(dirname $(location :byte.go))) \
     --go-header-file $(location //hack/boilerplate:boilerplate.go.txt) \
     --output-package sets
     """,


### PR DESCRIPTION
Along with the build-infra PR https://github.com/kubernetes/repo-infra/pull/19, this allows Kubernetes binaries (e.g. hyperkube) to be built as external dependencies in other Bazel projects.

```release-note
NONE
```
