### PR TITLE
expose method to allow externally setting defaults on an external type

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -302,7 +302,7 @@ func (o *Options) loadConfig(data []byte) (*componentconfig.KubeProxyConfigurati
 	return config, nil
 }
 
-func (o *Options) applyDefaults(in *componentconfig.KubeProxyConfiguration) (*componentconfig.KubeProxyConfiguration, error) {
+func (o *Options) ApplyDefaults(in *componentconfig.KubeProxyConfiguration) (*componentconfig.KubeProxyConfiguration, error) {
 	external, err := o.scheme.ConvertToVersion(in, v1alpha1.SchemeGroupVersion)
 	if err != nil {
 		return nil, err
@@ -344,7 +344,7 @@ with the apiserver API to configure the proxy.`,
 		},
 	}
 
-	opts.config, err = opts.applyDefaults(opts.config)
+	opts.config, err = opts.ApplyDefaults(opts.config)
 	if err != nil {
 		glog.Fatalf("unable to create flag defaults: %v", err)
 	}


### PR DESCRIPTION
The options are an exposed type.  This allows you to set the defaults on them.

@derekwaynecarr who normally owns this bit?