### PR TITLE
When faild create pod sandbox record event

### DIFF
--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -67,6 +67,8 @@ const (
 	FailedNodeAllocatableEnforcement     = "FailedNodeAllocatableEnforcement"
 	SuccessfulNodeAllocatableEnforcement = "NodeAllocatableEnforced"
 	UnsupportedMountOption               = "UnsupportedMountOption"
+	SuccessCreatePodSandBox = "SuccessCreatePodSandBox"
+	FailedCreatePodSandBox = "FailedCreatePodSandBox"
 
 	// Image manager event reason list
 	InvalidDiskCapacity = "InvalidDiskCapacity"

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -67,7 +67,6 @@ const (
 	FailedNodeAllocatableEnforcement     = "FailedNodeAllocatableEnforcement"
 	SuccessfulNodeAllocatableEnforcement = "NodeAllocatableEnforced"
 	UnsupportedMountOption               = "UnsupportedMountOption"
-	SuccessCreatePodSandBox = "SuccessCreatePodSandBox"
 	FailedCreatePodSandBox = "FailedCreatePodSandBox"
 
 	// Image manager event reason list

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -616,6 +616,8 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, _ v1.PodStatus, podStat
 		if err != nil {
 			createSandboxResult.Fail(kubecontainer.ErrCreatePodSandbox, msg)
 			glog.Errorf("createPodSandbox for pod %q failed: %v", format.Pod(pod), err)
+			ref, _ := ref.GetReference(api.Scheme, pod)
+			m.recorder.Eventf(ref, v1.EventTypeWarning, events.FailedCreatePodSandBox, "Failed create pod sandbox.")
 			return
 		}
 		glog.V(4).Infof("Created PodSandbox %q for pod %q", podSandboxID, format.Pod(pod))


### PR DESCRIPTION
I created the pod failed because the sandbox failed to create, but there was no very clear information telling me what was the failure because,so i wanted to be able to record an event when creating a sandbox failed.
**Release note**:
```release-note
NONE
```
