### PR TITLE
Fix comments and typo in the error message

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -940,7 +940,7 @@ func (kl *Kubelet) podKiller() {
 	}
 }
 
-// checkHostPortConflicts detects pods with conflicted host ports.
+// hasHostPortConflicts detects pods with conflicted host ports.
 func hasHostPortConflicts(pods []*v1.Pod) bool {
 	ports := sets.String{}
 	for _, pod := range pods {
@@ -1653,7 +1653,7 @@ func (kl *Kubelet) hasHostMountPVC(pod *v1.Pod) bool {
 			if pvc != nil {
 				referencedVolume, err := kl.kubeClient.Core().PersistentVolumes().Get(pvc.Spec.VolumeName, metav1.GetOptions{})
 				if err != nil {
-					glog.Warningf("unable to retrieve pvc %s - %v", pvc.Spec.VolumeName, err)
+					glog.Warningf("unable to retrieve pv %s - %v", pvc.Spec.VolumeName, err)
 					continue
 				}
 				if referencedVolume != nil && referencedVolume.Spec.HostPath != nil {

--- a/pkg/kubelet/util.go
+++ b/pkg/kubelet/util.go
@@ -88,7 +88,7 @@ func allowHostNetwork(pod *v1.Pod) (bool, error) {
 	return false, nil
 }
 
-// Determined whether the specified pod is allowed to use host networking
+// Determined whether the specified pod is allowed to use host PID
 func allowHostPID(pod *v1.Pod) (bool, error) {
 	podSource, err := kubetypes.GetPodSource(pod)
 	if err != nil {

--- a/pkg/volume/empty_dir/empty_dir.go
+++ b/pkg/volume/empty_dir/empty_dir.go
@@ -234,8 +234,7 @@ func (ed *emptyDir) SetUpAt(dir string, fsGroup *int64) error {
 	return err
 }
 
-// setupTmpfs creates a tmpfs mount at the specified directory with the
-// specified SELinux context.
+// setupTmpfs creates a tmpfs mount at the specified directory.
 func (ed *emptyDir) setupTmpfs(dir string) error {
 	if ed.mounter == nil {
 		return fmt.Errorf("memory storage requested, but mounter is nil")
@@ -258,8 +257,7 @@ func (ed *emptyDir) setupTmpfs(dir string) error {
 	return ed.mounter.Mount("tmpfs", dir, "tmpfs", nil /* options */)
 }
 
-// setupDir creates the directory with the specified SELinux context and
-// the default permissions specified by the perm constant.
+// setupDir creates the directory with the default permissions specified by the perm constant.
 func (ed *emptyDir) setupDir(dir string) error {
 	// Create the directory if it doesn't already exist.
 	if err := os.MkdirAll(dir, perm); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes outdated comments and typo in the error message.

**Release note**:
```release-note
NONE
```

CC @simo5