### PR TITLE
pass nodename in join checks

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -600,7 +600,7 @@ func RunJoinNodeChecks(cfg *kubeadmapi.NodeConfiguration) error {
 	checks := []Checker{
 		SystemVerificationCheck{},
 		IsRootCheck{},
-		HostnameCheck{},
+		HostnameCheck{nodeName: cfg.NodeName},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		PortOpenCheck{port: 10250},


### PR DESCRIPTION
Fix preflight HostnameCheck when running kubeadm in join mode

fixes kubernetes/kubeadm#347

```release-note
kubeadm: Fix passing the node name to `kubeadm join` preflight checks
```