### PR TITLE
Cleanup the conversion of ObjectReference

### DIFF
--- a/pkg/kubelet/container/BUILD
+++ b/pkg/kubelet/container/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/v1/ref:go_default_library",
         "//pkg/kubelet/apis/cri/v1alpha1/runtime:go_default_library",
-        "//pkg/kubelet/events:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/kubelet/util/ioutils:go_default_library",
         "//pkg/util/hash:go_default_library",

--- a/pkg/kubelet/container/helpers.go
+++ b/pkg/kubelet/container/helpers.go
@@ -27,13 +27,11 @@ import (
 	"github.com/golang/glog"
 
 	"k8s.io/api/core/v1"
-	clientv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
-	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
@@ -176,19 +174,13 @@ type innerEventRecorder struct {
 	recorder record.EventRecorder
 }
 
-func (irecorder *innerEventRecorder) shouldRecordEvent(object runtime.Object) (*clientv1.ObjectReference, bool) {
+func (irecorder *innerEventRecorder) shouldRecordEvent(object runtime.Object) (*v1.ObjectReference, bool) {
 	if object == nil {
 		return nil, false
 	}
-	if ref, ok := object.(*clientv1.ObjectReference); ok {
-		if !strings.HasPrefix(ref.FieldPath, ImplicitContainerPrefix) {
-			return ref, true
-		}
-	}
-	// just in case we miss a spot, be sure that we still log something
 	if ref, ok := object.(*v1.ObjectReference); ok {
 		if !strings.HasPrefix(ref.FieldPath, ImplicitContainerPrefix) {
-			return events.ToObjectReference(ref), true
+			return ref, true
 		}
 	}
 	return nil, false

--- a/pkg/kubelet/events/BUILD
+++ b/pkg/kubelet/events/BUILD
@@ -11,7 +11,6 @@ go_library(
     name = "go_default_library",
     srcs = ["event.go"],
     tags = ["automanaged"],
-    deps = ["//vendor/k8s.io/api/core/v1:go_default_library"],
 )
 
 filegroup(

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package events
 
-import (
-	"k8s.io/api/core/v1"
-	clientv1 "k8s.io/api/core/v1"
-)
-
 const (
 	// Container event reason list
 	CreatedContainer        = "Created"
@@ -86,19 +81,3 @@ const (
 	FailedPreStopHook     = "FailedPreStopHook"
 	UnfinishedPreStopHook = "UnfinishedPreStopHook"
 )
-
-// ToObjectReference takes an old style object reference and converts it to a client-go one
-func ToObjectReference(ref *v1.ObjectReference) *clientv1.ObjectReference {
-	if ref == nil {
-		return nil
-	}
-	return &clientv1.ObjectReference{
-		Kind:            ref.Kind,
-		Namespace:       ref.Namespace,
-		Name:            ref.Name,
-		UID:             ref.UID,
-		APIVersion:      ref.APIVersion,
-		ResourceVersion: ref.ResourceVersion,
-		FieldPath:       ref.FieldPath,
-	}
-}

--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -75,7 +75,7 @@ func shouldPullImage(container *v1.Container, imagePresent bool) bool {
 // records an event using ref, event msg.  log to glog using prefix, msg, logFn
 func (m *imageManager) logIt(ref *v1.ObjectReference, eventtype, event, prefix, msg string, logFn func(args ...interface{})) {
 	if ref != nil {
-		m.recorder.Event(events.ToObjectReference(ref), eventtype, event, msg)
+		m.recorder.Event(ref, eventtype, event, msg)
 	} else {
 		logFn(fmt.Sprint(prefix, " ", msg))
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
No need to convert ObjectReference as `k8s.io/kubernetes/pkg/api/v1` and `k8s.io/client-go/pkg/api/v1` has been consistent in `k8s.io/api/core/v1`.

**Which issue this PR fixes**: fixes #48747

**Special notes for your reviewer**:
/assign @caesarxuchao

**Release note**:
```release-note
NONE
```
