### PR TITLE
Minor refactor of storage tests.

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -58,7 +58,6 @@ go_library(
         "dns_common.go",
         "dns_configmap.go",
         "e2e.go",
-        "empty_dir_wrapper.go",
         "etcd_failure.go",
         "events.go",
         "example_cluster_dns.go",

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -10,6 +10,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "empty_dir_wrapper.go",
         "pd.go",
         "persistent_volumes.go",
         "persistent_volumes-disruptive.go",
@@ -58,6 +59,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package storage
 
 import (
 	"k8s.io/api/core/v1"

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -52,7 +52,7 @@ import (
 	11. Delete PVC, PV and Storage Class
 */
 
-var _ = framework.KubeDescribe("Volume Disk Format [Volumes]", func() {
+var _ = framework.KubeDescribe("Volume Disk Format [Volume]", func() {
 	f := framework.NewDefaultFramework("volume-disk-format")
 	var (
 		client            clientset.Interface


### PR DESCRIPTION
- Kept storage tests in test/e2e/common/ in the same place in order for e2e_node tests to pick them up.
- Test files not limited to just storage tests are kept in test/e2e/.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->
Establishing ownership of storage tests by moving tests under test/e2e/storage, and by connecting it to testgrid.
