### PR TITLE
Add e2e tests for kubectl core reapers

### DIFF
--- a/test/e2e/testing-manifests/kubectl/nginx-daemonset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-daemonset.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: nginx-daemonset
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google_containers/nginx-slim:0.8
+        ports:
+        - containerPort: 80

--- a/test/e2e/testing-manifests/kubectl/nginx-daemonset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-daemonset.yaml
@@ -2,11 +2,16 @@ apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: nginx-daemonset
+  labels:
+    run: nginx-daemonset
 spec:
+  selector: # is this needed?
+    matchLabels:
+       run: nginx-daemonset
   template:
     metadata:
       labels:
-        app: nginx
+        run: nginx-daemonset
     spec:
       containers:
       - name: nginx

--- a/test/e2e/testing-manifests/kubectl/nginx-replicaset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-replicaset.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: ReplicaSet
+metadata:
+  name: nginx-replicaset
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google_containers/nginx-slim:0.8
+        ports:
+        - containerPort: 80

--- a/test/e2e/testing-manifests/kubectl/nginx-replicaset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-replicaset.yaml
@@ -2,11 +2,13 @@ apiVersion: extensions/v1beta1
 kind: ReplicaSet
 metadata:
   name: nginx-replicaset
+  labels:
+    run: nginx-replicaset
 spec:
   template:
     metadata:
       labels:
-        app: nginx
+        run: nginx-replicaset
     spec:
       containers:
       - name: nginx

--- a/test/e2e/testing-manifests/kubectl/nginx-statefulset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-statefulset.yaml
@@ -1,12 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-statefulset
+  labels:
+    run: nginx-statefulset
+spec:
+  ports:
+  - port: 80
+    name: web
+  clusterIP: None
+  selector:
+    run: nginx-statefulset
+---
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
   name: nginx-statefulset
+  labels:
+    run: nginx-statefulset
 spec:
+  serviceName: "nginx"
   template:
     metadata:
       labels:
-        app: nginx
+        run: nginx-statefulset
     spec:
       terminationGracePeriodSeconds: 10
       containers:

--- a/test/e2e/testing-manifests/kubectl/nginx-statefulset.yaml
+++ b/test/e2e/testing-manifests/kubectl/nginx-statefulset.yaml
@@ -1,0 +1,30 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: nginx-statefulset
+spec:
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: nginx
+        image: gcr.io/google_containers/nginx-slim:0.8
+        ports:
+        - containerPort: 80
+          name: web
+        volumeMounts:
+        - name: www
+          mountPath: /usr/share/nginx/html
+  volumeClaimTemplates:
+  - metadata:
+      name: www
+      annotations:
+        volume.beta.kubernetes.io/storage-class: anything
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR adds a kubectl reaper version skew test for v1.6 kubectl and v1.5 cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43324

**Special notes for your reviewer**: This is my first time working on a skew test PR. I may be working at the wrong direction. Feel free to provide _high level_ feedback if so. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
