### PR TITLE
vSphere for cloud-controller-manager

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -580,7 +580,8 @@ func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, 
 // This method will not be called from the node that is requesting this ID. i.e. metadata service
 // and other local methods cannot be used here
 func (vs *VSphere) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error) {
-	return []v1.NodeAddress{}, errors.New("unimplemented")
+	vmName := path.Base(providerID)
+	return vs.NodeAddresses(vmNameToNodeName(vmName))
 }
 
 func (vs *VSphere) AddSSHKeyToAllInstances(user string, keyData []byte) error {
@@ -663,7 +664,7 @@ func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 // This method will not be called from the node that is requesting this ID. i.e. metadata service
 // and other local methods cannot be used here
 func (vs *VSphere) InstanceTypeByProviderID(providerID string) (string, error) {
-	return "", errors.New("unimplemented")
+	return "", nil
 }
 
 func (vs *VSphere) InstanceType(name k8stypes.NodeName) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to implement the `NodeAddressesByProviderID` and `InstanceTypeByProviderID` methods for cloud-controller-manager for vSphere cloud provider.

Currently vSphere cloud provider only supports VMs in the same folder.
Thus `NodeAddressesByProviderID` is similar to `NodeAddresses` with a simple ProviderID to NodeName translation.

`InstanceTypeByProviderID`  returns nil as same as `InstanceType`.

**Which issue this PR fixes**
Part of Issue https://github.com/kubernetes/kubernetes/issues/47257

**Release note**:
```NONE
```
