### PR TITLE
Use `select` to disable building static binaries if `--cpu=darwin`.

### DIFF
--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -7,12 +7,17 @@ load("//pkg/version:def.bzl", "version_x_defs")
 
 go_binary(
     name = "kubectl",
-    gc_linkopts = [
-        "-linkmode",
-        "external",
-        "-extldflags",
-        "-static",
-    ],
+    gc_linkopts = select({
+        # Mac OS X doesn't support static binaries:
+        # https://developer.apple.com/library/content/qa/qa1118/_index.html
+        "@io_bazel_rules_go//go/platform:darwin_amd64": [],
+        "//conditions:default": [
+            "-linkmode",
+            "external",
+            "-extldflags",
+            "-static",
+        ],
+    }),
     library = ":go_default_library",
     visibility = [
         "//build/visible_to:COMMON_release",


### PR DESCRIPTION
This change allows kubectl to be built on MacOS machines using
`bazel build //cmd/kubectl`.
    
Mac OS X doesn't support static binaries because it does not have a
stable syscall API. Userspace binaries are expected to dynamically
link against libcrt instead.
    
https://developer.apple.com/library/content/qa/qa1118/_index.html

```release-note
None
```
