### PR TITLE
Remove KIBANA_BASE_URL

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
@@ -29,8 +29,6 @@ spec:
         env:
           - name: "ELASTICSEARCH_URL"
             value: "http://elasticsearch-logging:9200"
-          - name: "KIBANA_BASE_URL"
-            value: "/api/v1/proxy/namespaces/kube-system/services/kibana-logging"
         ports:
         - containerPort: 5601
           name: ui


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `KIBANA_BASE_URL` parameter from Kibana Deployment environment variables, in order to be able to access Kibana pods via `kubectl port-forward` mechanism instead of via proxy, for simplicity.

```release-note
Remove `KIBANA_BASE_URL` parameter from Kibana Deployment environment variables, in order to be able to access Kibana pods via `kubectl port-forward` mechanism instead of via proxy, for simpler access.
```
