### PR TITLE
adding kube-apiserver starting option tests

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -34,7 +34,16 @@ go_test(
     srcs = ["options_test.go"],
     library = ":go_default_library",
     tags = ["automanaged"],
-    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/kubeapiserver/options:go_default_library",
+        "//pkg/kubelet/client:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -17,26 +17,180 @@ limitations under the License.
 package options
 
 import (
+	"net"
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/spf13/pflag"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+	apiserveroptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/storage/storagebackend"
+	utilconfig "k8s.io/apiserver/pkg/util/flag"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
+	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 )
 
 func TestAddFlagsFlag(t *testing.T) {
-	// TODO: This only tests the enable-swagger-ui flag for now.
-	// Expand the test to include other flags as well.
+	// TODO: Expand the test to include other flags as well.
 	f := pflag.NewFlagSet("addflagstest", pflag.ContinueOnError)
 	s := NewServerRunOptions()
 	s.AddFlags(f)
-	if s.Features.EnableSwaggerUI {
-		t.Errorf("Expected s.EnableSwaggerUI to be false by default")
-	}
 
 	args := []string{
+		"--admission-control=AlwaysDeny",
+		"--admission-control-config-file=/admission-control-config",
+		"--advertise-address=192.168.10.10",
+		"--allow-privileged=false",
+		"--anonymous-auth=false",
+		"--apiserver-count=5",
+		"--audit-log-maxage=11",
+		"--audit-log-maxbackup=12",
+		"--audit-log-maxsize=13",
+		"--audit-log-path=/var/log",
+		"--audit-policy-file=/policy",
+		"--audit-webhook-config-file=/webhook-config",
+		"--audit-webhook-mode=blocking",
+		"--authentication-token-webhook-cache-ttl=3m",
+		"--authentication-token-webhook-config-file=/token-webhook-config",
+		"--authorization-mode=AlwaysDeny",
+		"--authorization-policy-file=/policy",
+		"--authorization-webhook-cache-authorized-ttl=3m",
+		"--authorization-webhook-cache-unauthorized-ttl=1m",
+		"--authorization-webhook-config-file=/webhook-config",
+		"--bind-address=192.168.10.20",
+		"--client-ca-file=/client-ca",
+		"--cloud-config=/cloud-config",
+		"--cloud-provider=azure",
+		"--cors-allowed-origins=10.10.10.100,10.10.10.200",
+		"--enable-aggregator-routing=true",
+		"--enable-logs-handler=false",
 		"--enable-swagger-ui=true",
 	}
 	f.Parse(args)
-	if !s.Features.EnableSwaggerUI {
-		t.Errorf("Expected s.EnableSwaggerUI to be true")
+
+	// This is a snapshot of expected options parsed by args.
+	expected := &ServerRunOptions{
+		ServiceNodePortRange: DefaultServiceNodePortRange,
+		MasterCount:          5,
+		AllowPrivileged:      false,
+		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
+			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
+			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},
+			MaxRequestsInFlight:         400,
+			MaxMutatingRequestsInFlight: 200,
+			MinRequestTimeout:           1800,
+		},
+		Admission: &apiserveroptions.AdmissionOptions{
+			PluginNames: []string{"AlwaysDeny"},
+			ConfigFile:  "/admission-control-config",
+			Plugins:     s.Admission.Plugins,
+		},
+		Etcd: &apiserveroptions.EtcdOptions{
+			StorageConfig: storagebackend.Config{
+				ServerList: nil,
+				Prefix:     "/registry",
+				DeserializationCacheSize: 0,
+				Copier: kapi.Scheme,
+			},
+			DefaultStorageMediaType: "application/vnd.kubernetes.protobuf",
+			DeleteCollectionWorkers: 1,
+			EnableGarbageCollection: true,
+			EnableWatchCache:        true,
+			DefaultWatchCacheSize:   100,
+		},
+		SecureServing: &apiserveroptions.SecureServingOptions{
+			BindAddress: net.ParseIP("192.168.10.20"),
+			BindPort:    6443,
+			ServerCert: apiserveroptions.GeneratableKeyCert{
+				CertDirectory: "/var/run/kubernetes",
+				PairName:      "apiserver",
+			},
+		},
+		InsecureServing: &kubeoptions.InsecureServingOptions{
+			BindAddress: net.ParseIP("127.0.0.1"),
+			BindPort:    8080,
+		},
+		EventTTL: 1 * time.Hour,
+		KubeletConfig: kubeletclient.KubeletClientConfig{
+			Port:         10250,
+			ReadOnlyPort: 10255,
+			PreferredAddressTypes: []string{
+				string(kapi.NodeHostName),
+				string(kapi.NodeInternalDNS),
+				string(kapi.NodeInternalIP),
+				string(kapi.NodeExternalDNS),
+				string(kapi.NodeExternalIP),
+			},
+			EnableHttps: true,
+			HTTPTimeout: time.Duration(5) * time.Second,
+		},
+		Audit: &apiserveroptions.AuditOptions{
+			LogOptions: apiserveroptions.AuditLogOptions{
+				Path:       "/var/log",
+				MaxAge:     11,
+				MaxBackups: 12,
+				MaxSize:    13,
+				Format:     "legacy",
+			},
+			WebhookOptions: apiserveroptions.AuditWebhookOptions{
+				Mode:       "blocking",
+				ConfigFile: "/webhook-config",
+			},
+			PolicyFile: "/policy",
+		},
+		Features: &apiserveroptions.FeatureOptions{
+			EnableSwaggerUI: true,
+			EnableProfiling: true,
+		},
+		Authentication: &kubeoptions.BuiltInAuthenticationOptions{
+			Anonymous: &kubeoptions.AnonymousAuthenticationOptions{
+				Allow: false,
+			},
+			ClientCert: &apiserveroptions.ClientCertAuthenticationOptions{
+				ClientCA: "/client-ca",
+			},
+			WebHook: &kubeoptions.WebHookAuthenticationOptions{
+				CacheTTL:   180000000000,
+				ConfigFile: "/token-webhook-config",
+			},
+			BootstrapToken: &kubeoptions.BootstrapTokenAuthenticationOptions{},
+			Keystone:       &kubeoptions.KeystoneAuthenticationOptions{},
+			OIDC: &kubeoptions.OIDCAuthenticationOptions{
+				UsernameClaim: "sub",
+			},
+			PasswordFile:  &kubeoptions.PasswordFileAuthenticationOptions{},
+			RequestHeader: &apiserveroptions.RequestHeaderAuthenticationOptions{},
+			ServiceAccounts: &kubeoptions.ServiceAccountAuthenticationOptions{
+				Lookup: true,
+			},
+			TokenFile: &kubeoptions.TokenFileAuthenticationOptions{},
+		},
+		Authorization: &kubeoptions.BuiltInAuthorizationOptions{
+			Mode:                        "AlwaysDeny",
+			PolicyFile:                  "/policy",
+			WebhookConfigFile:           "/webhook-config",
+			WebhookCacheAuthorizedTTL:   180000000000,
+			WebhookCacheUnauthorizedTTL: 60000000000,
+		},
+		CloudProvider: &kubeoptions.CloudProviderOptions{
+			CloudConfigFile: "/cloud-config",
+			CloudProvider:   "azure",
+		},
+		StorageSerialization: &kubeoptions.StorageSerializationOptions{
+			StorageVersions:        kapi.Registry.AllPreferredGroupVersions(),
+			DefaultStorageVersions: kapi.Registry.AllPreferredGroupVersions(),
+		},
+		APIEnablement: &kubeoptions.APIEnablementOptions{
+			RuntimeConfig: utilconfig.ConfigurationMap{},
+		},
+		EnableLogsHandler:       false,
+		EnableAggregatorRouting: true,
+	}
+
+	if !reflect.DeepEqual(expected, s) {
+		t.Errorf("Got different run options than expected.\nDifference detected on:\n%s", diff.ObjectReflectDiff(expected, s))
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
There is only one test for `--enable-swagger-ui` option in `cmd/kube-apiserver/app/options/options_test.go`, I have expanded this test with more kube-apiserver starting options.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`