### PR TITLE
Add cos-beta-60-9592-52-0 to the benchmark tests

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -48,22 +48,43 @@ images:
     machine: n1-standard-1
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
-  gci-resource1:
+  gci1-resource1:
     image: cos-stable-59-9460-64-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
-  gci-resource2:
+  gci1-resource2:
     image: cos-stable-59-9460-64-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
-  gci-resource3:
+  gci1-resource3:
     image: cos-stable-59-9460-64-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 105 pods per node \[Benchmark\]'
+  gci2-resource1:
+    image: cos-beta-60-9592-52-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  gci2-resource2:
+    image: cos-beta-60-9592-52-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  gci2-resource3:
+    image: cos-beta-60-9592-52-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This PR depends on https://github.com/kubernetes/kubernetes/pull/48824.

This PR adds new resource usage tests for cos-beta-60-9592-52-0 (docker 1.13.1).

Ref: #42926

**Release note**:
```
None
```
/sig node
/area node-e2e
/assign @dchen1107
/cc @abgworrall 