### PR TITLE
use built-in path separator instead of hard coded

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -311,11 +311,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection) (sets.St
 		}
 
 		relativePath := strings.TrimPrefix(path, w.targetDir)
-		if runtime.GOOS == "windows" {
-			relativePath = strings.TrimPrefix(relativePath, "\\")
-		} else {
-			relativePath = strings.TrimPrefix(relativePath, "/")
-		}
+		relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
 		if strings.HasPrefix(relativePath, "..") {
 			return nil
 		}
@@ -339,7 +335,7 @@ func (w *AtomicWriter) pathsToRemove(payload map[string]FileProjection) (sets.St
 		for subPath := file; subPath != ""; {
 			newPaths.Insert(subPath)
 			subPath, _ = filepath.Split(subPath)
-			subPath = strings.TrimSuffix(subPath, "/")
+			subPath = strings.TrimSuffix(subPath, string(os.PathSeparator))
 		}
 	}
 	glog.V(5).Infof("%s: new paths:       %+v", w.targetDir, newPaths.List())
@@ -424,7 +420,7 @@ func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection)
 			// Since filepath.Split leaves a trailing path separator, in this
 			// example, dir = "foo/".  In order to calculate the number of
 			// subdirectories, we must subtract 1 from the number returned by split.
-			subDirs = len(strings.Split(dir, "/")) - 1
+			subDirs = len(strings.Split(dir, string(os.PathSeparator))) - 1
 			err := os.MkdirAll(path.Join(w.targetDir, dir), os.ModePerm)
 			if err != nil {
 				return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

We should use built-in path separator to avoid hard coded strings.

**Which issue this PR fixes** :

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
