### PR TITLE
Implement a preflight localhost check - rebase to 1.6

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"crypto/tls"
@@ -489,6 +490,7 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		SystemVerificationCheck{},
 		IsRootCheck{},
 		HostnameCheck{},
+		HostResolvesLocalCheck{hostname: "localhost"},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		FirewalldCheck{ports: []int{int(cfg.API.BindPort), 10250}},
@@ -540,6 +542,7 @@ func RunJoinNodeChecks(cfg *kubeadmapi.NodeConfiguration) error {
 		SystemVerificationCheck{},
 		IsRootCheck{},
 		HostnameCheck{},
+		HostResolvesLocalCheck{hostname: "localhost"},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		PortOpenCheck{port: 10250},
@@ -604,4 +607,56 @@ func TryStartKubelet() {
 			fmt.Println("[preflight] WARNING: Please ensure kubelet is running manually.")
 		}
 	}
+}
+
+// HostResolvesLocalCheck checks that a given hostname resovles to a local IP address.
+type HostResolvesLocalCheck struct {
+	hostname string
+}
+
+func (lc HostResolvesLocalCheck) Check() (warnings, errors []error) {
+
+	resolvedIPs, err := net.LookupIP(lc.hostname)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("Could not resolve %s: %s", lc.hostname, err))
+		return nil, errors
+	}
+
+	warnings = []error{}
+
+	// Early exit if the address is a loopback address.
+	// note: this does not address the extreme corner case where lo interface is down.
+	for _, ri := range resolvedIPs {
+		if ri.IsLoopback() {
+			return nil, errors
+		}
+	}
+
+	localIPAddrs, err := net.InterfaceAddrs()
+	if err != nil {
+		errors = append(errors, fmt.Errorf("Could not retrieve interface addresses: %s", err))
+		return nil, errors
+	}
+
+	for _, li := range localIPAddrs {
+		ip, _, err := net.ParseCIDR(li.String())
+		if err != nil {
+			errors = append(errors, fmt.Errorf("Could not parse interface address '%s': %s", li.String(), err))
+			return nil, errors
+		}
+		for _, ri := range resolvedIPs {
+			if ip.Equal(ri) {
+				return nil, errors
+			}
+		}
+	}
+
+	var resolvedIPStrs []string
+	for _, ip := range resolvedIPs {
+		resolvedIPStrs = append(resolvedIPStrs, ip.String())
+	}
+	warnings = append(warnings, fmt.Errorf("%s resolves to %s, which does not appear to be a local address",
+		lc.hostname, strings.Join(resolvedIPStrs, ", ")))
+
+	return warnings, errors
 }

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -231,6 +231,10 @@ func TestRunChecks(t *testing.T) {
 		{[]Checker{preflightCheckTest{"warning"}}, true, "[preflight] WARNING: warning\n"}, // should just print warning
 		{[]Checker{preflightCheckTest{"error"}}, false, ""},
 		{[]Checker{preflightCheckTest{"test"}}, false, ""},
+		{[]Checker{HostResolvesLocalCheck{"localhost"}}, true, ""},
+		{[]Checker{HostResolvesLocalCheck{""}}, false, ""},
+		{[]Checker{HostResolvesLocalCheck{"127.0.0.1"}}, true, ""},
+		{[]Checker{HostResolvesLocalCheck{"randomsubdomain.k8s.io"}}, false, ""},
 		{[]Checker{DirAvailableCheck{Path: "/does/not/exist"}}, true, ""},
 		{[]Checker{DirAvailableCheck{Path: "/"}}, false, ""},
 		{[]Checker{FileAvailableCheck{Path: "/does/not/exist"}}, true, ""},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
There have been a few instances of users who have had failed kubeadm
runs due to 'localhost' not resolving to an address local to the machine
being deployed. This can happen when the environment's search domain has
an entry for localhost.

This case is addressed in apiserver pull request:
https://github.com/kubernetes/kubernetes/pull/46772

That said, checking for this scenario would be a valuable preflight
check. While this check is primarily implemented for checking the
"localhost," it may be used to check to check whether any name/ip is
local. This functionality could be leveraged by other checks in the
future, but this approach also helps to test this check now.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubeadm/issues/302

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kubeadm: Add preflight check for localhost resolution.
```
