### PR TITLE
Add new option "env-from" for `kubectl run` command.

### DIFF
--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -50,6 +50,7 @@ func (DeploymentV1Beta1) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"serviceaccount", false},
@@ -63,6 +64,11 @@ func (DeploymentV1Beta1) Generate(genericParams map[string]interface{}) (runtime
 	}
 
 	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envFroms, err := getEnvFroms(genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +99,7 @@ func (DeploymentV1Beta1) Generate(genericParams map[string]interface{}) (runtime
 	}
 
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, podSpec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, podSpec); err != nil {
 		return nil, err
 	}
 
@@ -140,6 +146,7 @@ func (DeploymentAppsV1Beta1) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"serviceaccount", false},
@@ -153,6 +160,11 @@ func (DeploymentAppsV1Beta1) Generate(genericParams map[string]interface{}) (run
 	}
 
 	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envFroms, err := getEnvFroms(genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +195,7 @@ func (DeploymentAppsV1Beta1) Generate(genericParams map[string]interface{}) (run
 	}
 
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, podSpec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, podSpec); err != nil {
 		return nil, err
 	}
 
@@ -288,6 +300,25 @@ func getEnvs(genericParams map[string]interface{}) ([]v1.EnvVar, error) {
 	return envs, nil
 }
 
+// getEnvFroms returns EnvFrom variables.
+func getEnvFroms(genericParams map[string]interface{}) ([]v1.EnvFromSource, error) {
+	var envFroms []v1.EnvFromSource
+	envFromStrings, found := genericParams["env-from"]
+	if found {
+		if envFromStringArray, isArray := envFromStrings.([]string); isArray {
+			var err error
+			envFroms, err = parseEnvFroms(envFromStringArray)
+			if err != nil {
+				return nil, err
+			}
+			delete(genericParams, "env-from")
+		} else {
+			return nil, fmt.Errorf("expected []string, found: %T", envFromStrings)
+		}
+	}
+	return envFroms, nil
+}
+
 type JobV1 struct{}
 
 func (JobV1) ParamNames() []GeneratorParam {
@@ -305,6 +336,7 @@ func (JobV1) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"restart", false},
@@ -319,6 +351,11 @@ func (JobV1) Generate(genericParams map[string]interface{}) (runtime.Object, err
 	}
 
 	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envFroms, err := getEnvFroms(genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +381,7 @@ func (JobV1) Generate(genericParams map[string]interface{}) (runtime.Object, err
 	}
 
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, podSpec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, podSpec); err != nil {
 		return nil, err
 	}
 
@@ -399,6 +436,7 @@ func (CronJobV2Alpha1) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"restart", false},
@@ -414,6 +452,11 @@ func (CronJobV2Alpha1) Generate(genericParams map[string]interface{}) (runtime.O
 	}
 
 	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envFroms, err := getEnvFroms(genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +482,7 @@ func (CronJobV2Alpha1) Generate(genericParams map[string]interface{}) (runtime.O
 	}
 
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, podSpec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, podSpec); err != nil {
 		return nil, err
 	}
 
@@ -500,6 +543,7 @@ func (BasicReplicationController) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"serviceaccount", false},
@@ -633,6 +677,11 @@ func (BasicReplicationController) Generate(genericParams map[string]interface{})
 		return nil, err
 	}
 
+	envFroms, err := getEnvFroms(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
 	params, err := getParams(genericParams)
 	if err != nil {
 		return nil, err
@@ -659,7 +708,7 @@ func (BasicReplicationController) Generate(genericParams map[string]interface{})
 	}
 
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, podSpec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, podSpec); err != nil {
 		return nil, err
 	}
 
@@ -688,7 +737,7 @@ func (BasicReplicationController) Generate(genericParams map[string]interface{})
 }
 
 // updatePodContainers updates PodSpec.Containers with passed parameters.
-func updatePodContainers(params map[string]string, args []string, envs []v1.EnvVar, imagePullPolicy v1.PullPolicy, podSpec *v1.PodSpec) error {
+func updatePodContainers(params map[string]string, args []string, envs []v1.EnvVar, envFroms []v1.EnvFromSource, imagePullPolicy v1.PullPolicy, podSpec *v1.PodSpec) error {
 	if len(args) > 0 {
 		command, err := GetBool(params, "command", false)
 		if err != nil {
@@ -703,6 +752,10 @@ func updatePodContainers(params map[string]string, args []string, envs []v1.EnvV
 
 	if len(envs) > 0 {
 		podSpec.Containers[0].Env = envs
+	}
+
+	if len(envFroms) > 0 {
+		podSpec.Containers[0].EnvFrom = envFroms
 	}
 
 	if len(imagePullPolicy) > 0 {
@@ -765,6 +818,7 @@ func (BasicPod) ParamNames() []GeneratorParam {
 		{"command", false},
 		{"args", false},
 		{"env", false},
+		{"env-from", false},
 		{"requests", false},
 		{"limits", false},
 		{"serviceaccount", false},
@@ -778,6 +832,11 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 	}
 
 	envs, err := getEnvs(genericParams)
+	if err != nil {
+		return nil, err
+	}
+
+	envFroms, err := getEnvFroms(genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +904,7 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 		},
 	}
 	imagePullPolicy := v1.PullPolicy(params["image-pull-policy"])
-	if err = updatePodContainers(params, args, envs, imagePullPolicy, &pod.Spec); err != nil {
+	if err = updatePodContainers(params, args, envs, envFroms, imagePullPolicy, &pod.Spec); err != nil {
 		return nil, err
 	}
 
@@ -875,4 +934,45 @@ func parseEnvs(envArray []string) ([]v1.EnvVar, error) {
 		envs = append(envs, envVar)
 	}
 	return envs, nil
+}
+
+// parseEnvFroms converts string into EnvFromSource objects.
+func parseEnvFroms(envFromArray []string) ([]v1.EnvFromSource, error) {
+	envFroms := make([]v1.EnvFromSource, 0, len(envFromArray))
+	for _, envFromString := range envFromArray {
+		pos := strings.Index(envFromString, "=")
+		if pos == -1 {
+			return nil, fmt.Errorf("invalid env-from: %v", envFromString)
+		}
+		refType := envFromString[:pos]
+		name := envFromString[pos+1:]
+		if len(refType) == 0 || len(name) == 0 {
+			return nil, fmt.Errorf("invalid env-from: %v", envFromString)
+		}
+
+		var envFrom v1.EnvFromSource
+		switch refType {
+		case "ConfigMapRef":
+			envFrom = v1.EnvFromSource{
+				ConfigMapRef: &v1.ConfigMapEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: name,
+					},
+				},
+			}
+		case "SecretRef":
+			envFrom = v1.EnvFromSource{
+				SecretRef: &v1.SecretEnvSource{
+					LocalObjectReference: v1.LocalObjectReference{
+						Name: name,
+					},
+				},
+			}
+		default:
+			return nil, fmt.Errorf("env-from can only be 'ConfigMapRef' or 'SecretRef': %v", envFrom)
+		}
+
+		envFroms = append(envFroms, envFrom)
+	}
+	return envFroms, nil
 }


### PR DESCRIPTION
Propose to add new option "env-from" for `kubectl run` command so that user
can config ConfigMap or Secret env variables from run command.

Fixed #48361 

**Release note**:
```
None
```
