### PR TITLE
Modify podpreset lister to use correct namespace

### DIFF
--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -103,7 +103,7 @@ func (c *podPresetPlugin) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	list, err := c.lister.PodPresets(pod.GetNamespace()).List(labels.Everything())
+	list, err := c.lister.PodPresets(a.GetNamespace()).List(labels.Everything())
 
 	// Ignore if exclusion annotation is present
 	if podAnnotations := pod.GetAnnotations(); podAnnotations != nil {


### PR DESCRIPTION
Previously a pod with an empty namespace field submitted to a given namespace
was incorrectly matching preset labels in a different namespace.

Fixes https://github.com/kubernetes/kubernetes/issues/49141

Release note:
```release-note
Fix pod preset to ignore input pod namespace in favor of request namespace
```