### PR TITLE
use https to check healthz in hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -59,7 +59,7 @@ ENABLE_CLUSTER_DNS=${KUBE_ENABLE_CLUSTER_DNS:-true}
 DNS_SERVER_IP=${KUBE_DNS_SERVER_IP:-10.0.0.10}
 DNS_DOMAIN=${KUBE_DNS_NAME:-"cluster.local"}
 KUBECTL=${KUBECTL:-cluster/kubectl.sh}
-WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-10}
+WAIT_FOR_URL_API_SERVER=${WAIT_FOR_URL_API_SERVER:-20}
 ENABLE_DAEMON=${ENABLE_DAEMON:-false}
 HOSTNAME_OVERRIDE=${HOSTNAME_OVERRIDE:-"127.0.0.1"}
 CLOUD_PROVIDER=${CLOUD_PROVIDER:-""}
@@ -536,7 +536,7 @@ function start_apiserver {
     # this uses the API port because if you don't have any authenticator, you can't seem to use the secure port at all.
     # this matches what happened with the combination in 1.4.
     # TODO change this conditionally based on whether API_PORT is on or off
-    kube::util::wait_for_url "http://${API_HOST_IP}:${API_SECURE_PORT}/healthz" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} \
+    kube::util::wait_for_url "https://${API_HOST_IP}:${API_SECURE_PORT}/healthz" "apiserver: " 1 ${WAIT_FOR_URL_API_SERVER} \
         || { echo "check apiserver logs: ${APISERVER_LOG}" ; exit 1 ; }
 
     # Create kubeconfigs for all components, using client certs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
```
# PSP_ADMISSION=true ALLOW_PRIVILEGED=true ALLOW_SECURITY_CONTEXT=true ALLOW_ANY_TOKEN=true ENABLE_RBAC=true RUNTIME_CONFIG="extensions/v1beta1=true,extensions/v1beta1/podsecuritypolicy=true" hack/local-up-cluster.sh
...
Waiting for apiserver to come up
+++ [0718 09:34:38] On try 5, apiserver: : 
Cluster "local-up-cluster" set.
use 'kubectl --kubeconfig=/var/run/kubernetes/admin-kube-aggregator.kubeconfig' to use the aggregated API server
Creating kube-system namespace
clusterrolebinding "system:kube-dns" created
serviceaccount "kube-dns" created
configmap "kube-dns" created
error: unable to recognize "kubedns-deployment.yaml": no matches for extensions/, Kind=Deployment
service "kube-dns" created
Kube-dns deployment and service successfully deployed.
kubelet ( 10952 ) is running.
Create podsecuritypolicy policies for RBAC.
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/policies.yaml": no matches for extensions/, Kind=PodSecurityPolicy
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/policies.yaml": no matches for extensions/, Kind=PodSecurityPolicy
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/roles.yaml": no matches for rbac.authorization.k8s.io/, Kind=ClusterRole
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/roles.yaml": no matches for rbac.authorization.k8s.io/, Kind=ClusterRole
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/bindings.yaml": no matches for rbac.authorization.k8s.io/, Kind=ClusterRoleBinding
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/bindings.yaml": no matches for rbac.authorization.k8s.io/, Kind=ClusterRoleBinding
unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/examples/podsecuritypolicy/rbac/bindings.yaml": no matches for rbac.authorization.k8s.io/, Kind=ClusterRoleBinding
Create default storage class for 
error: unable to recognize "/home/nfs/mygo/src/k8s.io/kubernetes/cluster/addons/storage-class/local/default.yaml": no matches for storage.k8s.io/, Kind=StorageClass
Local Kubernetes cluster is running. Press Ctrl-C to shut it down.

Logs:
  /tmp/kube-apiserver.log
  /tmp/kube-controller-manager.log
  /tmp/kube-proxy.log
  /tmp/kube-scheduler.log
  /tmp/kubelet.log
...
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47739

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
