### PR TITLE
remove extra WriteHeader function

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -109,9 +109,6 @@ func WriteObjectNegotiated(ctx request.Context, s runtime.NegotiatedSerializer, 
 		audit.LogResponseObject(ae, object, gv, s)
 	}
 
-	w.Header().Set("Content-Type", serializer.MediaType)
-	w.WriteHeader(statusCode)
-
 	encoder := s.EncoderForVersion(serializer.Serializer, gv)
 	SerializeObject(serializer.MediaType, encoder, w, req, statusCode, object)
 }


### PR DESCRIPTION
The deleted two functions will be called later in the function
SerializeObject(). Not necessary to call them twice.

**Release note**:
```
NONE
```
