### PR TITLE
proxy/userspace: honor listen IP address as host IP if given

### DIFF
--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -166,9 +166,15 @@ func NewCustomProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptab
 		return nil, ErrProxyOnLocalhost
 	}
 
-	hostIP, err := utilnet.ChooseHostInterface()
-	if err != nil {
-		return nil, fmt.Errorf("failed to select a host interface: %v", err)
+	// If listenIP is given, assume that is the intended host IP.  Otherwise
+	// try to find a suitable host IP address from network interfaces.
+	var err error
+	hostIP := listenIP
+	if hostIP.Equal(net.IPv4zero) {
+		hostIP, err = utilnet.ChooseHostInterface()
+		if err != nil {
+			return nil, fmt.Errorf("failed to select a host interface: %v", err)
+		}
 	}
 
 	err = setRLimit(64 * 1000)


### PR DESCRIPTION
Allows the proxier to be used on an interface that's not the default route,
otherwise hostIP gets set to the default route interface even if that's
not what the user intended.

If listen IP isn't given, falls back to previous behavior.

```release-note
To allow the userspace proxy to work correctly on multi-interface hosts when using the non-default-route interface, you may now set the `bindAddress` configuration option to an IP address assigned to a network interface.  The proxy will use that IP address for any required NAT operations instead of the IP address of the interface which has the default route.
```

@kubernetes/sig-network-misc @thockin @wojtek-t 