### PR TITLE
bootstrap token auth: don't accept deleted tokens

### DIFF
--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -102,6 +102,11 @@ func (t *TokenAuthenticator) AuthenticateToken(token string) (user.Info, bool, e
 		return nil, false, err
 	}
 
+	if secret.DeletionTimestamp != nil {
+		tokenErrorf(secret, "is deleted and awaiting removal")
+		return nil, false, nil
+	}
+
 	if string(secret.Type) != string(bootstrapapi.SecretTypeBootstrapToken) || secret.Data == nil {
 		tokenErrorf(secret, "has invalid type, expected %s.", bootstrapapi.SecretTypeBootstrapToken)
 		return nil, false, nil

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
@@ -52,6 +52,8 @@ const (
 )
 
 func TestTokenAuthenticator(t *testing.T) {
+	now := metav1.Now()
+
 	tests := []struct {
 		name string
 
@@ -133,6 +135,25 @@ func TestTokenAuthenticator(t *testing.T) {
 				},
 			},
 			token:        "barfoo" + "." + tokenSecret,
+			wantNotFound: true,
+		},
+		{
+			name: "deleted token",
+			secrets: []*api.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              bootstrapapi.BootstrapTokenSecretPrefix + tokenID,
+						DeletionTimestamp: &now,
+					},
+					Data: map[string][]byte{
+						bootstrapapi.BootstrapTokenIDKey:               []byte(tokenID),
+						bootstrapapi.BootstrapTokenSecretKey:           []byte(tokenSecret),
+						bootstrapapi.BootstrapTokenUsageAuthentication: []byte("true"),
+					},
+					Type: "bootstrap.kubernetes.io/token",
+				},
+			},
+			token:        tokenID + "." + tokenSecret,
 			wantNotFound: true,
 		},
 		{


### PR DESCRIPTION
Closes #48345

Same fix as #48343


```release-note
Previously a deleted bootstrapping token secret would be considered valid until it was reaped.  Now it is invalid as soon as the deletionTimestamp is set.
```

cc @luxas @kubernetes/sig-auth-pr-reviews 