### PR TITLE
Record 429 and timeout errors to prometheus

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/proxy.go
@@ -60,10 +60,12 @@ func (r *ProxyHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	var httpCode int
 	reqStart := time.Now()
 	defer func() {
-		metrics.Monitor(&verb, &apiResource, &subresource,
+		metrics.Monitor(
+			verb, apiResource, subresource,
 			net.GetHTTPClient(req),
 			w.Header().Get("Content-Type"),
-			httpCode, reqStart)
+			httpCode, reqStart,
+		)
 	}()
 
 	ctx, ok := r.Mapper.Get(req)

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/httplog:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -19,9 +19,12 @@ package filters
 import (
 	"fmt"
 	"net/http"
+	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/httplog"
@@ -94,6 +97,7 @@ func WithMaxInFlightLimit(
 				defer func() { <-c }()
 				handler.ServeHTTP(w, r)
 			default:
+				metrics.MonitorRequest(r, strings.ToUpper(requestInfo.Verb), requestInfo.Resource, requestInfo.Subresource, "", errors.StatusTooManyRequests, time.Now())
 				tooManyRequests(r, w)
 			}
 		}

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/timeout_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,12 +32,30 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
+type recorder struct {
+	lock  sync.Mutex
+	count int
+}
+
+func (r *recorder) Record() {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	r.count++
+}
+
+func (r *recorder) Count() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.count
+}
+
 func TestTimeout(t *testing.T) {
 	sendResponse := make(chan struct{}, 1)
 	writeErrors := make(chan error, 1)
 	timeout := make(chan time.Time, 1)
 	resp := "test response"
 	timeoutErr := apierrors.NewServerTimeout(schema.GroupResource{Group: "foo", Resource: "bar"}, "get", 0)
+	record := &recorder{}
 
 	ts := httptest.NewServer(WithTimeout(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
@@ -44,8 +63,8 @@ func TestTimeout(t *testing.T) {
 			_, err := w.Write([]byte(resp))
 			writeErrors <- err
 		}),
-		func(*http.Request) (<-chan time.Time, *apierrors.StatusError) {
-			return timeout, timeoutErr
+		func(*http.Request) (<-chan time.Time, func(), *apierrors.StatusError) {
+			return timeout, record.Record, timeoutErr
 		}))
 	defer ts.Close()
 
@@ -65,6 +84,9 @@ func TestTimeout(t *testing.T) {
 	if err := <-writeErrors; err != nil {
 		t.Errorf("got unexpected Write error on first request: %v", err)
 	}
+	if record.Count() != 0 {
+		t.Errorf("invoked record method: %#v", record)
+	}
 
 	// Times out
 	timeout <- time.Time{}
@@ -82,6 +104,9 @@ func TestTimeout(t *testing.T) {
 	}
 	if !reflect.DeepEqual(status, &timeoutErr.ErrStatus) {
 		t.Errorf("unexpected object: %s", diff.ObjectReflectDiff(&timeoutErr.ErrStatus, status))
+	}
+	if record.Count() != 1 {
+		t.Errorf("did not invoke record method: %#v", record)
 	}
 
 	// Now try to send a response


### PR DESCRIPTION
Allows gathering of load being shed.

Fixes #48559

@deads2k please review, there was a logic error in apiserver RequestInfo (minor, fortunately)

```release-note
Requests with the query parameter `?watch=` are treated by the API server as a request to watch, but authorization and metrics were not correctly identifying those as watch requests, instead grouping them as list calls.
```