### PR TITLE
client-gen: don't ignore nil clientsets

### DIFF
--- a/federation/client/clientset_generated/federation_clientset/clientset.go
+++ b/federation/client/clientset_generated/federation_clientset/clientset.go
@@ -60,86 +60,56 @@ type Clientset struct {
 
 // AutoscalingV1 retrieves the AutoscalingV1Client
 func (c *Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingV1Client
 }
 
 // Deprecated: Autoscaling retrieves the default version of AutoscalingClient.
 // Please explicitly pick a version.
 func (c *Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingV1Client
 }
 
 // BatchV1 retrieves the BatchV1Client
 func (c *Clientset) BatchV1() batchv1.BatchV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchV1Client
 }
 
 // Deprecated: Batch retrieves the default version of BatchClient.
 // Please explicitly pick a version.
 func (c *Clientset) Batch() batchv1.BatchV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchV1Client
 }
 
 // CoreV1 retrieves the CoreV1Client
 func (c *Clientset) CoreV1() corev1.CoreV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CoreV1Client
 }
 
 // Deprecated: Core retrieves the default version of CoreClient.
 // Please explicitly pick a version.
 func (c *Clientset) Core() corev1.CoreV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CoreV1Client
 }
 
 // ExtensionsV1beta1 retrieves the ExtensionsV1beta1Client
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ExtensionsV1beta1Client
 }
 
 // Deprecated: Extensions retrieves the default version of ExtensionsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ExtensionsV1beta1Client
 }
 
 // FederationV1beta1 retrieves the FederationV1beta1Client
 func (c *Clientset) FederationV1beta1() federationv1beta1.FederationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.FederationV1beta1Client
 }
 
 // Deprecated: Federation retrieves the default version of FederationClient.
 // Please explicitly pick a version.
 func (c *Clientset) Federation() federationv1beta1.FederationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.FederationV1beta1Client
 }
 

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -80,121 +80,76 @@ type Clientset struct {
 
 // Admissionregistration retrieves the AdmissionregistrationClient
 func (c *Clientset) Admissionregistration() admissionregistrationinternalversion.AdmissionregistrationInterface {
-	if c == nil {
-		return nil
-	}
 	return c.AdmissionregistrationClient
 }
 
 // Core retrieves the CoreClient
 func (c *Clientset) Core() coreinternalversion.CoreInterface {
-	if c == nil {
-		return nil
-	}
 	return c.CoreClient
 }
 
 // Apps retrieves the AppsClient
 func (c *Clientset) Apps() appsinternalversion.AppsInterface {
-	if c == nil {
-		return nil
-	}
 	return c.AppsClient
 }
 
 // Authentication retrieves the AuthenticationClient
 func (c *Clientset) Authentication() authenticationinternalversion.AuthenticationInterface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthenticationClient
 }
 
 // Authorization retrieves the AuthorizationClient
 func (c *Clientset) Authorization() authorizationinternalversion.AuthorizationInterface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthorizationClient
 }
 
 // Autoscaling retrieves the AutoscalingClient
 func (c *Clientset) Autoscaling() autoscalinginternalversion.AutoscalingInterface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingClient
 }
 
 // Batch retrieves the BatchClient
 func (c *Clientset) Batch() batchinternalversion.BatchInterface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchClient
 }
 
 // Certificates retrieves the CertificatesClient
 func (c *Clientset) Certificates() certificatesinternalversion.CertificatesInterface {
-	if c == nil {
-		return nil
-	}
 	return c.CertificatesClient
 }
 
 // Extensions retrieves the ExtensionsClient
 func (c *Clientset) Extensions() extensionsinternalversion.ExtensionsInterface {
-	if c == nil {
-		return nil
-	}
 	return c.ExtensionsClient
 }
 
 // Networking retrieves the NetworkingClient
 func (c *Clientset) Networking() networkinginternalversion.NetworkingInterface {
-	if c == nil {
-		return nil
-	}
 	return c.NetworkingClient
 }
 
 // Policy retrieves the PolicyClient
 func (c *Clientset) Policy() policyinternalversion.PolicyInterface {
-	if c == nil {
-		return nil
-	}
 	return c.PolicyClient
 }
 
 // Rbac retrieves the RbacClient
 func (c *Clientset) Rbac() rbacinternalversion.RbacInterface {
-	if c == nil {
-		return nil
-	}
 	return c.RbacClient
 }
 
 // Scheduling retrieves the SchedulingClient
 func (c *Clientset) Scheduling() schedulinginternalversion.SchedulingInterface {
-	if c == nil {
-		return nil
-	}
 	return c.SchedulingClient
 }
 
 // Settings retrieves the SettingsClient
 func (c *Clientset) Settings() settingsinternalversion.SettingsInterface {
-	if c == nil {
-		return nil
-	}
 	return c.SettingsClient
 }
 
 // Storage retrieves the StorageClient
 func (c *Clientset) Storage() storageinternalversion.StorageInterface {
-	if c == nil {
-		return nil
-	}
 	return c.StorageClient
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -40,18 +40,12 @@ type Clientset struct {
 
 // ApiextensionsV1beta1 retrieves the ApiextensionsV1beta1Client
 func (c *Clientset) ApiextensionsV1beta1() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiextensionsV1beta1Client
 }
 
 // Deprecated: Apiextensions retrieves the default version of ApiextensionsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Apiextensions() apiextensionsv1beta1.ApiextensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiextensionsV1beta1Client
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
@@ -38,9 +38,6 @@ type Clientset struct {
 
 // Apiextensions retrieves the ApiextensionsClient
 func (c *Clientset) Apiextensions() apiextensionsinternalversion.ApiextensionsInterface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiextensionsClient
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -131,312 +131,201 @@ type Clientset struct {
 
 // AdmissionregistrationV1alpha1 retrieves the AdmissionregistrationV1alpha1Client
 func (c *Clientset) AdmissionregistrationV1alpha1() admissionregistrationv1alpha1.AdmissionregistrationV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AdmissionregistrationV1alpha1Client
 }
 
 // Deprecated: Admissionregistration retrieves the default version of AdmissionregistrationClient.
 // Please explicitly pick a version.
 func (c *Clientset) Admissionregistration() admissionregistrationv1alpha1.AdmissionregistrationV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AdmissionregistrationV1alpha1Client
 }
 
 // AppsV1beta1 retrieves the AppsV1beta1Client
 func (c *Clientset) AppsV1beta1() appsv1beta1.AppsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AppsV1beta1Client
 }
 
 // AppsV1beta2 retrieves the AppsV1beta2Client
 func (c *Clientset) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AppsV1beta2Client
 }
 
 // Deprecated: Apps retrieves the default version of AppsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Apps() appsv1beta2.AppsV1beta2Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AppsV1beta2Client
 }
 
 // AuthenticationV1 retrieves the AuthenticationV1Client
 func (c *Clientset) AuthenticationV1() authenticationv1.AuthenticationV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthenticationV1Client
 }
 
 // Deprecated: Authentication retrieves the default version of AuthenticationClient.
 // Please explicitly pick a version.
 func (c *Clientset) Authentication() authenticationv1.AuthenticationV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthenticationV1Client
 }
 
 // AuthenticationV1beta1 retrieves the AuthenticationV1beta1Client
 func (c *Clientset) AuthenticationV1beta1() authenticationv1beta1.AuthenticationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthenticationV1beta1Client
 }
 
 // AuthorizationV1 retrieves the AuthorizationV1Client
 func (c *Clientset) AuthorizationV1() authorizationv1.AuthorizationV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthorizationV1Client
 }
 
 // Deprecated: Authorization retrieves the default version of AuthorizationClient.
 // Please explicitly pick a version.
 func (c *Clientset) Authorization() authorizationv1.AuthorizationV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthorizationV1Client
 }
 
 // AuthorizationV1beta1 retrieves the AuthorizationV1beta1Client
 func (c *Clientset) AuthorizationV1beta1() authorizationv1beta1.AuthorizationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AuthorizationV1beta1Client
 }
 
 // AutoscalingV1 retrieves the AutoscalingV1Client
 func (c *Clientset) AutoscalingV1() autoscalingv1.AutoscalingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingV1Client
 }
 
 // Deprecated: Autoscaling retrieves the default version of AutoscalingClient.
 // Please explicitly pick a version.
 func (c *Clientset) Autoscaling() autoscalingv1.AutoscalingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingV1Client
 }
 
 // AutoscalingV2alpha1 retrieves the AutoscalingV2alpha1Client
 func (c *Clientset) AutoscalingV2alpha1() autoscalingv2alpha1.AutoscalingV2alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.AutoscalingV2alpha1Client
 }
 
 // BatchV1 retrieves the BatchV1Client
 func (c *Clientset) BatchV1() batchv1.BatchV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchV1Client
 }
 
 // Deprecated: Batch retrieves the default version of BatchClient.
 // Please explicitly pick a version.
 func (c *Clientset) Batch() batchv1.BatchV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchV1Client
 }
 
 // BatchV2alpha1 retrieves the BatchV2alpha1Client
 func (c *Clientset) BatchV2alpha1() batchv2alpha1.BatchV2alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.BatchV2alpha1Client
 }
 
 // CertificatesV1beta1 retrieves the CertificatesV1beta1Client
 func (c *Clientset) CertificatesV1beta1() certificatesv1beta1.CertificatesV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CertificatesV1beta1Client
 }
 
 // Deprecated: Certificates retrieves the default version of CertificatesClient.
 // Please explicitly pick a version.
 func (c *Clientset) Certificates() certificatesv1beta1.CertificatesV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CertificatesV1beta1Client
 }
 
 // CoreV1 retrieves the CoreV1Client
 func (c *Clientset) CoreV1() corev1.CoreV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CoreV1Client
 }
 
 // Deprecated: Core retrieves the default version of CoreClient.
 // Please explicitly pick a version.
 func (c *Clientset) Core() corev1.CoreV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.CoreV1Client
 }
 
 // ExtensionsV1beta1 retrieves the ExtensionsV1beta1Client
 func (c *Clientset) ExtensionsV1beta1() extensionsv1beta1.ExtensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ExtensionsV1beta1Client
 }
 
 // Deprecated: Extensions retrieves the default version of ExtensionsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Extensions() extensionsv1beta1.ExtensionsV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ExtensionsV1beta1Client
 }
 
 // NetworkingV1 retrieves the NetworkingV1Client
 func (c *Clientset) NetworkingV1() networkingv1.NetworkingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.NetworkingV1Client
 }
 
 // Deprecated: Networking retrieves the default version of NetworkingClient.
 // Please explicitly pick a version.
 func (c *Clientset) Networking() networkingv1.NetworkingV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.NetworkingV1Client
 }
 
 // PolicyV1beta1 retrieves the PolicyV1beta1Client
 func (c *Clientset) PolicyV1beta1() policyv1beta1.PolicyV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.PolicyV1beta1Client
 }
 
 // Deprecated: Policy retrieves the default version of PolicyClient.
 // Please explicitly pick a version.
 func (c *Clientset) Policy() policyv1beta1.PolicyV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.PolicyV1beta1Client
 }
 
 // RbacV1beta1 retrieves the RbacV1beta1Client
 func (c *Clientset) RbacV1beta1() rbacv1beta1.RbacV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.RbacV1beta1Client
 }
 
 // Deprecated: Rbac retrieves the default version of RbacClient.
 // Please explicitly pick a version.
 func (c *Clientset) Rbac() rbacv1beta1.RbacV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.RbacV1beta1Client
 }
 
 // RbacV1alpha1 retrieves the RbacV1alpha1Client
 func (c *Clientset) RbacV1alpha1() rbacv1alpha1.RbacV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.RbacV1alpha1Client
 }
 
 // SchedulingV1alpha1 retrieves the SchedulingV1alpha1Client
 func (c *Clientset) SchedulingV1alpha1() schedulingv1alpha1.SchedulingV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.SchedulingV1alpha1Client
 }
 
 // Deprecated: Scheduling retrieves the default version of SchedulingClient.
 // Please explicitly pick a version.
 func (c *Clientset) Scheduling() schedulingv1alpha1.SchedulingV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.SchedulingV1alpha1Client
 }
 
 // SettingsV1alpha1 retrieves the SettingsV1alpha1Client
 func (c *Clientset) SettingsV1alpha1() settingsv1alpha1.SettingsV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.SettingsV1alpha1Client
 }
 
 // Deprecated: Settings retrieves the default version of SettingsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Settings() settingsv1alpha1.SettingsV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.SettingsV1alpha1Client
 }
 
 // StorageV1beta1 retrieves the StorageV1beta1Client
 func (c *Clientset) StorageV1beta1() storagev1beta1.StorageV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.StorageV1beta1Client
 }
 
 // StorageV1 retrieves the StorageV1Client
 func (c *Clientset) StorageV1() storagev1.StorageV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.StorageV1Client
 }
 
 // Deprecated: Storage retrieves the default version of StorageClient.
 // Please explicitly pick a version.
 func (c *Clientset) Storage() storagev1.StorageV1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.StorageV1Client
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -40,18 +40,12 @@ type Clientset struct {
 
 // ApiregistrationV1beta1 retrieves the ApiregistrationV1beta1Client
 func (c *Clientset) ApiregistrationV1beta1() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiregistrationV1beta1Client
 }
 
 // Deprecated: Apiregistration retrieves the default version of ApiregistrationClient.
 // Please explicitly pick a version.
 func (c *Clientset) Apiregistration() apiregistrationv1beta1.ApiregistrationV1beta1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiregistrationV1beta1Client
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -38,9 +38,6 @@ type Clientset struct {
 
 // Apiregistration retrieves the ApiregistrationClient
 func (c *Clientset) Apiregistration() apiregistrationinternalversion.ApiregistrationInterface {
-	if c == nil {
-		return nil
-	}
 	return c.ApiregistrationClient
 }
 

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/generator_for_clientset.go
@@ -124,9 +124,6 @@ type Clientset struct {
 var clientsetInterfaceImplTemplate = `
 // $.GroupVersion$ retrieves the $.GroupVersion$Client
 func (c *Clientset) $.GroupVersion$() $.PackageName$.$.GroupVersion$Interface {
-	if c == nil {
-		return nil
-	}
 	return c.$.GroupVersion$Client
 }
 `
@@ -135,9 +132,6 @@ var clientsetInterfaceDefaultVersionImpl = `
 // Deprecated: $.Group$ retrieves the default version of $.Group$Client.
 // Please explicitly pick a version.
 func (c *Clientset) $.Group$() $.PackageName$.$.GroupVersion$Interface {
-	if c == nil {
-		return nil
-	}
 	return c.$.GroupVersion$Client
 }
 `

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/clientset.go
@@ -38,9 +38,6 @@ type Clientset struct {
 
 // Testgroup retrieves the TestgroupClient
 func (c *Clientset) Testgroup() testgroupinternalversion.TestgroupInterface {
-	if c == nil {
-		return nil
-	}
 	return c.TestgroupClient
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
@@ -40,18 +40,12 @@ type Clientset struct {
 
 // MetricsV1alpha1 retrieves the MetricsV1alpha1Client
 func (c *Clientset) MetricsV1alpha1() metricsv1alpha1.MetricsV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.MetricsV1alpha1Client
 }
 
 // Deprecated: Metrics retrieves the default version of MetricsClient.
 // Please explicitly pick a version.
 func (c *Clientset) Metrics() metricsv1alpha1.MetricsV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.MetricsV1alpha1Client
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/clientset.go
@@ -40,18 +40,12 @@ type Clientset struct {
 
 // WardleV1alpha1 retrieves the WardleV1alpha1Client
 func (c *Clientset) WardleV1alpha1() wardlev1alpha1.WardleV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.WardleV1alpha1Client
 }
 
 // Deprecated: Wardle retrieves the default version of WardleClient.
 // Please explicitly pick a version.
 func (c *Clientset) Wardle() wardlev1alpha1.WardleV1alpha1Interface {
-	if c == nil {
-		return nil
-	}
 	return c.WardleV1alpha1Client
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -38,9 +38,6 @@ type Clientset struct {
 
 // Wardle retrieves the WardleClient
 func (c *Clientset) Wardle() wardleinternalversion.WardleInterface {
-	if c == nil {
-		return nil
-	}
 	return c.WardleClient
 }
 


### PR DESCRIPTION
Closes https://github.com/kubernetes/client-go/issues/240

When a clientset is nil, fail fast instead of returning a nil value as an interface.

/cc @kubernetes/sig-api-machinery-pr-reviews
