### PR TITLE
Fix godep verify to use godep restore script

### DIFF
--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -48,7 +48,8 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 readonly branch=${1:-${KUBE_VERIFY_GIT_BRANCH:-master}}
 if ! [[ ${KUBE_FORCE_VERIFY_CHECKS:-} =~ ^[yY]$ ]] && \
   ! kube::util::has_changes_against_upstream_branch "${branch}" 'Godeps/' && \
-  ! kube::util::has_changes_against_upstream_branch "${branch}" 'vendor/'; then
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'vendor/' && \
+  ! kube::util::has_changes_against_upstream_branch "${branch}" 'hack/'; then
   exit 0
 fi
 

--- a/hack/verify-godeps.sh
+++ b/hack/verify-godeps.sh
@@ -86,13 +86,8 @@ _kubetmp="${_kubetmp}/kubernetes"
 export GOPATH="${_tmpdir}"
 
 pushd "${_kubetmp}" 2>&1 > /dev/null
-  kube::util::ensure_godep_version v79
-
-  export GOPATH="${GOPATH}:${_kubetmp}/staging"
-  # Fill out that nice clean place with the kube godeps
-  echo "Starting to download all kubernetes godeps. This takes a while"
-  godep restore
-  echo "Download finished"
+  # Restore the Godeps into our temp directory
+  hack/godep-restore.sh
 
   # Destroy deps in the copy of the kube tree
   rm -rf ./Godeps ./vendor


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
A bug was introduced in #48615. `hack/verify-godeps.sh` only downloads and compares if godeps have changed, so it wasn't caught on the original PR. However, when it does run (e.g. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/48630/pull-kubernetes-verify/38350/) it fails because the godep-save script now doesn't permit a compex GOPATH. verify-godeps.sh actually sets one because it restores godeps not using the `hack/godep-restore.sh` script.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @sttts
/priority failing-test