### PR TITLE
Add e2e test for privileged containers

### DIFF
--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -459,4 +459,65 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		})
 	})
 
+	Context("When creating a pod with privileged", func() {
+		makeUserPod := func(podName, image string, command []string, privileged bool) *v1.Pod {
+			return &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: podName,
+				},
+				Spec: v1.PodSpec{
+					RestartPolicy: v1.RestartPolicyNever,
+					Containers: []v1.Container{
+						{
+							Image:   image,
+							Name:    podName,
+							Command: command,
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &privileged,
+							},
+						},
+					},
+				},
+			}
+		}
+		createAndWaitUserPod := func(privileged bool) string {
+			podName := fmt.Sprintf("busybox-privileged-%v-%s", privileged, uuid.NewUUID())
+			podClient.Create(makeUserPod(podName,
+				"gcr.io/google_containers/busybox:1.24",
+				[]string{"sh", "-c", "ip link add dummy0 type dummy || true"},
+				privileged,
+			))
+
+			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+
+			return podName
+		}
+
+		It("should run the container as privileged when true", func() {
+			podName := createAndWaitUserPod(true)
+			logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
+			if err != nil {
+				framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
+			}
+
+			framework.Logf("Got logs for pod %q: %q", podName, logs)
+			if strings.Contains(logs, "Operation not permitted") {
+				framework.Failf("privileged container should be able to create dummy device")
+			}
+		})
+
+		It("should run the container as unprivileged when false", func() {
+			podName := createAndWaitUserPod(false)
+			logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
+			if err != nil {
+				framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
+			}
+
+			framework.Logf("Got logs for pod %q: %q", podName, logs)
+			if !strings.Contains(logs, "Operation not permitted") {
+				framework.Failf("unprivileged container shouldn't be able to create dummy device")
+			}
+		})
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds node e2e test for privileged containers.

**Which issue this PR fixes**

Part of #44118.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @Random-Liu 