### PR TITLE
GCE: Default network project to the compute project

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -188,8 +188,9 @@ func newGCECloud(config io.Reader) (*GCECloud, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Default networkProjectID to known network project number
-	networkProjectID := networkProjectNumber
+	// Default networkProjectID to projectNumber
+	// TODO: This should default to networkProjectNumber. See kubernetes/kubernetes/issues/48521
+	networkProjectID := projectNumber
 
 	networkURL := gceNetworkURL(apiEndpoint, networkProjectNumber, networkName)
 	subnetworkURL := ""


### PR DESCRIPTION
Fixes #48521

GKE currently does not set the `NETWORK_PROJECT_ID` environment variable, which means the master's network is used by default. This PR should be rolled back once this environment variable is plumbed through.

**Release note**:
```release-note
NONE
```