### PR TITLE
Relax restrictions on environment variable names.

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1440,7 +1440,7 @@ type SecretKeySelector struct {
 
 // EnvFromSource represents the source of a set of ConfigMaps
 type EnvFromSource struct {
-	// An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
+	// An optional identifier to prepend to each key in the ConfigMap.
 	// +optional
 	Prefix string
 	// The ConfigMap to select from.

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1548,7 +1548,7 @@ func ValidateEnv(vars []api.EnvVar, fldPath *field.Path) field.ErrorList {
 		if len(ev.Name) == 0 {
 			allErrs = append(allErrs, field.Required(idxPath.Child("name"), ""))
 		} else {
-			for _, msg := range validation.IsCIdentifier(ev.Name) {
+			for _, msg := range validation.IsEnvVarName(ev.Name) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), ev.Name, msg))
 			}
 		}
@@ -1637,7 +1637,7 @@ func ValidateEnvFrom(vars []api.EnvFromSource, fldPath *field.Path) field.ErrorL
 	for i, ev := range vars {
 		idxPath := fldPath.Index(i)
 		if len(ev.Prefix) > 0 {
-			for _, msg := range validation.IsCIdentifier(ev.Prefix) {
+			for _, msg := range validation.IsEnvVarName(ev.Prefix) {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("prefix"), ev.Prefix, msg))
 			}
 		}

