### PR TITLE
use port configuration

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -29,6 +29,7 @@ from charms.layer import nginx
 from subprocess import Popen
 from subprocess import PIPE
 from subprocess import STDOUT
+from subprocess import CalledProcessError
 
 
 @when('certificates.available')
@@ -49,6 +50,16 @@ def request_server_certificates(tls):
     tls.request_server_cert(common_name, sans, certificate_name)
 
 
+@when('config.changed.port')
+def close_old_port():
+    config = hookenv.config()
+    old_port = config.previous('port')
+    try:
+        hookenv.close_port(old_port)
+    except CalledProcessError:
+        hookenv.log('Port %d already closed, skipping.' % old_port)
+
+
 @when('nginx.available', 'apiserver.available',
       'certificates.server.cert.available')
 def install_load_balancer(apiserver, tls):
@@ -63,20 +74,23 @@ def install_load_balancer(apiserver, tls):
     if cert_exists and key_exists:
         # At this point the cert and key exist, and they are owned by root.
         chown = ['chown', 'www-data:www-data', server_cert_path]
+
         # Change the owner to www-data so the nginx process can read the cert.
         subprocess.call(chown)
         chown = ['chown', 'www-data:www-data', server_key_path]
+
         # Change the owner to www-data so the nginx process can read the key.
         subprocess.call(chown)
 
-        hookenv.open_port(hookenv.config('port'))
+        port = hookenv.config('port')
+        hookenv.open_port(port)
         services = apiserver.services()
         nginx.configure_site(
                 'apilb',
                 'apilb.conf',
                 server_name='_',
                 services=services,
-                port=hookenv.config('port'),
+                port=port,
                 server_certificate=server_cert_path,
                 server_key=server_key_path,
         )

--- a/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
+++ b/cluster/juju/layers/kubeapi-load-balancer/templates/apilb.conf
@@ -8,7 +8,7 @@ upstream target_service {
 
 
 server {
-    listen 443 ssl http2;
+    listen {{ port }} ssl http2;
     server_name {{ server_name }};
 
     access_log /var/log/nginx.access.log;


### PR DESCRIPTION
**What this PR does / why we need it**: Uses the `port` config option in the kubeapi-load-balancer charm.

**Release note**:
```release-note
Uses the port config option in the kubeapi-load-balancer charm.
```
