### PR TITLE
Allow unmounting bind-mounted directories.

### DIFF
--- a/pkg/volume/flexvolume/unmounter.go
+++ b/pkg/volume/flexvolume/unmounter.go
@@ -51,22 +51,14 @@ func (f *flexVolumeUnmounter) TearDownAt(dir string) error {
 		return nil
 	}
 
-	notmnt, err := isNotMounted(f.mounter, dir)
+	call := f.plugin.NewDriverCall(unmountCmd)
+	call.Append(dir)
+	_, err := call.Run()
+	if isCmdNotSupportedErr(err) {
+		err = (*unmounterDefaults)(f).TearDownAt(dir)
+	}
 	if err != nil {
 		return err
-	}
-	if notmnt {
-		glog.Warningf("Warning: Path: %v already unmounted", dir)
-	} else {
-		call := f.plugin.NewDriverCall(unmountCmd)
-		call.Append(dir)
-		_, err := call.Run()
-		if isCmdNotSupportedErr(err) {
-			err = (*unmounterDefaults)(f).TearDownAt(dir)
-		}
-		if err != nil {
-			return err
-		}
 	}
 
 	// Flexvolume driver may remove the directory. Ignore if it does.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

For files, we cannot use `path/..`;
we could use `filepath.Dir` but for bind-mounted, `isNotMounted` which calls `IsLikelyNotMountPoint` would not work anyway.
Let's just have the driver do the work.

Addressing
```
Error: UnmountVolume.TearDown failed for volume "..." (volume.spec.Name: "...") pod "..." (UID: "...") with: lstat /path/.../test-flex/..: not a directory
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a bug with binding mount directories and files using flexVolumes
```
