### PR TITLE
fix subpath error when mouting configmap volume

### DIFF
--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -237,8 +237,9 @@ func TestMakePayload(t *testing.T) {
 		},
 	}
 
+	podSpec := v1.PodSpec{}
 	for _, tc := range cases {
-		actualPayload, err := MakePayload(tc.mappings, tc.configMap, &tc.mode, tc.optional)
+		actualPayload, err := MakePayload(tc.mappings, tc.configMap, &tc.mode, tc.optional, "", podSpec)
 		if err != nil && tc.success {
 			t.Errorf("%v: unexpected failure making payload: %v", tc.name, err)
 			continue

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -274,7 +274,7 @@ func (s *projectedVolumeMounter) collectData() (map[string]volumeutil.FileProjec
 					},
 				}
 			}
-			configMapPayload, err := configmap.MakePayload(source.ConfigMap.Items, configMap, s.source.DefaultMode, optional)
+			configMapPayload, err := configmap.MakePayload(source.ConfigMap.Items, configMap, s.source.DefaultMode, optional, s.volName, s.pod.Spec)
 			if err != nil {
 				glog.Errorf("Couldn't get configMap payload %v/%v: %v", s.pod.Namespace, source.ConfigMap.Name, err)
 				errlist = append(errlist, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Configmap Volume can't mount **subpath** using symlink (or relative path).

**Which issue this PR fixes** : fixes #48656 

**Special notes for your reviewer**:

/cc @thockin @brendandburns @derekwaynecarr @rootfs @jingxu97

This bug will also exist in `secret` and `downwardapi`, shall I submit another PRs respectively or fix them all in this PR?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix subpath error when mouting configmap volume
```
