### PR TITLE
Automated cherry pick of #48838

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -85,6 +85,12 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 			i, err := NewInit(cfgPath, internalcfg, skipPreFlight, skipTokenPrint)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(i.Validate(cmd))
+
+			// TODO: remove this warning in 1.9
+			if !cmd.Flags().Lookup("token-ttl").Changed {
+				fmt.Println("[kubeadm] WARNING: starting in 1.8, tokens expire after 24 hours by default (if you require a non-expiring token use --token-ttl 0)")
+			}
+
 			kubeadmutil.CheckErr(i.Run(out))
 		},
 	}

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -109,6 +109,12 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			client, err := kubeconfigutil.ClientSetFromFile(kubeConfigFile)
 			kubeadmutil.CheckErr(err)
 
+			// TODO: remove this warning in 1.9
+			if !tokenCmd.Flags().Lookup("ttl").Changed {
+				// sending this output to stderr s
+				fmt.Fprintln(errW, "[kubeadm] WARNING: starting in 1.8, tokens expire after 24 hours by default (if you require a non-expiring token use --ttl 0)")
+			}
+
 			err = RunCreateToken(out, client, token, tokenDuration, usages, description)
 			kubeadmutil.CheckErr(err)
 		},


### PR DESCRIPTION
Cherry pick of #48838 on release-1.7.

#48838: kubeadm: add a warning about the default token TTL changing