### PR TITLE
Add missing short names to kubectl help text

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -242,8 +242,8 @@ __custom_func() {
     * secrets
     * serviceaccounts (aka 'sa')
     * services (aka 'svc')
-    * statefulsets
-    * storageclasses
+    * statefulsets (aka 'sts')
+    * storageclasses (aka 'sc')
 
 `
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds two short names that exist but are not listed in the help text that `kubectl get` produces.

**Special notes for your reviewer**:
🍰 

**Release note**:
```release-note
NONE
```