### PR TITLE
Automated cherry pick of #49017 #49073

### DIFF
--- a/cmd/kubeadm/app/phases/addons/BUILD
+++ b/cmd/kubeadm/app/phases/addons/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",
+        "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -541,7 +541,7 @@ func RunJoinNodeChecks(cfg *kubeadmapi.NodeConfiguration) error {
 	checks := []Checker{
 		SystemVerificationCheck{},
 		IsRootCheck{},
-		HostnameCheck{},
+		HostnameCheck{nodeName: cfg.NodeName},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		PortOpenCheck{port: 10250},


### PR DESCRIPTION
Cherry pick of #49017 #49073 on release-1.7.

#49017: kubeadm: Make kube-proxy tolerate the uninitialized cloud
#49073: pass nodename in join checks