### PR TITLE
RFC: kubeadm: build dag executor

### DIFF
--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -53,6 +53,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//cmd/kubeadm/app/util/config:all-srcs",
+        "//cmd/kubeadm/app/util/executor:all-srcs",
         "//cmd/kubeadm/app/util/kubeconfig:all-srcs",
         "//cmd/kubeadm/app/util/token:all-srcs",
     ],

--- a/cmd/kubeadm/app/util/executor/BUILD
+++ b/cmd/kubeadm/app/util/executor/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "executor.go",
+        "unitlike.go",
+    ],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["executor_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)

--- a/cmd/kubeadm/app/util/executor/executor.go
+++ b/cmd/kubeadm/app/util/executor/executor.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+)
+
+func New(out io.Writer, units []*Unit) (*Queue, error) {
+	q := &Queue{
+		units: map[string]*Unit{},
+		waits: map[string]chan struct{}{},
+		queue: []string{},
+		out:   out,
+	}
+
+	for _, u := range units {
+		q.units[u.Name] = u
+		q.waits[u.Name] = make(chan struct{})
+	}
+
+	if err := q.validate(); err != nil {
+		return nil, err
+	}
+
+	if err := q.sort(); err != nil {
+		return nil, err
+	}
+
+	return q, nil
+}
+
+type Queue struct {
+	units map[string]*Unit
+	waits map[string]chan struct{}
+	queue []string
+
+	mu  sync.Mutex
+	idx int
+
+	outMu sync.Mutex
+	out   io.Writer
+}
+
+func (q *Queue) Run(ctx context.Context, workers int) error {
+	ctx, cancel := context.WithCancel(ctx)
+
+	var (
+		wg       sync.WaitGroup
+		errGuard sync.Mutex
+		err      error
+	)
+
+	done := make(chan struct{})
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if workErr := q.work(ctx); workErr != nil {
+				errGuard.Lock()
+				err = workErr
+				errGuard.Unlock()
+
+				done <- struct{}{}
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		done <- struct{}{}
+	}()
+
+	<-done
+	cancel()
+	return err
+}
+
+func (q *Queue) work(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			q.mu.Lock()
+			idx := q.idx
+			q.idx++
+			q.mu.Unlock()
+
+			if idx >= len(q.queue) {
+				return nil
+			}
+			if err := q.doOne(ctx, q.queue[idx]); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (q *Queue) doOne(ctx context.Context, name string) error {
+	u := q.units[name]
+	for _, dep := range u.Deps {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-q.waits[dep]:
+			if ok {
+				return fmt.Errorf("unexpected channel open")
+			}
+		}
+	}
+
+	var out bytes.Buffer
+
+	err := u.Action(ctx, &out)
+	if err != nil {
+		return err
+	}
+
+	q.outMu.Lock()
+	out.WriteTo(q.out)
+	q.outMu.Unlock()
+
+	close(q.waits[name])
+
+	return nil
+}
+
+func (q *Queue) sort() error {
+	sorted, err := topoSort(q.units)
+	if err != nil {
+		return err
+	}
+	q.queue = sorted
+	return nil
+}
+
+// topoSort implements Kahn's algorithm to topologically sort the queue by
+// dependency. This sort is not stable. This sort returns an error if it
+// detects a circular dependency.
+func topoSort(units map[string]*Unit) ([]string, error) {
+	type node struct {
+		name string
+		in   []string
+		out  []string
+	}
+
+	nodes := map[string]*node{}
+	for _, u := range units {
+		nodes[u.Name] = &node{
+			name: u.Name,
+			in:   u.Deps,
+		}
+	}
+	for _, u := range units {
+		for _, dep := range u.Deps {
+			nodes[dep].out = append(nodes[dep].out, u.Name)
+		}
+	}
+
+	for _, n := range nodes {
+		sort.Strings(n.in)
+		sort.Strings(n.out)
+	}
+
+	sorted := []string{}
+
+	roots := []string{}
+	for _, n := range nodes {
+		if len(n.in) == 0 {
+			roots = append(roots, n.name)
+		}
+	}
+	sort.Strings(roots)
+
+	for len(roots) != 0 {
+		cur := nodes[roots[0]]
+		sorted = append(sorted, cur.name)
+
+		for _, out := range cur.out {
+			found := false
+			n := nodes[out]
+			for i, in := range n.in {
+				if in != cur.name {
+					continue
+				}
+				n.in = append(n.in[:i], n.in[i+1:]...)
+				found = true
+				break
+			}
+			if !found {
+				panic("programmer error")
+			}
+			if len(n.in) == 0 {
+				roots = append(roots, n.name)
+			}
+		}
+		roots = roots[1:]
+	}
+
+	if len(sorted) != len(nodes) {
+		return nil, fmt.Errorf("circular dependency")
+	}
+
+	return sorted, nil
+}
+
+func (q *Queue) validate() error {
+	for _, u := range q.units {
+		for _, dep := range u.Deps {
+			if _, ok := q.units[dep]; !ok {
+				return fmt.Errorf("unknown dep: %v", dep)
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/kubeadm/app/util/executor/executor_test.go
+++ b/cmd/kubeadm/app/util/executor/executor_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSort(t *testing.T) {
+	cs := []struct {
+		units     []*Unit
+		expected  []string
+		expectErr bool
+	}{
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+				},
+			},
+			expected: []string{"a"},
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+				},
+				&Unit{
+					Name: "b",
+				},
+				&Unit{
+					Name: "c",
+				},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "c",
+				},
+				&Unit{
+					Name: "b",
+				},
+				&Unit{
+					Name: "a",
+				},
+			},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+				},
+				&Unit{
+					Name: "b",
+					Deps: []string{"a", "c"},
+				},
+				&Unit{
+					Name: "c",
+				},
+			},
+			expected: []string{"a", "c", "b"},
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+					Deps: []string{"b"},
+				},
+				&Unit{
+					Name: "b",
+					Deps: []string{"c"},
+				},
+				&Unit{
+					Name: "c",
+					Deps: []string{"a"},
+				},
+			},
+			expectErr: true,
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+					Deps: []string{"a"},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for i, c := range cs {
+		q, err := New(os.Stderr, c.units)
+		if err != nil {
+			if c.expectErr {
+				continue
+			}
+			t.Errorf("[%d]unexpected err: %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(c.expected, q.queue) {
+			t.Errorf("[%d]\nexpected:\n\t%#v\ngot:\n\t%#v", i, c.expected, q.queue)
+		}
+	}
+}
+
+func TestRun(t *testing.T) {
+	cs := []struct {
+		units     []*Unit
+		expectErr bool
+	}{
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("a\n"))
+						return nil
+					},
+				},
+				&Unit{
+					Name: "b",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("b\n"))
+						return nil
+					},
+					Deps: []string{"c"},
+				},
+				&Unit{
+					Name: "c",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("c\n"))
+						return nil
+					},
+				},
+			},
+		},
+		{
+			units: []*Unit{
+				&Unit{
+					Name: "a",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("a\n"))
+						return fmt.Errorf("here")
+					},
+				},
+				&Unit{
+					Name: "b",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("b\n"))
+						return nil
+					},
+					Deps: []string{"c"},
+				},
+				&Unit{
+					Name: "c",
+					Execute: func(ctx context.Context, out io.Writer) error {
+						out.Write([]byte("c\n"))
+						return nil
+					},
+				},
+			},
+			expectErr: true,
+		},
+	}
+
+	for i, c := range cs {
+		ctx := context.Background()
+		q, err := New(os.Stderr, c.units)
+		if err != nil {
+			t.Errorf("[%d]unexpected err: %v", i, err)
+			continue
+		}
+		if err := q.Run(ctx, len(c.units)); err != nil {
+			if c.expectErr {
+				continue
+			}
+			t.Errorf("[%d]unexpected err: %v", i, err)
+			continue
+		}
+	}
+}

--- a/cmd/kubeadm/app/util/executor/unitlike.go
+++ b/cmd/kubeadm/app/util/executor/unitlike.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"io"
+)
+
+// Unit represents a single task.
+type Unit struct {
+	// Name is the name of the task.
+	Name string
+	// Deps is a slice of the names of tasks that this task depends on
+	Deps []string
+
+	// Action is that action to preform.
+	Action func(ctx context.Context, out io.Writer) error
+}


### PR DESCRIPTION
This PR adds a simple dag executor capable of executing dependent tasks in parallel without violating dependencies. I want to evaluate if this would be a useful abstraction to model kubeadm task execution. In this model, each task that kubeadm performs is a `Unit` with a name, dependencies, and an action. Units can compose easily and naturally.

Specifically I want to evaluate if this model can improve:
* testability: unit tests!
* performance through concurrency
* code readability/maintainability: phases are one or more units that expose a single logical unit.
* log consistency

@kubernetes/sig-cluster-lifecycle-misc 