### PR TITLE
adds an admission plugin initializer to the sample apiserver.

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/BUILD
@@ -1,0 +1,34 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "interfaces.go",
+        "wardleinitializer.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["wardleinitializer_test.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/sample-apiserver/pkg/admission/wardleinitializer:go_default_library",
+        "//vendor/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/fake:go_default_library",
+        "//vendor/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion:go_default_library",
+    ],
+)

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/interfaces.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wardleinitializer
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	informers "k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion"
+)
+
+// WantsInternalWardleInformerFactory defines a function which sets InformerFactory for admission plugins that need it
+type WantsInternalWardleInformerFactory interface {
+	SetInternalWardleInformerFactory(informers.SharedInformerFactory)
+	admission.Validator
+}

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/wardleinitializer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/wardleinitializer.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wardleinitializer
+
+import (
+	"k8s.io/apiserver/pkg/admission"
+	informers "k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion"
+)
+
+type pluginInitializer struct {
+	informers informers.SharedInformerFactory
+}
+
+var _ admission.PluginInitializer = pluginInitializer{}
+
+// New creates an instance of wardle admission plugins initializer.
+func New(informers informers.SharedInformerFactory) (pluginInitializer, error) {
+	return pluginInitializer{
+		informers: informers,
+	}, nil
+}
+
+// Initialize checks the initialization interfaces implemented by a plugin
+// and provide the appropriate initialization data
+func (i pluginInitializer) Initialize(plugin admission.Interface) {
+	if wants, ok := plugin.(WantsInternalWardleInformerFactory); ok {
+		wants.SetInternalWardleInformerFactory(i.informers)
+	}
+}

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/wardleinitializer_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/wardleinitializer/wardleinitializer_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wardleinitializer_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/sample-apiserver/pkg/admission/wardleinitializer"
+	"k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/fake"
+	informers "k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion"
+)
+
+// TestWantsInternalWardleInformerFactory ensures that the informer factory is injected
+// when the WantsInternalWardleInformerFactory interface is implemented by a plugin.
+func TestWantsInternalWardleInformerFactory(t *testing.T) {
+	cs := &fake.Clientset{}
+	sf := informers.NewSharedInformerFactory(cs, time.Duration(1)*time.Second)
+	target, err := wardleinitializer.New(sf)
+	if err != nil {
+		t.Fatalf("expected to create an instance of initializer but got an error = %s", err.Error())
+	}
+	wantWardleInformerFactory := &wantInternalWardleInformerFactory{}
+	target.Initialize(wantWardleInformerFactory)
+	if wantWardleInformerFactory.sf != sf {
+		t.Errorf("expected informer factory to be initialized")
+	}
+}
+
+// wantInternalWardleInformerFactory is a test stub that fulfills the WantsInternalWardleInformerFactory interface
+type wantInternalWardleInformerFactory struct {
+	sf informers.SharedInformerFactory
+}
+
+func (self *wantInternalWardleInformerFactory) SetInternalWardleInformerFactory(sf informers.SharedInformerFactory) {
+	self.sf = sf
+}
+func (self *wantInternalWardleInformerFactory) Admit(a admission.Attributes) error { return nil }
+func (self *wantInternalWardleInformerFactory) Handles(o admission.Operation) bool { return false }
+func (self *wantInternalWardleInformerFactory) Validate() error                    { return nil }
+
+var _ admission.Interface = &wantInternalWardleInformerFactory{}
+var _ wardleinitializer.WantsInternalWardleInformerFactory = &wantInternalWardleInformerFactory{}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
this PR adds an admission plugin initializer to the sample apiserver.
the plugin initializer is going to be used by an admission plugin
that will use generated informers/listers to list the cluster-scoped resources.

#47868

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
