### PR TITLE
Add cos-dev-61-9733-0-0 to the benchmark tests

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -48,43 +48,64 @@ images:
     machine: n1-standard-1
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
-  gci1-resource1:
+  cosstable-resource1:
     image: cos-stable-59-9460-64-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
-  gci1-resource2:
+  cosstable-resource2:
     image: cos-stable-59-9460-64-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
-  gci1-resource3:
+  cosstable-resource3:
     image: cos-stable-59-9460-64-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
-  gci2-resource1:
+  cosbeta-resource1:
     image: cos-beta-60-9592-52-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
-  gci2-resource2:
+  cosbeta-resource2:
     image: cos-beta-60-9592-52-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
-  gci2-resource3:
+  cosbeta-resource3:
     image: cos-beta-60-9592-52-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 105 pods per node \[Benchmark\]'
+  cosdev-resource1:
+    image: cos-dev-61-9733-0-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  cosdev-resource2:
+    image: cos-dev-61-9733-0-0
+    project: cos-cloud
+    machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  cosdev-resource3:
+    image: cos-dev-61-9733-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/42926

m60 has docker 1.13.1 while m61 has 17.03. This PR adds m61 to the benchmark tests so that we will have more data to compare.

PS: We will support fetching the latest image in an image family in the node e2e tests in the future.

**Release note**:

```
None
```

/assign @yujuhong 
/cc @kewu1992 @abgworrall 