### PR TITLE
apimachinery: remove unneeded GetObjectKind() impls

### DIFF
--- a/cmd/libs/go2idl/client-gen/test_apis/testgroup/register.go
+++ b/cmd/libs/go2idl/client-gen/test_apis/testgroup/register.go
@@ -38,6 +38,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion)
 	return nil
 }
-
-func (obj *TestType) GetObjectKind() schema.ObjectKind     { return &obj.TypeMeta }
-func (obj *TestTypeList) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1/register.go
+++ b/cmd/libs/go2idl/client-gen/test_apis/testgroup/v1/register.go
@@ -52,6 +52,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }
-
-func (obj *TestType) GetObjectKind() schema.ObjectKind     { return &obj.TypeMeta }
-func (obj *TestTypeList) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/pkg/api/ref/ref_test.go
+++ b/pkg/api/ref/ref_test.go
@@ -35,8 +35,6 @@ type ExtensionAPIObject struct {
 	metav1.ObjectMeta
 }
 
-func (obj *ExtensionAPIObject) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-
 func TestGetReference(t *testing.T) {
 
 	// when vendoring kube, if you don't force the set of registered versions (like make test does)

--- a/pkg/apis/abac/v0/register.go
+++ b/pkg/apis/abac/v0/register.go
@@ -60,5 +60,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
-
-func (obj *Policy) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/pkg/apis/abac/v1beta1/register.go
+++ b/pkg/apis/abac/v1beta1/register.go
@@ -60,5 +60,3 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 	)
 	return nil
 }
-
-func (obj *Policy) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/pkg/controller/garbagecollector/metaonly/metaonly.go
+++ b/pkg/controller/garbagecollector/metaonly/metaonly.go
@@ -27,9 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-func (obj *MetadataOnlyObject) GetObjectKind() schema.ObjectKind     { return obj }
-func (obj *MetadataOnlyObjectList) GetObjectKind() schema.ObjectKind { return obj }
-
 type metaOnlyJSONScheme struct{}
 
 // This function can be extended to mapping different gvk to different MetadataOnlyObject,

--- a/pkg/kubectl/testing/BUILD
+++ b/pkg/kubectl/testing/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//vendor/github.com/ugorji/go/codec:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/kubectl/testing/types.go
+++ b/pkg/kubectl/testing/types.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type TestStruct struct {
@@ -30,5 +29,3 @@ type TestStruct struct {
 	StringList        []string       `json:"StringList"`
 	IntList           []int          `json:"IntList"`
 }
-
-func (obj *TestStruct) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/register.go
@@ -28,7 +28,7 @@ func (obj *TypeMeta) GroupVersionKind() schema.GroupVersionKind {
 	return schema.FromAPIVersionAndKind(obj.APIVersion, obj.Kind)
 }
 
-func (obj *Unknown) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
+func (obj *TypeMeta) GetObjectKind() schema.ObjectKind { return obj }
 
 // GetObjectKind implements Object for VersionedObjects, returning an empty ObjectKind
 // interface if no objects are provided, or the ObjectKind interface of the object in the

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -441,15 +441,10 @@ func TestAddKnownTypesIdemPotent(t *testing.T) {
 	}
 }
 
-// EmbeddableTypeMeta passes GetObjectKind to the type which embeds it.
-type EmbeddableTypeMeta runtime.TypeMeta
-
-func (tm *EmbeddableTypeMeta) GetObjectKind() schema.ObjectKind { return (*runtime.TypeMeta)(tm) }
-
 // redefine InternalSimple with the same name, but obviously as a different type than in runtimetesting
 type InternalSimple struct {
-	EmbeddableTypeMeta `json:",inline"`
-	TestString         string `json:"testString"`
+	runtime.TypeMeta `json:",inline"`
+	TestString       string `json:"testString"`
 }
 
 func (s *InternalSimple) DeepCopyObject() runtime.Object { return nil }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/types.go
