### PR TITLE
Make pkg/features more granular and component related

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -11,6 +11,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "features.go",
         "options.go",
         "validation.go",
     ],
@@ -24,8 +25,10 @@ go_library(
         "//pkg/master/ports:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/cmd/kube-apiserver/app/options/features.go
+++ b/cmd/kube-apiserver/app/options/features.go
@@ -1,0 +1,18 @@
+package options
+
+import (
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+	features.ExternalTrafficLocalOnly: {Default: true, PreRelease: utilfeature.GA},
+	features.AppArmor:                 {Default: true, PreRelease: utilfeature.Beta},
+	features.StreamingProxyRedirects:  {Default: true, PreRelease: utilfeature.Beta},
+	features.PodPriority:              {Default: false, PreRelease: utilfeature.Alpha},
+
+	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
+	// unintentionally on either side:
+	genericfeatures.AdvancedAuditing: {Default: false, PreRelease: utilfeature.Alpha},
+}

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -24,14 +24,12 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/validation"
 	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/master/ports"
-
-	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
 
 	"github.com/spf13/pflag"
 )
@@ -230,4 +228,9 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableAggregatorRouting, "enable-aggregator-routing", s.EnableAggregatorRouting,
 		"Turns on aggregator routing requests to endoints IP rather than cluster IP.")
 
+	// add binary-specific feature flags to global state
+	utilfeature.DefaultFeatureGate.Add(featureGates)
+
+	// add features to FlagSet struct
+	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }

--- a/cmd/kube-controller-manager/app/options/BUILD
+++ b/cmd/kube-controller-manager/app/options/BUILD
@@ -9,7 +9,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["options.go"],
+    srcs = [
+        "features.go",
+        "options.go",
+    ],
     tags = ["automanaged"],
     deps = [
         "//pkg/apis/componentconfig:go_default_library",

--- a/cmd/kube-controller-manager/app/options/features.go
+++ b/cmd/kube-controller-manager/app/options/features.go
@@ -1,0 +1,11 @@
+package options
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+	features.DynamicVolumeProvisioning: {Default: true, PreRelease: utilfeature.Alpha},
+	features.TaintBasedEvictions:       {Default: false, PreRelease: utilfeature.Alpha},
+}

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -32,9 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/garbagecollector"
 	"k8s.io/kubernetes/pkg/master/ports"
 
-	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
-
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/spf13/pflag"
 )
@@ -229,6 +226,10 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 
+	// add binary-specific feature flags to global state
+	utilfeature.DefaultFeatureGate.Add(featureGates)
+
+	// add features to FlagSet struct
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }
 

--- a/cmd/kubelet/app/options/BUILD
+++ b/cmd/kubelet/app/options/BUILD
@@ -11,6 +11,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "container_runtime.go",
+        "features.go",
         "options.go",
     ],
     tags = ["automanaged"],
@@ -19,6 +20,7 @@ go_library(
         "//pkg/apis/componentconfig:go_default_library",
         "//pkg/apis/componentconfig/install:go_default_library",
         "//pkg/apis/componentconfig/v1alpha1:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/util/taints:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kubelet/app/options/features.go
+++ b/cmd/kubelet/app/options/features.go
@@ -1,0 +1,17 @@
+package options
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+	features.DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
+	features.ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
+	features.ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
+	features.Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},
+	features.RotateKubeletServerCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
+	features.RotateKubeletClientCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
+	features.LocalStorageCapacityIsolation:               {Default: false, PreRelease: utilfeature.Alpha},
+	features.DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
+}

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -19,7 +19,6 @@ package options
 
 import (
 	_ "net/http/pprof"
-	"strings"
 
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/apiserver/pkg/util/flag"
@@ -232,8 +231,6 @@ func (c *kubeletConfiguration) addFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&c.VolumePluginDir, "volume-plugin-dir", c.VolumePluginDir, "<Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins")
 	fs.StringVar(&c.CloudProvider, "cloud-provider", c.CloudProvider, "The provider for cloud services. By default, kubelet will attempt to auto-detect the cloud provider. Specify empty string for running with no cloud provider.")
 	fs.StringVar(&c.CloudConfigFile, "cloud-config", c.CloudConfigFile, "The path to the cloud provider configuration file.  Empty string for no configuration file.")
