### PR TITLE
Do not generate warning event on dns search deduplication

### DIFF
--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -95,10 +95,6 @@ func omitDuplicates(kl *Kubelet, pod *v1.Pod, combinedSearch []string) []string 
 		if _, exists := uniqueDomains[dnsDomain]; !exists {
 			combinedSearch[len(uniqueDomains)] = dnsDomain
 			uniqueDomains[dnsDomain] = true
-		} else {
-			log := fmt.Sprintf("Found and omitted duplicated dns domain in host search line: '%s' during merging with cluster dns domains", dnsDomain)
-			kl.recorder.Event(pod, v1.EventTypeWarning, "DNSSearchForming", log)
-			glog.Error(log)
 		}
 	}
 	return combinedSearch[:len(uniqueDomains)]

--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -138,10 +138,7 @@ func TestComposeDNSSearch(t *testing.T) {
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST"},
 			[]string{"AAA", "svc.TEST", "BBB", "TEST"},
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB"},
-			[]string{
-				"Found and omitted duplicated dns domain in host search line: 'svc.TEST' during merging with cluster dns domains",
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
-			},
+			[]string{},
 		},
 
 		{
@@ -156,8 +153,6 @@ func TestComposeDNSSearch(t *testing.T) {
 			[]string{"AAA", "TEST", "BBB", "TEST", "CCC", "DDD"},
 			[]string{"testNS.svc.TEST", "svc.TEST", "TEST", "AAA", "BBB", "CCC"},
 			[]string{
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
-				"Found and omitted duplicated dns domain in host search line: 'TEST' during merging with cluster dns domains",
 				"Search Line limits were exceeded, some dns names have been omitted, the applied search line is: testNS.svc.TEST svc.TEST TEST AAA BBB CCC",
 			},
 		},


### PR DESCRIPTION
In the case that the node is able to use the cluster DNS, `cluster.local` will already be in the node search domains in `/etc/resolv.conf`.  The kubelet then parses `/etc/resolv.conf` on the node and combines it with  $namespace.svc.$clusterDomain, svc.$clusterDomain, and $clusterDomain to create the pod DNS search domains.  clusterDomain is `cluster.local` by default.  This causes the code to generate a Warning event visible to the user for _every_ pod:

```
Warning   DNSSearchForming     Found and omitted duplicated dns domain in host search line: 'cluster.local' during merging with cluster dns domains
```
This is really overkill.  IMHO, this should be done in the background with no user level notification or logging at all.

xref https://bugzilla.redhat.com/show_bug.cgi?id=1471198

@derekwaynecarr @eparis @vefimova

 