### PR TITLE
Implement kubectl describe <fibre-channel PV>

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -700,6 +700,14 @@ func TestPersistentVolumeDescriber(t *testing.T) {
 				},
 			},
 		},
+		"fc": {
+			ObjectMeta: metav1.ObjectMeta{Name: "bar"},
+			Spec: api.PersistentVolumeSpec{
+				PersistentVolumeSource: api.PersistentVolumeSource{
+					FC: &api.FCVolumeSource{},
+				},
+			},
+		},
 	}
 
 	for name, pv := range tests {


### PR DESCRIPTION
kubectl did not show any details about Fibre Channel volumes, someone just forgot to implement it.

Tested with:

```shell
$ kubectl create -f - <<EOF
apiVersion: v1
kind: PersistentVolume
metadata:
  name: myfc
spec:
  capacity:
    storage: 100Gi
  accessModes:
    - ReadWriteOnce
  persistentVolumeReclaimPolicy: Delete
  fc:
       targetWWNs: ['500a0982991b8dc5', '500a0982891b8dc5']
       lun: 2
       fsType: ext4
       readOnly: true
EOF

$ kubectl describe pv myfc
Name:		myfc
Labels:		<none>
Annotations:	<none>
StorageClass:	
Status:		Available
Claim:		
Reclaim Policy:	Delete
Access Modes:	RWO
Capacity:	100Gi
Message:	
Source:
    Type:	FC (a Fibre Channel disk)
    TargetWWNs:	500a0982991b8dc5, 500a0982891b8dc5
    LUN:	2
    FSType:	ext4
    ReadOnly:	true
Events:		<none>
```

```release-note
NONE
```
@kubernetes/sig-cli-pr-reviews 