### PR TITLE
Correctly filter terminated pods in kubectl

### DIFF
--- a/pkg/kubectl/resource_filter.go
+++ b/pkg/kubectl/resource_filter.go
@@ -38,21 +38,18 @@ func NewResourceFilter() Filters {
 }
 
 // filterPods returns true if a pod should be skipped.
-// defaults to true for terminated pods
+// If show-all is true, the pod will be never be skipped (return false);
+// otherwise, skip terminated pod.
 func filterPods(obj runtime.Object, options printers.PrintOptions) bool {
+	if options.ShowAll {
+		return false
+	}
+
 	switch p := obj.(type) {
 	case *v1.Pod:
-		reason := string(p.Status.Phase)
-		if p.Status.Reason != "" {
-			reason = p.Status.Reason
-		}
-		return !options.ShowAll && (reason == string(v1.PodSucceeded) || reason == string(v1.PodFailed))
+		return p.Status.Phase == v1.PodSucceeded || p.Status.Phase == v1.PodFailed
 	case *api.Pod:
-		reason := string(p.Status.Phase)
-		if p.Status.Reason != "" {
-			reason = p.Status.Reason
-		}
-		return !options.ShowAll && (reason == string(api.PodSucceeded) || reason == string(api.PodFailed))
+		return p.Status.Phase == api.PodSucceeded || p.Status.Phase == api.PodFailed
 	}
 	return false
 }


### PR DESCRIPTION
We shouldn't use `Status.Reason` to determine whether the pod has terminated or not.

```release-note
kubectl: Fix bug that showed terminated/evicted pods even without `--show-all`.
```