@@ -190,23 +190,5 @@ func (obj *MyWeirdCustomEmbeddedVersionKindField) GroupVersionKind() schema.Grou
 	return schema.FromAPIVersionAndKind(obj.APIVersion, obj.ObjectKind)
 }
 
-func (obj *TestType2) GetObjectKind() schema.ObjectKind            { return schema.EmptyObjectKind }
-func (obj *ExternalTestType2) GetObjectKind() schema.ObjectKind    { return schema.EmptyObjectKind }
-func (obj *InternalComplex) GetObjectKind() schema.ObjectKind      { return &obj.TypeMeta }
-func (obj *ExternalComplex) GetObjectKind() schema.ObjectKind      { return &obj.TypeMeta }
-func (obj *EmbeddedTest) GetObjectKind() schema.ObjectKind         { return &obj.TypeMeta }
-func (obj *EmbeddedTestExternal) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-func (obj *InternalSimple) GetObjectKind() schema.ObjectKind       { return &obj.TypeMeta }
-func (obj *ExternalSimple) GetObjectKind() schema.ObjectKind       { return &obj.TypeMeta }
-func (obj *InternalOptionalExtensionType) GetObjectKind() schema.ObjectKind {
-	return &obj.TypeMeta
-}
-func (obj *ObjectTestExternal) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-func (obj *ObjectTest) GetObjectKind() schema.ObjectKind         { return &obj.TypeMeta }
-func (obj *ExternalOptionalExtensionType) GetObjectKind() schema.ObjectKind {
-	return &obj.TypeMeta
-}
-func (obj *InternalExtensionType) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-func (obj *ExternalExtensionType) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-func (obj *ExtensionA) GetObjectKind() schema.ObjectKind            { return &obj.TypeMeta }
-func (obj *ExtensionB) GetObjectKind() schema.ObjectKind            { return &obj.TypeMeta }
+func (obj *TestType2) GetObjectKind() schema.ObjectKind         { return schema.EmptyObjectKind }
+func (obj *ExternalTestType2) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -64,8 +64,6 @@ type TestPatchSubType struct {
 	StringField string `json:"theField"`
 }
 
-func (obj *testPatchType) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-
 func TestPatchAnonymousField(t *testing.T) {
 	testGV := schema.GroupVersion{Group: "", Version: "v"}
 	scheme.AddKnownTypes(testGV, &testPatchType{})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//vendor/github.com/ugorji/go/codec:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/types.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type Simple struct {
@@ -30,8 +29,6 @@ type Simple struct {
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-func (obj *Simple) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-
 type SimpleRoot struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
@@ -40,8 +37,6 @@ type SimpleRoot struct {
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 }
-
-func (obj *SimpleRoot) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
 
 type SimpleGetOptions struct {
 	metav1.TypeMeta `json:",inline"`
@@ -57,16 +52,12 @@ func (SimpleGetOptions) SwaggerDoc() map[string]string {
 	}
 }
 
-func (obj *SimpleGetOptions) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
-
 type SimpleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,inline"`
 	// +optional
 	Items []Simple `json:"items,omitempty"`
 }
-
-func (obj *SimpleList) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }
 
 // SimpleXGSubresource is a cross group subresource, i.e. the subresource does not belong to the
 // same group as its parent resource.
@@ -76,5 +67,3 @@ type SimpleXGSubresource struct {
 	SubresourceInfo   string            `json:"subresourceInfo,omitempty"`
 	Labels            map[string]string `json:"labels,omitempty"`
 }
-
-func (obj *SimpleXGSubresource) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/storage/testing/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/testing/types.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type TestResource struct {
@@ -26,5 +25,3 @@ type TestResource struct {
 	metav1.ObjectMeta `json:"metadata"`
 	Value             int `json:"value"`
 }
-
-func (obj *TestResource) GetObjectKind() schema.ObjectKind { return &obj.TypeMeta }


### PR DESCRIPTION
Based on https://github.com/kubernetes/kubernetes/pull/48601