### PR TITLE
client-go: add canonical import comment

### DIFF
--- a/pkg/client/clientset_generated/clientset/BUILD
+++ b/pkg/client/clientset_generated/clientset/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = [
         "clientset.go",
         "doc.go",
+        "import.go",
         "import_known_versions.go",
     ],
     tags = ["automanaged"],

--- a/pkg/client/clientset_generated/clientset/import.go
+++ b/pkg/client/clientset_generated/clientset/import.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file exists to enforce this clientset's vanity import path.
+
+package clientset // import "k8s.io/kubernetes/pkg/client/clientset_generated/clientset"

--- a/staging/src/k8s.io/client-go/kubernetes/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = [
         "clientset.go",
         "doc.go",
+        "import.go",
     ],
     tags = ["automanaged"],
     deps = [

--- a/staging/src/k8s.io/client-go/kubernetes/import.go
+++ b/staging/src/k8s.io/client-go/kubernetes/import.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file exists to enforce this clientset's vanity import path.
+
+package kubernetes // import "k8s.io/client-go/kubernetes"


### PR DESCRIPTION
Ensure users check out client-go to the correct location. The install error now reads:

```
can't load package: package github.com/kubernetes/client-go/kubernetes: code in directory /home/eric/src/github.com/kubernetes/client-go/kubernetes expects import "k8s.io/client-go/kubernetes"
```

ref https://github.com/kubernetes/client-go/issues/223

/cc @caesarxuchao @lavalamp 

```release-note
NONE
```