--- a/pkg/kubectl/configmap_test.go
+++ b/pkg/kubectl/configmap_test.go
@@ -157,7 +157,7 @@ func TestConfigMapGenerate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			setup: setupEnvFile("key.1=value1"),
+			setup: setupEnvFile("key#1=value1"),
 			params: map[string]interface{}{
 				"name":          "invalid_key",
 				"from-env-file": "file.env",

--- a/pkg/kubectl/env_file.go
+++ b/pkg/kubectl/env_file.go
@@ -55,7 +55,7 @@ func proccessEnvFileLine(line []byte, filePath string,
 
 	data := strings.SplitN(string(line), "=", 2)
 	key = data[0]
-	if errs := validation.IsCIdentifier(key); len(errs) != 0 {
+	if errs := validation.IsEnvVarName(key); len(errs) != 0 {
 		return ``, ``, fmt.Errorf("%q is not a valid key name: %s", key, strings.Join(errs, ";"))
 	}
 

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -868,7 +868,7 @@ func parseEnvs(envArray []string) ([]v1.EnvVar, error) {
 		if len(name) == 0 {
 			return nil, fmt.Errorf("invalid env: %v", env)
 		}
-		if len(validation.IsCIdentifier(name)) != 0 {
+		if len(validation.IsEnvVarName(name)) != 0 {
 			return nil, fmt.Errorf("invalid env: %v", env)
 		}
 		envVar := v1.EnvVar{Name: name, Value: value}

--- a/pkg/kubectl/run_test.go
+++ b/pkg/kubectl/run_test.go
@@ -1030,6 +1030,7 @@ func TestParseEnv(t *testing.T) {
 		{
 			envArray: []string{
 				"THIS_ENV=isOK",
+				"this.dotted.env=isOKToo",
 				"HAS_COMMAS=foo,bar",
 				"HAS_EQUALS=jJnro54iUu75xNy==",
 			},
@@ -1037,6 +1038,10 @@ func TestParseEnv(t *testing.T) {
 				{
 					Name:  "THIS_ENV",
 					Value: "isOK",
+				},
+				{
+					Name:  "this.dotted.env",
+					Value: "isOKToo",
 				},
 				{
 					Name:  "HAS_COMMAS",

--- a/pkg/kubectl/secret_test.go
+++ b/pkg/kubectl/secret_test.go
@@ -157,7 +157,7 @@ func TestSecretGenerate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			setup: setupEnvFile("key.1=value1"),
+			setup: setupEnvFile("key#1=value1"),
 			params: map[string]interface{}{
 				"name":          "invalid_key",
 				"from-env-file": "file.env",

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -472,7 +472,7 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 				if len(envFrom.Prefix) > 0 {
 					k = envFrom.Prefix + k
 				}
-				if errMsgs := utilvalidation.IsCIdentifier(k); len(errMsgs) != 0 {
+				if errMsgs := utilvalidation.IsEnvVarName(k); len(errMsgs) != 0 {
 					invalidKeys = append(invalidKeys, k)
 					continue
 				}
@@ -507,7 +507,7 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 				if len(envFrom.Prefix) > 0 {
 					k = envFrom.Prefix + k
 				}
-				if errMsgs := utilvalidation.IsCIdentifier(k); len(errMsgs) != 0 {
+				if errMsgs := utilvalidation.IsEnvVarName(k); len(errMsgs) != 0 {
 					invalidKeys = append(invalidKeys, k)
 					continue
 				}

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -1219,14 +1219,14 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Name:      "test-secret",
 				},
 				Data: map[string][]byte{
-					"1234": []byte("abc"),
-					"1z":   []byte("abc"),
-					"key":  []byte("value"),
+					"1234":  []byte("abc"),
+					"1z":    []byte("abc"),
+					"key.1": []byte("value"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
-					Name:  "key",
+					Name:  "key.1",
 					Value: "value",
 				},
 			},
@@ -1250,12 +1250,12 @@ func TestMakeEnvironmentVariables(t *testing.T) {
 					Name:      "test-secret",
 				},
 				Data: map[string][]byte{
-					"1234": []byte("abc"),
+					"1234.name": []byte("abc"),
 				},
 			},
 			expectedEnvs: []kubecontainer.EnvVar{
 				{
-					Name:  "p_1234",
+					Name:  "p_1234.name",
 					Value: "abc",
 				},
 			},

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -277,6 +277,22 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
+const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
+const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
+
+var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
+
+// IsEnvVarName tests if a string is a valid environment variable name.
+func IsEnvVarName(value string) []string {
+	var errs []string
+	if !envVarNameRegexp.MatchString(value) {
+		errs = append(errs, RegexError(envVarNameFmtErrMsg, envVarNameFmt, "my.env-name", "MY_ENV.NAME", "MyEnvName1"))
+	}
+
+	errs = append(errs, hasChDirPrefix(value)...)
+	return errs
+}
+
 const configMapKeyFmt = `[-._a-zA-Z0-9]+`
 const configMapKeyErrMsg string = "a valid config key must consist of alphanumeric characters, '-', '_' or '.'"
 
@@ -291,13 +307,7 @@ func IsConfigMapKey(value string) []string {
 	if !configMapKeyRegexp.MatchString(value) {
 		errs = append(errs, RegexError(configMapKeyErrMsg, configMapKeyFmt, "key.name", "KEY_NAME", "key-name"))
 	}
-	if value == "." {
-		errs = append(errs, `must not be '.'`)
-	} else if value == ".." {
-		errs = append(errs, `must not be '..'`)
-	} else if strings.HasPrefix(value, "..") {
-		errs = append(errs, `must not start with '..'`)
-	}
+	errs = append(errs, hasChDirPrefix(value)...)
 	return errs
 }
 
@@ -340,4 +350,17 @@ func prefixEach(msgs []string, prefix string) []string {
 // between" validation failure.
 func InclusiveRangeError(lo, hi int) string {
 	return fmt.Sprintf(`must be between %d and %d, inclusive`, lo, hi)
+}
+
+func hasChDirPrefix(value string) []string {
+	var errs []string
+	switch {
+	case value == ".":
+		errs = append(errs, `must not be '.'`)
+	case value == "..":
+		errs = append(errs, `must not be '..'`)
+	case strings.HasPrefix(value, ".."):
+		errs = append(errs, `must not start with '..'`)
+	}
+	return errs
 }


### PR DESCRIPTION
Fixes #2707

The POSIX standard restricts environment variable names to uppercase letters, digits, and the underscore character in shell contexts only. For generic application usage, it is stated that all other characters shall be tolerated. (Reference [here](http://pubs.opengroup.org/onlinepubs/009695399/basedefs/xbd_chap08.html), my prose reasoning [here](https://github.com/kubernetes/kubernetes/issues/2707#issuecomment-285309156).)

This change relaxes the rules to some degree. Namely, we stop requiring environment variable names to be strict `C_IDENTIFIERS` and start permitting lowercase, dot, and dash characters.

Public container images using environment variable names beyond the shell-only context can benefit from this relaxation. Elasticsearch is one popular example.