### PR TITLE
Add sorting to kubectl top

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -40,6 +40,7 @@ type TopNodeOptions struct {
 	HeapsterOptions HeapsterTopOptions
 	Client          *metricsutil.HeapsterMetricsClient
 	Printer         *metricsutil.TopCmdPrinter
+	SortBy          string
 }
 
 type HeapsterTopOptions struct {
@@ -82,8 +83,13 @@ func NewCmdTopNode(f cmdutil.Factory, out io.Writer) *cobra.Command {
 			if err := options.Complete(f, cmd, args, out); err != nil {
 				cmdutil.CheckErr(err)
 			}
+			sorting, err := cmd.Flags().GetString("sort-by")
+			options.SortBy = sorting
 			if err := options.Validate(); err != nil {
 				cmdutil.CheckErr(cmdutil.UsageErrorf(cmd, "%v", err))
+			}
+			if err != nil {
+				cmdutil.CheckErr(err)
 			}
 			if err := options.RunTopNode(); err != nil {
 				cmdutil.CheckErr(err)
@@ -92,6 +98,7 @@ func NewCmdTopNode(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Aliases: []string{"nodes", "no"},
 	}
 	cmd.Flags().StringVarP(&options.Selector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.")
+	cmd.Flags().StringVar(&options.SortBy, "sort-by", "", "If non-empty, sort list types using this field specification. For metrics, the valid fields are 'name', 'cpu' and 'memory'")
 	options.HeapsterOptions.Bind(cmd.Flags())
 	return cmd
 }
@@ -123,6 +130,9 @@ func (o *TopNodeOptions) Validate() error {
 		if err != nil {
 			return err
 		}
+	}
+	if len(o.SortBy) > 0 && o.SortBy != "name" && o.SortBy != "cpu" && o.SortBy != "memory" {
+		return errors.New("Please select either name, cpu, or memory to sort by")
 	}
 	return nil
 }
@@ -167,5 +177,5 @@ func (o TopNodeOptions) RunTopNode() error {
 		allocatable[n.Name] = n.Status.Allocatable
 	}
 
-	return o.Printer.PrintNodeMetrics(metrics, allocatable)
+	return o.Printer.PrintNodeMetrics(metrics, allocatable, api.ResourceName(o.SortBy))
 }

--- a/pkg/kubectl/cmd/top_pod_test.go
+++ b/pkg/kubectl/cmd/top_pod_test.go
@@ -84,6 +84,13 @@ func TestTopPod(t *testing.T) {
 			namespaces:   []string{testNS},
 			containers:   true,
 		},
+		{
+			name:            "sort",
+			flags:           map[string]string{"all-namespaces": "true", "sort-by": "cpu"},
+			expectedPath:    topPathPrefix + "/pods",
+			namespaces:      []string{testNS, "secondtestns", "thirdtestns"},
+			listsNamespaces: true,
+		},
 	}
 	initTestErrorHandler(t)
 	for _, testCase := range testCases {

--- a/pkg/kubectl/metricsutil/metrics_sorter.go
+++ b/pkg/kubectl/metricsutil/metrics_sorter.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metricsutil
+
+import (
+	"k8s.io/kubernetes/pkg/api"
+	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
+)
+
+type containerMetrics struct {
+	name    string
+	pod     *metricsapi.PodMetrics
+	metrics api.ResourceList
+}
+
+type containerMetricsSort struct {
+	metrics  []containerMetrics
+	sortType api.ResourceName
+}
+
+func (m containerMetricsSort) Len() int {
+	return len(m.metrics)
+}
+
+func (m containerMetricsSort) Swap(i, j int) {
+	m.metrics[i], m.metrics[j] = m.metrics[j], m.metrics[i]
+}
+
+func (m containerMetricsSort) Less(i, j int) bool {
+	switch m.sortType {
+	case api.ResourceName("name"):
+		return m.metrics[i].pod.Name < m.metrics[j].pod.Name
+	case api.ResourceCPU:
+		return m.metrics[i].metrics.Cpu().MilliValue() < m.metrics[j].metrics.Cpu().MilliValue()
+	case api.ResourceMemory:
+		return m.metrics[i].metrics.Memory().Value() < m.metrics[j].metrics.Memory().Value()
+	}
+	return false
+}
+
+type nodeMetricsSort struct {
+	metrics  []metricsapi.NodeMetrics
+	sortType api.ResourceName
+}
+
+func (m nodeMetricsSort) Len() int {
+	return len(m.metrics)
+}
+
+func (m nodeMetricsSort) Swap(i, j int) {
+	m.metrics[i], m.metrics[j] = m.metrics[j], m.metrics[i]
+}
+
+func (m nodeMetricsSort) Less(i, j int) bool {
+	switch m.sortType {
+	case api.ResourceName("name"):
+		return m.metrics[i].Name < m.metrics[j].Name
+	case api.ResourceCPU:
+		return m.metrics[i].Usage.Cpu().MilliValue() < m.metrics[j].Usage.Cpu().MilliValue()
+	case api.ResourceMemory:
+		return m.metrics[i].Usage.Memory().Value() < m.metrics[j].Usage.Memory().Value()
+	}
+	return false
+}
+
+type podMetricsSort struct {
+	metrics     []metricsapi.PodMetrics
+	fullMetrics []api.ResourceList
+	sortType    api.ResourceName
+}
+
+func (m podMetricsSort) Len() int {
+	return len(m.metrics)
+}
+
+func (m podMetricsSort) Swap(i, j int) {
+	m.metrics[i], m.metrics[j] = m.metrics[j], m.metrics[i]
+	m.fullMetrics[i], m.fullMetrics[j] = m.fullMetrics[j], m.fullMetrics[i]
+}
+
+func (m podMetricsSort) Less(i, j int) bool {
+	switch m.sortType {
+	case api.ResourceName("name"):
+		return m.metrics[i].Name < m.metrics[j].Name
+	case api.ResourceCPU:
+		return m.fullMetrics[i].Cpu().MilliValue() < m.fullMetrics[j].Cpu().MilliValue()
+	case api.ResourceMemory:
+		return m.fullMetrics[i].Memory().Value() < m.fullMetrics[j].Memory().Value()
+	}
+	return false
+}


### PR DESCRIPTION
Addresses part of #30507 
```release-note
**What this PR does / why we need it**: This PR  adds functionality to the kubectl top command to sort by a given resource name: name, cpu, or memory.
**Which issue this PR fixes**: Addresses part of #30507
**Special notes for your reviewer**: Due to the way container metrics were added when displaying pods beforehand, I had to refactor the way in which it was being done. I believe it is clearer now than before.
```
