### PR TITLE
kubeadm: Generate kube-proxy image name in its own pkg

### DIFF
--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -29,7 +29,6 @@ const (
 	KubeAPIServerImage         = "apiserver"
 	KubeControllerManagerImage = "controller-manager"
 	KubeSchedulerImage         = "scheduler"
-	KubeProxyImage             = "proxy"
 
 	etcdVersion = "3.0.17"
 )
@@ -45,6 +44,5 @@ func GetCoreImage(image string, cfg *kubeadmapi.MasterConfiguration, overrideIma
 		KubeAPIServerImage:         fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-apiserver", runtime.GOARCH, kubernetesImageTag),
 		KubeControllerManagerImage: fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-controller-manager", runtime.GOARCH, kubernetesImageTag),
 		KubeSchedulerImage:         fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-scheduler", runtime.GOARCH, kubernetesImageTag),
-		KubeProxyImage:             fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-proxy", runtime.GOARCH, kubernetesImageTag),
 	}[image]
 }

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -62,11 +62,6 @@ func TestGetCoreImage(t *testing.T) {
 			c: &kubeadmapi.MasterConfiguration{ImageRepository: gcrPrefix, KubernetesVersion: testversion}},
 			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-scheduler", runtime.GOARCH, expected),
 		},
-		{getCoreImageTest{
-			i: KubeProxyImage,
-			c: &kubeadmapi.MasterConfiguration{ImageRepository: gcrPrefix, KubernetesVersion: testversion}},
-			fmt.Sprintf("%s/%s-%s:%s", gcrPrefix, "kube-proxy", runtime.GOARCH, expected),
-		},
 	}
 	for _, it := range imageTest {
 		actual := GetCoreImage(it.t.i, it.t.c, it.t.o)

--- a/cmd/kubeadm/app/phases/addons/BUILD
+++ b/cmd/kubeadm/app/phases/addons/BUILD
@@ -18,7 +18,6 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/addons_test.go
+++ b/cmd/kubeadm/app/phases/addons/addons_test.go
@@ -54,11 +54,14 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: KubeProxyDaemonSet,
-			data: struct{ Image, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
-				Image:          "foo",
-				ClusterCIDR:    "foo",
-				MasterTaintKey: "foo",
-				CloudTaintKey:  "foo",
+			data: struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
+				ImageRepository: "foo",
+				Arch:            "foo",
+				Version:         "foo",
+				ImageOverride:   "foo",
+				ClusterCIDR:     "foo",
+				MasterTaintKey:  "foo",
+				CloudTaintKey:   "foo",
 			},
 			expected: true,
 		},

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
       - name: kube-proxy
-        image: {{ .Image }}
+        image: {{ if .ImageOverride }}{{ .ImageOverride }}{{ else }}{{ .ImageRepository }}/kube-proxy-{{ .Arch }}:{{ .Version }}{{ end }}
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy


### PR DESCRIPTION
**What this PR does / why we need it**: code cleanup. Control kube-proxy image parameter in DaemonSet template.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Minor cleanup. Attn @luxas 

**Release note**:
```release-note
NONE
```
