### PR TITLE
Add MostAccuratePodTemplateForObject to ObjectMappingFactory

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -455,6 +455,10 @@ func (f *FakeFactory) AttachablePodForObject(ob runtime.Object, timeout time.Dur
 	return nil, nil
 }
 
+func (f *FakeFactory) MostAccuratePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
+	return nil, nil
+}
+
 func (f *FakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
 	return false, nil
 }

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -606,7 +606,7 @@ func TestGetFirstPod(t *testing.T) {
 		}
 		selector := labels.Set(labelSet).AsSelector()
 
-		pod, numPods, err := GetFirstPod(fake.Core(), metav1.NamespaceDefault, selector, 1*time.Minute, test.sortBy)
+		pod, numPods, err := GetFirstPod(fake.Core(), metav1.NamespaceDefault, selector, 1*time.Minute, true, test.sortBy)
 		pod.Spec.SecurityContext = nil
 		if !test.expectedErr && err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -528,7 +528,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				ExecOrDie()
 			Expect(runOutput).ToNot(ContainSubstring("stdin closed"))
 			g := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }
-			runTestPod, _, err := util.GetFirstPod(f.InternalClientset.Core(), ns, labels.SelectorFromSet(map[string]string{"run": "run-test-3"}), 1*time.Minute, g)
+			runTestPod, _, err := util.GetFirstPod(f.InternalClientset.Core(), ns, labels.SelectorFromSet(map[string]string{"run": "run-test-3"}), 1*time.Minute, true, g)
 			if err != nil {
 				os.Exit(1)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This add a func MostAccuratePodTemplateForObject, so we can get a pod template of specific object to create a pod for debugging
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
xref: https://github.com/openshift/origin/issues/14915
**Release note**:

```
None
```
