### PR TITLE
kubelet client config has timeout

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -800,6 +800,8 @@ func CreateAPIServerClientConfig(s *options.KubeletServer) (*restclient.Config, 
 	// Override kubeconfig qps/burst settings from flags
 	clientConfig.QPS = float32(s.KubeAPIQPS)
 	clientConfig.Burst = int(s.KubeAPIBurst)
+	// TODO: soak this for now, probably should be a flag
+	clientConfig.Timeout = 60 * time.Second
 
 	addChaosToClientConfig(s, clientConfig)
 	return clientConfig, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Enforces a timeout on kubelet -> master operations client-side.

**Which issue this PR fixes**
Fixes https://github.com/kubernetes/kubernetes/issues/48638

**Special notes for your reviewer**:
we should probably have a flag for this.

**Release note**:
```release-note
kubelet to master communication has a client-side timeout
```
