### PR TITLE
Removed compatibality code for kubelet 1.2.

### DIFF
--- a/pkg/controller/node/BUILD
+++ b/pkg/controller/node/BUILD
@@ -60,7 +60,6 @@ go_library(
         "//pkg/util/node:go_default_library",
         "//pkg/util/system:go_default_library",
         "//pkg/util/taints:go_default_library",
-        "//pkg/util/version:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -55,7 +55,6 @@ import (
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/system"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
-	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
@@ -65,7 +64,6 @@ func init() {
 }
 
 var (
-	gracefulDeletionVersion = utilversion.MustParseSemantic("v1.1.0")
 	// UnreachableTaintTemplate is the taint for when a node becomes unreachable.
 	UnreachableTaintTemplate = &v1.Taint{
 		Key:    algorithm.TaintNodeUnreachable,

--- a/pkg/controller/node/util/BUILD
+++ b/pkg/controller/node/util/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/util/node:go_default_library",
-        "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/node/util/controller_utils.go
+++ b/pkg/controller/node/util/controller_utils.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	nodepkg "k8s.io/kubernetes/pkg/util/node"
-	utilversion "k8s.io/kubernetes/pkg/util/version"
 
 	"github.com/golang/glog"
 )
@@ -47,10 +46,6 @@ var (
 	// ErrCloudInstance occurs when the cloud provider does not support
 	// the Instances API.
 	ErrCloudInstance = errors.New("cloud provider doesn't support instances")
-	// podStatusReconciliationVersion is the the minimum kubelet version
-	// for which the nodecontroller can safely flip pod.Status to
-	// NotReady.
-	podStatusReconciliationVersion = utilversion.MustParseSemantic("v1.2.0")
 )
 
 // DeletePods will delete all pods from master running on given node,


### PR DESCRIPTION
**What this PR does / why we need it**:
The next release is 1.8, it's time to remove the backward compatibility code for kubelet 1.2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48995 

**Release note**:
```release-note
The NodeController will not support kubelet 1.2.
```