### PR TITLE
Fix hardcode errormsg for downstream to use

### DIFF
--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -66,7 +66,7 @@ const (
 	// how many times we can retry before back off
 	triesBeforeBackOff = 1
 
-	warningNoLastAppliedConfigAnnotation = "Warning: kubectl apply should be used on resource created by either kubectl create --save-config or kubectl apply\n"
+	warningNoLastAppliedConfigAnnotation = "Warning: %[1]s apply should be used on resource created by either %[1]s create --save-config or %[1]s apply\n"
 )
 
 var (
@@ -299,7 +299,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 				return err
 			}
 			if _, ok := annotationMap[api.LastAppliedConfigAnnotation]; !ok {
-				fmt.Fprintf(errOut, warningNoLastAppliedConfigAnnotation)
+				fmt.Fprintf(errOut, fmt.Sprintf(warningNoLastAppliedConfigAnnotation, cmd.Root().Name()))
 			}
 			overwrite := cmdutil.GetFlagBool(cmd, "overwrite")
 			helper := resource.NewHelper(info.Client, info.Mapping)

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -384,7 +384,7 @@ func TestApplyObjectWithoutAnnotation(t *testing.T) {
 
 	// uses the name from the file, not the response
 	expectRC := "replicationcontroller/" + nameRC + "\n"
-	expectWarning := warningNoLastAppliedConfigAnnotation
+	expectWarning := fmt.Sprintf(warningNoLastAppliedConfigAnnotation, cmd.Root().Name())
 	if errBuf.String() != expectWarning {
 		t.Fatalf("unexpected non-warning: %s\nexpected: %s", errBuf.String(), expectWarning)
 	}


### PR DESCRIPTION
In openshift/origin, we reuse lot of kubectl command and overwrite it's name from kubectl to oc using a wrapper [here](https://github.com/openshift/origin/blob/0787e5b5ee596b4590d2f9bf867e369db3f2ff27/pkg/cmd/cli/cmd/wrappers.go) mostly, but there's an hard coded err msg in `kubectl apply` will cause a bug in openshift, see bug here: https://bugzilla.redhat.com/show_bug.cgi?id=1455083

This pr change that hard-coded error msg to more flexible way to prompt error message, which could let downstream to reuse the code and prompt it's own command name with error message