### PR TITLE
Rebalance clients when server is overloaded

### DIFF
--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -47,7 +47,7 @@ func BuildInsecureHandlerChain(apiHandler http.Handler, c *server.Config) http.H
 	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
 	handler = genericfilters.WithPanicRecovery(handler)
 	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.RequestContextMapper, c.LongRunningFunc)
-	handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.RequestContextMapper, c.LongRunningFunc)
+	handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.DisconnectChanceOnMaxRequests, c.RequestContextMapper, c.LongRunningFunc)
 	handler = genericapifilters.WithRequestInfo(handler, server.NewRequestInfoResolver(c), c.RequestContextMapper)
 	handler = apirequest.WithRequestContext(handler, c.RequestContextMapper)
 

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go
@@ -23,14 +23,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/metrics"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
-	"k8s.io/apiserver/pkg/server/httplog"
-
-	"github.com/golang/glog"
 )
 
 // Constant for the retry-after interval on rate limiting.
@@ -109,10 +108,6 @@ func WithMaxInFlightLimit(
 }
 
 func tooManyRequests(req *http.Request, w http.ResponseWriter, disconnectChanceOnMaxRequests float64) {
-	// "Too Many Requests" response is returned before logger is setup for the request.
-	// So we need to explicitly log it here.
-	defer httplog.NewLogged(req, &w).Log()
-
 	if disconnectChanceOnMaxRequests > 0 && rand.Float64() < disconnectChanceOnMaxRequests {
 		w.Header().Set("Connection", "close")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -35,13 +35,14 @@ import (
 type ServerRunOptions struct {
 	AdvertiseAddress net.IP
 
-	CorsAllowedOriginList       []string
-	ExternalHost                string
-	MaxRequestsInFlight         int
-	MaxMutatingRequestsInFlight int
-	MinRequestTimeout           int
-	TargetRAMMB                 int
-	WatchCacheSizes             []string
+	CorsAllowedOriginList         []string
+	ExternalHost                  string
+	MaxRequestsInFlight           int
+	MaxMutatingRequestsInFlight   int
+	DisconnectChanceOnMaxRequests float64
+	MinRequestTimeout             int
+	TargetRAMMB                   int
+	WatchCacheSizes               []string
 }
 
 func NewServerRunOptions() *ServerRunOptions {
@@ -59,6 +60,7 @@ func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.ExternalAddress = s.ExternalHost
 	c.MaxRequestsInFlight = s.MaxRequestsInFlight
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
+	c.DisconnectChanceOnMaxRequests = s.DisconnectChanceOnMaxRequests
 	c.MinRequestTimeout = s.MinRequestTimeout
 	c.PublicAddress = s.AdvertiseAddress
 
@@ -121,6 +123,12 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.MaxMutatingRequestsInFlight, "max-mutating-requests-inflight", s.MaxMutatingRequestsInFlight, ""+
 		"The maximum number of mutating requests in flight at a given time. When the server exceeds this, "+
 		"it rejects requests. Zero for no limit.")
+
+	fs.Float64Var(&s.DisconnectChanceOnMaxRequests, "disconnect-chance-on-max-requests", s.DisconnectChanceOnMaxRequests, ""+
+		"If a request is rejected by either of the inflight request limits, then the server will use this probability to "+
+		"decide whether to disconnect the client. When running multiple servers behind a load balancer this helps load "+
+		"to move from overloaded servers to less busy servers. Set to 0.0 for never disconnect, 1.0 for always disconnect, "+
+		"defaults to 0.0.")
 
 	fs.IntVar(&s.MinRequestTimeout, "min-request-timeout", s.MinRequestTimeout, ""+
 		"An optional field indicating the minimum number of seconds a handler must keep "+


### PR DESCRIPTION
When a Kube or other client receives a 429, it normally waits and then tries again. However, because we have optimized our clients to not reconnect, a flurry of 429s will not disconnect clients and in scenarios where the apiservers are load balanced those clients will not get sent to other nodes.  This means when 3 api servers are sitting behind a load balancer, and one api server is overloaded by nodes or other clients, it will stay overloaded.

This commit adds a configurable probability (`--disconnect-chance-on-max-requests`) for a client that receives a 429 to also have its HTTP1/2 connection closed, forcing it to reconnect. On reconnect, intervening load balancers then have an opportunity to redistribute load to backends. The default is zero (no rebalance), but a reasonable value for most clusters would be 0.01.

Fixes #48610

```release-note
Heavily loaded API servers behind a load balancer may become unbalanced because clients don't reconnect. A new Kube API server flag `--disconnect-chance-on-max-requests` will disconnect clients receiving a 429 with the given probability. For production clusters behind a load balancer, a value of 0.01 should be sufficient to evenly spread load.
```