### PR TITLE
Automated cherry pick of #48915

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -197,7 +197,7 @@ type Init struct {
 
 // Validate validates configuration passed to "kubeadm init"
 func (i *Init) Validate(cmd *cobra.Command) error {
-	if err := validation.ValidateMixedArguments(cmd.PersistentFlags()); err != nil {
+	if err := validation.ValidateMixedArguments(cmd.Flags()); err != nil {
 		return err
 	}
 	return validation.ValidateMasterConfiguration(i.cfg).ToAggregate()


### PR DESCRIPTION
Cherry pick of #48915 on release-1.7.

#48915: kubeadm: fix broken `kubeadm init --config` flag.