### PR TITLE
Fix parsing empty CIDR

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	goruntime "runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	clientv1 "k8s.io/api/core/v1"
@@ -208,11 +209,6 @@ func StartControllers(s *options.CloudControllerManagerServer, kubeconfig *restc
 	versionedClient := client("shared-informers")
 	sharedInformers := informers.NewSharedInformerFactory(versionedClient, resyncPeriod(s)())
 
-	_, clusterCIDR, err := net.ParseCIDR(s.ClusterCIDR)
-	if err != nil {
-		glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", s.ClusterCIDR, err)
-	}
-
 	// Start the CloudNodeController
 	nodeController := nodecontroller.NewCloudNodeController(
 		sharedInformers.Core().V1().Nodes(),
@@ -243,6 +239,14 @@ func StartControllers(s *options.CloudControllerManagerServer, kubeconfig *restc
 		if routes, ok := cloud.Routes(); !ok {
 			glog.Warning("configure-cloud-routes is set, but cloud provider does not support routes. Will not configure cloud provider routes.")
 		} else {
+			var clusterCIDR *net.IPNet
+			if len(strings.TrimSpace(s.ClusterCIDR)) != 0 {
+				_, clusterCIDR, err = net.ParseCIDR(s.ClusterCIDR)
+				if err != nil {
+					glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", s.ClusterCIDR, err)
+				}
+			}
+
 			routeController := routecontroller.New(routes, client("route-controller"), sharedInformers.Core().V1().Nodes(), s.ClusterName, clusterCIDR)
 			go routeController.Run(stop, s.RouteReconciliationPeriod.Duration)
 			time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -23,6 +23,7 @@ package app
 import (
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -71,14 +72,23 @@ func startServiceController(ctx ControllerContext) (bool, error) {
 }
 
 func startNodeController(ctx ControllerContext) (bool, error) {
-	_, clusterCIDR, err := net.ParseCIDR(ctx.Options.ClusterCIDR)
-	if err != nil {
-		glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", ctx.Options.ClusterCIDR, err)
+	var clusterCIDR *net.IPNet
+	var err error
+	if len(strings.TrimSpace(ctx.Options.ClusterCIDR)) != 0 {
+		_, clusterCIDR, err = net.ParseCIDR(ctx.Options.ClusterCIDR)
+		if err != nil {
+			glog.Warningf("Unsuccessful parsing of cluster CIDR %v: %v", ctx.Options.ClusterCIDR, err)
+		}
 	}
-	_, serviceCIDR, err := net.ParseCIDR(ctx.Options.ServiceCIDR)
-	if err != nil {
-		glog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.Options.ServiceCIDR, err)
+
+	var serviceCIDR *net.IPNet
+	if len(strings.TrimSpace(ctx.Options.ServiceCIDR)) != 0 {
+		_, serviceCIDR, err = net.ParseCIDR(ctx.Options.ServiceCIDR)
+		if err != nil {
+			glog.Warningf("Unsuccessful parsing of service CIDR %v: %v", ctx.Options.ServiceCIDR, err)
+		}
 	}
+
 	nodeController, err := nodecontroller.NewNodeController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Nodes(),

--- a/pkg/controller/route/routecontroller.go
+++ b/pkg/controller/route/routecontroller.go
@@ -64,6 +64,11 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInform
 	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
 		metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.Core().RESTClient().GetRateLimiter())
 	}
+
+	if clusterCIDR == nil {
+		glog.Fatal("RouteController: Must specify clusterCIDR.")
+	}
+
 	rc := &RouteController{
 		routes:           routes,
 		kubeClient:       kubeClient,


### PR DESCRIPTION
Fix #48795
Checking ClusterCIDR and ServiceCIDR before parsing them.

**Release note**:
```release-note
NONE
```
