### PR TITLE
Add approvers to owners file for hpa

### DIFF
--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -4,3 +4,10 @@ reviewers:
 - piosz
 - jszczepkowski
 - fgrzadkowski
+- MaciekPytel
+approvers:
+- DirectXMan12
+- mwielgus
+- piosz
+- jszczepkowski
+- MaciekPytel


### PR DESCRIPTION
Currently none of hpa developers or people in sig-autoscaling has the right to approve PRs to hpa, meaning it needs to be approved at pkg/controller level by people not working on autoscaling.