### PR TITLE
Make storage e2e tests start with [sig-storage] instead of [k8s.io].

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -58,7 +58,6 @@ go_library(
         "dns_common.go",
         "dns_configmap.go",
         "e2e.go",
-        "empty_dir_wrapper.go",
         "etcd_failure.go",
         "events.go",
         "example_cluster_dns.go",

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -32,46 +32,46 @@ import (
 var _ = framework.KubeDescribe("ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
-	It("should be consumable from pods in volume [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with defaultMode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root [Conformance] [sig-storage]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings and Item mode set[Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]", func() {
 		doConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
-	It("updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -149,7 +149,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
-	It("optional updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -410,7 +410,7 @@ var _ = framework.KubeDescribe("ConfigMap", func() {
 		})
 	})
 
-	It("should be consumable in multiple volumes in the same pod [Conformance] [Volume]", func() {
+	It("should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]", func() {
 		var (
 			name             = "configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "configmap-volume"

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -39,7 +39,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		podClient = f.PodClient()
 	})
 
-	It("should provide podname only [Conformance] [Volume]", func() {
+	It("should provide podname only [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
 
@@ -48,7 +48,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should set DefaultMode on files [Conformance] [Volume]", func() {
+	It("should set DefaultMode on files [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", nil, &defaultMode)
@@ -58,7 +58,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should set mode on item file [Conformance] [Volume]", func() {
+	It("should set mode on item file [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := downwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
@@ -68,7 +68,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup [Feature:FSGroup] [Volume]", func() {
+	It("should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -82,7 +82,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [Volume]", func() {
+	It("should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -97,7 +97,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should update labels on modification [Conformance] [Volume]", func() {
+	It("should update labels on modification [Conformance] [sig-storage]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -124,7 +124,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 	})
 
-	It("should update annotations on modification [Conformance] [Volume]", func() {
+	It("should update annotations on modification [Conformance] [sig-storage]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -153,7 +153,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"foo\"\n"))
 	})
 
-	It("should provide container's cpu limit [Conformance] [Volume]", func() {
+	It("should provide container's cpu limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
 
@@ -162,7 +162,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide container's memory limit [Conformance] [Volume]", func() {
+	It("should provide container's memory limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
 
@@ -171,7 +171,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide container's cpu request [Conformance] [Volume]", func() {
+	It("should provide container's cpu request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
 
@@ -180,7 +180,7 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide container's memory request [Conformance] [Volume]", func() {
+	It("should provide container's memory request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
 
@@ -189,14 +189,14 @@ var _ = framework.KubeDescribe("Downward API volume", func() {
 		})
 	})
 
-	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [Volume]", func() {
+	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
-	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [Volume]", func() {
+	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")
 

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -40,84 +40,84 @@ var _ = framework.KubeDescribe("EmptyDir volumes", func() {
 	f := framework.NewDefaultFramework("emptydir")
 
 	Context("when FSGroup is specified [Feature:FSGroup]", func() {
-		It("new files should be created with FSGroup ownership when container is root [Volume]", func() {
+		It("new files should be created with FSGroup ownership when container is root [sig-storage]", func() {
 			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})
 
-		It("new files should be created with FSGroup ownership when container is non-root [Volume]", func() {
+		It("new files should be created with FSGroup ownership when container is non-root [sig-storage]", func() {
 			doTestSetgidFSGroup(f, testImageNonRootUid, v1.StorageMediumMemory)
 		})
 
-		It("nonexistent volume subPath should have the correct mode and owner using FSGroup [Volume]", func() {
+		It("nonexistent volume subPath should have the correct mode and owner using FSGroup [sig-storage]", func() {
 			doTestSubPathFSGroup(f, testImageNonRootUid, v1.StorageMediumMemory)
 		})
 
-		It("files with FSGroup ownership should support (root,0644,tmpfs) [Volume]", func() {
+		It("files with FSGroup ownership should support (root,0644,tmpfs) [sig-storage]", func() {
 			doTest0644FSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})
 
-		It("volume on default medium should have the correct mode using FSGroup [Volume]", func() {
+		It("volume on default medium should have the correct mode using FSGroup [sig-storage]", func() {
 			doTestVolumeModeFSGroup(f, testImageRootUid, v1.StorageMediumDefault)
 		})
 
-		It("volume on tmpfs should have the correct mode using FSGroup [Volume]", func() {
+		It("volume on tmpfs should have the correct mode using FSGroup [sig-storage]", func() {
 			doTestVolumeModeFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
 		})
 	})
 
-	It("volume on tmpfs should have the correct mode [Conformance] [Volume]", func() {
+	It("volume on tmpfs should have the correct mode [Conformance] [sig-storage]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (root,0644,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (root,0644,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (root,0666,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (root,0666,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (root,0777,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (root,0777,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0644,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (non-root,0644,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0666,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (non-root,0666,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	It("should support (non-root,0777,tmpfs) [Conformance] [Volume]", func() {
+	It("should support (non-root,0777,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	It("volume on default medium should have the correct mode [Conformance] [Volume]", func() {
+	It("volume on default medium should have the correct mode [Conformance] [sig-storage]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (root,0644,default) [Conformance] [Volume]", func() {
+	It("should support (root,0644,default) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (root,0666,default) [Conformance] [Volume]", func() {
+	It("should support (root,0666,default) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (root,0777,default) [Conformance] [Volume]", func() {
+	It("should support (root,0777,default) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0644,default) [Conformance] [Volume]", func() {
+	It("should support (non-root,0644,default) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0666,default) [Conformance] [Volume]", func() {
+	It("should support (non-root,0666,default) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
-	It("should support (non-root,0777,default) [Conformance] [Volume]", func() {
+	It("should support (non-root,0777,default) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 })

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -40,7 +40,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		_ = os.Remove("/tmp/test-file")
 	})
 
-	It("should give a volume the correct mode [Conformance] [Volume]", func() {
+	It("should give a volume the correct mode [Conformance] [sig-storage]", func() {
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",
 		}
@@ -56,7 +56,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 	})
 
 	// This test requires mounting a folder into a container with write privileges.
-	It("should support r/w [Volume]", func() {
+	It("should support r/w [sig-storage]", func() {
 		filePath := path.Join(volumePath, "test-file")
 		retryDuration := 180
 		source := &v1.HostPathVolumeSource{
@@ -80,7 +80,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		})
 	})
 
-	It("should support subPath [Volume]", func() {
+	It("should support subPath [sig-storage]", func() {
 		subPath := "sub-path"
 		fileName := "test-file"
 		retryDuration := 180
@@ -112,7 +112,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		})
 	})
 
-	It("should support existing directory subPath [Volume]", func() {
+	It("should support existing directory subPath [sig-storage]", func() {
 		framework.SkipUnlessSSHKeyPresent()
 
 		subPath := "sub-path"
@@ -158,7 +158,7 @@ var _ = framework.KubeDescribe("HostPath", func() {
 	})
 
 	// TODO consolidate common code of this test and above
-	It("should support existing single file subPath [Volume]", func() {
+	It("should support existing single file subPath [sig-storage]", func() {
 		framework.SkipUnlessSSHKeyPresent()
 
 		subPath := "sub-path-test-file"

--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -35,32 +35,32 @@ var _ = framework.KubeDescribe("Projected", func() {
 	// Part 1/3 - Secrets
 	f := framework.NewDefaultFramework("projected")
 
-	It("should be consumable from pods in volume [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
-	It("should be consumable from pods in volume with defaultMode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), &fsGroup, &uid)
 	})
 
-	It("should be consumable from pods in volume with mappings [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doProjectedSecretE2EWithMapping(f, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doProjectedSecretE2EWithMapping(f, &mode)
 	})
 
-	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [Volume]", func() {
+	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]", func() {
 		var (
 			namespace2  *v1.Namespace
 			err         error
@@ -81,7 +81,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, secret2.Name, nil, nil)
 	})
 
-	It("should be consumable in multiple volumes in a pod [Conformance] [Volume]", func() {
+	It("should be consumable in multiple volumes in a pod [Conformance] [sig-storage]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -170,7 +170,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("optional updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -367,46 +367,46 @@ var _ = framework.KubeDescribe("Projected", func() {
 	})
 
 	// Part 2/3 - ConfigMaps
-	It("should be consumable from pods in volume [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with defaultMode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Feature:FSGroup] [sig-storage]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
 
-	It("should be consumable from pods in volume as non-root [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with FSGroup [Feature:FSGroup] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings and Item mode set[Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings as non-root with FSGroup [Feature:FSGroup] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
-	It("updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 
@@ -489,7 +489,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
-	It("optional updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true
@@ -685,7 +685,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("Error reading file /etc/projected-configmap-volumes/delete/data-1"))
 	})
 
-	It("should be consumable in multiple volumes in the same pod [Conformance] [Volume]", func() {
+	It("should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]", func() {
 		var (
 			name             = "projected-configmap-test-volume-" + string(uuid.NewUUID())
 			volumeName       = "projected-configmap-volume"
@@ -778,7 +778,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		podClient = f.PodClient()
 	})
 
-	It("should provide podname only [Conformance] [Volume]", func() {
+	It("should provide podname only [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
 
@@ -787,7 +787,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should set DefaultMode on files [Conformance] [Volume]", func() {
+	It("should set DefaultMode on files [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podname", nil, &defaultMode)
@@ -797,7 +797,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should set mode on item file [Conformance] [Volume]", func() {
+	It("should set mode on item file [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
 		pod := projectedDownwardAPIVolumePodForModeTest(podName, "/etc/podname", &mode, nil)
@@ -807,7 +807,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup [Feature:FSGroup] [Volume]", func() {
+	It("should provide podname as non-root with fsgroup [Feature:FSGroup] [sig-storage]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -821,7 +821,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [Volume]", func() {
+	It("should provide podname as non-root with fsgroup and defaultMode [Feature:FSGroup] [sig-storage]", func() {
 		podName := "metadata-volume-" + string(uuid.NewUUID())
 		uid := int64(1001)
 		gid := int64(1234)
@@ -836,7 +836,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should update labels on modification [Conformance] [Volume]", func() {
+	It("should update labels on modification [Conformance] [sig-storage]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
 		labels["key2"] = "value2"
@@ -863,7 +863,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 	})
 
-	It("should update annotations on modification [Conformance] [Volume]", func() {
+	It("should update annotations on modification [Conformance] [sig-storage]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
 		podName := "annotationupdate" + string(uuid.NewUUID())
@@ -892,7 +892,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"foo\"\n"))
 	})
 
-	It("should provide container's cpu limit [Conformance] [Volume]", func() {
+	It("should provide container's cpu limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
 
@@ -901,7 +901,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide container's memory limit [Conformance] [Volume]", func() {
+	It("should provide container's memory limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
 
@@ -910,7 +910,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide container's cpu request [Conformance] [Volume]", func() {
+	It("should provide container's cpu request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
 
@@ -919,7 +919,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide container's memory request [Conformance] [Volume]", func() {
+	It("should provide container's memory request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
 
@@ -928,14 +928,14 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
-	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [Volume]", func() {
+	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
-	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [Volume]", func() {
+	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")
 
@@ -943,7 +943,7 @@ var _ = framework.KubeDescribe("Projected", func() {
 	})
 
 	// Test multiple projections
-	It("should project all components that make up the projection API [Conformance] [Volume] [Projection]", func() {
+	It("should project all components that make up the projection API [Conformance] [sig-storage] [Projection]", func() {
 		var err error
 		podName := "projected-volume-" + string(uuid.NewUUID())
 		secretName := "secret-projected-all-test-volume-" + string(uuid.NewUUID())

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -33,32 +33,32 @@ import (
 var _ = framework.KubeDescribe("Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
-	It("should be consumable from pods in volume [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
-	It("should be consumable from pods in volume with defaultMode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
-	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
 		uid := int64(1000)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), &fsGroup, &uid)
 	})
 
-	It("should be consumable from pods in volume with mappings [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doSecretE2EWithMapping(f, nil)
 	})
 
-	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance] [Volume]", func() {
+	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doSecretE2EWithMapping(f, &mode)
 	})
 
-	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [Volume]", func() {
+	It("should be able to mount in a volume regardless of a different secret existing with same name in different namespace [sig-storage]", func() {
 		var (
 			namespace2  *v1.Namespace
 			err         error
@@ -79,7 +79,7 @@ var _ = framework.KubeDescribe("Secrets", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, secret2.Name, nil, nil)
 	})
 
-	It("should be consumable in multiple volumes in a pod [Conformance] [Volume]", func() {
+	It("should be consumable in multiple volumes in a pod [Conformance] [sig-storage]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
 		// regressions that break this use-case.
@@ -152,7 +152,7 @@ var _ = framework.KubeDescribe("Secrets", func() {
 		})
 	})
 
-	It("optional updates should be reflected in volume [Conformance] [Volume]", func() {
+	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
 		trueVal := true

--- a/test/e2e/common/volumes.go
+++ b/test/e2e/common/volumes.go
@@ -75,7 +75,7 @@ var _ = framework.KubeDescribe("GCP Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 
 	framework.KubeDescribe("NFSv4", func() {
-		It("should be mountable for NFSv4 [Volume]", func() {
+		It("should be mountable for NFSv4 [sig-storage]", func() {
 
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -114,7 +114,7 @@ var _ = framework.KubeDescribe("GCP Volumes", func() {
 	})
 
 	framework.KubeDescribe("NFSv3", func() {
-		It("should be mountable for NFSv3 [Volume]", func() {
+		It("should be mountable for NFSv3 [sig-storage]", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
 				Prefix:      "nfs",
@@ -153,7 +153,7 @@ var _ = framework.KubeDescribe("GCP Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 
 	framework.KubeDescribe("GlusterFS", func() {
-		It("should be mountable [Volume]", func() {
+		It("should be mountable [sig-storage]", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
 				Prefix:      "gluster",

--- a/test/e2e/kubelet.go
+++ b/test/e2e/kubelet.go
@@ -396,7 +396,7 @@ var _ = framework.KubeDescribe("kubelet", func() {
 	})
 
 	// Test host cleanup when disrupting the volume environment.
-	framework.KubeDescribe("host cleanup with volume mounts [Volume][HostCleanup][Flaky]", func() {
+	framework.KubeDescribe("host cleanup with volume mounts [sig-storage][HostCleanup][Flaky]", func() {
 
 		type hostCleanupTest struct {
 			itDescr string

--- a/test/e2e/resource_quota.go
+++ b/test/e2e/resource_quota.go
@@ -282,7 +282,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should create a ResourceQuota and capture the life of a persistent volume claim. [Volume]", func() {
+	It("should create a ResourceQuota and capture the life of a persistent volume claim. [sig-storage]", func() {
 		By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)
@@ -320,7 +320,7 @@ var _ = framework.KubeDescribe("ResourceQuota", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [Volume]", func() {
+	It("should create a ResourceQuota and capture the life of a persistent volume claim with a storage class. [sig-storage]", func() {
 		By("Creating a ResourceQuota")
 		quotaName := "test-quota"
 		resourceQuota := newTestResourceQuota(quotaName)

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -10,6 +10,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "empty_dir_wrapper.go",
         "framework.go",
         "pd.go",
         "persistent_volumes.go",
@@ -59,6 +60,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -10,6 +10,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "framework.go",
         "pd.go",
         "persistent_volumes.go",
         "persistent_volumes-disruptive.go",

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package storage
 
 import (
 	"k8s.io/api/core/v1"
@@ -50,7 +50,7 @@ const (
 	wrappedVolumeRaceRCNamePrefix            = "wrapped-volume-race-"
 )
 
-var _ = framework.KubeDescribe("EmptyDir wrapper volumes", func() {
+var _ = SIGDescribe("EmptyDir wrapper volumes", func() {
 	f := framework.NewDefaultFramework("emptydir-wrapper")
 
 	It("should not conflict [Volume]", func() {

--- a/test/e2e/storage/framework.go
+++ b/test/e2e/storage/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-storage] "+text, body)
+}

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		mathrand.Seed(time.Now().UTC().UnixNano())
 	})
 
-	It("should schedule a pod w/ a RW PD, ungracefully remove it, then schedule it on another host [Slow] [Volume]", func() {
+	It("should schedule a pod w/ a RW PD, ungracefully remove it, then schedule it on another host [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
@@ -133,7 +133,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		return
 	})
 
-	It("Should schedule a pod w/ a RW PD, gracefully remove it, then schedule it on another host [Slow] [Volume]", func() {
+	It("Should schedule a pod w/ a RW PD, gracefully remove it, then schedule it on another host [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
@@ -193,7 +193,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		return
 	})
 
-	It("should schedule a pod w/ a readonly PD on two hosts, then remove both ungracefully. [Slow] [Volume]", func() {
+	It("should schedule a pod w/ a readonly PD on two hosts, then remove both ungracefully. [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 
 		By("creating PD")
@@ -245,7 +245,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		waitForPDDetach(diskName, host1Name)
 	})
 
-	It("Should schedule a pod w/ a readonly PD on two hosts, then remove both gracefully. [Slow] [Volume]", func() {
+	It("Should schedule a pod w/ a readonly PD on two hosts, then remove both gracefully. [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 
 		By("creating PD")
@@ -297,7 +297,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		waitForPDDetach(diskName, host1Name)
 	})
 
-	It("should schedule a pod w/ a RW PD shared between multiple containers, write to PD, delete pod, verify contents, and repeat in rapid succession [Slow] [Volume]", func() {
+	It("should schedule a pod w/ a RW PD shared between multiple containers, write to PD, delete pod, verify contents, and repeat in rapid succession [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD")
@@ -350,7 +350,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		waitForPDDetach(diskName, host0Name)
 	})
 
-	It("should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession [Slow] [Volume]", func() {
+	It("should schedule a pod w/two RW PDs both mounted to one container, write to PD, verify contents, delete pod, recreate pod, verify contents, and repeat in rapid succession [Slow]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke", "aws")
 
 		By("creating PD1")
@@ -410,7 +410,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		waitForPDDetach(disk2Name, host0Name)
 	})
 
-	It("should be able to detach from a node which was deleted [Slow] [Disruptive] [Volume]", func() {
+	It("should be able to detach from a node which was deleted [Slow] [Disruptive]", func() {
 		framework.SkipUnlessProviderIs("gce")
 
 		initialGroupSize, err := framework.GroupSize(framework.TestContext.CloudConfig.NodeInstanceGroup)
@@ -469,7 +469,7 @@ var _ = SIGDescribe("Pod Disks", func() {
 		return
 	})
 
-	It("should be able to detach from a node whose api object was deleted [Slow] [Disruptive] [Volume]", func() {
+	It("should be able to detach from a node whose api object was deleted [Slow] [Disruptive]", func() {
 		framework.SkipUnlessProviderIs("gce")
 		initialGroupSize, err := framework.GroupSize(framework.TestContext.CloudConfig.NodeInstanceGroup)
 		framework.ExpectNoError(err, "Error getting group size")

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -48,7 +48,7 @@ const (
 	maxReadRetry        = 3
 )
 
-var _ = framework.KubeDescribe("Pod Disks", func() {
+var _ = SIGDescribe("Pod Disks", func() {
 	var (
 		podClient  v1core.PodInterface
 		nodeClient v1core.NodeInterface

--- a/test/e2e/storage/persistent_volumes-disruptive.go
+++ b/test/e2e/storage/persistent_volumes-disruptive.go
@@ -46,7 +46,7 @@ const (
 	kRestart         kubeletOpt = "restart"
 )
 
-var _ = framework.KubeDescribe("PersistentVolumes [Volume][Disruptive][Flaky]", func() {
+var _ = SIGDescribe("PersistentVolumes [Volume][Disruptive][Flaky]", func() {
 
 	f := framework.NewDefaultFramework("disruptive-pv")
 	var (

--- a/test/e2e/storage/persistent_volumes-disruptive.go
+++ b/test/e2e/storage/persistent_volumes-disruptive.go
@@ -46,7 +46,7 @@ const (
 	kRestart         kubeletOpt = "restart"
 )
 
-var _ = SIGDescribe("PersistentVolumes [Volume][Disruptive][Flaky]", func() {
+var _ = SIGDescribe("PersistentVolumes[Disruptive][Flaky]", func() {
 
 	f := framework.NewDefaultFramework("disruptive-pv")
 	var (

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -51,7 +51,7 @@ func initializeGCETestSpec(c clientset.Interface, ns string, pvConfig framework.
 }
 
 // Testing configurations of single a PV/PVC pair attached to a GCE PD
-var _ = SIGDescribe("PersistentVolumes:GCEPD [Volume]", func() {
+var _ = SIGDescribe("PersistentVolumes:GCEPD", func() {
 	var (
 		c         clientset.Interface
 		diskName  string

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -51,7 +51,7 @@ func initializeGCETestSpec(c clientset.Interface, ns string, pvConfig framework.
 }
 
 // Testing configurations of single a PV/PVC pair attached to a GCE PD
-var _ = framework.KubeDescribe("PersistentVolumes:GCEPD [Volume]", func() {
+var _ = SIGDescribe("PersistentVolumes:GCEPD [Volume]", func() {
 	var (
 		c         clientset.Interface
 		diskName  string

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -58,7 +58,7 @@ const (
 	testSC        = "local-test-storagclass"
 )
 
-var _ = framework.KubeDescribe("[Volume] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial]", func() {
+var _ = SIGDescribe("[Volume] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial]", func() {
 	f := framework.NewDefaultFramework("persistent-local-volumes-test")
 
 	var (

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -58,7 +58,7 @@ const (
 	testSC        = "local-test-storagclass"
 )
 
-var _ = SIGDescribe("[Volume] PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial]", func() {
+var _ = SIGDescribe("PersistentVolumes-local [Feature:LocalPersistentVolumes] [Serial]", func() {
 	f := framework.NewDefaultFramework("persistent-local-volumes-test")
 
 	var (

--- a/test/e2e/storage/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/persistent_volumes-vsphere.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Testing configurations of single a PV/PVC pair attached to a vSphere Disk
-var _ = framework.KubeDescribe("PersistentVolumes:vsphere", func() {
+var _ = SIGDescribe("PersistentVolumes:vsphere", func() {
 	var (
 		c          clientset.Interface
 		ns         string

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -97,7 +97,7 @@ func initNFSserverPod(c clientset.Interface, ns string) *v1.Pod {
 	})
 }
 
-var _ = framework.KubeDescribe("PersistentVolumes", func() {
+var _ = SIGDescribe("PersistentVolumes", func() {
 
 	// global vars for the Context()s and It()'s below
 	f := framework.NewDefaultFramework("pv")
@@ -123,7 +123,7 @@ var _ = framework.KubeDescribe("PersistentVolumes", func() {
 
 	// Testing configurations of a single a PV/PVC pair, multiple evenly paired PVs/PVCs,
 	// and multiple unevenly paired PV/PVCs
-	framework.KubeDescribe("PersistentVolumes:NFS", func() {
+	SIGDescribe("PersistentVolumes:NFS", func() {
 
 		var (
 			nfsServerPod *v1.Pod

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -287,7 +287,7 @@ var _ = SIGDescribe("PersistentVolumes", func() {
 			// This It() tests a scenario where a PV is written to by a Pod, recycled, then the volume checked
 			// for files. If files are found, the checking Pod fails, failing the test.  Otherwise, the pod
 			// (and test) succeed.
-			It("should test that a PV becomes Available and is clean after the PVC is deleted. [Volume]", func() {
+			It("should test that a PV becomes Available and is clean after the PVC is deleted.", func() {
 				By("Writing to the volume.")
 				pod := framework.MakeWritePod(ns, pvc)
 				pod, err = c.CoreV1().Pods(ns).Create(pod)

--- a/test/e2e/storage/pv_reclaimpolicy.go
+++ b/test/e2e/storage/pv_reclaimpolicy.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = framework.KubeDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
+var _ = SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
 	f := framework.NewDefaultFramework("persistentvolumereclaim")
 	var (
 		c          clientset.Interface
@@ -46,7 +46,7 @@ var _ = framework.KubeDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func
 		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
 	})
 
-	framework.KubeDescribe("persistentvolumereclaim:vsphere", func() {
+	SIGDescribe("persistentvolumereclaim:vsphere", func() {
 		BeforeEach(func() {
 			framework.SkipUnlessProviderIs("vsphere")
 			pv = nil

--- a/test/e2e/storage/pvc_label_selector.go
+++ b/test/e2e/storage/pvc_label_selector.go
@@ -44,7 +44,7 @@ import (
    9. delete pvc_vvol
 
 */
-var _ = framework.KubeDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
+var _ = SIGDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
 	f := framework.NewDefaultFramework("pvclabelselector")
 	var (
 		c          clientset.Interface
@@ -69,7 +69,7 @@ var _ = framework.KubeDescribe("PersistentVolumes [Feature:LabelSelector]", func
 
 	})
 
-	framework.KubeDescribe("Selector-Label Volume Binding:vsphere", func() {
+	SIGDescribe("Selector-Label Volume Binding:vsphere", func() {
 		AfterEach(func() {
 			By("Running clean up actions")
 			if framework.ProviderIs("vsphere") {

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -211,7 +211,7 @@ func checkGCEPD(volume *v1.PersistentVolume, volumeType string) error {
 	return nil
 }
 
-var _ = framework.KubeDescribe("Dynamic Provisioning", func() {
+var _ = SIGDescribe("Dynamic Provisioning", func() {
 	f := framework.NewDefaultFramework("volume-provisioning")
 
 	// filled in BeforeEach
@@ -223,7 +223,7 @@ var _ = framework.KubeDescribe("Dynamic Provisioning", func() {
 		ns = f.Namespace.Name
 	})
 
-	framework.KubeDescribe("DynamicProvisioner", func() {
+	SIGDescribe("DynamicProvisioner", func() {
 		It("should provision storage with different parameters [Slow] [Volume]", func() {
 			cloudZone := getRandomCloudZone(c)
 
@@ -517,7 +517,7 @@ var _ = framework.KubeDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	framework.KubeDescribe("DynamicProvisioner External", func() {
+	SIGDescribe("DynamicProvisioner External", func() {
 		It("should let an external dynamic provisioner create and delete persistent volumes [Slow] [Volume]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner role
@@ -555,7 +555,7 @@ var _ = framework.KubeDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	framework.KubeDescribe("DynamicProvisioner Default", func() {
+	SIGDescribe("DynamicProvisioner Default", func() {
 		It("should create and delete default persistent volumes [Slow] [Volume]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -224,7 +224,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 	})
 
 	SIGDescribe("DynamicProvisioner", func() {
-		It("should provision storage with different parameters [Slow] [Volume]", func() {
+		It("should provision storage with different parameters [Slow]", func() {
 			cloudZone := getRandomCloudZone(c)
 
 			// This test checks that dynamic provisioning can provision a volume
@@ -409,7 +409,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 
 		// NOTE: Slow!  The test will wait up to 5 minutes (framework.ClaimProvisionTimeout)
 		// when there is no regression.
-		It("should not provision a volume in an unmanaged GCE zone. [Slow] [Volume]", func() {
+		It("should not provision a volume in an unmanaged GCE zone. [Slow]", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
 			var suffix string = "unmananged"
 
@@ -467,7 +467,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 			framework.Logf(err.Error())
 		})
 
-		It("should test that deleting a claim before the volume is provisioned deletes the volume. [Volume]", func() {
+		It("should test that deleting a claim before the volume is provisioned deletes the volume.", func() {
 			// This case tests for the regressions of a bug fixed by PR #21268
 			// REGRESSION: Deleting the PVC before the PV is provisioned can result in the PV
 			// not being deleted.
@@ -518,7 +518,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 	})
 
 	SIGDescribe("DynamicProvisioner External", func() {
-		It("should let an external dynamic provisioner create and delete persistent volumes [Slow] [Volume]", func() {
+		It("should let an external dynamic provisioner create and delete persistent volumes [Slow]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner role
 			framework.BindClusterRole(c.Rbac(), "system:persistent-volume-provisioner", ns,
@@ -556,7 +556,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 	})
 
 	SIGDescribe("DynamicProvisioner Default", func() {
-		It("should create and delete default persistent volumes [Slow] [Volume]", func() {
+		It("should create and delete default persistent volumes [Slow]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 
 			By("creating a claim with no annotation")
@@ -570,7 +570,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 		})
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
-		It("should be disabled by changing the default annotation[Slow] [Serial] [Disruptive] [Volume]", func() {
+		It("should be disabled by changing the default annotation[Slow] [Serial] [Disruptive]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 			scName := getDefaultStorageClassName(c)
 			test := storageClassTest{
@@ -601,7 +601,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 		})
 
 		// Modifying the default storage class can be disruptive to other tests that depend on it
-		It("should be disabled by removing the default annotation[Slow] [Serial] [Disruptive] [Volume]", func() {
+		It("should be disabled by removing the default annotation[Slow] [Serial] [Disruptive]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 			scName := getDefaultStorageClassName(c)
 			test := storageClassTest{

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -79,7 +79,7 @@ func DeleteCinderVolume(name string) error {
 }
 
 // These tests need privileged containers, which are disabled by default.
-var _ = SIGDescribe("Volumes [Volume]", func() {
+var _ = SIGDescribe("Volumes", func() {
 	f := framework.NewDefaultFramework("volume")
 
 	// If 'false', the test won't clear its volumes upon completion. Useful for debugging,

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -79,7 +79,7 @@ func DeleteCinderVolume(name string) error {
 }
 
 // These tests need privileged containers, which are disabled by default.
-var _ = framework.KubeDescribe("Volumes [Volume]", func() {
+var _ = SIGDescribe("Volumes [Volume]", func() {
 	f := framework.NewDefaultFramework("volume")
 
 	// If 'false', the test won't clear its volumes upon completion. Useful for debugging,
@@ -98,7 +98,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// NFS
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("NFS", func() {
+	SIGDescribe("NFS", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -138,7 +138,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("GlusterFS [Feature:Volumes]", func() {
+	SIGDescribe("GlusterFS [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			//TODO (copejon) GFS is not supported on debian image.
 			framework.SkipUnlessNodeOSDistroIs("gci")
@@ -226,7 +226,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// are installed on all nodes!
 	// Run the test with "go run hack/e2e.go ... --ginkgo.focus=iSCSI"
 
-	framework.KubeDescribe("iSCSI [Feature:Volumes]", func() {
+	SIGDescribe("iSCSI [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -273,7 +273,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// Ceph RBD
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("Ceph RBD [Feature:Volumes]", func() {
+	SIGDescribe("Ceph RBD [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -351,7 +351,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// Ceph
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("CephFS [Feature:Volumes]", func() {
+	SIGDescribe("CephFS [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -429,7 +429,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// and that the usual OpenStack authentication env. variables are set
 	// (OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME at least).
 
-	framework.KubeDescribe("Cinder [Feature:Volumes]", func() {
+	SIGDescribe("Cinder [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("openstack")
 			config := framework.VolumeTestConfig{
@@ -505,7 +505,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// GCE PD
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("PD", func() {
+	SIGDescribe("PD", func() {
 		// Flaky issue: #43977
 		It("should be mountable [Flaky]", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
@@ -559,7 +559,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// ConfigMap
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("ConfigMap", func() {
+	SIGDescribe("ConfigMap", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace: namespace.Name,
@@ -637,7 +637,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	// vSphere
 	////////////////////////////////////////////////////////////////////////
 
-	framework.KubeDescribe("vsphere [Feature:Volumes]", func() {
+	SIGDescribe("vsphere [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("vsphere")
 			var (
@@ -689,7 +689,7 @@ var _ = framework.KubeDescribe("Volumes [Volume]", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Azure Disk
 	////////////////////////////////////////////////////////////////////////
-	framework.KubeDescribe("Azure Disk [Feature:Volumes]", func() {
+	SIGDescribe("Azure Disk [Feature:Volumes]", func() {
 		It("should be mountable [Slow]", func() {
 			framework.SkipUnlessProviderIs("azure")
 			config := framework.VolumeTestConfig{

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -52,7 +52,7 @@ import (
 	11. Delete PVC, PV and Storage Class
 */
 
-var _ = SIGDescribe("Volume Disk Format [Volumes]", func() {
+var _ = SIGDescribe("Volume Disk Format", func() {
 	f := framework.NewDefaultFramework("volume-disk-format")
 	var (
 		client            clientset.Interface

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -52,7 +52,7 @@ import (
 	11. Delete PVC, PV and Storage Class
 */
 
-var _ = framework.KubeDescribe("Volume Disk Format [Volumes]", func() {
+var _ = SIGDescribe("Volume Disk Format [Volumes]", func() {
 	f := framework.NewDefaultFramework("volume-disk-format")
 	var (
 		client            clientset.Interface

--- a/test/e2e/storage/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere_volume_fstype.go
@@ -45,7 +45,7 @@ import (
 	9. Delete PVC, PV and Storage Class.
 */
 
-var _ = framework.KubeDescribe("vsphere Volume fstype [Volume]", func() {
+var _ = SIGDescribe("vsphere Volume fstype [Volume]", func() {
 	f := framework.NewDefaultFramework("volume-fstype")
 	var (
 		client       clientset.Interface

--- a/test/e2e/storage/vsphere_volume_fstype.go
+++ b/test/e2e/storage/vsphere_volume_fstype.go
@@ -45,7 +45,7 @@ import (
 	9. Delete PVC, PV and Storage Class.
 */
 
-var _ = SIGDescribe("vsphere Volume fstype [Volume]", func() {
+var _ = SIGDescribe("vsphere Volume fstype", func() {
 	f := framework.NewDefaultFramework("volume-fstype")
 	var (
 		client       clientset.Interface

--- a/test/e2e/storage/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere_volume_ops_storm.go
@@ -47,7 +47,7 @@ import (
 		10. Delete storage class.
 */
 
-var _ = SIGDescribe("vsphere volume operations storm [Volume]", func() {
+var _ = SIGDescribe("vsphere volume operations storm", func() {
 	f := framework.NewDefaultFramework("volume-ops-storm")
 	const DEFAULT_VOLUME_OPS_SCALE = 30
 	var (

--- a/test/e2e/storage/vsphere_volume_ops_storm.go
+++ b/test/e2e/storage/vsphere_volume_ops_storm.go
@@ -47,7 +47,7 @@ import (
 		10. Delete storage class.
 */
 
-var _ = framework.KubeDescribe("vsphere volume operations storm [Volume]", func() {
+var _ = SIGDescribe("vsphere volume operations storm [Volume]", func() {
 	f := framework.NewDefaultFramework("volume-ops-storm")
 	const DEFAULT_VOLUME_OPS_SCALE = 30
 	var (

--- a/test/e2e/storage/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere_volume_placement.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = SIGDescribe("Volume Placement [Volume]", func() {
+var _ = SIGDescribe("Volume Placement", func() {
 	f := framework.NewDefaultFramework("volume-placement")
 	var (
 		c                  clientset.Interface

--- a/test/e2e/storage/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere_volume_placement.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
-var _ = framework.KubeDescribe("Volume Placement [Volume]", func() {
+var _ = SIGDescribe("Volume Placement [Volume]", func() {
 	f := framework.NewDefaultFramework("volume-placement")
 	var (
 		c                  clientset.Interface

--- a/test/e2e/storage/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere_volume_vsan_policy.go
@@ -83,7 +83,7 @@ const (
    8. Delete PVC, PV and Storage Class
 */
 
-var _ = SIGDescribe("vSphere Storage policy support for dynamic provisioning [Volume]", func() {
+var _ = SIGDescribe("vSphere Storage policy support for dynamic provisioning", func() {
 	f := framework.NewDefaultFramework("volume-vsan-policy")
 	var (
 		client       clientset.Interface

--- a/test/e2e/storage/vsphere_volume_vsan_policy.go
+++ b/test/e2e/storage/vsphere_volume_vsan_policy.go
@@ -83,7 +83,7 @@ const (
    8. Delete PVC, PV and Storage Class
 */
 
-var _ = framework.KubeDescribe("vSphere Storage policy support for dynamic provisioning [Volume]", func() {
+var _ = SIGDescribe("vSphere Storage policy support for dynamic provisioning [Volume]", func() {
 	f := framework.NewDefaultFramework("volume-vsan-policy")
 	var (
 		client       clientset.Interface


### PR DESCRIPTION
This makes understanding sig ownership from a test name very easy for
tools and humans.

- Use a SIGDescribe helper function that adds a [sig-storage] prefix instead of [k8s.io] for tests in storage/
- Move a test that should be in storage into storage.
- Make tests owned by multiple SIGs (configmap test) have [sig-storage] instead of [Volume] labels.

This means that all tests that sig-storage directly owns can be found with a simple regex.

/cc @kubernetes/sig-storage-pr-reviews 

**What this PR does / why we need it**:
This will be used to make a testgrid dashboard for sig-storage.

**Release note**:
```release-note
NONE
```

Issue #48779 