### PR TITLE
kubeadm: Make kube-proxy tolerate the uninitialized cloud taint

### DIFF
--- a/cmd/kubeadm/app/phases/addons/BUILD
+++ b/cmd/kubeadm/app/phases/addons/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/addons.go
+++ b/cmd/kubeadm/app/phases/addons/addons.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
 // CreateEssentialAddons creates the kube-proxy and kube-dns addons
@@ -44,10 +45,11 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 		return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
 	}
 
-	proxyDaemonSetBytes, err := kubeadmutil.ParseTemplate(KubeProxyDaemonSet, struct{ Image, ClusterCIDR, MasterTaintKey string }{
+	proxyDaemonSetBytes, err := kubeadmutil.ParseTemplate(KubeProxyDaemonSet, struct{ Image, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
 		Image:          images.GetCoreImage("proxy", cfg, cfg.UnifiedControlPlaneImage),
 		ClusterCIDR:    getClusterCIDR(cfg.Networking.PodSubnet),
 		MasterTaintKey: kubeadmconstants.LabelNodeRoleMaster,
+		CloudTaintKey:  algorithm.TaintExternalCloudProvider,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)

--- a/cmd/kubeadm/app/phases/addons/addons_test.go
+++ b/cmd/kubeadm/app/phases/addons/addons_test.go
@@ -54,10 +54,11 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: KubeProxyDaemonSet,
-			data: struct{ Image, ClusterCIDR, MasterTaintKey string }{
+			data: struct{ Image, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
 				Image:          "foo",
 				ClusterCIDR:    "foo",
 				MasterTaintKey: "foo",
+				CloudTaintKey:  "foo",
 			},
 			expected: true,
 		},

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -88,6 +88,9 @@ spec:
       tolerations:
       - key: {{ .MasterTaintKey }}
         effect: NoSchedule
+      - key: {{ .CloudTaintKey }}
+        value: "true"
+        effect: NoSchedule
       volumes:
       - name: kube-proxy
         configMap:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This is needed in order to start the cloud-controller-manager successfully. The cloud controller manager should run as a DaemonSet with a nodeSelector for master nodes. The cloud controller manager should run on the hostNetwork to avoid the bootstrap problem when there is no CNI network yet. But the cloud controller manager needs to know how to address the master. It does this by talking to the kubernetes service (e.g. 10.96.0.1). That iptables rule must exist at the time, which now isn't the case when kube-proxy isn't running. kube-proxy isn't running due to that the kubelet is tainted with the external cloud taint.

This PR makes kube-proxy tolerate the cloud taint, so that the cloud controller manager can run easily on kubeadm clusters.

This was found by @prydie, thanks! 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

This should probably be a cherrypick candidate so folks can use kubeadm to easily create external cloud clusters. The change is small and isolated.

cc @wojtek-t 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kubeadm: Make kube-proxy tolerate the external cloud provider taint so that an external cloud provider can be easily used on top of kubeadm
```
cc @kubernetes/sig-cluster-lifecycle-pr-reviews @wlan0 @thockin 