### PR TITLE
add [sig-apps] prefix to workload e2e tests

### DIFF
--- a/test/e2e/network_partition.go
+++ b/test/e2e/network_partition.go
@@ -98,7 +98,7 @@ func newPodOnNode(c clientset.Interface, namespace, podName, nodeName string) er
 	return err
 }
 
-var _ = framework.KubeDescribe("Network Partition [Disruptive] [Slow]", func() {
+var _ = framework.KubeDescribe("[sig-apps] Network Partition [Disruptive] [Slow]", func() {
 	f := framework.NewDefaultFramework("network-partition")
 	var systemPodsNo int32
 	var c clientset.Interface

--- a/test/e2e/workload/BUILD
+++ b/test/e2e/workload/BUILD
@@ -15,6 +15,7 @@ go_library(
         "daemon_set.go",
         "deployment.go",
         "disruption.go",
+        "framework.go",
         "job.go",
         "rc.go",
         "replica_set.go",

--- a/test/e2e/workload/cronjob.go
+++ b/test/e2e/workload/cronjob.go
@@ -42,7 +42,7 @@ const (
 	cronJobTimeout = 5 * time.Minute
 )
 
-var _ = framework.KubeDescribe("CronJob", func() {
+var _ = SIGDescribe("CronJob", func() {
 	f := framework.NewDefaultFramework("cronjob")
 
 	sleepCommand := []string{"sleep", "300"}

--- a/test/e2e/workload/daemon_restart.go
+++ b/test/e2e/workload/daemon_restart.go
@@ -177,7 +177,7 @@ func getContainerRestarts(c clientset.Interface, ns string, labelSelector labels
 	return failedContainers, containerRestartNodes.List()
 }
 
-var _ = framework.KubeDescribe("DaemonRestart [Disruptive]", func() {
+var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 
 	f := framework.NewDefaultFramework("daemonrestart")
 	rcName := "daemonrestart" + strconv.Itoa(numPods) + "-" + string(uuid.NewUUID())

--- a/test/e2e/workload/daemon_set.go
+++ b/test/e2e/workload/daemon_set.go
@@ -62,7 +62,7 @@ const (
 // happen.  In the future, running in parallel may work if we have an eviction
 // model which lets the DS controller kick out other pods to make room.
 // See http://issues.k8s.io/21767 for more details
-var _ = framework.KubeDescribe("Daemon set [Serial]", func() {
+var _ = SIGDescribe("Daemon set [Serial]", func() {
 	var f *framework.Framework
 
 	AfterEach(func() {

--- a/test/e2e/workload/deployment.go
+++ b/test/e2e/workload/deployment.go
@@ -55,7 +55,7 @@ var (
 	nilRs *extensions.ReplicaSet
 )
 
-var _ = framework.KubeDescribe("Deployment", func() {
+var _ = SIGDescribe("Deployment", func() {
 	var ns string
 	var c clientset.Interface
 

--- a/test/e2e/workload/disruption.go
+++ b/test/e2e/workload/disruption.go
@@ -41,7 +41,7 @@ const (
 	timeout           = 60 * time.Second
 )
 
-var _ = framework.KubeDescribe("DisruptionController", func() {
+var _ = SIGDescribe("DisruptionController", func() {
 	f := framework.NewDefaultFramework("disruption")
 	var ns string
 	var cs *kubernetes.Clientset

--- a/test/e2e/workload/framework.go
+++ b/test/e2e/workload/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workload
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-apps] "+text, body)
+}

--- a/test/e2e/workload/job.go
+++ b/test/e2e/workload/job.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Job", func() {
+var _ = SIGDescribe("Job", func() {
 	f := framework.NewDefaultFramework("job")
 	parallelism := int32(2)
 	completions := int32(4)

--- a/test/e2e/workload/rc.go
+++ b/test/e2e/workload/rc.go
@@ -34,7 +34,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("ReplicationController", func() {
+var _ = SIGDescribe("ReplicationController", func() {
 	f := framework.NewDefaultFramework("replication-controller")
 
 	It("should serve a basic image on each replica with a public image [Conformance]", func() {

--- a/test/e2e/workload/replica_set.go
+++ b/test/e2e/workload/replica_set.go
@@ -74,7 +74,7 @@ func newPodQuota(name, number string) *v1.ResourceQuota {
 	}
 }
 
-var _ = framework.KubeDescribe("ReplicaSet", func() {
+var _ = SIGDescribe("ReplicaSet", func() {
 	f := framework.NewDefaultFramework("replicaset")
 
 	It("should serve a basic image on each replica with a public image [Conformance]", func() {

--- a/test/e2e/workload/statefulset.go
+++ b/test/e2e/workload/statefulset.go
@@ -50,7 +50,7 @@ const (
 
 // GCE Quota requirements: 3 pds, one per stateful pod manifest declared above.
 // GCE Api requirements: nodes and master need storage r/w permissions.
-var _ = framework.KubeDescribe("StatefulSet", func() {
+var _ = SIGDescribe("StatefulSet", func() {
 	f := framework.NewDefaultFramework("statefulset")
 	var ns string
 	var c clientset.Interface


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR adds [sig-apps] prefix to workload e2e tests in accord to requirements of adding a SIG dashboard to testgrid. Refer PR #48781 for guidelines.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
