### PR TITLE
Setting default FlexVolume driver directory on COS images.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -745,6 +745,12 @@ EOF
 FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})
 EOF
   fi
+  if [[ "${master}" == "true" && "${MASTER_OS_DISTRIBUTION}" == "gci" ]] ||
+     [[ "${master}" == "false" && "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
+    cat >>$file <<EOF
+VOLUME_PLUGIN_DIR: $(yaml-quote ${VOLUME_PLUGIN_DIR:-/home/kubernetes/flexvolume})
+EOF
+  fi
 
   if [ -n "${PROVIDER_VARS:-}" ]; then
     local var_name


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The original default FlexVolume driver directory is not writable on COS. A new location is necessary to make FlexVolume work.

This directory doesn't exist by default. FlexVolume users need to create this directory, bind mount it, and remount with the executable permission. The other candidate is /home/kubernetes/bin, but the directory is already getting cluttered. I will submit a different PR for a script that automates this step.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48570
