### PR TITLE
Fix a typo in the Power arch keyword

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -22,7 +22,7 @@ ENV KUBE_DYNAMIC_CROSSPLATFORMS \
   armhf \
   arm64 \
   s390x \
-  ppc64el
+  ppc64le
 
 ENV KUBE_CROSSPLATFORMS \
   linux/386 \


### PR DESCRIPTION
s/ppc64el/ppc64le/ (note the "el" vs "le")

Signed-off-by: Doug Davis <dug@us.ibm.com>