### PR TITLE
Added sig-storage labels to upgrade tests and moved them to appropriate directory

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -819,6 +819,7 @@ test/e2e/scheduling
 test/e2e/storage
 test/e2e/upgrades
 test/e2e/upgrades/apps
+test/e2e/upgrades/storage
 test/e2e_federation
 test/e2e_federation/framework
 test/e2e_federation/upgrades

--- a/test/e2e/lifecycle/BUILD
+++ b/test/e2e/lifecycle/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//test/e2e/framework/ginkgowrapper:go_default_library",
         "//test/e2e/upgrades:go_default_library",
         "//test/e2e/upgrades/apps:go_default_library",
+        "//test/e2e/upgrades/storage:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/junit:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/test/e2e/lifecycle/cluster_upgrade.go
+++ b/test/e2e/lifecycle/cluster_upgrade.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 	"k8s.io/kubernetes/test/e2e/upgrades"
 	apps "k8s.io/kubernetes/test/e2e/upgrades/apps"
+	"k8s.io/kubernetes/test/e2e/upgrades/storage"
 	"k8s.io/kubernetes/test/utils/junit"
 
 	. "github.com/onsi/ginkgo"
@@ -46,7 +47,7 @@ var upgradeTests = []upgrades.Test{
 	&apps.JobUpgradeTest{},
 	&upgrades.ConfigMapUpgradeTest{},
 	&upgrades.HPAUpgradeTest{},
-	&upgrades.PersistentVolumeUpgradeTest{},
+	&storage.PersistentVolumeUpgradeTest{},
 	&apps.DaemonSetUpgradeTest{},
 	&upgrades.IngressUpgradeTest{},
 	&upgrades.AppArmorUpgradeTest{},

--- a/test/e2e/upgrades/BUILD
+++ b/test/e2e/upgrades/BUILD
@@ -16,7 +16,6 @@ go_library(
         "horizontal_pod_autoscalers.go",
         "ingress.go",
         "mysql.go",
-        "persistent_volumes.go",
         "secrets.go",
         "services.go",
         "sysctl.go",
@@ -36,7 +35,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
@@ -54,6 +52,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//test/e2e/upgrades/apps:all-srcs",
+        "//test/e2e/upgrades/storage:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -33,7 +33,9 @@ type ConfigMapUpgradeTest struct {
 	configMap *v1.ConfigMap
 }
 
-func (ConfigMapUpgradeTest) Name() string { return "configmap-upgrade" }
+func (ConfigMapUpgradeTest) Name() string {
+	return "configmap-upgrade [sig-storage] [sig-api-machinery]"
+}
 
 // Setup creates a ConfigMap and then verifies that a pod can consume it.
 func (t *ConfigMapUpgradeTest) Setup(f *framework.Framework) {

--- a/test/e2e/upgrades/secrets.go
+++ b/test/e2e/upgrades/secrets.go
@@ -33,7 +33,7 @@ type SecretUpgradeTest struct {
 	secret *v1.Secret
 }
 
-func (SecretUpgradeTest) Name() string { return "secret-upgrade" }
+func (SecretUpgradeTest) Name() string { return "secret-upgrade [sig-storage] [sig-api-machinery]" }
 
 // Setup creates a secret and then verifies that a pod can consume it.
 func (t *SecretUpgradeTest) Setup(f *framework.Framework) {

--- a/test/e2e/upgrades/storage/BUILD
+++ b/test/e2e/upgrades/storage/BUILD
@@ -1,0 +1,35 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["persistent_volumes.go"],
+    tags = ["automanaged"],
+    deps = [
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/upgrades:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package upgrades
+package storage
 
 import (
 	"k8s.io/api/core/v1"
@@ -23,6 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/kubernetes/test/e2e/upgrades"
 )
 
 // PersistentVolumeUpgradeTest test that a pv is available before and after a cluster upgrade.
@@ -32,7 +33,7 @@ type PersistentVolumeUpgradeTest struct {
 	pvc      *v1.PersistentVolumeClaim
 }
 
-func (PersistentVolumeUpgradeTest) Name() string { return "persistent-volume-upgrade" }
+func (PersistentVolumeUpgradeTest) Name() string { return "persistent-volume-upgrade [sig-storage]" }
 
 const (
 	pvTestFile string = "/mnt/volume1/pv_upgrade_test"
@@ -89,7 +90,7 @@ func (t *PersistentVolumeUpgradeTest) Setup(f *framework.Framework) {
 
 // Test waits for the upgrade to complete, and then verifies that a pod can still consume the pv
 // and that the volume data persists.
-func (t *PersistentVolumeUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
+func (t *PersistentVolumeUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	<-done
 	By("Consuming the PV after upgrade")
 	t.testPod(f, pvReadCmd)


### PR DESCRIPTION
**What this PR does / why we need it**: Adding necessary sig identifier for storage upgrade tests.

/release-note-none