### PR TITLE
support json output for log backend of advanced audit

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/BUILD
@@ -23,11 +23,14 @@ go_test(
     deps = [
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit/policy:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
@@ -35,6 +38,7 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/audit/log:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/audit/webhook:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
@@ -12,7 +12,9 @@ go_library(
     srcs = ["backend.go"],
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
@@ -19,20 +19,38 @@ package log
 import (
 	"fmt"
 	"io"
+	"strings"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	auditv1alpha1 "k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 	"k8s.io/apiserver/pkg/audit"
 )
 
+const (
+	// FormatLegacy saves event in 1-line text format.
+	FormatLegacy = "legacy"
+	// FormatJson saves event in structured json format.
+	FormatJson = "json"
+)
+
+// AllowedFormats are the formats known by log backend.
+var AllowedFormats = []string{
+	FormatLegacy,
+	FormatJson,
+}
+
 type backend struct {
-	out io.Writer
+	out    io.Writer
+	format string
 }
 
 var _ audit.Backend = &backend{}
 
-func NewBackend(out io.Writer) *backend {
+func NewBackend(out io.Writer, format string) *backend {
 	return &backend{
-		out: out,
+		out:    out,
+		format: format,
 	}
 }
 
@@ -43,8 +61,23 @@ func (b *backend) ProcessEvents(events ...*auditinternal.Event) {
 }
 
 func (b *backend) logEvent(ev *auditinternal.Event) {
-	line := audit.EventString(ev)
-	if _, err := fmt.Fprintln(b.out, line); err != nil {
+	line := ""
+	switch b.format {
+	case FormatLegacy:
+		line = audit.EventString(ev) + "\n"
+	case FormatJson:
+		bs, err := runtime.Encode(audit.Codecs.LegacyCodec(auditv1alpha1.SchemeGroupVersion), ev)
+		if err != nil {
+			audit.HandlePluginError("log", err, ev)
+			return
+		}
+		line = string(bs[:])
+	default:
+		audit.HandlePluginError("log", fmt.Errorf("log format %q is not in list of known formats (%s)",
+			b.format, strings.Join(AllowedFormats, ",")), ev)
+		return
+	}
+	if _, err := fmt.Fprint(b.out, line); err != nil {
 		audit.HandlePluginError("log", err, ev)
 	}
 }


### PR DESCRIPTION
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add json format support for advanced audit in apiserver. Use --audit-log-format=json to emit json to log backend.
```
