### PR TITLE
prevent unsetting of nonexistent previous port in kubeapi-load-balancer charm

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -54,6 +54,8 @@ def request_server_certificates(tls):
 def close_old_port():
     config = hookenv.config()
     old_port = config.previous('port')
+    if not old_port:
+        return
     try:
         hookenv.close_port(old_port)
     except CalledProcessError:


### PR DESCRIPTION
**What this PR does / why we need it**: prevent unsetting of nonexistent previous port in kubeapi-load-balancer charm

**Release note**:
```release-note
prevent unsetting of nonexistent previous port in kubeapi-load-balancer charm
```
