### PR TITLE
On GCE check whether NODE_LOCAL_SSDS=0 and handle this case appropriately

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -576,9 +576,13 @@ function create-node-template() {
 
   local local_ssds=""
   if [[ ! -z ${NODE_LOCAL_SSDS+x} ]]; then
+    # The NODE_LOCAL_SSDS check below fixes issue #49171
+    # Some versions of seq will count down from 1 if "seq 0" is specified
+    if [[ ${NODE_LOCAL_SSDS} -ge 1 ]]; then
       for i in $(seq ${NODE_LOCAL_SSDS}); do
-          local_ssds="$local_ssds--local-ssd=interface=SCSI "
+        local_ssds="$local_ssds--local-ssd=interface=SCSI "
       done
+    fi
   fi
 
   local network=$(make-gcloud-network-argument \


### PR DESCRIPTION

**What this PR does / why we need it**: Presently if you are using a mac and GCE and specify NODE_LOCAL_SSDS=0, or use the default, you end up with 2 local SSDs.

**Which issue this PR fixes** : fixes https://github.com/kubernetes/kubernetes/issues/49171

**Special notes for your reviewer**:

I've discovered that this issue is due to https://github.com/kubernetes/kubernetes/blob/b353792f9c349abb50a312bc1adaea1b3a8e115c/cluster/gce/util.sh#L579

If NODE_LOCAL_SSDS=0, this evaluates to $(seq 0)

```
$ for i in $(seq 0); do echo $i; done
1
0
```

From man seq on mac osx

```
The seq utility prints a sequence of numbers, one per line (default), from first (default 1), 
to near last as possible, in increments of incr (default 1).When first is larger than last the 
default incr is -1.
```

This was run on mac with the seq manpage indicating it comes from BSD Feb 19 2010.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```