### PR TITLE
Test Ubuntu image using GKE image spec

### DIFF
--- a/test/e2e_node/jenkins/jenkins-ci-ubuntu.properties
+++ b/test/e2e_node/jenkins/jenkins-ci-ubuntu.properties
@@ -8,3 +8,5 @@ CLEANUP=true
 GINKGO_FLAGS='--skip="\[Flaky\]|\[Serial\]"'
 KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
 TIMEOUT=1h
+# Use the system spec defined in test/e2e_node/system/specs/gke.yaml.
+SYSTEM_SPEC_NAME=gke

--- a/test/e2e_node/jenkins/jenkins-serial-ubuntu.properties
+++ b/test/e2e_node/jenkins/jenkins-serial-ubuntu.properties
@@ -10,3 +10,5 @@ TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
 KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
 PARALLELISM=1
 TIMEOUT=3h
+# Use the system spec defined at test/e2e_node/system/specs/gke.yaml.
+SYSTEM_SPEC_NAME=gke


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/46891

This PR changes the files referenced in test-infra for running Ubuntu image tests against GKE system spec on master.

The two properties files are shared by the tests against all k8s branches but the `SYSTEM_SPEC_NAME` is only available on master. This should be fine because the tests in the non master branches will just ignore the unknown env variable.

**Release note**:
```
None
```

/assign @yujuhong 