### PR TITLE
Do not mutate already scheduled pods

### DIFF
--- a/plugin/pkg/admission/alwayspullimages/BUILD
+++ b/plugin/pkg/admission/alwayspullimages/BUILD
@@ -14,6 +14,7 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
     ],

--- a/plugin/pkg/admission/alwayspullimages/admission.go
+++ b/plugin/pkg/admission/alwayspullimages/admission.go
@@ -27,12 +27,14 @@ package alwayspullimages
 import (
 	"io"
 
+	"github.com/golang/glog"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// Register registers a plugin
+// Register registers a plugin.
 func Register(plugins *admission.Plugins) {
 	plugins.Register("AlwaysPullImages", func(config io.Reader) (admission.Interface, error) {
 		return NewAlwaysPullImages(), nil
@@ -69,6 +71,6 @@ func (a *alwaysPullImages) Admit(attributes admission.Attributes) (err error) {
 // NewAlwaysPullImages creates a new always pull images admission control handler
 func NewAlwaysPullImages() admission.Interface {
 	return &alwaysPullImages{
-		Handler: admission.NewHandler(admission.Create, admission.Update),
+		Handler: admission.NewHandler(admission.Create),
 	}
 }

--- a/plugin/pkg/admission/defaulttolerationseconds/BUILD
+++ b/plugin/pkg/admission/defaulttolerationseconds/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/helper:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
     ],

--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -62,7 +62,7 @@ var _ = kubeapiserveradmission.WantsInternalKubeClientSet(&podPresetPlugin{})
 // NewPlugin creates a new pod preset admission plugin.
 func NewPlugin() *podPresetPlugin {
 	return &podPresetPlugin{
-		Handler: admission.NewHandler(admission.Create, admission.Update),
+		Handler: admission.NewHandler(admission.Create),
 	}
 }
 


### PR DESCRIPTION
Admission controllers that mutate an already scheduled pod will block
future updates to the pod unless the admin disables the admission
plugin. Only applies to AC which mutates pods during an update after
spec.nodeName has been set.

@deads2k

Upstream of openshift/origin#15190, more details in openshift/origin#15188