### PR TITLE
expose RegisterAllAdmissionPlugins so that admission chains can be reused

### DIFF
--- a/cmd/kube-apiserver/app/plugins.go
+++ b/cmd/kube-apiserver/app/plugins.go
@@ -51,8 +51,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/webhook"
 )
 
-// registerAllAdmissionPlugins registers all admission plugins
-func registerAllAdmissionPlugins(plugins *admission.Plugins) {
+// RegisterAllAdmissionPlugins registers all admission plugins
+func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	admit.Register(plugins)
 	alwayspullimages.Register(plugins)
 	antiaffinity.Register(plugins)

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -247,7 +247,7 @@ func CreateNodeDialer(s *options.ServerRunOptions) (tunneler.Tunneler, *http.Tra
 // CreateKubeAPIServerConfig creates all the resources for running the API server, but runs none of them
 func CreateKubeAPIServerConfig(s *options.ServerRunOptions, nodeTunneler tunneler.Tunneler, proxyTransport http.RoundTripper) (*master.Config, informers.SharedInformerFactory, clientgoinformers.SharedInformerFactory, *kubeserver.InsecureServingInfo, aggregatorapiserver.ServiceResolver, error) {
 	// register all admission plugins
-	registerAllAdmissionPlugins(s.Admission.Plugins)
+	RegisterAllAdmissionPlugins(s.Admission.Plugins)
 
 	// set defaults in the options before trying to create the generic config
 	if err := defaultOptions(s); err != nil {

--- a/federation/cmd/federation-apiserver/app/plugins.go
+++ b/federation/cmd/federation-apiserver/app/plugins.go
@@ -32,8 +32,8 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/admission/initialization"
 )
 
-// registerAllAdmissionPlugins registers all admission plugins
-func registerAllAdmissionPlugins(plugins *admission.Plugins) {
+// RegisterAllAdmissionPlugins registers all admission plugins
+func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	admit.Register(plugins)
 	deny.Register(plugins)
 	gc.Register(plugins)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -87,7 +87,7 @@ func Run(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 // stop with the given channel.
 func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	// register all admission plugins
-	registerAllAdmissionPlugins(s.Admission.Plugins)
+	RegisterAllAdmissionPlugins(s.Admission.Plugins)
 
 	// set defaults
 	if err := s.GenericServerRunOptions.DefaultAdvertiseAddress(s.SecureServing); err != nil {


### PR DESCRIPTION
Exposes the admission plugin registration functions so that sets of plugins can be re-used.

@sttts @p0lyn0mial 