### PR TITLE
GCE: Fix panic when service loadbalancer has static IP address

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_addresses.go
+++ b/pkg/cloudprovider/providers/gce/gce_addresses.go
@@ -33,18 +33,13 @@ func newAddressMetricContext(request, region string) *metricContext {
 // Caller is allocated a random IP if they do not specify an ipAddress. If an
 // ipAddress is specified, it must belong to the current project, eg: an
 // ephemeral IP associated with a global forwarding rule.
-func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) (*compute.Address, error) {
+func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) error {
 	mc := newAddressMetricContext("reserve", "")
 	op, err := gce.service.GlobalAddresses.Insert(gce.projectID, addr).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-
-	if err := gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-
-	return gce.GetGlobalAddress(addr.Name)
+	return gce.waitForGlobalOp(op, mc)
 }
 
 // DeleteGlobalAddress deletes a global address by name.
@@ -65,17 +60,13 @@ func (gce *GCECloud) GetGlobalAddress(name string) (*compute.Address, error) {
 }
 
 // ReserveRegionAddress creates a region address
-func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) (*compute.Address, error) {
+func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) error {
 	mc := newAddressMetricContext("reserve", region)
 	op, err := gce.service.Addresses.Insert(gce.projectID, region, addr).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err := gce.waitForRegionOp(op, region, mc); err != nil {
-		return nil, err
-	}
-
-	return gce.GetRegionAddress(addr.Name, region)
+	return gce.waitForRegionOp(op, region, mc)
 }
 
 // DeleteRegionAddress deletes a region address by name.

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -922,8 +922,7 @@ func (gce *GCECloud) ensureStaticIP(name, serviceName, region, existingIP string
 		addressObj.Address = existingIP
 	}
 
-	address, err := gce.ReserveRegionAddress(addressObj, region)
-	if err != nil {
+	if err = gce.ReserveRegionAddress(addressObj, region); err != nil {
 		if !isHTTPErrorCode(err, http.StatusConflict) {
 			return "", false, fmt.Errorf("error creating gce static IP address: %v", err)
 		}
@@ -931,5 +930,10 @@ func (gce *GCECloud) ensureStaticIP(name, serviceName, region, existingIP string
 		existed = true
 	}
 
-	return address.Address, existed, nil
+	addr, err := gce.GetRegionAddress(name, region)
+	if err != nil {
+		return "", false, fmt.Errorf("error getting static IP address: %v", err)
+	}
+
+	return addr.Address, existed, nil
 }


### PR DESCRIPTION
Fixes #48848 

```release-note
Fix service controller crash loop when Service with GCP LoadBalancer uses static IP (#48848, @nicksardo)
```