### PR TITLE
kubectl: deduplicate deployment generators

### DIFF
--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -103,16 +103,22 @@ func generatorFromName(
 
 	switch generatorName {
 	case cmdutil.DeploymentBasicAppsV1Beta1GeneratorName:
-		return &kubectl.DeploymentBasicAppsGeneratorV1{
-			Name:   deploymentName,
-			Images: imageNames,
-		}, true
+		generator := &kubectl.DeploymentBasicAppsGeneratorV1{
+			BaseDeploymentGenerator: kubectl.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		return generator, true
 
 	case cmdutil.DeploymentBasicV1Beta1GeneratorName:
-		return &kubectl.DeploymentBasicGeneratorV1{
-			Name:   deploymentName,
-			Images: imageNames,
-		}, true
+		generator := &kubectl.DeploymentBasicGeneratorV1{
+			BaseDeploymentGenerator: kubectl.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		return generator, true
 	}
 
 	return nil, false

--- a/pkg/kubectl/cmd/create_deployment_test.go
+++ b/pkg/kubectl/cmd/create_deployment_test.go
@@ -47,17 +47,29 @@ func Test_generatorFromName(t *testing.T) {
 
 	generator, ok = generatorFromName(basicName, imageNames, deploymentName)
 	assert.True(t, ok)
-	assert.Equal(t, &kubectl.DeploymentBasicGeneratorV1{
-		Name:   deploymentName,
-		Images: imageNames,
-	}, generator)
+
+	{
+		expectedGenerator := &kubectl.DeploymentBasicGeneratorV1{
+			BaseDeploymentGenerator: kubectl.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		assert.Equal(t, expectedGenerator, generator)
+	}
 
 	generator, ok = generatorFromName(basicAppsName, imageNames, deploymentName)
 	assert.True(t, ok)
-	assert.Equal(t, &kubectl.DeploymentBasicAppsGeneratorV1{
-		Name:   deploymentName,
-		Images: imageNames,
-	}, generator)
+
+	{
+		expectedGenerator := &kubectl.DeploymentBasicAppsGeneratorV1{
+			BaseDeploymentGenerator: kubectl.BaseDeploymentGenerator{
+				Name:   deploymentName,
+				Images: imageNames,
+			},
+		}
+		assert.Equal(t, expectedGenerator, generator)
+	}
 }
 
 func TestCreateDeployment(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: See the description on https://github.com/kubernetes/kubectl/issues/44

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubectl/issues/44

**Special notes for your reviewer**: Yes, the lines added and removed are about the same. This is because I added 20+ lines of docstrings. Check the diff. You'll see I deleted a lot of duplicated logic :)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
