### PR TITLE
Always use gcr.io/google_containers for side-loaded Docker images

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -258,7 +258,7 @@ function kube::release::build_hyperkube_image() {
   ARCH="${arch}" REGISTRY="${registry}" VERSION="${version}" \
     make -C cluster/images/hyperkube/ build >/dev/null
 
-  local hyperkube_tag="${docker_registry}/hyperkube-${arch}:${docker_tag}"
+  local hyperkube_tag="${registry}/hyperkube-${arch}:${version}"
   if [[ -n "${save_dir}" ]]; then
     "${DOCKER[@]}" save "${hyperkube_tag}" > "${save_dir}/hyperkube-${arch}.tar"
   fi
@@ -284,7 +284,7 @@ function kube::release::create_docker_images_for_server() {
     local images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
-    local docker_registry="${KUBE_DOCKER_REGISTRY:-gcr.io/google_containers}"
+    local -r docker_registry="gcr.io/google_containers"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
     if [[ -z "${docker_tag}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**: #45391 changed the behavior for what registry we use in the sideloaded docker images tarfiles shipped with releases. As a result of that change, if `KUBE_DOCKER_REGISTRY` is set to anything other than `gcr.io/google_containers`, clusters will fail to start on GCE (and other places where the side-loaded images are used).

This PR reverts that change in behavior, which I believe was unintentional; we'll always use `gcr.io/google_containers` for the docker image tarfiles, but will tag the images with `$KUBE_DOCKER_REGISTRY` if different.

Also, I'm fixing a small bug in variable names that I introduced in #47939.

Note that with recent changes here and in the release repo, we don't even need to tag with `KUBE_DOCKER_REGISTRY` and `KUBE_DOCKER_IMAGE_TAG`, but that's a more extensive change, and this smaller fix is more suitable for cherry-picking to 1.7.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/release-note-none
/sig release
/assign @david-mcmahon 