### PR TITLE
Add sig/api-machinery labels

### DIFF
--- a/cmd/kube-apiserver/OWNERS
+++ b/cmd/kube-apiserver/OWNERS
@@ -19,3 +19,5 @@ reviewers:
 - nikhiljindal
 - ncdc
 - sttts
+labels:
+ - sig/api-machinery

--- a/cmd/libs/go2idl/OWNERS
+++ b/cmd/libs/go2idl/OWNERS
@@ -4,3 +4,5 @@ approvers:
 reviewers:
 - lavalamp
 - wojtek-t
+labels:
+ - sig/api-machinery

--- a/pkg/kubeapiserver/OWNERS
+++ b/pkg/kubeapiserver/OWNERS
@@ -8,3 +8,5 @@ reviewers:
 - lavalamp
 - liggitt
 - sttts
+labels:
+ - sig/api-machinery

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -38,3 +38,5 @@ reviewers:
 - madhusudancs
 - hongchaodeng
 - jszczepkowski
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/apiextensions-apiserver/OWNERS
+++ b/staging/src/k8s.io/apiextensions-apiserver/OWNERS
@@ -6,3 +6,5 @@ approvers:
 - deads2k
 - lavalamp
 - sttts
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -19,3 +19,5 @@ reviewers:
 - sttts
 - ncdc
 - tallclair
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -15,3 +15,5 @@ reviewers:
 - ncdc
 - tallclair
 - timothysc
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/client-go/OWNERS
+++ b/staging/src/k8s.io/client-go/OWNERS
@@ -42,3 +42,5 @@ reviewers:
 - soltysh
 - piosz
 - jsafrane
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -10,3 +10,5 @@ reviewers:
 - liggitt
 - sttts
 - cheftako
+labels:
+ - sig/api-machinery

--- a/staging/src/k8s.io/sample-apiserver/OWNERS
+++ b/staging/src/k8s.io/sample-apiserver/OWNERS
@@ -10,3 +10,5 @@ reviewers:
 - deads2k
 - sttts
 - liggitt
+labels:
+ - sig/api-machinery


### PR DESCRIPTION
Make the bot label PRs modifying directories sig/api-machinery owns. (Won't take effect until https://github.com/kubernetes/test-infra/pull/3502 rolls out.)