### PR TITLE
Automated cherry pick of #48997

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -450,14 +450,14 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 		case desiredReplicas > scaleUpLimit:
 			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "ScaleUpLimit", "the desired replica count is increasing faster than the maximum scale rate")
 			desiredReplicas = scaleUpLimit
-		case desiredReplicas == 0:
-			//  never scale down to 0, reserved for disabling autoscaling
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was zero")
-			desiredReplicas = 1
 		case hpa.Spec.MinReplicas != nil && desiredReplicas < *hpa.Spec.MinReplicas:
 			// make sure we aren't below our minimum
 			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was less than the minimum replica count")
 			desiredReplicas = *hpa.Spec.MinReplicas
+		case desiredReplicas == 0:
+			//  never scale down to 0, reserved for disabling autoscaling
+			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was zero")
+			desiredReplicas = 1
 		case desiredReplicas > hpa.Spec.MaxReplicas:
 			// make sure we aren't above our maximum
 			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooManyReplicas", "the desired replica count was more than the maximum replica count")

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -994,6 +994,25 @@ func TestMinReplicas(t *testing.T) {
 	tc.runTest(t)
 }
 
+func TestMinReplicasDesiredZero(t *testing.T) {
+	tc := testCase{
+		minReplicas:         2,
+		maxReplicas:         5,
+		initialReplicas:     3,
+		desiredReplicas:     2,
+		CPUTarget:           90,
+		reportedLevels:      []uint64{0, 0, 0},
+		reportedCPURequests: []resource.Quantity{resource.MustParse("0.9"), resource.MustParse("1.0"), resource.MustParse("1.1")},
+		useMetricsApi:       true,
+		expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
+			Type:   autoscalingv2.ScalingLimited,
+			Status: v1.ConditionTrue,
+			Reason: "TooFewReplicas",
+		}),
+	}
+	tc.runTest(t)
+}
+
 func TestZeroReplicas(t *testing.T) {
 	tc := testCase{
 		minReplicas:         3,


### PR DESCRIPTION
Cherry pick of #48997 on release-1.7.

#48997: hpa: Prevent scaling below MinReplicas if desiredReplicas is