### PR TITLE
add InstanceID to fake cadvisor (used in Kubemark)

### DIFF
--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -112,7 +112,9 @@ func main() {
 	}
 
 	if config.Morph == "kubelet" {
-		cadvisorInterface := new(cadvisortest.Fake)
+		cadvisorInterface := &cadvisortest.Fake{
+			NodeName: config.NodeName,
+		}
 		containerManager := cm.NewStubContainerManager()
 		fakeDockerClient := libdocker.NewFakeDockerClient().WithTraceDisabled()
 		fakeDockerClient.EnableSleep = true

--- a/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
+++ b/pkg/kubelet/cadvisor/testing/cadvisor_fake.go
@@ -25,6 +25,7 @@ import (
 
 // Fake cAdvisor implementation.
 type Fake struct {
+	NodeName string
 }
 
 var _ cadvisor.Interface = new(Fake)
@@ -54,6 +55,7 @@ func (c *Fake) MachineInfo() (*cadvisorapi.MachineInfo, error) {
 	// We set it to non-zero values to make non-zero-capacity machines in Kubemark.
 	return &cadvisorapi.MachineInfo{
 		NumCores:       1,
+		InstanceID:     cadvisorapi.InstanceID(c.NodeName),
 		MemoryCapacity: 4026531840,
 	}, nil
 }


### PR DESCRIPTION
This change is for setting Node.Spec.ProviderID field in Kubemark hollow nodes. It shouldn't affect other tests using cadvisor.Fake as field is nil by default.

cc @gmarek 