### PR TITLE
OpenAPI bug: Array/Map Ptr Elements' handing was incorrect

### DIFF
--- a/cmd/libs/go2idl/openapi-gen/generators/openapi.go
+++ b/cmd/libs/go2idl/openapi-gen/generators/openapi.go
@@ -579,7 +579,7 @@ func (g openAPITypeWriter) generateMapProperty(t *types.Type) error {
 	case types.Builtin:
 		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function.", elemType)
 	case types.Struct:
-		g.generateReferenceProperty(t.Elem)
+		g.generateReferenceProperty(elemType)
 	case types.Slice, types.Array:
 		g.generateSliceProperty(elemType)
 	default:
@@ -603,7 +603,7 @@ func (g openAPITypeWriter) generateSliceProperty(t *types.Type) error {
 	case types.Builtin:
 		return fmt.Errorf("please add type %v to getOpenAPITypeFormat function.", elemType)
 	case types.Struct:
-		g.generateReferenceProperty(t.Elem)
+		g.generateReferenceProperty(elemType)
 	default:
 		return fmt.Errorf("slice Element kind %v is not supported in %v", elemType.Kind, t)
 	}


### PR DESCRIPTION
If you have an array of map of pointers, OpenAPI spec generation would fail.

fixes: #49074