### PR TITLE
Set default snap channel on charms to 1.7 stable

### DIFF
--- a/cluster/juju/layers/kubernetes-e2e/config.yaml
+++ b/cluster/juju/layers/kubernetes-e2e/config.yaml
@@ -1,6 +1,6 @@
 options:
   channel:
     type: string
-    default: "stable"
+    default: "1.7/stable"
     description: |
       Snap channel to install Kubernetes snaps from

--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -23,7 +23,7 @@ options:
       detected on a worker node.
   channel:
     type: string
-    default: "stable"
+    default: "1.7/stable"
     description: |
       Snap channel to install Kubernetes master services from
   client_password:

--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -22,7 +22,7 @@ options:
       switch to privileged mode if gpu hardware is detected.
   channel:
     type: string
-    default: "stable"
+    default: "1.7/stable"
     description: |
       Snap channel to install Kubernetes worker services from
   require-manual-upgrade:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR sets the default snap channel on charms to 1.7/stable. 
This addresses problems where the the user might want to deploy the charm and get the same kubernetes version found on the bundles.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/305

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Set default snap channel on charms to 1.7/stable
```
