### PR TITLE
Automated cherry pick of #48712

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -46,7 +46,7 @@ spec:
       containers:
       # TODO: Add resources in 1.8
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.0-r2
+        image: gcr.io/google-containers/event-exporter:v0.1.4
         command:
         - '/event-exporter'
       - name: prometheus-to-sd-exporter


### PR DESCRIPTION
Cherry pick of #48712 on release-1.7.

#48712: Bump event-exporter version

```release-note
Reduce amount of noise in Stackdriver Logging, generated by the event-exporter component in the fluentd-gcp addon.
```