### PR TITLE
Cleanup storage e2e test names

### DIFF
--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -51,7 +51,7 @@ func initializeGCETestSpec(c clientset.Interface, ns string, pvConfig framework.
 }
 
 // Testing configurations of single a PV/PVC pair attached to a GCE PD
-var _ = SIGDescribe("PersistentVolumes:GCEPD", func() {
+var _ = SIGDescribe("PersistentVolumes GCEPD", func() {
 	var (
 		c         clientset.Interface
 		diskName  string

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -111,7 +111,7 @@ var _ = SIGDescribe("PersistentVolumes", func() {
 
 	// Testing configurations of a single a PV/PVC pair, multiple evenly paired PVs/PVCs,
 	// and multiple unevenly paired PV/PVCs
-	SIGDescribe("PersistentVolumes:NFS", func() {
+	Describe("NFS", func() {
 
 		var (
 			nfsServerPod *v1.Pod

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -223,7 +223,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 		ns = f.Namespace.Name
 	})
 
-	SIGDescribe("DynamicProvisioner", func() {
+	Describe("DynamicProvisioner", func() {
 		It("should provision storage with different parameters [Slow]", func() {
 			cloudZone := getRandomCloudZone(c)
 
@@ -517,7 +517,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	SIGDescribe("DynamicProvisioner External", func() {
+	Describe("DynamicProvisioner External", func() {
 		It("should let an external dynamic provisioner create and delete persistent volumes [Slow]", func() {
 			// external dynamic provisioner pods need additional permissions provided by the
 			// persistent-volume-provisioner role
@@ -555,7 +555,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 		})
 	})
 
-	SIGDescribe("DynamicProvisioner Default", func() {
+	Describe("DynamicProvisioner Default", func() {
 		It("should create and delete default persistent volumes [Slow]", func() {
 			framework.SkipUnlessProviderIs("openstack", "gce", "aws", "gke", "vsphere", "azure")
 

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -98,7 +98,7 @@ var _ = SIGDescribe("Volumes", func() {
 	// NFS
 	////////////////////////////////////////////////////////////////////////
 
-	SIGDescribe("NFS", func() {
+	Describe("NFS", func() {
 		It("should be mountable", func() {
 			config, _, serverIP := framework.NewNFSServer(cs, namespace.Name, []string{})
 			defer func() {
@@ -129,7 +129,7 @@ var _ = SIGDescribe("Volumes", func() {
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
 
-	SIGDescribe("GlusterFS", func() {
+	Describe("GlusterFS", func() {
 		It("should be mountable", func() {
 			//TODO (copejon) GFS is not supported on debian image.
 			framework.SkipUnlessNodeOSDistroIs("gci")
@@ -172,7 +172,7 @@ var _ = SIGDescribe("Volumes", func() {
 	// are installed on all nodes!
 	// Run the test with "go run hack/e2e.go ... --ginkgo.focus=iSCSI"
 
-	SIGDescribe("iSCSI [Feature:Volumes]", func() {
+	Describe("iSCSI [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config, _, serverIP := framework.NewISCSIServer(cs, namespace.Name)
 			defer func() {
@@ -206,7 +206,7 @@ var _ = SIGDescribe("Volumes", func() {
 	// Ceph RBD
 	////////////////////////////////////////////////////////////////////////
 
-	SIGDescribe("Ceph RBD [Feature:Volumes]", func() {
+	Describe("Ceph RBD [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config, _, serverIP := framework.NewRBDServer(cs, namespace.Name)
 			defer func() {
@@ -270,7 +270,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Ceph
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("CephFS [Feature:Volumes]", func() {
+	Describe("CephFS [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
@@ -345,7 +345,7 @@ var _ = SIGDescribe("Volumes", func() {
 	// (/usr/bin/nova, /usr/bin/cinder and /usr/bin/keystone)
 	// and that the usual OpenStack authentication env. variables are set
 	// (OS_USERNAME, OS_PASSWORD, OS_TENANT_NAME at least).
-	SIGDescribe("Cinder [Feature:Volumes]", func() {
+	Describe("Cinder [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("openstack")
 			config := framework.VolumeTestConfig{
@@ -420,7 +420,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// GCE PD
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("PD", func() {
+	Describe("PD", func() {
 		// Flaky issue: #43977
 		It("should be mountable [Flaky]", func() {
 			framework.SkipUnlessProviderIs("gce", "gke")
@@ -473,7 +473,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// ConfigMap
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("ConfigMap", func() {
+	Describe("ConfigMap", func() {
 		It("should be mountable", func() {
 			config := framework.VolumeTestConfig{
 				Namespace: namespace.Name,
@@ -550,7 +550,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// vSphere
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("vsphere [Feature:Volumes]", func() {
+	Describe("vsphere [Feature:Volumes]", func() {
 		It("should be mountable", func() {
 			framework.SkipUnlessProviderIs("vsphere")
 			var (
@@ -603,7 +603,7 @@ var _ = SIGDescribe("Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Azure Disk
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("Azure Disk [Feature:Volumes]", func() {
+	Describe("Azure Disk [Feature:Volumes]", func() {
 		It("should be mountable [Slow]", func() {
 			framework.SkipUnlessProviderIs("azure")
 			config := framework.VolumeTestConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:
Some test names had redundant [sig-storage] tags.  Also, some tests still had [Volume] tag.  This PR removes those tags.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/release-note-none
/sig storage
