### PR TITLE
stop jsonpath panicing on negative array length

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -259,10 +259,10 @@ func (j *JSONPath) evalArray(input []reflect.Value, node *ArrayNode) ([]reflect.
 
 		sliceLength := value.Len()
 		if params[1].Value != params[0].Value { // if you're requesting zero elements, allow it through.
-			if params[0].Value >= sliceLength {
+			if params[0].Value >= sliceLength || params[0].Value < 0 {
 				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[0].Value, sliceLength)
 			}
-			if params[1].Value > sliceLength {
+			if params[1].Value > sliceLength || params[1].Value < 0 {
 				return input, fmt.Errorf("array index out of bounds: index %d, length %d", params[1].Value-1, sliceLength)
 			}
 		}


### PR DESCRIPTION
Related downstream issue: https://github.com/openshift/origin/issues/15075

Returns error if provided jsonpath value results in a negative slice index after adding the length of the slice:

```go
a := [0, 1, 2, 3]
b := a[-1:] // 3
c := a[-4:] // 0
d := a[-5:] // out of range error
e := a[4:]  // out of range error
```

**Release note**:
```release-note
NONE
```

cc @fabianofranz 