### PR TITLE
update vendored gengo

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2885,43 +2885,43 @@
 		},
 		{
 			"ImportPath": "k8s.io/gengo/args",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/deepcopy-gen/generators",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/defaulter-gen/generators",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/import-boss/generators",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/generators",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/examples/set-gen/sets",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/generator",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/namer",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/parser",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/gengo/types",
-			"Rev": "c79c13d131b0a8f42d05faa6491c12e94ccc6f30"
+			"Rev": "d3548819d587579f7fc1a18712e13e080acf40a4"
 		},
 		{
 			"ImportPath": "k8s.io/heapster/metrics/api/v1/types",

--- a/federation/apis/federation/zz_generated.deepcopy.go
+++ b/federation/apis/federation/zz_generated.deepcopy.go
@@ -203,7 +203,7 @@ func DeepCopy_federation_ReplicaAllocationPreferences(in interface{}, out interf
 		*out = *in
 		if in.Clusters != nil {
 			in, out := &in.Clusters, &out.Clusters
-			*out = make(map[string]ClusterPreferences)
+			*out = make(map[string]ClusterPreferences, len(*in))
 			for key, val := range *in {
 				newVal := new(ClusterPreferences)
 				if err := DeepCopy_federation_ClusterPreferences(&val, newVal, c); err != nil {

--- a/pkg/api/zz_generated.deepcopy.go
+++ b/pkg/api/zz_generated.deepcopy.go
@@ -449,7 +449,7 @@ func DeepCopy_api_ConfigMap(in interface{}, out interface{}, c *conversion.Clone
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -1142,7 +1142,7 @@ func DeepCopy_api_FlexVolumeSource(in interface{}, out interface{}, c *conversio
 		}
 		if in.Options != nil {
 			in, out := &in.Options, &out.Options
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -1355,35 +1355,35 @@ func DeepCopy_api_LimitRangeItem(in interface{}, out interface{}, c *conversion.
 		*out = *in
 		if in.Max != nil {
 			in, out := &in.Max, &out.Max
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Min != nil {
 			in, out := &in.Min, &out.Min
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Default != nil {
 			in, out := &in.Default, &out.Default
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.DefaultRequest != nil {
 			in, out := &in.DefaultRequest, &out.DefaultRequest
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.MaxLimitRequestRatio != nil {
 			in, out := &in.MaxLimitRequestRatio, &out.MaxLimitRequestRatio
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1715,7 +1715,7 @@ func DeepCopy_api_NodeResources(in interface{}, out interface{}, c *conversion.C
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1804,14 +1804,14 @@ func DeepCopy_api_NodeStatus(in interface{}, out interface{}, c *conversion.Clon
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Allocatable != nil {
 			in, out := &in.Allocatable, &out.Allocatable
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1892,14 +1892,14 @@ func DeepCopy_api_ObjectMeta(in interface{}, out interface{}, c *conversion.Clon
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.Annotations != nil {
 			in, out := &in.Annotations, &out.Annotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -2044,7 +2044,7 @@ func DeepCopy_api_PersistentVolumeClaimStatus(in interface{}, out interface{}, c
 		}
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -2221,7 +2221,7 @@ func DeepCopy_api_PersistentVolumeSpec(in interface{}, out interface{}, c *conve
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -2572,7 +2572,7 @@ func DeepCopy_api_PodSpec(in interface{}, out interface{}, c *conversion.Cloner)
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -2941,7 +2941,7 @@ func DeepCopy_api_ReplicationControllerSpec(in interface{}, out interface{}, c *
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -3035,7 +3035,7 @@ func DeepCopy_api_ResourceQuotaSpec(in interface{}, out interface{}, c *conversi
 		*out = *in
 		if in.Hard != nil {
 			in, out := &in.Hard, &out.Hard
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3057,14 +3057,14 @@ func DeepCopy_api_ResourceQuotaStatus(in interface{}, out interface{}, c *conver
 		*out = *in
 		if in.Hard != nil {
 			in, out := &in.Hard, &out.Hard
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Used != nil {
 			in, out := &in.Used, &out.Used
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3081,14 +3081,14 @@ func DeepCopy_api_ResourceRequirements(in interface{}, out interface{}, c *conve
 		*out = *in
 		if in.Limits != nil {
 			in, out := &in.Limits, &out.Limits
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Requests != nil {
 			in, out := &in.Requests, &out.Requests
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3135,7 +3135,7 @@ func DeepCopy_api_Secret(in interface{}, out interface{}, c *conversion.Cloner) 
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
-			*out = make(map[string][]byte)
+			*out = make(map[string][]byte, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err
@@ -3424,7 +3424,7 @@ func DeepCopy_api_ServiceSpec(in interface{}, out interface{}, c *conversion.Clo
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/pkg/apis/authentication/zz_generated.deepcopy.go
+++ b/pkg/apis/authentication/zz_generated.deepcopy.go
@@ -96,7 +96,7 @@ func DeepCopy_authentication_UserInfo(in interface{}, out interface{}, c *conver
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/pkg/apis/authorization/zz_generated.deepcopy.go
+++ b/pkg/apis/authorization/zz_generated.deepcopy.go
@@ -163,7 +163,7 @@ func DeepCopy_authorization_SubjectAccessReviewSpec(in interface{}, out interfac
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/pkg/apis/certificates/zz_generated.deepcopy.go
+++ b/pkg/apis/certificates/zz_generated.deepcopy.go
@@ -117,7 +117,7 @@ func DeepCopy_certificates_CertificateSigningRequestSpec(in interface{}, out int
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -293,7 +293,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		}
 		if in.NodeLabels != nil {
 			in, out := &in.NodeLabels, &out.NodeLabels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -315,7 +315,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		}
 		if in.ExperimentalQOSReserved != nil {
 			in, out := &in.ExperimentalQOSReserved, &out.ExperimentalQOSReserved
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -342,14 +342,14 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		}
 		if in.SystemReserved != nil {
 			in, out := &in.SystemReserved, &out.SystemReserved
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.KubeReserved != nil {
 			in, out := &in.KubeReserved, &out.KubeReserved
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -232,14 +232,14 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		}
 		if in.NodeLabels != nil {
 			in, out := &in.NodeLabels, &out.NodeLabels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.ExperimentalQOSReserved != nil {
 			in, out := &in.ExperimentalQOSReserved, &out.ExperimentalQOSReserved
-			*out = make(ConfigurationMap)
+			*out = make(ConfigurationMap, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -251,14 +251,14 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		}
 		if in.SystemReserved != nil {
 			in, out := &in.SystemReserved, &out.SystemReserved
-			*out = make(ConfigurationMap)
+			*out = make(ConfigurationMap, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.KubeReserved != nil {
 			in, out := &in.KubeReserved, &out.KubeReserved
-			*out = make(ConfigurationMap)
+			*out = make(ConfigurationMap, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/pkg/apis/extensions/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/zz_generated.deepcopy.go
@@ -328,7 +328,7 @@ func DeepCopy_extensions_DeploymentRollback(in interface{}, out interface{}, c *
 		*out = *in
 		if in.UpdatedAnnotations != nil {
 			in, out := &in.UpdatedAnnotations, &out.UpdatedAnnotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/pkg/apis/imagepolicy/zz_generated.deepcopy.go
+++ b/pkg/apis/imagepolicy/zz_generated.deepcopy.go
@@ -83,7 +83,7 @@ func DeepCopy_imagepolicy_ImageReviewSpec(in interface{}, out interface{}, c *co
 		}
 		if in.Annotations != nil {
 			in, out := &in.Annotations, &out.Annotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/pkg/apis/policy/zz_generated.deepcopy.go
+++ b/pkg/apis/policy/zz_generated.deepcopy.go
@@ -143,7 +143,7 @@ func DeepCopy_policy_PodDisruptionBudgetStatus(in interface{}, out interface{}, 
 		*out = *in
 		if in.DisruptedPods != nil {
 			in, out := &in.DisruptedPods, &out.DisruptedPods
-			*out = make(map[string]v1.Time)
+			*out = make(map[string]v1.Time, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}

--- a/pkg/apis/storage/zz_generated.deepcopy.go
+++ b/pkg/apis/storage/zz_generated.deepcopy.go
@@ -53,7 +53,7 @@ func DeepCopy_storage_StorageClass(in interface{}, out interface{}, c *conversio
 		}
 		if in.Parameters != nil {
 			in, out := &in.Parameters, &out.Parameters
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/apps/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/zz_generated.deepcopy.go
@@ -159,7 +159,7 @@ func DeepCopy_v1beta1_DeploymentRollback(in interface{}, out interface{}, c *con
 		*out = *in
 		if in.UpdatedAnnotations != nil {
 			in, out := &in.UpdatedAnnotations, &out.UpdatedAnnotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -334,7 +334,7 @@ func DeepCopy_v1beta1_ScaleStatus(in interface{}, out interface{}, c *conversion
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/authentication/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authentication/v1/zz_generated.deepcopy.go
@@ -96,7 +96,7 @@ func DeepCopy_v1_UserInfo(in interface{}, out interface{}, c *conversion.Cloner)
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/api/authentication/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/zz_generated.deepcopy.go
@@ -96,7 +96,7 @@ func DeepCopy_v1beta1_UserInfo(in interface{}, out interface{}, c *conversion.Cl
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/api/authorization/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authorization/v1/zz_generated.deepcopy.go
@@ -163,7 +163,7 @@ func DeepCopy_v1_SubjectAccessReviewSpec(in interface{}, out interface{}, c *con
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/api/authorization/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/zz_generated.deepcopy.go
@@ -163,7 +163,7 @@ func DeepCopy_v1beta1_SubjectAccessReviewSpec(in interface{}, out interface{}, c
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/api/certificates/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/zz_generated.deepcopy.go
@@ -117,7 +117,7 @@ func DeepCopy_v1beta1_CertificateSigningRequestSpec(in interface{}, out interfac
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/core/v1/zz_generated.deepcopy.go
@@ -447,7 +447,7 @@ func DeepCopy_v1_ConfigMap(in interface{}, out interface{}, c *conversion.Cloner
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -1140,7 +1140,7 @@ func DeepCopy_v1_FlexVolumeSource(in interface{}, out interface{}, c *conversion
 		}
 		if in.Options != nil {
 			in, out := &in.Options, &out.Options
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -1353,35 +1353,35 @@ func DeepCopy_v1_LimitRangeItem(in interface{}, out interface{}, c *conversion.C
 		*out = *in
 		if in.Max != nil {
 			in, out := &in.Max, &out.Max
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Min != nil {
 			in, out := &in.Min, &out.Min
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Default != nil {
 			in, out := &in.Default, &out.Default
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.DefaultRequest != nil {
 			in, out := &in.DefaultRequest, &out.DefaultRequest
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.MaxLimitRequestRatio != nil {
 			in, out := &in.MaxLimitRequestRatio, &out.MaxLimitRequestRatio
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1697,7 +1697,7 @@ func DeepCopy_v1_NodeResources(in interface{}, out interface{}, c *conversion.Cl
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1786,14 +1786,14 @@ func DeepCopy_v1_NodeStatus(in interface{}, out interface{}, c *conversion.Clone
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Allocatable != nil {
 			in, out := &in.Allocatable, &out.Allocatable
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -1874,14 +1874,14 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.Annotations != nil {
 			in, out := &in.Annotations, &out.Annotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -2026,7 +2026,7 @@ func DeepCopy_v1_PersistentVolumeClaimStatus(in interface{}, out interface{}, c 
 		}
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -2203,7 +2203,7 @@ func DeepCopy_v1_PersistentVolumeSpec(in interface{}, out interface{}, c *conver
 		*out = *in
 		if in.Capacity != nil {
 			in, out := &in.Capacity, &out.Capacity
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -2554,7 +2554,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -2928,7 +2928,7 @@ func DeepCopy_v1_ReplicationControllerSpec(in interface{}, out interface{}, c *c
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -3022,7 +3022,7 @@ func DeepCopy_v1_ResourceQuotaSpec(in interface{}, out interface{}, c *conversio
 		*out = *in
 		if in.Hard != nil {
 			in, out := &in.Hard, &out.Hard
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3044,14 +3044,14 @@ func DeepCopy_v1_ResourceQuotaStatus(in interface{}, out interface{}, c *convers
 		*out = *in
 		if in.Hard != nil {
 			in, out := &in.Hard, &out.Hard
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Used != nil {
 			in, out := &in.Used, &out.Used
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3068,14 +3068,14 @@ func DeepCopy_v1_ResourceRequirements(in interface{}, out interface{}, c *conver
 		*out = *in
 		if in.Limits != nil {
 			in, out := &in.Limits, &out.Limits
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
 		}
 		if in.Requests != nil {
 			in, out := &in.Requests, &out.Requests
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -3122,7 +3122,7 @@ func DeepCopy_v1_Secret(in interface{}, out interface{}, c *conversion.Cloner) e
 		}
 		if in.Data != nil {
 			in, out := &in.Data, &out.Data
-			*out = make(map[string][]byte)
+			*out = make(map[string][]byte, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err
@@ -3133,7 +3133,7 @@ func DeepCopy_v1_Secret(in interface{}, out interface{}, c *conversion.Cloner) e
 		}
 		if in.StringData != nil {
 			in, out := &in.StringData, &out.StringData
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -3418,7 +3418,7 @@ func DeepCopy_v1_ServiceSpec(in interface{}, out interface{}, c *conversion.Clon
 		}
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/zz_generated.deepcopy.go
@@ -329,7 +329,7 @@ func DeepCopy_v1beta1_DeploymentRollback(in interface{}, out interface{}, c *con
 		*out = *in
 		if in.UpdatedAnnotations != nil {
 			in, out := &in.UpdatedAnnotations, &out.UpdatedAnnotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -1060,7 +1060,7 @@ func DeepCopy_v1beta1_ScaleStatus(in interface{}, out interface{}, c *conversion
 		*out = *in
 		if in.Selector != nil {
 			in, out := &in.Selector, &out.Selector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/zz_generated.deepcopy.go
@@ -83,7 +83,7 @@ func DeepCopy_v1alpha1_ImageReviewSpec(in interface{}, out interface{}, c *conve
 		}
 		if in.Annotations != nil {
 			in, out := &in.Annotations, &out.Annotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/policy/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/zz_generated.deepcopy.go
@@ -143,7 +143,7 @@ func DeepCopy_v1beta1_PodDisruptionBudgetStatus(in interface{}, out interface{},
 		*out = *in
 		if in.DisruptedPods != nil {
 			in, out := &in.DisruptedPods, &out.DisruptedPods
-			*out = make(map[string]v1.Time)
+			*out = make(map[string]v1.Time, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}

--- a/staging/src/k8s.io/api/storage/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/storage/v1/zz_generated.deepcopy.go
@@ -53,7 +53,7 @@ func DeepCopy_v1_StorageClass(in interface{}, out interface{}, c *conversion.Clo
 		}
 		if in.Parameters != nil {
 			in, out := &in.Parameters, &out.Parameters
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/api/storage/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/zz_generated.deepcopy.go
@@ -53,7 +53,7 @@ func DeepCopy_v1beta1_StorageClass(in interface{}, out interface{}, c *conversio
 		}
 		if in.Parameters != nil {
 			in, out := &in.Parameters, &out.Parameters
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/zz_generated.deepcopy.go
@@ -358,7 +358,7 @@ func DeepCopy_v1_LabelSelector(in interface{}, out interface{}, c *conversion.Cl
 		*out = *in
 		if in.MatchLabels != nil {
 			in, out := &in.MatchLabels, &out.MatchLabels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -447,14 +447,14 @@ func DeepCopy_v1_ObjectMeta(in interface{}, out interface{}, c *conversion.Clone
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.Annotations != nil {
 			in, out := &in.Annotations, &out.Annotations
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/zz_generated.deepcopy.go
@@ -119,7 +119,7 @@ func DeepCopy_v1_CarpSpec(in interface{}, out interface{}, c *conversion.Cloner)
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/zz_generated.deepcopy.go
@@ -119,7 +119,7 @@ func DeepCopy_testapigroup_CarpSpec(in interface{}, out interface{}, c *conversi
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/testing/zz_generated.deepcopy.go
@@ -54,14 +54,14 @@ func DeepCopy_testing_ExternalTestType1(in interface{}, out interface{}, c *conv
 		*out = *in
 		if in.M != nil {
 			in, out := &in.M, &out.M
-			*out = make(map[string]int)
+			*out = make(map[string]int, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.N != nil {
 			in, out := &in.N, &out.N
-			*out = make(map[string]ExternalTestType2)
+			*out = make(map[string]ExternalTestType2, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -98,14 +98,14 @@ func DeepCopy_testing_TestType1(in interface{}, out interface{}, c *conversion.C
 		*out = *in
 		if in.M != nil {
 			in, out := &in.M, &out.M
-			*out = make(map[string]int)
+			*out = make(map[string]int, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.N != nil {
 			in, out := &in.N, &out.N
-			*out = make(map[string]TestType2)
+			*out = make(map[string]TestType2, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/zz_generated.deepcopy.go
@@ -187,14 +187,14 @@ func DeepCopy_testing_ExternalTestType1(in interface{}, out interface{}, c *conv
 		*out = *in
 		if in.M != nil {
 			in, out := &in.M, &out.M
-			*out = make(map[string]int)
+			*out = make(map[string]int, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.N != nil {
 			in, out := &in.N, &out.N
-			*out = make(map[string]ExternalTestType2)
+			*out = make(map[string]ExternalTestType2, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -329,14 +329,14 @@ func DeepCopy_testing_TestType1(in interface{}, out interface{}, c *conversion.C
 		*out = *in
 		if in.M != nil {
 			in, out := &in.M, &out.M
-			*out = make(map[string]int)
+			*out = make(map[string]int, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
 		}
 		if in.N != nil {
 			in, out := &in.N, &out.N
-			*out = make(map[string]TestType2)
+			*out = make(map[string]TestType2, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/zz_generated.deepcopy.go
@@ -256,7 +256,7 @@ func DeepCopy_audit_UserInfo(in interface{}, out interface{}, c *conversion.Clon
 		}
 		if in.Extra != nil {
 			in, out := &in.Extra, &out.Extra
-			*out = make(map[string]ExtraValue)
+			*out = make(map[string]ExtraValue, len(*in))
 			for key, val := range *in {
 				if newVal, err := c.DeepCopy(&val); err != nil {
 					return err

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/zz_generated.deepcopy.go
@@ -119,7 +119,7 @@ func DeepCopy_v1_PodSpec(in interface{}, out interface{}, c *conversion.Cloner) 
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/zz_generated.deepcopy.go
@@ -119,7 +119,7 @@ func DeepCopy_example_PodSpec(in interface{}, out interface{}, c *conversion.Clo
 		}
 		if in.NodeSelector != nil {
 			in, out := &in.NodeSelector, &out.NodeSelector
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/testing/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/testing/zz_generated.deepcopy.go
@@ -50,7 +50,7 @@ func DeepCopy_testing_Simple(in interface{}, out interface{}, c *conversion.Clon
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -103,7 +103,7 @@ func DeepCopy_testing_SimpleRoot(in interface{}, out interface{}, c *conversion.
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}
@@ -125,7 +125,7 @@ func DeepCopy_testing_SimpleXGSubresource(in interface{}, out interface{}, c *co
 		}
 		if in.Labels != nil {
 			in, out := &in.Labels, &out.Labels
-			*out = make(map[string]string)
+			*out = make(map[string]string, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val
 			}

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/zz_generated.deepcopy.go
@@ -52,7 +52,7 @@ func DeepCopy_v1alpha1_ContainerMetrics(in interface{}, out interface{}, c *conv
 		*out = *in
 		if in.Usage != nil {
 			in, out := &in.Usage, &out.Usage
-			*out = make(v1.ResourceList)
+			*out = make(v1.ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -75,7 +75,7 @@ func DeepCopy_v1alpha1_NodeMetrics(in interface{}, out interface{}, c *conversio
 		out.Timestamp = in.Timestamp.DeepCopy()
 		if in.Usage != nil {
 			in, out := &in.Usage, &out.Usage
-			*out = make(v1.ResourceList)
+			*out = make(v1.ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/zz_generated.deepcopy.go
@@ -51,7 +51,7 @@ func DeepCopy_metrics_ContainerMetrics(in interface{}, out interface{}, c *conve
 		*out = *in
 		if in.Usage != nil {
 			in, out := &in.Usage, &out.Usage
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}
@@ -74,7 +74,7 @@ func DeepCopy_metrics_NodeMetrics(in interface{}, out interface{}, c *conversion
 		out.Timestamp = in.Timestamp.DeepCopy()
 		if in.Usage != nil {
 			in, out := &in.Usage, &out.Usage
-			*out = make(ResourceList)
+			*out = make(ResourceList, len(*in))
 			for key, val := range *in {
 				(*out)[key] = val.DeepCopy()
 			}

--- a/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
+++ b/vendor/k8s.io/gengo/examples/deepcopy-gen/generators/deepcopy.go
@@ -498,7 +498,7 @@ func (g *genDeepCopy) doBuiltin(t *types.Type, sw *generator.SnippetWriter) {
 }
 
 func (g *genDeepCopy) doMap(t *types.Type, sw *generator.SnippetWriter) {
-	sw.Do("*out = make($.|raw$)\n", t)
+	sw.Do("*out = make($.|raw$, len(*in))\n", t)
 	if t.Key.IsAssignable() {
 		switch {
 		case hasDeepCopyMethod(t.Elem):


### PR DESCRIPTION
Need to fix defaulter-gen for https://github.com/kubernetes/kubernetes/pull/47263.
To pull in changes from https://github.com/kubernetes/gengo/pull/61.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @sttts 