### PR TITLE
do not close os.Stdin manually

### DIFF
--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -487,11 +487,12 @@ func (v *FileVisitor) Visit(fn VisitorFunc) error {
 		f = os.Stdin
 	} else {
 		var err error
-		if f, err = os.Open(v.Path); err != nil {
+		f, err = os.Open(v.Path)
+		if err != nil {
 			return err
 		}
+		defer f.Close()
 	}
-	defer f.Close()
 
 	// TODO: Consider adding a flag to force to UTF16, apparently some
 	// Windows tools don't write the BOM


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't need close os.Stdin manually, it will block our read from stdin after finish the visit.
**Special notes for your reviewer**:

**Release note**:
```
None
```
