### PR TITLE
Automated cherry pick of #48683

### DIFF
--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -1376,7 +1376,11 @@ func tlsHandshake(t *testing.T, sCfg, cCfg *tls.Config) error {
 		}
 	}()
 
-	c, err := tls.Dial("tcp", s.Addr().String(), cCfg)
+	// workaround [::] not working in ipv4 only systems (https://github.com/golang/go/issues/18806)
+	// TODO: remove with Golang 1.9 with https://go-review.googlesource.com/c/45088/
+	addr := strings.TrimPrefix(s.Addr().String(), "[::]")
+
+	c, err := tls.Dial("tcp", addr, cCfg)
 	if err != nil {
 		// Intentionally not serializing the error received because we want to
 		// test for the failure case in the caller test function.


### PR DESCRIPTION
Cherry pick of #48683 on release-1.6.

#48683: Workaround tcpv4-only-systems connect issue in test