### PR TITLE
Migrate sig-auth e2e tests.

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -800,6 +800,7 @@ staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
 test/e2e
 test/e2e/apimachinery
 test/e2e/apps
+test/e2e/auth
 test/e2e/autoscaling
 test/e2e/chaosmonkey
 test/e2e/common

--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -16,6 +16,7 @@ go_test(
     deps = [
         "//test/e2e/apimachinery:go_default_library",
         "//test/e2e/apps:go_default_library",
+        "//test/e2e/auth:go_default_library",
         "//test/e2e/autoscaling:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
@@ -44,8 +45,6 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
-        "audit.go",
-        "certificates.go",
         "dashboard.go",
         "e2e.go",
         "events.go",
@@ -61,7 +60,6 @@ go_library(
         "pods.go",
         "pre_stop.go",
         "resource_quota.go",
-        "service_accounts.go",
         "ssh.go",
         "ubernetes_lite.go",
     ],
@@ -75,8 +73,6 @@ go_library(
         "//pkg/kubectl/util/logs:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/quota/evaluator/core:go_default_library",
-        "//pkg/util/version:go_default_library",
-        "//plugin/pkg/admission/serviceaccount:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",
@@ -92,11 +88,9 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
-        "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/api/settings/v1alpha1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
@@ -111,9 +105,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )
 
@@ -141,6 +133,7 @@ filegroup(
         ":package-srcs",
         "//test/e2e/apimachinery:all-srcs",
         "//test/e2e/apps:all-srcs",
+        "//test/e2e/auth:all-srcs",
         "//test/e2e/autoscaling:all-srcs",
         "//test/e2e/chaosmonkey:all-srcs",
         "//test/e2e/common:all-srcs",

--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "audit.go",
+        "certificates.go",
+        "framework.go",
+        "service_accounts.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/util/version:go_default_library",
+        "//plugin/pkg/admission/serviceaccount:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/e2e/auth/OWNERS
+++ b/test/e2e/auth/OWNERS
@@ -1,0 +1,14 @@
+reviewers:
+  - liggitt
+  - mikedanese
+  - smarterclayton
+  - sttts
+  - tallclair
+  - ericchiang
+approvers:
+  - liggitt
+  - mikedanese
+  - smarterclayton
+  - sttts
+  - tallclair
+  - ericchiang

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package auth
 
 import (
 	"bufio"
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Advanced Audit [Feature:Audit]", func() {
+var _ = SIGDescribe("Advanced Audit [Feature:Audit]", func() {
 	f := framework.NewDefaultFramework("audit")
 
 	It("should audit API calls", func() {

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package auth
 
 import (
 	"crypto/x509"
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var _ = framework.KubeDescribe("Certificates API", func() {
+var _ = SIGDescribe("Certificates API", func() {
 	f := framework.NewDefaultFramework("certificates")
 
 	It("should support building a client with a CSR", func() {

--- a/test/e2e/auth/framework.go
+++ b/test/e2e/auth/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-auth] "+text, body)
+}

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package auth
 
 import (
 	"fmt"
@@ -37,7 +37,7 @@ var serviceAccountTokenNamespaceVersion = utilversion.MustParseSemantic("v1.2.0"
 
 var serviceAccountTokenAutomountVersion = utilversion.MustParseSemantic("v1.6.0-alpha.2")
 
-var _ = framework.KubeDescribe("ServiceAccounts", func() {
+var _ = SIGDescribe("ServiceAccounts", func() {
 	f := framework.NewDefaultFramework("svcaccounts")
 
 	It("should ensure a single API token exists", func() {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,7 @@ import (
 	// test sources
 	_ "k8s.io/kubernetes/test/e2e/apimachinery"
 	_ "k8s.io/kubernetes/test/e2e/apps"
+	_ "k8s.io/kubernetes/test/e2e/auth"
 	_ "k8s.io/kubernetes/test/e2e/autoscaling"
 	_ "k8s.io/kubernetes/test/e2e/common"
 	_ "k8s.io/kubernetes/test/e2e/instrumentation"


### PR DESCRIPTION
**What this PR does / why we need it:** This PR adds [sig-auth] prefix to
workload e2e tests in accord to requirements of adding a SIG dashboard
to testgrid. Refer PR #48781 for guidelines.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
