### PR TITLE
Support podAffinity on podPresets

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2086,7 +2086,7 @@ func validateImagePullSecrets(imagePullSecrets []api.LocalObjectReference, fldPa
 }
 
 // validateAffinity checks if given affinities are valid
-func validateAffinity(affinity *api.Affinity, fldPath *field.Path) field.ErrorList {
+func ValidateAffinity(affinity *api.Affinity, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if affinity != nil {
@@ -2265,7 +2265,7 @@ func ValidatePodSpec(spec *api.PodSpec, fldPath *field.Path) field.ErrorList {
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabels(spec.NodeSelector, fldPath.Child("nodeSelector"))...)
 	allErrs = append(allErrs, ValidatePodSecurityContext(spec.SecurityContext, spec, fldPath, fldPath.Child("securityContext"))...)
 	allErrs = append(allErrs, validateImagePullSecrets(spec.ImagePullSecrets, fldPath.Child("imagePullSecrets"))...)
-	allErrs = append(allErrs, validateAffinity(spec.Affinity, fldPath.Child("affinity"))...)
+	allErrs = append(allErrs, ValidateAffinity(spec.Affinity, fldPath.Child("affinity"))...)
 	if len(spec.ServiceAccountName) > 0 {
 		for _, msg := range ValidateServiceAccountName(spec.ServiceAccountName, false) {
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("serviceAccountName"), spec.ServiceAccountName, msg))

--- a/pkg/apis/settings/types.go
+++ b/pkg/apis/settings/types.go
@@ -45,6 +45,9 @@ type PodPresetSpec struct {
 	// EnvFrom defines the collection of EnvFromSource to inject into containers.
 	// +optional
 	EnvFrom []api.EnvFromSource
+	// Affinity defines the group of affinity to inject into containers
+	// +optional
+	Affinity *api.Affinity
 	// Volumes defines the collection of Volume to inject into the pod.
 	// +optional
 	Volumes []api.Volume

--- a/pkg/apis/settings/validation/validation.go
+++ b/pkg/apis/settings/validation/validation.go
@@ -39,12 +39,13 @@ func ValidatePodPresetSpec(spec *settings.PodPresetSpec, fldPath *field.Path) fi
 
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(&spec.Selector, fldPath.Child("selector"))...)
 
-	if spec.Env == nil && spec.EnvFrom == nil && spec.VolumeMounts == nil && spec.Volumes == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("volumes", "env", "envFrom", "volumeMounts"), "must specify at least one"))
+	if spec.Affinity == nil && spec.Env == nil && spec.EnvFrom == nil && spec.VolumeMounts == nil && spec.Volumes == nil {
+		allErrs = append(allErrs, field.Required(fldPath.Child("affinity", "volumes", "env", "envFrom", "volumeMounts"), "must specify at least one"))
 	}
 
 	volumes, vErrs := apivalidation.ValidateVolumes(spec.Volumes, fldPath.Child("volumes"))
 	allErrs = append(allErrs, vErrs...)
+	allErrs = append(allErrs, apivalidation.ValidateAffinity(spec.Affinity, fldPath.Child("affinity"))...)
 	allErrs = append(allErrs, apivalidation.ValidateEnv(spec.Env, fldPath.Child("env"))...)
 	allErrs = append(allErrs, apivalidation.ValidateEnvFrom(spec.EnvFrom, fldPath.Child("envFrom"))...)
 	allErrs = append(allErrs, apivalidation.ValidateVolumeMounts(spec.VolumeMounts, volumes, fldPath.Child("volumeMounts"))...)

--- a/pkg/apis/settings/validation/validation_test.go
+++ b/pkg/apis/settings/validation/validation_test.go
@@ -144,6 +144,53 @@ func TestValidatePodPresets(t *testing.T) {
 			t.Fatalf("errors: %#v", errList.ToAggregate().Error())
 		}
 	}
+
+	p = &settings.PodPreset{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "validate-affinity",
+			Namespace: "sample",
+		},
+		Spec: settings.PodPresetSpec{
+			Selector: v1.LabelSelector{
+				MatchExpressions: []v1.LabelSelectorRequirement{
+					{
+						Key:      "security",
+						Operator: v1.LabelSelectorOpIn,
+						Values:   []string{"S2"},
+					},
+				},
+			},
+			Affinity: &api.Affinity{
+				PodAffinity: &api.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []api.WeightedPodAffinityTerm{
+						{
+							Weight: 5,
+							PodAffinityTerm: api.PodAffinityTerm{
+								LabelSelector: &v1.LabelSelector{
+									MatchExpressions: []v1.LabelSelectorRequirement{
+										{
+											Key:      "security",
+											Operator: v1.LabelSelectorOpIn,
+											Values:   []string{"S1"},
+										},
+									},
+								},
+								TopologyKey: "region",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	errList = ValidatePodPreset(p)
+	if errList != nil {
+		if errList.ToAggregate() != nil {
+			t.Fatalf("errors: %#v", errList.ToAggregate().Error())
+		}
+	}
+
 }
 
 func TestValidatePodPresetsiVolumeMountError(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support por pod affinity on pod presets.

k8s operators are facilitating the life of developers taking care of deployments, services, etc... Sometimes the users want to customize some k8s specs, on the deployed objects. Some of this customisation can be achieved specifying a podPreset on the deployed pod without any changes in the operator code.

Ex. I'm using prometheus-operator and I would like to set the pod affinity for each of my replicas.

**Release note**:
```release-note
Support podAffinity on podPresets
```


