### PR TITLE
add svc and netpol to discovery

### DIFF
--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -77,6 +77,16 @@ func NewStorage(registry Registry, endpoints endpoint.Registry, serviceIPs ipall
 	}
 }
 
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (rs *REST) ShortNames() []string {
+	return []string{"svc"}
+}
+
+// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
+func (rs *REST) Categories() []string {
+	return []string{"all"}
+}
+
 // TODO: implement includeUninitialized by refactoring this to move to store
 func (rs *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	service := obj.(*api.Service)

--- a/pkg/registry/networking/networkpolicy/storage/BUILD
+++ b/pkg/registry/networking/networkpolicy/storage/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
     ],
 )
 

--- a/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	networkingapi "k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/registry/cachesize"
@@ -51,4 +52,12 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	}
 
 	return &REST{store}
+}
+
+// Implement ShortNamesProvider
+var _ rest.ShortNamesProvider = &REST{}
+
+// ShortNames implements the ShortNamesProvider interface. Returns a list of short names for a resource.
+func (r *REST) ShortNames() []string {
+	return []string{"netpol"}
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/48962

one shortname was missing entirely, the other was on a storage not actually used as storage.

@ncdc 