### PR TITLE
kubelet: remove code for handling old pod/containers paths

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -71,23 +71,7 @@ func (kl *Kubelet) GetPodDir(podUID types.UID) string {
 // getPodDir returns the full path to the per-pod directory for the pod with
 // the given UID.
 func (kl *Kubelet) getPodDir(podUID types.UID) string {
-	// Backwards compat.  The "old" stuff should be removed before 1.0
-	// release.  The thinking here is this:
-	//     !old && !new = use new
-	//     !old && new  = use new
-	//     old && !new  = use old
-	//     old && new   = use new (but warn)
-	oldPath := filepath.Join(kl.getRootDir(), string(podUID))
-	oldExists := dirExists(oldPath)
-	newPath := filepath.Join(kl.getPodsDir(), string(podUID))
-	newExists := dirExists(newPath)
-	if oldExists && !newExists {
-		return oldPath
-	}
-	if oldExists {
-		glog.Warningf("Data dir for pod %q exists in both old and new form, using new", podUID)
-	}
-	return newPath
+	return filepath.Join(kl.getPodsDir(), string(podUID))
 }
 
 // getPodVolumesDir returns the full path to the per-pod data directory under
@@ -122,23 +106,7 @@ func (kl *Kubelet) getPodPluginDir(podUID types.UID, pluginName string) string {
 // which container data is held for the specified pod.  This directory may not
 // exist if the pod or container does not exist.
 func (kl *Kubelet) getPodContainerDir(podUID types.UID, ctrName string) string {
-	// Backwards compat.  The "old" stuff should be removed before 1.0
-	// release.  The thinking here is this:
-	//     !old && !new = use new
-	//     !old && new  = use new
-	//     old && !new  = use old
-	//     old && new   = use new (but warn)
-	oldPath := filepath.Join(kl.getPodDir(podUID), ctrName)
-	oldExists := dirExists(oldPath)
-	newPath := filepath.Join(kl.getPodDir(podUID), options.DefaultKubeletContainersDirName, ctrName)
-	newExists := dirExists(newPath)
-	if oldExists && !newExists {
-		return oldPath
-	}
-	if oldExists {
-		glog.Warningf("Data dir for pod %q, container %q exists in both old and new form, using new", podUID, ctrName)
-	}
-	return newPath
+	return filepath.Join(kl.getPodDir(podUID), options.DefaultKubeletContainersDirName, ctrName)
 }
 
 // GetPods returns all pods bound to the kubelet and their spec, and the mirror

--- a/pkg/kubelet/kubelet_getters_test.go
+++ b/pkg/kubelet/kubelet_getters_test.go
@@ -17,13 +17,10 @@ limitations under the License.
 package kubelet
 
 import (
-	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKubeletDirs(t *testing.T) {
@@ -69,44 +66,4 @@ func TestKubeletDirs(t *testing.T) {
 	got = kubelet.getPodContainerDir("abc123", "def456")
 	exp = filepath.Join(root, "pods/abc123/containers/def456")
 	assert.Equal(t, exp, got)
-}
-
-func TestKubeletDirsCompat(t *testing.T) {
-	testKubelet := newTestKubelet(t, false /* controllerAttachDetachEnabled */)
-	defer testKubelet.Cleanup()
-	kubelet := testKubelet.kubelet
-	root := kubelet.rootDirectory
-	require.NoError(t, os.MkdirAll(root, 0750), "can't mkdir(%q)", root)
-
-	// Old-style pod dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/oldpod", root), 0750), "can't mkdir(%q)", root)
-
-	// New-style pod dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/pods/newpod", root), 0750), "can't mkdir(%q)", root)
-
-	// Both-style pod dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/bothpod", root), 0750), "can't mkdir(%q)", root)
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/pods/bothpod", root), 0750), "can't mkdir(%q)", root)
-
-	assert.Equal(t, filepath.Join(root, "oldpod"), kubelet.getPodDir("oldpod"))
-	assert.Equal(t, filepath.Join(root, "pods/newpod"), kubelet.getPodDir("newpod"))
-	assert.Equal(t, filepath.Join(root, "pods/bothpod"), kubelet.getPodDir("bothpod"))
-	assert.Equal(t, filepath.Join(root, "pods/neitherpod"), kubelet.getPodDir("neitherpod"))
-
-	root = kubelet.getPodDir("newpod")
-
-	// Old-style container dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/oldctr", root), 0750), "can't mkdir(%q)", root)
-
-	// New-style container dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/containers/newctr", root), 0750), "can't mkdir(%q)", root)
-
-	// Both-style container dir.
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/bothctr", root), 0750), "can't mkdir(%q)", root)
-	require.NoError(t, os.MkdirAll(fmt.Sprintf("%s/containers/bothctr", root), 0750), "can't mkdir(%q)", root)
-
-	assert.Equal(t, filepath.Join(root, "oldctr"), kubelet.getPodContainerDir("newpod", "oldctr"))
-	assert.Equal(t, filepath.Join(root, "containers/newctr"), kubelet.getPodContainerDir("newpod", "newctr"))
-	assert.Equal(t, filepath.Join(root, "containers/bothctr"), kubelet.getPodContainerDir("newpod", "bothctr"))
-	assert.Equal(t, filepath.Join(root, "containers/neitherctr"), kubelet.getPodContainerDir("newpod", "neitherctr"))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the code for handling the paths that has been deprecated for a long time.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

CC @simo5
