### PR TITLE
make sure that the template param is the right type before using it

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -160,8 +160,10 @@ func extractOutputOptions(cmd *cobra.Command) *printers.OutputOptions {
 	// templates are logically optional for specifying a format.
 	// TODO once https://github.com/kubernetes/kubernetes/issues/12668 is fixed, this should fall back to GetFlagString
 	var templateFile string
-	if flags.Lookup("template") != nil {
-		templateFile = GetFlagString(cmd, "template")
+	if flag := flags.Lookup("template"); flag != nil {
+		if flag.Value.Type() == "string" {
+			templateFile = GetFlagString(cmd, "template")
+		}
 	}
 	if len(outputFormat) == 0 && len(templateFile) != 0 {
 		outputFormat = "template"


### PR DESCRIPTION
The CLI should attempt to make sure that the flags it uses conform to expectations instead of unconditionally killing a process.  This allows for possible re-use of the printing stack.