### PR TITLE
make externalAdmissionHookConfigurationManager distinguish API disabled error

### DIFF
--- a/pkg/kubeapiserver/admission/configuration/BUILD
+++ b/pkg/kubeapiserver/admission/configuration/BUILD
@@ -12,14 +12,17 @@ go_test(
     name = "go_default_test",
     srcs = [
         "configuration_manager_test.go",
+        "external_admission_hook_manager_test.go",
         "initializer_manager_test.go",
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )

--- a/pkg/kubeapiserver/admission/configuration/external_admission_hook_manager.go
+++ b/pkg/kubeapiserver/admission/configuration/external_admission_hook_manager.go
@@ -20,7 +20,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/golang/glog"
+
 	"k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -37,6 +40,10 @@ func NewExternalAdmissionHookConfigurationManager(c ExternalAdmissionHookConfigu
 	getFn := func() (runtime.Object, error) {
 		list, err := c.List(metav1.ListOptions{})
 		if err != nil {
+			if errors.IsNotFound(err) || errors.IsForbidden(err) {
+				glog.V(5).Infof("ExternalAdmissionHookConfiguration are disabled due to an error: %v", err)
+				return nil, ErrDisabled
+			}
 			return nil, err
 		}
 		return mergeExternalAdmissionHookConfigurations(list), nil

--- a/pkg/kubeapiserver/admission/configuration/external_admission_hook_manager_test.go
+++ b/pkg/kubeapiserver/admission/configuration/external_admission_hook_manager_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package configuration
+
+import (
+	"testing"
+
+	"k8s.io/api/admissionregistration/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type disabledWebhookConfigLister struct{}
+
+func (l *disabledWebhookConfigLister) List(options metav1.ListOptions) (*v1alpha1.ExternalAdmissionHookConfigurationList, error) {
+	return nil, errors.NewNotFound(schema.GroupResource{Group: "admissionregistration", Resource: "externalAdmissionHookConfigurations"}, "")
+}
+func TestWebhookConfigDisabled(t *testing.T) {
+	manager := NewExternalAdmissionHookConfigurationManager(&disabledWebhookConfigLister{})
+	manager.sync()
+	_, err := manager.ExternalAdmissionHooks()
+	if err.Error() != ErrDisabled.Error() {
+		t.Errorf("expected %v, got %v", ErrDisabled, err)
+	}
+}


### PR DESCRIPTION
The externalAdmissionHookConfigurationManager does not return "DisabledErr" even if the API is disabled, so the GenericWebhook admission controller will not fail open.

The GenericWebhook admission controller is default to off, so the bug is hidden in most cases. To be safe, we should cherrypick it to 1.7.

```release-note
Fix a bug where the GenericWebhook admission plugin does not fail open when the admissionregistration API is disabled
```