### PR TITLE
Allow to override build date

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -130,7 +130,9 @@ kube::version::ldflag() {
 kube::version::ldflags() {
   kube::version::get_version_vars
 
-  local -a ldflags=($(kube::version::ldflag "buildDate" "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"))
+  local buildDate=
+  [[ -z ${SOURCE_DATE_EPOCH-} ]] || buildDate="--date=@${SOURCE_DATE_EPOCH}"
+  local -a ldflags=($(kube::version::ldflag "buildDate" "$(date ${buildDate} -u +'%Y-%m-%dT%H:%M:%SZ')"))
   if [[ -n ${KUBE_GIT_COMMIT-} ]]; then
     ldflags+=($(kube::version::ldflag "gitCommit" "${KUBE_GIT_COMMIT}"))
     ldflags+=($(kube::version::ldflag "gitTreeState" "${KUBE_GIT_TREE_STATE}"))


### PR DESCRIPTION
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Background: issue #48710
when trying to build the kubernetes package
for the openSUSE Linux distribution
```
/usr/bin/hyperkube
/usr/bin/kubeadm
/usr/src/kubernetes/platforms/linux/amd64/e2e.test
```
had a date+time string embedded in them in the format
2018-08-15T19:08:34Z

which meant that each build produced new binaries
even when nothing actually changed.
Those then had to be synced to mirrors, wasting their and our users' bandwidth.