### PR TITLE
Revert "Remove old node role label that is not used by kubeadm"

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/BUILD
@@ -13,6 +13,7 @@ go_library(
         "doc.go",
         "register.go",
         "types.go",
+        "well_known_labels.go",
         "zz_generated.deepcopy.go",
     ],
     tags = ["automanaged"],

--- a/cmd/kubeadm/app/apis/kubeadm/well_known_labels.go
+++ b/cmd/kubeadm/app/apis/kubeadm/well_known_labels.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeadm
+
+// Role labels are applied to Nodes to mark their purpose.  In particular, we
+// usually want to distinguish the master, so that we can isolate privileged
+// pods and operations.
+//
+// Originally we relied on not registering the master, on the fact that the
+// master was Unschedulable, and on static manifests for master components.
+// But we now do register masters in many environments, are generally moving
+// away from static manifests (for better manageability), and working towards
+// deprecating the unschedulable field (replacing it with taints & tolerations
+// instead).
+//
+// Even with tainting, a label remains the easiest way of making a positive
+// selection, so that pods can schedule only to master nodes for example, and
+// thus installations will likely define a label for their master nodes.
+//
+// So that we can recognize master nodes in consequent places though (such as
+// kubectl get nodes), we encourage installations to use the well-known labels.
+// We define NodeLabelRole, which is the preferred form, but we will also recognize
+// other forms that are known to be in widespread use (NodeLabelKubeadmAlphaRole).
+
+const (
+	// NodeLabelKubeadmAlphaRole is a label that kubeadm applies to a Node as a hint that it has a particular purpose.
+	// Use of NodeLabelRole is preferred.
+	NodeLabelKubeadmAlphaRole = "kubeadm.alpha.kubernetes.io/role"
+)

--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -59,6 +59,7 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//federation/apis/federation:go_default_library",
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -2421,6 +2421,7 @@ func describeNode(node *api.Node, nodeNonTerminatedPodsList *api.PodList, events
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", node.Name)
+		w.Write(LEVEL_0, "Role:\t%s\n", findNodeRole(node))
 		printLabelsMultiline(w, "Labels", node.Labels)
 		printAnnotationsMultiline(w, "Annotations", node.Annotations)
 		printNodeTaintsMultiline(w, "Taints", node.Spec.Taints)

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/events"
@@ -1048,6 +1049,10 @@ func printNode(obj *api.Node, options printers.PrintOptions) ([]metav1alpha1.Tab
 	if obj.Spec.Unschedulable {
 		status = append(status, "SchedulingDisabled")
 	}
+	role := findNodeRole(obj)
+	if role != "" {
+		status = append(status, role)
+	}
 
 	row.Cells = append(row.Cells, obj.Name, strings.Join(status, ","), translateTimestamp(obj.CreationTimestamp), obj.Status.NodeInfo.KubeletVersion)
 	if options.Wide {
@@ -1076,6 +1081,19 @@ func getNodeExternalIP(node *api.Node) string {
 	}
 
 	return "<none>"
+}
+
+// findNodeRole returns the role of a given node, or "" if none found.
+// The role is determined by looking in order for:
+// * a kubernetes.io/role label
+// * a kubeadm.alpha.kubernetes.io/role label
+// If no role is found, ("", nil) is returned
+func findNodeRole(node *api.Node) string {
+	if role := node.Labels[kubeadm.NodeLabelKubeadmAlphaRole]; role != "" {
+		return role
+	}
+	// No role found
+	return ""
 }
 
 func printNodeList(list *api.NodeList, options printers.PrintOptions) ([]metav1alpha1.TableRow, error) {

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -825,6 +825,16 @@ func TestPrintNodeStatus(t *testing.T) {
 			},
 			status: "Unknown,SchedulingDisabled",
 		},
+		{
+			node: api.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo12",
+					Labels: map[string]string{"kubeadm.alpha.kubernetes.io/role": "node"},
+				},
+				Status: api.NodeStatus{Conditions: []api.NodeCondition{{Type: api.NodeReady, Status: api.ConditionTrue}}},
+			},
+			status: "Ready,node",
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
Revert the commit that removed printing of node roles from kubectl.

It sounds like we also need to update the labels we inspect, as these were previously removed.  But starting with a clean revert.

Issue #49124

```release-note
NONE
```
