### PR TITLE
Add quick-verify make rule.

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -126,6 +126,21 @@ verify: verify_generated_files
 	KUBE_VERIFY_GIT_BRANCH=$(BRANCH) hack/make-rules/verify.sh -v
 endif
 
+define QUICK_VERIFY_HELP_INFO
+# Runs only the presubmission verifications that aren't slow.
+#
+# Example:
+#   make quick-verify
+endef
+.PHONY: quick-verify
+ifeq ($(PRINT_HELP),y)
+quick-verify:
+	@echo "$$QUICK_VERIFY_HELP_INFO"
+else
+quick-verify: verify_generated_files
+	hack/make-rules/verify.sh -v -Q
+endif
+
 define UPDATE_HELP_INFO
 # Runs all the generated updates.
 #

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -71,6 +71,7 @@ function run-checks {
   done
 }
 
+SILENT=true
 while getopts ":v" opt; do
   case ${opt} in
     v)

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -29,10 +29,37 @@ EXCLUDED_PATTERNS=(
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
   )
 
+# Only run whitelisted fast checks in quick mode.
+# These run in <10s each on enisoc's workstation, assuming that
+# `make` and `hack/godep-restore.sh` had already been run.
+QUICK_PATTERNS+=(
+  "verify-api-groups.sh"
+  "verify-bazel.sh"
+  "verify-boilerplate.sh"
+  "verify-godep-licenses.sh"
+  "verify-gofmt.sh"
+  "verify-pkg-names.sh"
+  "verify-readonly-packages.sh"
+  "verify-staging-client-go.sh"
+  "verify-staging-imports.sh"
+  "verify-test-images.sh"
+  "verify-test-owners.sh"
+)
+
 EXCLUDED_CHECKS=$(ls ${EXCLUDED_PATTERNS[@]/#/${KUBE_ROOT}\/hack\/} 2>/dev/null || true)
+QUICK_CHECKS=$(ls ${QUICK_PATTERNS[@]/#/${KUBE_ROOT}\/hack\/} 2>/dev/null || true)
 
 function is-excluded {
   for e in ${EXCLUDED_CHECKS[@]}; do
+    if [[ $1 -ef "$e" ]]; then
+      return
+    fi
+  done
+  return 1
+}
+
+function is-quick {
+  for e in ${QUICK_CHECKS[@]}; do
     if [[ $1 -ef "$e" ]]; then
       return
     fi
@@ -58,6 +85,10 @@ function run-checks {
       echo "Skipping ${t}"
       continue
     fi
+    if ${QUICK} && ! is-quick "${t}" ; then
+      echo "Skipping ${t} in quick mode"
+      continue
+    fi
     echo -e "Verifying ${t}"
     local start=$(date +%s)
     run-cmd "${runner}" "${t}" && tr=$? || tr=$?
@@ -72,10 +103,15 @@ function run-checks {
 }
 
 SILENT=true
-while getopts ":v" opt; do
+QUICK=false
+
+while getopts ":vQ" opt; do
   case ${opt} in
     v)
       SILENT=false
+      ;;
+    Q)
+      QUICK=true
       ;;
     \?)
       echo "Invalid flag: -${OPTARG}" >&2
@@ -86,6 +122,10 @@ done
 
 if ${SILENT} ; then
   echo "Running in silent mode, run with -v if you want to see script logs."
+fi
+
+if ${QUICK} ; then
+  echo "Running in quick mode (-Q flag). Only fast checks will run."
 fi
 
 ret=0


### PR DESCRIPTION
This is useful for humans to run to catch obvious problems before
pushing commits and waiting for CI to run verify checks.

Quick mode only runs a whitelist of verify scripts that are reasonably fast.
I set the initial bar arbitrarily at <10s each on my workstation.

The whole set runs in <30s for me, assuming I had already run `make` and
`hack/godep-restore.sh`. This is compared to the full `make verify`
which takes [I don't know how long because I gave up after 45min].