### PR TITLE
Mark sig-scheduling tests with [sig-scheduling] so they can be selected for the testdash dashboard

### DIFF
--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "events.go",
+        "framework.go",
         "opaque_resource.go",
         "predicates.go",
         "priorities.go",

--- a/test/e2e/scheduling/framework.go
+++ b/test/e2e/scheduling/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-scheduling] "+text, body)
+}

--- a/test/e2e/scheduling/opaque_resource.go
+++ b/test/e2e/scheduling/opaque_resource.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Opaque resources [Feature:OpaqueResources]", func() {
+var _ = SIGDescribe("Opaque resources [Feature:OpaqueResources]", func() {
 	f := framework.NewDefaultFramework("opaque-resource")
 	opaqueResName := v1helper.OpaqueIntResourceName("foo")
 	var node *v1.Node

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -53,7 +53,7 @@ type pausePodConfig struct {
 	NodeName                          string
 }
 
-var _ = framework.KubeDescribe("SchedulerPredicates [Serial]", func() {
+var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 	var cs clientset.Interface
 	var nodeList *v1.NodeList
 	var systemPodsNo int

--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -57,7 +57,7 @@ var podRequestedResource *v1.ResourceRequirements = &v1.ResourceRequirements{
 }
 
 // This test suite is used to verifies scheduler priority functions based on the default provider
-var _ = framework.KubeDescribe("SchedulerPriorities [Serial]", func() {
+var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 	var cs clientset.Interface
 	var nodeList *v1.NodeList
 	var systemPodsNo int

--- a/test/e2e/scheduling/rescheduler.go
+++ b/test/e2e/scheduling/rescheduler.go
@@ -36,7 +36,7 @@ const (
 )
 
 // This test requires Rescheduler to be enabled.
-var _ = framework.KubeDescribe("Rescheduler [Serial]", func() {
+var _ = SIGDescribe("Rescheduler [Serial]", func() {
 	f := framework.NewDefaultFramework("rescheduler")
 	var ns string
 	var totalMillicores int


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark sig-scheduling tests with [sig-scheduling] so they can be selected for the testdash dashboard
(see kubernetes/test-infra#3529 for sig-scheduling dashboard definition).

cc/ @bsalamat @kubernetes/sig-scheduling-pr-reviews 
