### PR TITLE
Add organizational unit from client certificate to Kubernetes groups

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -156,9 +156,12 @@ var CommonNameUserConversion = UserConversionFunc(func(chain []*x509.Certificate
 	if len(chain[0].Subject.CommonName) == 0 {
 		return nil, false, nil
 	}
+	groups := make([]string, 0)
+	groups = append(groups, chain[0].Subject.Organization...)
+	groups = append(groups, chain[0].Subject.OrganizationalUnit...)
 	return &user.DefaultInfo{
 		Name:   chain[0].Subject.CommonName,
-		Groups: chain[0].Subject.Organization,
+		Groups: groups,
 	}, true, nil
 })
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -570,7 +570,7 @@ func TestX509(t *testing.T) {
 			User:  CommonNameUserConversion,
 
 			ExpectUserName: "client_cn",
-			ExpectGroups:   []string{"My Org"},
+			ExpectGroups:   []string{"My Org", "My Unit"},
 			ExpectOK:       true,
 			ExpectErr:      false,
 		},


### PR DESCRIPTION
This is a sketch (if this is merged there will also need to be corresponding documentation changes) -- looking for some high-level feedback first.

**What this PR does / why we need it**:

We're using an internal CA to issue client certificates for Kubernetes. Our CA has some different fixed assumptions from Kubernetes about how the `Organization` and `OrganizationalUnit` fields are set, and doesn't allow issuing certs with arbitrary values in the `Organization` field. 

The field that's natural for us to map to a Kubernetes group for us is the OrganizationalUnit, not the Organization.

The choice to map Organization -> Kubernetes group (instead of the OU) seems a bit arbitrary to me (and I can't find any documentation about why it was made), so -- do y'all think it would be reasonable to also include values from the `OU` field in the list of groups the API server recognizes? If not, I'd love to know more about the reasoning behind this mapping so we can figure out a solution that will work for us.
