### PR TITLE
check for nil value in interface for proxier health

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -463,8 +463,10 @@ func NewProxyServer(config *componentconfig.KubeProxyConfiguration, cleanupAndEx
 	recorder := eventBroadcaster.NewRecorder(scheme, clientv1.EventSource{Component: "kube-proxy", Host: hostname})
 
 	var healthzServer *healthcheck.HealthzServer
+	var healthzUpdater healthcheck.HealthzUpdater
 	if len(config.HealthzBindAddress) > 0 {
 		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration)
+		healthzUpdater = healthzServer
 	}
 
 	var proxier proxy.ProxyProvider
@@ -498,7 +500,7 @@ func NewProxyServer(config *componentconfig.KubeProxyConfiguration, cleanupAndEx
 			hostname,
 			nodeIP,
 			recorder,
-			healthzServer,
+			healthzUpdater,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)


### PR DESCRIPTION
golang allows for a non-nil interface to have a nil value (not type).  This results in an NPE at runtime.

@sttts remember that bit about go?  Trivia becomes real :(

```release-note
Fix a bug causing crash in case of disabled healthz server in kube-proxy
```