### PR TITLE
Bump event-exporter version

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
       # TODO: Add resources in 1.8
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.0-r2
+        image: gcr.io/google-containers/event-exporter:v0.1.4
         command:
         - '/event-exporter'
       - name: prometheus-to-sd-exporter


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/47914

```release-note
Reduce amount of noise in Stackdriver Logging, generated by the event-exporter component in the fluentd-gcp addon.
```