### PR TITLE
GCE: Remove resource Get function calls from Create functions

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
+++ b/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
@@ -29,27 +29,14 @@ func newForwardingRuleMetricContext(request, region string) *metricContext {
 	}
 }
 
-// CreateGlobalForwardingRule creates and returns a
-// GlobalForwardingRule that points to the given TargetHttp(s)Proxy.
-// targetProxyLink is the SelfLink of a TargetHttp(s)Proxy.
-func (gce *GCECloud) CreateGlobalForwardingRule(targetProxyLink, ip, name, portRange string) (*compute.ForwardingRule, error) {
+// CreateGlobalForwardingRule creates the passed GlobalForwardingRule
+func (gce *GCECloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) error {
 	mc := newForwardingRuleMetricContext("create", "")
-	rule := &compute.ForwardingRule{
-		Name:       name,
-		IPAddress:  ip,
-		Target:     targetProxyLink,
-		PortRange:  portRange,
-		IPProtocol: "TCP",
-	}
 	op, err := gce.service.GlobalForwardingRules.Insert(gce.projectID, rule).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-
-	return gce.GetGlobalForwardingRule(name)
+	return gce.waitForGlobalOp(op, mc)
 }
 
 // SetProxyForGlobalForwardingRule links the given TargetHttp(s)Proxy with the given GlobalForwardingRule.

--- a/pkg/cloudprovider/providers/gce/gce_instancegroup.go
+++ b/pkg/cloudprovider/providers/gce/gce_instancegroup.go
@@ -31,20 +31,14 @@ func newInstanceGroupMetricContext(request string, zone string) *metricContext {
 
 // CreateInstanceGroup creates an instance group with the given
 // instances. It is the callers responsibility to add named ports.
-func (gce *GCECloud) CreateInstanceGroup(name string, zone string) (*compute.InstanceGroup, error) {
+func (gce *GCECloud) CreateInstanceGroup(ig *compute.InstanceGroup, zone string) error {
 	mc := newInstanceGroupMetricContext("create", zone)
-	op, err := gce.service.InstanceGroups.Insert(
-		gce.projectID, zone, &compute.InstanceGroup{Name: name}).Do()
+	op, err := gce.service.InstanceGroups.Insert(gce.projectID, zone, ig).Do()
 	if err != nil {
-		mc.Observe(err)
-		return nil, err
+		return mc.Observe(err)
 	}
 
-	if err = gce.waitForZoneOp(op, zone, mc); err != nil {
-		return nil, err
-	}
-
-	return gce.GetInstanceGroup(name, zone)
+	return gce.waitForZoneOp(op, zone, mc)
 }
 
 // DeleteInstanceGroup deletes an instance group.

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -494,7 +494,7 @@ func (gce *GCECloud) createTargetPool(name, serviceName, ipAddress, region, clus
 		HealthChecks:    hcLinks,
 	}
 
-	if _, err := gce.CreateTargetPool(pool, region); err != nil && !isHTTPErrorCode(err, http.StatusConflict) {
+	if err := gce.CreateTargetPool(pool, region); err != nil && !isHTTPErrorCode(err, http.StatusConflict) {
 		return err
 	}
 	return nil

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -376,7 +376,12 @@ func (gce *GCECloud) ensureInternalInstanceGroup(name, zone string, nodes []*v1.
 	gceNodes := sets.NewString()
 	if ig == nil {
 		glog.V(2).Infof("ensureInternalInstanceGroup(%v, %v): creating instance group", name, zone)
-		ig, err = gce.CreateInstanceGroup(name, zone)
+		newIG := &compute.InstanceGroup{Name: name}
+		if err = gce.CreateInstanceGroup(newIG, zone); err != nil {
+			return "", err
+		}
+
+		ig, err = gce.GetInstanceGroup(name, zone)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/cloudprovider/providers/gce/gce_targetpool.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetpool.go
@@ -37,18 +37,14 @@ func (gce *GCECloud) GetTargetPool(name, region string) (*compute.TargetPool, er
 }
 
 // CreateTargetPool creates the passed TargetPool
-func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) (*compute.TargetPool, error) {
+func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) error {
 	mc := newTargetPoolMetricContext("create", region)
 	op, err := gce.service.TargetPools.Insert(gce.projectID, region, tp).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
 
-	if err := gce.waitForRegionOp(op, region, mc); err != nil {
-		return nil, err
-	}
-
-	return gce.GetTargetPool(tp.Name, region)
+	return gce.waitForRegionOp(op, region, mc)
 }
 
 // DeleteTargetPool deletes TargetPool by name.

--- a/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -37,22 +37,14 @@ func (gce *GCECloud) GetTargetHttpProxy(name string) (*compute.TargetHttpProxy, 
 	return v, mc.Observe(err)
 }
 
-// CreateTargetHttpProxy creates and returns a TargetHttpProxy with the given UrlMap.
-func (gce *GCECloud) CreateTargetHttpProxy(urlMap *compute.UrlMap, name string) (*compute.TargetHttpProxy, error) {
-	proxy := &compute.TargetHttpProxy{
-		Name:   name,
-		UrlMap: urlMap.SelfLink,
-	}
-
+// CreateTargetHttpProxy creates a TargetHttpProxy
+func (gce *GCECloud) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error {
 	mc := newTargetProxyMetricContext("create")
 	op, err := gce.service.TargetHttpProxies.Insert(gce.projectID, proxy).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-	return gce.GetTargetHttpProxy(name)
+	return gce.waitForGlobalOp(op, mc)
 }
 
 // SetUrlMapForTargetHttpProxy sets the given UrlMap for the given TargetHttpProxy.
@@ -96,22 +88,14 @@ func (gce *GCECloud) GetTargetHttpsProxy(name string) (*compute.TargetHttpsProxy
 	return v, mc.Observe(err)
 }
 
-// CreateTargetHttpsProxy creates and returns a TargetHttpsProxy with the given UrlMap and SslCertificate.
-func (gce *GCECloud) CreateTargetHttpsProxy(urlMap *compute.UrlMap, sslCert *compute.SslCertificate, name string) (*compute.TargetHttpsProxy, error) {
+// CreateTargetHttpsProxy creates a TargetHttpsProxy
+func (gce *GCECloud) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) error {
 	mc := newTargetProxyMetricContext("create")
-	proxy := &compute.TargetHttpsProxy{
-		Name:            name,
-		UrlMap:          urlMap.SelfLink,
-		SslCertificates: []string{sslCert.SelfLink},
-	}
 	op, err := gce.service.TargetHttpsProxies.Insert(gce.projectID, proxy).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-	return gce.GetTargetHttpsProxy(name)
+	return gce.waitForGlobalOp(op, mc)
 }
 
 // SetUrlMapForTargetHttpsProxy sets the given UrlMap for the given TargetHttpsProxy.

--- a/pkg/cloudprovider/providers/gce/gce_urlmap.go
+++ b/pkg/cloudprovider/providers/gce/gce_urlmap.go
@@ -37,34 +37,24 @@ func (gce *GCECloud) GetUrlMap(name string) (*compute.UrlMap, error) {
 	return v, mc.Observe(err)
 }
 
-// CreateUrlMap creates an url map, using the given backend service as the default service.
-func (gce *GCECloud) CreateUrlMap(backend *compute.BackendService, name string) (*compute.UrlMap, error) {
-	urlMap := &compute.UrlMap{
-		Name:           name,
-		DefaultService: backend.SelfLink,
-	}
+// CreateUrlMap creates a url map
+func (gce *GCECloud) CreateUrlMap(urlMap *compute.UrlMap) error {
 	mc := newUrlMapMetricContext("create")
 	op, err := gce.service.UrlMaps.Insert(gce.projectID, urlMap).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-	return gce.GetUrlMap(name)
+	return gce.waitForGlobalOp(op, mc)
 }
 
-// UpdateUrlMap applies the given UrlMap as an update, and returns the new UrlMap.
-func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) (*compute.UrlMap, error) {
+// UpdateUrlMap applies the given UrlMap as an update
+func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) error {
 	mc := newUrlMapMetricContext("update")
 	op, err := gce.service.UrlMaps.Update(gce.projectID, urlMap.Name, urlMap).Do()
 	if err != nil {
-		return nil, mc.Observe(err)
+		return mc.Observe(err)
 	}
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
-		return nil, err
-	}
-	return gce.service.UrlMaps.Get(gce.projectID, urlMap.Name).Do()
+	return gce.waitForGlobalOp(op, mc)
 }
 
 // DeleteUrlMap deletes a url map by name.


### PR DESCRIPTION
**What this PR does / why we need it**:
Consistency. This PR removes the GetXXX from the CreateXXX functions of the GCE cloudprovider. Consumers (specifically the ingress controller) will need to call the Get resource funcs separately when updating their vendored versions. 

**Release note**:
```release-note
NONE
```

/assign @bowei
