### PR TITLE
Fix health check node port test flake

### DIFF
--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -544,9 +544,9 @@ func (rs *REST) allocateHealthCheckNodePort(service *api.Service) error {
 		err := rs.serviceNodePorts.Allocate(int(healthCheckNodePort))
 		if err != nil {
 			return fmt.Errorf("failed to allocate requested HealthCheck NodePort %v: %v",
-				service.Spec.HealthCheckNodePort, err)
+				healthCheckNodePort, err)
 		}
-		glog.Infof("Reserved user requested nodePort: %d", service.Spec.HealthCheckNodePort)
+		glog.Infof("Reserved user requested nodePort: %d", healthCheckNodePort)
 	} else {
 		// If the request has no health check nodePort specified, allocate any.
 		healthCheckNodePort, err := rs.serviceNodePorts.AllocateNext()

--- a/pkg/registry/core/service/rest_test.go
+++ b/pkg/registry/core/service/rest_test.go
@@ -996,8 +996,10 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortAllocation(t *testing.
 	port := service.GetServiceHealthCheckNodePort(created_service)
 	if port == 0 {
 		t.Errorf("Failed to allocate health check node port and set the HealthCheckNodePort")
+	} else {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 	}
-
 }
 
 // Validate allocation of a nodePort when ExternalTraffic beta annotation is set to OnlyLocal
@@ -1034,8 +1036,10 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortAllocationBeta(t *test
 	port := service.GetServiceHealthCheckNodePort(created_service)
 	if port == 0 {
 		t.Errorf("Failed to allocate health check node port and set the HealthCheckNodePort")
+	} else {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 	}
-
 }
 
 // Validate using the user specified nodePort when ExternalTrafficPolicy is set to Local
@@ -1073,6 +1077,11 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation(t *test
 	}
 	if port != randomNodePort {
 		t.Errorf("Failed to allocate requested nodePort expected %d, got %d", randomNodePort, port)
+	}
+
+	if port != 0 {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 	}
 }
 
@@ -1115,6 +1124,11 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocationBeta(t *
 	}
 	if port != randomNodePort {
 		t.Errorf("Failed to allocate requested nodePort expected %d, got %d", randomNodePort, port)
+	}
+
+	if port != 0 {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 	}
 }
 
@@ -1203,6 +1217,8 @@ func TestServiceRegistryExternalTrafficGlobal(t *testing.T) {
 	// Make sure the service does not have the health check node port allocated
 	port := service.GetServiceHealthCheckNodePort(created_service)
 	if port != 0 {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 		t.Errorf("Unexpected allocation of health check node port: %v", port)
 	}
 }
@@ -1240,6 +1256,8 @@ func TestServiceRegistryExternalTrafficGlobalBeta(t *testing.T) {
 	// Make sure the service does not have the health check node port allocated
 	port := service.GetServiceHealthCheckNodePort(created_service)
 	if port != 0 {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 		t.Errorf("Unexpected allocation of health check node port: %v", port)
 	}
 }
@@ -1273,6 +1291,8 @@ func TestServiceRegistryExternalTrafficAnnotationClusterIP(t *testing.T) {
 	// Make sure that ClusterIP services do not have the health check node port allocated
 	port := service.GetServiceHealthCheckNodePort(created_service)
 	if port != 0 {
+		// Release the node port at the end of the test case.
+		storage.serviceNodePorts.Release(int(port))
 		t.Errorf("Unexpected allocation of health check node port annotation %s", api.BetaAnnotationHealthCheckNodePort)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
- Releases the allocated HealthCheck NodePort at the end of each associated test case.
- Fixes the weird output `0` in `failed to allocate requested HealthCheck NodePort 0`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49098

**Special notes for your reviewer**:
/cc @freehan 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