-	fs.StringVar(&c.FeatureGates, "feature-gates", c.FeatureGates, "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
 
 	fs.StringVar(&c.KubeletCgroups, "kubelet-cgroups", c.KubeletCgroups, "Optional absolute name of cgroups to create and run the Kubelet in.")
 	fs.StringVar(&c.SystemCgroups, "system-cgroups", c.SystemCgroups, "Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under `/`. Empty for no container. Rolling back the flag requires a reboot.")
@@ -300,4 +297,10 @@ func (c *kubeletConfiguration) addFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&c.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "experimental-allocatable-ignore-eviction", c.ExperimentalNodeAllocatableIgnoreEvictionThreshold, "When set to 'true', Hard Eviction Thresholds will be ignored while calculating Node Allocatable. See https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md for more details. [default=false]")
 
 	fs.Var(&c.ExperimentalQOSReserved, "experimental-qos-reserved", "A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. [default=none]")
+
+	// add binary-specific feature flags to global state
+	utilfeature.DefaultFeatureGate.Add(featureGates)
+
+	// add features to FlagSet struct
+	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -121,32 +121,3 @@ const (
 	// Add priority to pods. Priority affects scheduling and preemption of pods.
 	PodPriority utilfeature.Feature = "PodPriority"
 )
-
-func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
-}
-
-// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
-// To add a new feature, define a key for it above and add it here. The features will be
-// available throughout Kubernetes binaries.
-var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	ExternalTrafficLocalOnly:                    {Default: true, PreRelease: utilfeature.GA},
-	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
-	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
-	DynamicVolumeProvisioning:                   {Default: true, PreRelease: utilfeature.Alpha},
-	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
-	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
-	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},
-	TaintBasedEvictions:                         {Default: false, PreRelease: utilfeature.Alpha},
-	RotateKubeletServerCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
-	RotateKubeletClientCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
-	PersistentLocalVolumes:                      {Default: false, PreRelease: utilfeature.Alpha},
-	LocalStorageCapacityIsolation:               {Default: false, PreRelease: utilfeature.Alpha},
-	DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
-	PodPriority:                                 {Default: false, PreRelease: utilfeature.Alpha},
-
-	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
-	// unintentionally on either side:
-	StreamingProxyRedirects:          {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.AdvancedAuditing: {Default: false, PreRelease: utilfeature.Alpha},
-}

--- a/plugin/cmd/kube-scheduler/app/options/BUILD
+++ b/plugin/cmd/kube-scheduler/app/options/BUILD
@@ -9,7 +9,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["options.go"],
+    srcs = [
+        "features.go",
+        "options.go",
+    ],
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",

--- a/plugin/cmd/kube-scheduler/app/options/features.go
+++ b/plugin/cmd/kube-scheduler/app/options/features.go
@@ -1,0 +1,10 @@
+package options
+
+import (
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
+)
+
+var featureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+	features.PersistentLocalVolumes: {Default: false, PreRelease: utilfeature.Alpha},
+}

--- a/plugin/cmd/kube-scheduler/app/options/options.go
+++ b/plugin/cmd/kube-scheduler/app/options/options.go
@@ -28,8 +28,6 @@ import (
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
 
-	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
 	// install the componentconfig api so we get its defaulting and conversion functions
 	_ "k8s.io/kubernetes/pkg/apis/componentconfig/install"
 
@@ -92,5 +90,10 @@ func (s *SchedulerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.FailureDomains, "failure-domains", kubeletapis.DefaultFailureDomains, "Indicate the \"all topologies\" set for an empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.")
 	fs.MarkDeprecated("failure-domains", "Doesn't have any effect. Will be removed in future version.")
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
+
+	// add binary-specific feature flags to global state
+	utilfeature.DefaultFeatureGate.Add(featureGates)
+
+	// add features to FlagSet struct
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows commands to register specific feature flags, rather than having everything loaded globally. 

**Which issue this PR fixes** 

https://github.com/kubernetes/kubernetes/issues/46822

**Special notes for your reviewer**:

I deliberately didn't fix any breaking tests yet, because I want to get initial feedback before investing too much time. The initial motivation was that we didn't want irrelevant feature flags pop up to kubeadm users (see https://github.com/kubernetes/kubernetes/pull/48943).

If this PR isn't feasible, we can keep the current set-up but have kubeadm not load `pkg/features`, rather rather load its own features to utilfeature. I just thought it was worth a shot to refactor this first in core rather than introducing diverging implementations. 

/cc @xiangpengzhao @luxas @liggitt @sttts @vishh @timothysc 