### PR TITLE
remove redundant whitespace in atomic_writer

### DIFF
--- a/pkg/volume/util/atomic_writer.go
+++ b/pkg/volume/util/atomic_writer.go
@@ -47,9 +47,9 @@ const (
 //    by the caller.
 //
 // The visible files in this volume are symlinks to files in the writer's data
-// directory.  Actual files are stored in a hidden timestamped directory which
+// directory. Actual files are stored in a hidden timestamped directory which
 // is symlinked to by the data directory. The timestamped directory and
-// data directory symlink are created in the writer's target dir.  This scheme
+// data directory symlink are created in the writer's target dir. This scheme
 // allows the files to be atomically updated by changing the target of the
 // data directory symlink.
 //
@@ -83,7 +83,7 @@ const (
 )
 
 // Write does an atomic projection of the given payload into the writer's target
-// directory.  Input paths must not begin with '..'.
+// directory. Input paths must not begin with '..'.
 //
 // The Write algorithm is:
 //
@@ -215,7 +215,7 @@ func (w *AtomicWriter) Write(payload map[string]FileProjection) error {
 	return nil
 }
 
-// validatePayload returns an error if any path in the payload  returns a copy of the payload with the paths cleaned.
+// validatePayload returns an error if any path in the payload returns a copy of the payload with the paths cleaned.
 func validatePayload(payload map[string]FileProjection) (map[string]FileProjection, error) {
 	cleanPayload := make(map[string]FileProjection)
 	for k, content := range payload {
@@ -230,7 +230,7 @@ func validatePayload(payload map[string]FileProjection) (map[string]FileProjecti
 }
 
 // validatePath validates a single path, returning an error if the path is
-// invalid.  paths may not:
+// invalid. Paths may not:
 //
 // 1. be absolute
 // 2. contain '..' as an element
@@ -359,7 +359,7 @@ func (w *AtomicWriter) newTimestampDir() (string, error) {
 	}
 
 	// 0755 permissions are needed to allow 'group' and 'other' to recurse the
-	// directory tree.  do a chmod here to ensure that permissions are set correctly
+	// directory tree. Do a chmod here to ensure that permissions are set correctly
 	// regardless of the process' umask.
 	err = os.Chmod(tsDir, 0755)
 	if err != nil {
@@ -370,7 +370,7 @@ func (w *AtomicWriter) newTimestampDir() (string, error) {
 	return tsDir, nil
 }
 
-// writePayloadToDir writes the given payload to the given directory.  The
+// writePayloadToDir writes the given payload to the given directory. The
 // directory must exist.
 func (w *AtomicWriter) writePayloadToDir(payload map[string]FileProjection, dir string) error {
 	for userVisiblePath, fileProjection := range payload {
@@ -422,7 +422,7 @@ func (w *AtomicWriter) createUserVisibleFiles(payload map[string]FileProjection)
 			// If dir is not empty, the projection path contains at least one
 			// subdirectory (example: userVisiblePath := "foo/bar").
 			// Since filepath.Split leaves a trailing path separator, in this
-			// example, dir = "foo/".  In order to calculate the number of
+			// example, dir = "foo/". In order to calculate the number of
 			// subdirectories, we must subtract 1 from the number returned by split.
 			subDirs = len(strings.Split(dir, "/")) - 1
 			err := os.MkdirAll(path.Join(w.targetDir, dir), os.ModePerm)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

remove redundant whitespace in atomic_writer.go

**Which issue this PR fixes** : 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
