### PR TITLE
kubeadm: Make the hostPath volume mount code more secure

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/BUILD
+++ b/cmd/kubeadm/app/phases/controlplane/BUILD
@@ -10,7 +10,10 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["manifests_test.go"],
+    srcs = [
+        "manifests_test.go",
+        "volumes_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
@@ -25,7 +28,10 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["manifests.go"],
+    srcs = [
+        "manifests.go",
+        "volumes.go",
+    ],
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+const (
+	k8sCertsVolumeName   = "k8s-certs"
+	etcdVolumeName       = "etcd"
+	caCertsVolumeName    = "ca-certs"
+	caCertsVolumePath    = "/etc/ssl/certs"
+	caCertsPkiVolumeName = "ca-certs-etc-pki"
+	kubeConfigVolumeName = "kubeconfig"
+)
+
+// caCertsPkiVolumePath specifies the path that can be conditionally mounted into the apiserver and controller-manager containers
+// as /etc/ssl/certs might be a symlink to it. It's a variable since it may be changed in unit testing. This var MUST NOT be changed
+// in normal codepaths during runtime.
+var caCertsPkiVolumePath = "/etc/pki"
+
+// getHostPathVolumesForTheControlPlane gets the required hostPath volumes and mounts for the control plane
+func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) controlPlaneHostPathMounts {
+	mounts := newControlPlaneHostPathMounts()
+
+	// HostPath volumes for the API Server
+	// Read-only mount for the certificates directory
+	// TODO: Always mount the K8s Certificates directory to a static path inside of the container
+	mounts.NewHostPathMount(kubeAPIServer, k8sCertsVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
+	// Read-only mount for the ca certs (/etc/ssl/certs) directory
+	mounts.NewHostPathMount(kubeAPIServer, caCertsVolumeName, caCertsVolumePath, caCertsVolumePath, true)
+
+	// If external etcd is specified, mount the directories needed for accessing the CA/serving certs and the private key
+	if len(cfg.Etcd.Endpoints) != 0 {
+		etcdVols, etcdVolMounts := getEtcdCertVolumes(cfg.Etcd)
+		mounts.AddHostPathMounts(kubeAPIServer, etcdVols, etcdVolMounts)
+	}
+
+	// HostPath volumes for the controller manager
+	// Read-only mount for the certificates directory
+	// TODO: Always mount the K8s Certificates directory to a static path inside of the container
+	mounts.NewHostPathMount(kubeControllerManager, k8sCertsVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
+	// Read-only mount for the ca certs (/etc/ssl/certs) directory
+	mounts.NewHostPathMount(kubeControllerManager, caCertsVolumeName, caCertsVolumePath, caCertsVolumePath, true)
+	// Read-only mount for the controller manager kubeconfig file
+	controllerManagerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
+	mounts.NewHostPathMount(kubeControllerManager, kubeConfigVolumeName, controllerManagerKubeConfigFile, controllerManagerKubeConfigFile, true)
+
+	// HostPath volumes for the scheduler
+	// Read-only mount for the scheduler kubeconfig file
+	schedulerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName)
+	mounts.NewHostPathMount(kubeScheduler, kubeConfigVolumeName, schedulerKubeConfigFile, schedulerKubeConfigFile, true)
+
+	// On some systems were we host-mount /etc/ssl/certs, it is also required to mount /etc/pki. This is needed
+	// due to symlinks pointing from files in /etc/ssl/certs into /etc/pki/
+	if isPkiVolumeMountNeeded() {
+		mounts.NewHostPathMount(kubeAPIServer, caCertsPkiVolumeName, caCertsPkiVolumePath, caCertsPkiVolumePath, true)
+		mounts.NewHostPathMount(kubeControllerManager, caCertsPkiVolumeName, caCertsPkiVolumePath, caCertsPkiVolumePath, true)
+	}
+
+	return mounts
+}
+
+// controlPlaneHostPathMounts is a helper struct for handling all the control plane's hostPath mounts in an easy way
+type controlPlaneHostPathMounts struct {
+	volumes      map[string][]v1.Volume
+	volumeMounts map[string][]v1.VolumeMount
+}
+
+func newControlPlaneHostPathMounts() controlPlaneHostPathMounts {
+	return controlPlaneHostPathMounts{
+		volumes:      map[string][]v1.Volume{},
+		volumeMounts: map[string][]v1.VolumeMount{},
+	}
+}
+
+func (c *controlPlaneHostPathMounts) NewHostPathMount(component, mountName, hostPath, containerPath string, readOnly bool) {
+	c.volumes[component] = append(c.volumes[component], newVolume(mountName, hostPath))
+	c.volumeMounts[component] = append(c.volumeMounts[component], newVolumeMount(mountName, containerPath, readOnly))
+}
+
+func (c *controlPlaneHostPathMounts) AddHostPathMounts(component string, vols []v1.Volume, volMounts []v1.VolumeMount) {
+	c.volumes[component] = append(c.volumes[component], vols...)
+	c.volumeMounts[component] = append(c.volumeMounts[component], volMounts...)
+}
+
+func (c *controlPlaneHostPathMounts) GetVolumes(component string) []v1.Volume {
+	return c.volumes[component]
+}
+
+func (c *controlPlaneHostPathMounts) GetVolumeMounts(component string) []v1.VolumeMount {
+	return c.volumeMounts[component]
+}
+
+// newVolume creates a v1.Volume with a hostPath mount to the specified location
+func newVolume(name, path string) v1.Volume {
+	return v1.Volume{
+		Name: name,
+		VolumeSource: v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{Path: path},
+		},
+	}
+}
+
+// newVolumeMount creates a v1.VolumeMount to the specified location
+func newVolumeMount(name, path string, readOnly bool) v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      name,
+		MountPath: path,
+		ReadOnly:  readOnly,
+	}
+}
+
+// getEtcdCertVolumes returns the volumes/volumemounts needed for talking to an external etcd cluster
+func getEtcdCertVolumes(etcdCfg kubeadmapi.Etcd) ([]v1.Volume, []v1.VolumeMount) {
+	certPaths := []string{etcdCfg.CAFile, etcdCfg.CertFile, etcdCfg.KeyFile}
+	certDirs := sets.NewString()
+	for _, certPath := range certPaths {
+		certDir := filepath.Dir(certPath)
+		// Ignore ".", which is the result of passing an empty path.
+		// Also ignore the cert directories that already may be mounted; /etc/ssl/certs and /etc/pki. If the etcd certs are in there, it's okay, we don't have to do anything
+		if certDir == "." || strings.HasPrefix(certDir, caCertsVolumePath) || strings.HasPrefix(certDir, caCertsPkiVolumePath) {
+			continue
+		}
+		// Filter out any existing hostpath mounts in the list that contains a subset of the path
+		alreadyExists := false
+		for _, existingCertDir := range certDirs.List() {
+			// If the current directory is a parent of an existing one, remove the already existing one
+			if strings.HasPrefix(existingCertDir, certDir) {
+				certDirs.Delete(existingCertDir)
+			} else if strings.HasPrefix(certDir, existingCertDir) {
+				// If an existing directory is a parent of the current one, don't add the current one
+				alreadyExists = true
+			}
+		}
+		if alreadyExists {
+			continue
+		}
+		certDirs.Insert(certDir)
+	}
+
+	volumes := []v1.Volume{}
+	volumeMounts := []v1.VolumeMount{}
+	for i, certDir := range certDirs.List() {
+		name := fmt.Sprintf("etcd-certs-%d", i)
+		volumes = append(volumes, newVolume(name, certDir))
+		volumeMounts = append(volumeMounts, newVolumeMount(name, certDir, true))
+	}
+	return volumes, volumeMounts
+}
+
+// isPkiVolumeMountNeeded specifies whether /etc/pki should be host-mounted into the containers
+// On some systems were we host-mount /etc/ssl/certs, it is also required to mount /etc/pki. This is needed
+// due to symlinks pointing from files in /etc/ssl/certs into /etc/pki/
+func isPkiVolumeMountNeeded() bool {
+	if _, err := os.Stat(caCertsPkiVolumePath); err == nil {
+		return true
+	}
+	return false
+}

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -1,0 +1,534 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controlplane
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+)
+
+func TestNewVolume(t *testing.T) {
+	var tests = []struct {
+		name     string
+		path     string
+		expected v1.Volume
+	}{
+		{
+			name: "foo",
+			path: "/etc/foo",
+			expected: v1.Volume{
+				Name: "foo",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{Path: "/etc/foo"},
+				},
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := newVolume(rt.name, rt.path)
+		if !reflect.DeepEqual(actual, rt.expected) {
+			t.Errorf(
+				"failed newVolume:\n\texpected: %v\n\t  actual: %v",
+				rt.expected,
+				actual,
+			)
+		}
+	}
+}
+
+func TestNewVolumeMount(t *testing.T) {
+	var tests = []struct {
+		name     string
+		path     string
+		ro       bool
+		expected v1.VolumeMount
+	}{
+		{
+			name: "foo",
+			path: "/etc/foo",
+			ro:   false,
+			expected: v1.VolumeMount{
+				Name:      "foo",
+				MountPath: "/etc/foo",
+				ReadOnly:  false,
+			},
+		},
+		{
+			name: "bar",
+			path: "/etc/foo/bar",
+			ro:   true,
+			expected: v1.VolumeMount{
+				Name:      "bar",
+				MountPath: "/etc/foo/bar",
+				ReadOnly:  true,
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := newVolumeMount(rt.name, rt.path, rt.ro)
+		if !reflect.DeepEqual(actual, rt.expected) {
+			t.Errorf(
+				"failed newVolumeMount:\n\texpected: %v\n\t  actual: %v",
+				rt.expected,
+				actual,
+			)
+		}
+	}
+}
+
+func TestGetEtcdCertVolumes(t *testing.T) {
+	var tests = []struct {
+		ca, cert, key string
+		vol           []v1.Volume
+		volMount      []v1.VolumeMount
+	}{
+		{
+			// Should ignore files in /etc/ssl/certs
+			ca:       "/etc/ssl/certs/my-etcd-ca.crt",
+			cert:     "/etc/ssl/certs/my-etcd.crt",
+			key:      "/etc/ssl/certs/my-etcd.key",
+			vol:      []v1.Volume{},
+			volMount: []v1.VolumeMount{},
+		},
+		{
+			// Should ignore files in subdirs of /etc/ssl/certs
+			ca:       "/etc/ssl/certs/etcd/my-etcd-ca.crt",
+			cert:     "/etc/ssl/certs/etcd/my-etcd.crt",
+			key:      "/etc/ssl/certs/etcd/my-etcd.key",
+			vol:      []v1.Volume{},
+			volMount: []v1.VolumeMount{},
+		},
+		{
+			// Should ignore files in /etc/pki
+			ca:       "/etc/pki/my-etcd-ca.crt",
+			cert:     "/etc/pki/my-etcd.crt",
+			key:      "/etc/pki/my-etcd.key",
+			vol:      []v1.Volume{},
+			volMount: []v1.VolumeMount{},
+		},
+		{
+			// All in the same dir
+			ca:   "/var/lib/certs/etcd/my-etcd-ca.crt",
+			cert: "/var/lib/certs/etcd/my-etcd.crt",
+			key:  "/var/lib/certs/etcd/my-etcd.key",
+			vol: []v1.Volume{
+				{
+					Name: "etcd-certs-0",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/certs/etcd"},
+					},
+				},
+			},
+			volMount: []v1.VolumeMount{
+				{
+					Name:      "etcd-certs-0",
+					MountPath: "/var/lib/certs/etcd",
+					ReadOnly:  true,
+				},
+			},
+		},
+		{
+			// One file + two files in separate dirs
+			ca:   "/etc/certs/etcd/my-etcd-ca.crt",
+			cert: "/var/lib/certs/etcd/my-etcd.crt",
+			key:  "/var/lib/certs/etcd/my-etcd.key",
+			vol: []v1.Volume{
+				{
+					Name: "etcd-certs-0",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/etc/certs/etcd"},
+					},
+				},
+				{
+					Name: "etcd-certs-1",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/certs/etcd"},
+					},
+				},
+			},
+			volMount: []v1.VolumeMount{
+				{
+					Name:      "etcd-certs-0",
+					MountPath: "/etc/certs/etcd",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "etcd-certs-1",
+					MountPath: "/var/lib/certs/etcd",
+					ReadOnly:  true,
+				},
+			},
+		},
+		{
+			// All three files in different directories
+			ca:   "/etc/certs/etcd/my-etcd-ca.crt",
+			cert: "/var/lib/certs/etcd/my-etcd.crt",
+			key:  "/var/lib/certs/private/my-etcd.key",
+			vol: []v1.Volume{
+				{
+					Name: "etcd-certs-0",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/etc/certs/etcd"},
+					},
+				},
+				{
+					Name: "etcd-certs-1",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/certs/etcd"},
+					},
+				},
+				{
+					Name: "etcd-certs-2",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/certs/private"},
+					},
+				},
+			},
+			volMount: []v1.VolumeMount{
+				{
+					Name:      "etcd-certs-0",
+					MountPath: "/etc/certs/etcd",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "etcd-certs-1",
+					MountPath: "/var/lib/certs/etcd",
+					ReadOnly:  true,
+				},
+				{
+					Name:      "etcd-certs-2",
+					MountPath: "/var/lib/certs/private",
+					ReadOnly:  true,
+				},
+			},
+		},
+		{
+			// The most top-level dir should be used
+			ca:   "/etc/certs/etcd/my-etcd-ca.crt",
+			cert: "/etc/certs/etcd/serving/my-etcd.crt",
+			key:  "/etc/certs/etcd/serving/my-etcd.key",
+			vol: []v1.Volume{
+				{
+					Name: "etcd-certs-0",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/etc/certs/etcd"},
+					},
+				},
+			},
+			volMount: []v1.VolumeMount{
+				{
+					Name:      "etcd-certs-0",
+					MountPath: "/etc/certs/etcd",
+					ReadOnly:  true,
+				},
+			},
+		},
+		{
+			// The most top-level dir should be used, regardless of order
+			ca:   "/etc/certs/etcd/ca/my-etcd-ca.crt",
+			cert: "/etc/certs/etcd/my-etcd.crt",
+			key:  "/etc/certs/etcd/my-etcd.key",
+			vol: []v1.Volume{
+				{
+					Name: "etcd-certs-0",
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{Path: "/etc/certs/etcd"},
+					},
+				},
+			},
+			volMount: []v1.VolumeMount{
+				{
+					Name:      "etcd-certs-0",
+					MountPath: "/etc/certs/etcd",
+					ReadOnly:  true,
+				},
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actualVol, actualVolMount := getEtcdCertVolumes(kubeadmapi.Etcd{
+			CAFile:   rt.ca,
+			CertFile: rt.cert,
+			KeyFile:  rt.key,
+		})
+		if !reflect.DeepEqual(actualVol, rt.vol) {
+			t.Errorf(
+				"failed getEtcdCertVolumes:\n\texpected: %v\n\t  actual: %v",
+				rt.vol,
+				actualVol,
+			)
+		}
+		if !reflect.DeepEqual(actualVolMount, rt.volMount) {
+			t.Errorf(
+				"failed getEtcdCertVolumes:\n\texpected: %v\n\t  actual: %v",
+				rt.volMount,
+				actualVolMount,
+			)
+		}
+	}
+}
+
+func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
+	var tests = []struct {
+		cfg      *kubeadmapi.MasterConfiguration
+		vol      map[string][]v1.Volume
+		volMount map[string][]v1.VolumeMount
+	}{
+		{
+			// Should ignore files in /etc/ssl/certs
+			cfg: &kubeadmapi.MasterConfiguration{
+				CertificatesDir: testCertsDir,
+				Etcd:            kubeadmapi.Etcd{},
+			},
+			vol: map[string][]v1.Volume{
+				kubeAPIServer: {
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: testCertsDir},
+						},
+					},
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/ssl/certs"},
+						},
+					},
+				},
+				kubeControllerManager: {
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: testCertsDir},
+						},
+					},
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/ssl/certs"},
+						},
+					},
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/controller-manager.conf"},
+						},
+					},
+				},
+				kubeScheduler: {
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/scheduler.conf"},
+						},
+					},
+				},
+			},
+			volMount: map[string][]v1.VolumeMount{
+				kubeAPIServer: {
+					{
+						Name:      "k8s-certs",
+						MountPath: testCertsDir,
+						ReadOnly:  true,
+					},
+					{
+						Name:      "ca-certs",
+						MountPath: "/etc/ssl/certs",
+						ReadOnly:  true,
+					},
+				},
+				kubeControllerManager: {
+					{
+						Name:      "k8s-certs",
+						MountPath: testCertsDir,
+						ReadOnly:  true,
+					},
+					{
+						Name:      "ca-certs",
+						MountPath: "/etc/ssl/certs",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "kubeconfig",
+						MountPath: "/etc/kubernetes/controller-manager.conf",
+						ReadOnly:  true,
+					},
+				},
+				kubeScheduler: {
+					{
+						Name:      "kubeconfig",
+						MountPath: "/etc/kubernetes/scheduler.conf",
+						ReadOnly:  true,
+					},
+				},
+			},
+		},
+		{
+			// Should ignore files in /etc/ssl/certs
+			cfg: &kubeadmapi.MasterConfiguration{
+				CertificatesDir: testCertsDir,
+				Etcd: kubeadmapi.Etcd{
+					Endpoints: []string{"foo"},
+					CAFile:    "/etc/certs/etcd/my-etcd-ca.crt",
+					CertFile:  "/var/lib/certs/etcd/my-etcd.crt",
+					KeyFile:   "/var/lib/certs/etcd/my-etcd.key",
+				},
+			},
+			vol: map[string][]v1.Volume{
+				kubeAPIServer: {
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: testCertsDir},
+						},
+					},
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/ssl/certs"},
+						},
+					},
+					{
+						Name: "etcd-certs-0",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/certs/etcd"},
+						},
+					},
+					{
+						Name: "etcd-certs-1",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/var/lib/certs/etcd"},
+						},
+					},
+				},
+				kubeControllerManager: {
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: testCertsDir},
+						},
+					},
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/ssl/certs"},
+						},
+					},
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/controller-manager.conf"},
+						},
+					},
+				},
+				kubeScheduler: {
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{Path: "/etc/kubernetes/scheduler.conf"},
+						},
+					},
+				},
+			},
+			volMount: map[string][]v1.VolumeMount{
+				kubeAPIServer: {
+					{
+						Name:      "k8s-certs",
+						MountPath: testCertsDir,
+						ReadOnly:  true,
+					},
+					{
+						Name:      "ca-certs",
+						MountPath: "/etc/ssl/certs",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "etcd-certs-0",
+						MountPath: "/etc/certs/etcd",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "etcd-certs-1",
+						MountPath: "/var/lib/certs/etcd",
+						ReadOnly:  true,
+					},
+				},
+				kubeControllerManager: {
+					{
+						Name:      "k8s-certs",
+						MountPath: testCertsDir,
+						ReadOnly:  true,
+					},
+					{
+						Name:      "ca-certs",
+						MountPath: "/etc/ssl/certs",
+						ReadOnly:  true,
+					},
+					{
+						Name:      "kubeconfig",
+						MountPath: "/etc/kubernetes/controller-manager.conf",
+						ReadOnly:  true,
+					},
+				},
+				kubeScheduler: {
+					{
+						Name:      "kubeconfig",
+						MountPath: "/etc/kubernetes/scheduler.conf",
+						ReadOnly:  true,
+					},
+				},
+			},
+		},
+	}
+
+	tmpdir, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Couldn't create tmpdir")
+	}
+	defer os.RemoveAll(tmpdir)
+
+	// set up tmp caCertsPkiVolumePath for testing
+	caCertsPkiVolumePath = fmt.Sprintf("%s/etc/pki", tmpdir)
+	defer func() { caCertsPkiVolumePath = "/etc/pki" }()
+
+	for _, rt := range tests {
+		mounts := getHostPathVolumesForTheControlPlane(rt.cfg)
+		if !reflect.DeepEqual(mounts.volumes, rt.vol) {
+			t.Errorf(
+				"failed getHostPathVolumesForTheControlPlane:\n\texpected: %v\n\t  actual: %v",
+				rt.vol,
+				mounts.volumes,
+			)
+		}
+		if !reflect.DeepEqual(mounts.volumeMounts, rt.volMount) {
+			t.Errorf(
+				"failed getHostPathVolumesForTheControlPlane:\n\texpected: %v\n\t  actual: %v",
+				rt.volMount,
+				mounts.volumeMounts,
+			)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

 - Refactors the hostpath volume mounting code for the Static Pods
 - Splits out the functionality that was in a big function to something testable
 - Unit test a lot
 - Adds support for mounting external etcd CA/cert/key files in an other path than `/etc/ssl/certs`. Before this you **had** to have your files in there or the apiserver would crashloop
 - Significantly improves comment coverage
 - Now only mounts the bare essentials instead of nearly everything. For example, don't mount full `/etc/kubernetes` when the only thing you need is `/etc/kubernetes/scheduler.conf`
 - Make everything but the etcd datadir read-only for components.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes: https://github.com/kubernetes/kubeadm/issues/341

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
cc @kubernetes/sig-cluster-lifecycle-pr-reviews 