### PR TITLE
Unify genclient tags and add more fine control on verbs generated

### DIFF
--- a/federation/apis/federation/types.go
+++ b/federation/apis/federation/types.go
@@ -91,8 +91,8 @@ type ClusterStatus struct {
 	Region string
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.

--- a/federation/apis/federation/v1beta1/types.go
+++ b/federation/apis/federation/v1beta1/types.go
@@ -92,9 +92,9 @@ type ClusterStatus struct {
 	Region string `json:"region,omitempty" protobuf:"bytes,6,opt,name=region"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +nonNamespaced=true
+// +genclient:nonNamespaced
 
 // Information about a registered cluster in a federated kubernetes setup. Clusters are not namespaced and have unique names in the federation.
 type Cluster struct {

--- a/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/autoscaling/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscaling_v1 "k8s.io/api/autoscaling/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,21 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"}
 
-func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
-func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling_v1.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (*v1.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &v1.HorizontalPodAutoscaler{})
-
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.HorizontalPodAutoscalerList{})
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &v1.HorizontalPodAutoscalerList{})
+		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &autoscaling_v1.HorizontalPodAutoscalerList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +60,8 @@ func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.HorizontalPodAutoscalerList{}
-	for _, item := range obj.(*v1.HorizontalPodAutoscalerList).Items {
+	list := &autoscaling_v1.HorizontalPodAutoscalerList{}
+	for _, item := range obj.(*autoscaling_v1.HorizontalPodAutoscalerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +70,69 @@ func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v
 }
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error) {
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (*autoscaling_v1.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &autoscaling_v1.HorizontalPodAutoscalerList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -85,7 +85,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.Horizontal
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}

--- a/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -59,6 +59,41 @@ func newHorizontalPodAutoscalers(c *AutoscalingV1Client, namespace string) *hori
 	}
 }
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
+	result = &v1.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
+	result = &v1.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
@@ -120,41 +155,6 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *meta_v1.DeleteOptio
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
-func (c *horizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
-	result = &v1.HorizontalPodAutoscaler{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
-	result = &v1.HorizontalPodAutoscalerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/federation/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_job.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/batch/v1/fake/fake_job.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/batch/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batch_v1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,21 @@ var jobsResource = schema.GroupVersionResource{Group: "batch", Version: "v1", Re
 
 var jobsKind = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 
-func (c *FakeJobs) Create(job *v1.Job) (result *v1.Job, err error) {
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &v1.Job{})
+		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &batch_v1.Job{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Job), err
+	return obj.(*batch_v1.Job), err
 }
 
-func (c *FakeJobs) Update(job *v1.Job) (result *v1.Job, err error) {
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *FakeJobs) List(opts v1.ListOptions) (result *batch_v1.JobList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) UpdateStatus(job *v1.Job) (*v1.Job, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &v1.Job{})
-
-	return err
-}
-
-func (c *FakeJobs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.JobList{})
-	return err
-}
-
-func (c *FakeJobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &v1.JobList{})
+		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &batch_v1.JobList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +60,8 @@ func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.JobList{}
-	for _, item := range obj.(*v1.JobList).Items {
+	list := &batch_v1.JobList{}
+	for _, item := range obj.(*batch_v1.JobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +70,69 @@ func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error
 }
 
 // Watch returns a watch.Interface that watches the requested jobs.
-func (c *FakeJobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(jobsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched job.
-func (c *FakeJobs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Job, err error) {
+// Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Create(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &v1.Job{})
+		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch_v1.Job{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Job), err
+	return obj.(*batch_v1.Job), err
+}
+
+// Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Update(job *batch_v1.Job) (result *batch_v1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeJobs) UpdateStatus(job *batch_v1.Job) (*batch_v1.Job, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
+}
+
+// Delete takes name of the job and deletes it. Returns an error if one occurs.
+func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch_v1.Job{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch_v1.JobList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched job.
+func (c *FakeJobs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *batch_v1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
@@ -85,7 +85,7 @@ func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *jobs) UpdateStatus(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}

--- a/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/batch/v1/job.go
@@ -59,6 +59,41 @@ func newJobs(c *BatchV1Client, namespace string) *jobs {
 	}
 }
 
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *jobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
+	result = &v1.Job{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
+	result = &v1.JobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Create(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
@@ -120,41 +155,6 @@ func (c *jobs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
-func (c *jobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
-	result = &v1.Job{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Jobs that match those selectors.
-func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
-	result = &v1.JobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested jobs.
-func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched job.

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/configmap.go
@@ -58,6 +58,41 @@ func newConfigMaps(c *CoreV1Client, namespace string) *configMaps {
 	}
 }
 
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
+func (c *configMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
+	result = &v1.ConfigMap{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
+	result = &v1.ConfigMapList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested configMaps.
+func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
 	result = &v1.ConfigMap{}
@@ -103,41 +138,6 @@ func (c *configMaps) DeleteCollection(options *meta_v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
-func (c *configMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
-	result = &v1.ConfigMap{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
-func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
-	result = &v1.ConfigMapList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested configMaps.
-func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/event.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/event.go
@@ -58,6 +58,41 @@ func newEvents(c *CoreV1Client, namespace string) *events {
 	}
 }
 
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *events) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
+	result = &v1.Event{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
+	result = &v1.EventList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *v1.Event) (result *v1.Event, err error) {
 	result = &v1.Event{}
@@ -103,41 +138,6 @@ func (c *events) DeleteCollection(options *meta_v1.DeleteOptions, listOptions me
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
-func (c *events) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
-	result = &v1.Event{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Events that match those selectors.
-func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
-	result = &v1.EventList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested events.
-func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched event.

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_configmap.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_configmap.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,21 @@ var configmapsResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var configmapsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 
-func (c *FakeConfigMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
+func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &v1.ConfigMap{})
+		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ConfigMap), err
+	return obj.(*core_v1.ConfigMap), err
 }
 
-func (c *FakeConfigMaps) Update(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *core_v1.ConfigMapList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &v1.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &v1.ConfigMap{})
-
-	return err
-}
-
-func (c *FakeConfigMaps) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ConfigMapList{})
-	return err
-}
-
-func (c *FakeConfigMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &v1.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &v1.ConfigMapList{})
+		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &core_v1.ConfigMapList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +60,8 @@ func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapLis
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ConfigMapList{}
-	for _, item := range obj.(*v1.ConfigMapList).Items {
+	list := &core_v1.ConfigMapList{}
+	for _, item := range obj.(*core_v1.ConfigMapList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +70,57 @@ func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapLis
 }
 
 // Watch returns a watch.Interface that watches the requested configMaps.
-func (c *FakeConfigMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(configmapsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched configMap.
-func (c *FakeConfigMaps) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
+// Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Create(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &v1.ConfigMap{})
+		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ConfigMap), err
+	return obj.(*core_v1.ConfigMap), err
+}
+
+// Update takes the representation of a configMap and updates it. Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Update(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ConfigMap), err
+}
+
+// Delete takes name of the configMap and deletes it. Returns an error if one occurs.
+func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ConfigMapList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched configMap.
+func (c *FakeConfigMaps) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &core_v1.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ConfigMap), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_event.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_event.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,21 @@ var eventsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resou
 
 var eventsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}
 
-func (c *FakeEvents) Create(event *v1.Event) (result *v1.Event, err error) {
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &v1.Event{})
+		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &core_v1.Event{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Event), err
+	return obj.(*core_v1.Event), err
 }
 
-func (c *FakeEvents) Update(event *v1.Event) (result *v1.Event, err error) {
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *FakeEvents) List(opts v1.ListOptions) (result *core_v1.EventList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &v1.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Event), err
-}
-
-func (c *FakeEvents) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &v1.Event{})
-
-	return err
-}
-
-func (c *FakeEvents) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.EventList{})
-	return err
-}
-
-func (c *FakeEvents) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &v1.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Event), err
-}
-
-func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &v1.EventList{})
+		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &core_v1.EventList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +60,8 @@ func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err e
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.EventList{}
-	for _, item := range obj.(*v1.EventList).Items {
+	list := &core_v1.EventList{}
+	for _, item := range obj.(*core_v1.EventList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +70,57 @@ func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err e
 }
 
 // Watch returns a watch.Interface that watches the requested events.
-func (c *FakeEvents) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(eventsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched event.
-func (c *FakeEvents) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Event, err error) {
+// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Create(event *core_v1.Event) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &v1.Event{})
+		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &core_v1.Event{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Event), err
+	return obj.(*core_v1.Event), err
+}
+
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Update(event *core_v1.Event) (result *core_v1.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &core_v1.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Event), err
+}
+
+// Delete takes name of the event and deletes it. Returns an error if one occurs.
+func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &core_v1.Event{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.EventList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched event.
+func (c *FakeEvents) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &core_v1.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Event), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_namespace.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_namespace.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,58 +35,20 @@ var namespacesResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var namespacesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 
-func (c *FakeNamespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &v1.Namespace{})
+		Invokes(testing.NewRootGetAction(namespacesResource, name), &core_v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Namespace), err
+	return obj.(*core_v1.Namespace), err
 }
 
-func (c *FakeNamespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *FakeNamespaces) List(opts v1.ListOptions) (result *core_v1.NamespaceList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) UpdateStatus(namespace *v1.Namespace) (*v1.Namespace, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &v1.Namespace{})
-	return err
-}
-
-func (c *FakeNamespaces) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.NamespaceList{})
-	return err
-}
-
-func (c *FakeNamespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(namespacesResource, name), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &v1.NamespaceList{})
+		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &core_v1.NamespaceList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +57,8 @@ func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceLis
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.NamespaceList{}
-	for _, item := range obj.(*v1.NamespaceList).Items {
+	list := &core_v1.NamespaceList{}
+	for _, item := range obj.(*core_v1.NamespaceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -105,17 +67,63 @@ func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceLis
 }
 
 // Watch returns a watch.Interface that watches the requested namespaces.
-func (c *FakeNamespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(namespacesResource, opts))
 }
 
-// Patch applies the patch and returns the patched namespace.
-func (c *FakeNamespaces) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error) {
+// Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Create(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &v1.Namespace{})
+		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &core_v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Namespace), err
+	return obj.(*core_v1.Namespace), err
+}
+
+// Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Update(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeNamespaces) UpdateStatus(namespace *core_v1.Namespace) (*core_v1.Namespace, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
+}
+
+// Delete takes name of the namespace and deletes it. Returns an error if one occurs.
+func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &core_v1.Namespace{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.NamespaceList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched namespace.
+func (c *FakeNamespaces) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_secret.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_secret.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,21 @@ var secretsResource = schema.GroupVersionResource{Group: "", Version: "v1", Reso
 
 var secretsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
-func (c *FakeSecrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &v1.Secret{})
+		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &core_v1.Secret{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Secret), err
+	return obj.(*core_v1.Secret), err
 }
 
-func (c *FakeSecrets) Update(secret *v1.Secret) (result *v1.Secret, err error) {
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *FakeSecrets) List(opts v1.ListOptions) (result *core_v1.SecretList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &v1.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Secret), err
-}
-
-func (c *FakeSecrets) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &v1.Secret{})
-
-	return err
-}
-
-func (c *FakeSecrets) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.SecretList{})
-	return err
-}
-
-func (c *FakeSecrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &v1.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Secret), err
-}
-
-func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &v1.SecretList{})
+		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &core_v1.SecretList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +60,8 @@ func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.SecretList{}
-	for _, item := range obj.(*v1.SecretList).Items {
+	list := &core_v1.SecretList{}
+	for _, item := range obj.(*core_v1.SecretList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +70,57 @@ func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err
 }
 
 // Watch returns a watch.Interface that watches the requested secrets.
-func (c *FakeSecrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(secretsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched secret.
-func (c *FakeSecrets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Secret, err error) {
+// Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Create(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &v1.Secret{})
+		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Secret), err
+	return obj.(*core_v1.Secret), err
+}
+
+// Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Update(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Secret), err
+}
+
+// Delete takes name of the secret and deletes it. Returns an error if one occurs.
+func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &core_v1.Secret{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.SecretList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched secret.
+func (c *FakeSecrets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &core_v1.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Secret), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/fake/fake_service.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,21 @@ var servicesResource = schema.GroupVersionResource{Group: "", Version: "v1", Res
 
 var servicesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
 
-func (c *FakeServices) Create(service *v1.Service) (result *v1.Service, err error) {
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *FakeServices) Get(name string, options v1.GetOptions) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &v1.Service{})
+		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &core_v1.Service{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Service), err
+	return obj.(*core_v1.Service), err
 }
 
-func (c *FakeServices) Update(service *v1.Service) (result *v1.Service, err error) {
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *FakeServices) List(opts v1.ListOptions) (result *core_v1.ServiceList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) UpdateStatus(service *v1.Service) (*v1.Service, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &v1.Service{})
-
-	return err
-}
-
-func (c *FakeServices) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ServiceList{})
-	return err
-}
-
-func (c *FakeServices) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &v1.ServiceList{})
+		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &core_v1.ServiceList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +60,8 @@ func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, e
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ServiceList{}
-	for _, item := range obj.(*v1.ServiceList).Items {
+	list := &core_v1.ServiceList{}
+	for _, item := range obj.(*core_v1.ServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +70,69 @@ func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, e
 }
 
 // Watch returns a watch.Interface that watches the requested services.
-func (c *FakeServices) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicesResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
+// Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Create(service *core_v1.Service) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &v1.Service{})
+		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &core_v1.Service{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Service), err
+	return obj.(*core_v1.Service), err
+}
+
+// Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Update(service *core_v1.Service) (result *core_v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeServices) UpdateStatus(service *core_v1.Service) (*core_v1.Service, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
+}
+
+// Delete takes name of the service and deletes it. Returns an error if one occurs.
+func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &core_v1.Service{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ServiceList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
 }

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
@@ -81,7 +81,7 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/namespace.go
@@ -57,6 +57,38 @@ func newNamespaces(c *CoreV1Client) *namespaces {
 	}
 }
 
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *namespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
+	err = c.client.Get().
+		Resource("namespaces").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
+	result = &v1.NamespaceList{}
+	err = c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
@@ -113,38 +145,6 @@ func (c *namespaces) DeleteCollection(options *meta_v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
-func (c *namespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
-	result = &v1.Namespace{}
-	err = c.client.Get().
-		Resource("namespaces").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
-func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
-	result = &v1.NamespaceList{}
-	err = c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested namespaces.
-func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/secret.go
@@ -58,6 +58,41 @@ func newSecrets(c *CoreV1Client, namespace string) *secrets {
 	}
 }
 
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *secrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
+	result = &v1.Secret{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
+	result = &v1.SecretList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
 	result = &v1.Secret{}
@@ -103,41 +138,6 @@ func (c *secrets) DeleteCollection(options *meta_v1.DeleteOptions, listOptions m
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
-func (c *secrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
-	result = &v1.Secret{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Secrets that match those selectors.
-func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
-	result = &v1.SecretList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested secrets.
-func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
@@ -85,7 +85,7 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}

--- a/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/core/v1/service.go
@@ -59,6 +59,41 @@ func newServices(c *CoreV1Client, namespace string) *services {
 	}
 }
 
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *services) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
+	result = &v1.Service{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
+	result = &v1.ServiceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Create(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
@@ -120,41 +155,6 @@ func (c *services) DeleteCollection(options *meta_v1.DeleteOptions, listOptions 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
-func (c *services) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
-	result = &v1.Service{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Services that match those selectors.
-func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
-	result = &v1.ServiceList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested services.
-func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched service.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
@@ -85,7 +85,7 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/daemonset.go
@@ -59,6 +59,41 @@ func newDaemonSets(c *ExtensionsV1beta1Client, namespace string) *daemonSets {
 	}
 }
 
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
+func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
+	result = &v1beta1.DaemonSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
+	result = &v1beta1.DaemonSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
@@ -120,41 +155,6 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
-func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
-	result = &v1beta1.DaemonSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
-func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
-	result = &v1beta1.DaemonSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *ExtensionsV1beta1Client, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
+	result = &v1beta1.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	result = &v1beta1.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
-	result = &v1beta1.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
-	result = &v1beta1.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
@@ -85,7 +85,7 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -36,50 +36,7 @@ var daemonsetsResource = schema.GroupVersionResource{Group: "extensions", Versio
 
 var daemonsetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "DaemonSet"}
 
-func (c *FakeDaemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (*v1beta1.DaemonSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &v1beta1.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
-
-	return err
-}
-
-func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.DaemonSetList{})
-	return err
-}
-
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
 func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
@@ -90,6 +47,7 @@ func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta
 	return obj.(*v1beta1.DaemonSet), err
 }
 
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &v1beta1.DaemonSetList{})
@@ -116,6 +74,56 @@ func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(daemonsetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.DaemonSet), err
+}
+
+// Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.DaemonSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDaemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (*v1beta1.DaemonSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &v1beta1.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.DaemonSet), err
+}
+
+// Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
+func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.DaemonSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -36,50 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var deploymentsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}
 
-func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Deployment), err
-}
-
-func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Deployment), err
-}
-
-func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta1.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Deployment), err
-}
-
-func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
-
-	return err
-}
-
-func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.DeploymentList{})
-	return err
-}
-
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
@@ -90,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
@@ -116,6 +74,56 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.DeploymentList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -36,50 +36,7 @@ var ingressesResource = schema.GroupVersionResource{Group: "extensions", Version
 
 var ingressesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
 
-func (c *FakeIngresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Ingress), err
-}
-
-func (c *FakeIngresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Ingress), err
-}
-
-func (c *FakeIngresses) UpdateStatus(ingress *v1beta1.Ingress) (*v1beta1.Ingress, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &v1beta1.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Ingress), err
-}
-
-func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
-
-	return err
-}
-
-func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.IngressList{})
-	return err
-}
-
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
 func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
@@ -90,6 +47,7 @@ func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1
 	return obj.(*v1beta1.Ingress), err
 }
 
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &v1beta1.IngressList{})
@@ -116,6 +74,56 @@ func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(ingressesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), err
+}
+
+// Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeIngresses) UpdateStatus(ingress *v1beta1.Ingress) (*v1beta1.Ingress, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &v1beta1.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), err
+}
+
+// Delete takes name of the ingress and deletes it. Returns an error if one occurs.
+func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.IngressList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -36,50 +36,7 @@ var replicasetsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var replicasetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}
 
-func (c *FakeReplicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (*v1beta1.ReplicaSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &v1beta1.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
-
-	return err
-}
-
-func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ReplicaSetList{})
-	return err
-}
-
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
 func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
@@ -90,6 +47,7 @@ func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.ReplicaSet), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
 func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &v1beta1.ReplicaSetList{})
@@ -116,6 +74,56 @@ func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(replicasetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ReplicaSet), err
+}
+
+// Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ReplicaSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeReplicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (*v1beta1.ReplicaSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &v1beta1.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ReplicaSet), err
+}
+
+// Delete takes name of the replicaSet and deletes it. Returns an error if one occurs.
+func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ReplicaSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
@@ -85,7 +85,7 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/ingress.go
@@ -59,6 +59,41 @@ func newIngresses(c *ExtensionsV1beta1Client, namespace string) *ingresses {
 	}
 }
 
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
+func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
+	result = &v1beta1.Ingress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
+	result = &v1beta1.IngressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
@@ -120,41 +155,6 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
-	result = &v1beta1.Ingress{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
-func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
-	result = &v1beta1.IngressList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
@@ -59,6 +59,41 @@ func newReplicaSets(c *ExtensionsV1beta1Client, namespace string) *replicaSets {
 	}
 }
 
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
+func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
+	result = &v1beta1.ReplicaSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
+func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
+	result = &v1beta1.ReplicaSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicaSets.
+func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
@@ -120,41 +155,6 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
-func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
-	result = &v1beta1.ReplicaSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
-func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
-	result = &v1beta1.ReplicaSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
@@ -85,7 +85,7 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}

--- a/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
@@ -81,7 +81,7 @@ func (c *clusters) Update(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, er
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *clusters) UpdateStatus(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
 	result = &v1beta1.Cluster{}

--- a/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/cluster.go
@@ -57,6 +57,38 @@ func newClusters(c *FederationV1beta1Client) *clusters {
 	}
 }
 
+// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
+func (c *clusters) Get(name string, options v1.GetOptions) (result *v1beta1.Cluster, err error) {
+	result = &v1beta1.Cluster{}
+	err = c.client.Get().
+		Resource("clusters").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Clusters that match those selectors.
+func (c *clusters) List(opts v1.ListOptions) (result *v1beta1.ClusterList, err error) {
+	result = &v1beta1.ClusterList{}
+	err = c.client.Get().
+		Resource("clusters").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusters.
+func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusters").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a cluster and creates it.  Returns the server's representation of the cluster, and an error, if there is any.
 func (c *clusters) Create(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
 	result = &v1beta1.Cluster{}
@@ -113,38 +145,6 @@ func (c *clusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
-func (c *clusters) Get(name string, options v1.GetOptions) (result *v1beta1.Cluster, err error) {
-	result = &v1beta1.Cluster{}
-	err = c.client.Get().
-		Resource("clusters").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Clusters that match those selectors.
-func (c *clusters) List(opts v1.ListOptions) (result *v1beta1.ClusterList, err error) {
-	result = &v1beta1.ClusterList{}
-	err = c.client.Get().
-		Resource("clusters").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusters.
-func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusters").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched cluster.

--- a/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/federation/v1beta1/fake/fake_cluster.go
@@ -35,46 +35,7 @@ var clustersResource = schema.GroupVersionResource{Group: "federation", Version:
 
 var clustersKind = schema.GroupVersionKind{Group: "federation", Version: "v1beta1", Kind: "Cluster"}
 
-func (c *FakeClusters) Create(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clustersResource, cluster), &v1beta1.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Cluster), err
-}
-
-func (c *FakeClusters) Update(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clustersResource, cluster), &v1beta1.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Cluster), err
-}
-
-func (c *FakeClusters) UpdateStatus(cluster *v1beta1.Cluster) (*v1beta1.Cluster, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(clustersResource, "status", cluster), &v1beta1.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Cluster), err
-}
-
-func (c *FakeClusters) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clustersResource, name), &v1beta1.Cluster{})
-	return err
-}
-
-func (c *FakeClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clustersResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ClusterList{})
-	return err
-}
-
+// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1beta1.Cluster, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clustersResource, name), &v1beta1.Cluster{})
@@ -84,6 +45,7 @@ func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *v1beta1.
 	return obj.(*v1beta1.Cluster), err
 }
 
+// List takes label and field selectors, and returns the list of Clusters that match those selectors.
 func (c *FakeClusters) List(opts v1.ListOptions) (result *v1beta1.ClusterList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clustersResource, clustersKind, opts), &v1beta1.ClusterList{})
@@ -108,6 +70,52 @@ func (c *FakeClusters) List(opts v1.ListOptions) (result *v1beta1.ClusterList, e
 func (c *FakeClusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clustersResource, opts))
+}
+
+// Create takes the representation of a cluster and creates it.  Returns the server's representation of the cluster, and an error, if there is any.
+func (c *FakeClusters) Create(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clustersResource, cluster), &v1beta1.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Cluster), err
+}
+
+// Update takes the representation of a cluster and updates it. Returns the server's representation of the cluster, and an error, if there is any.
+func (c *FakeClusters) Update(cluster *v1beta1.Cluster) (result *v1beta1.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clustersResource, cluster), &v1beta1.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Cluster), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeClusters) UpdateStatus(cluster *v1beta1.Cluster) (*v1beta1.Cluster, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(clustersResource, "status", cluster), &v1beta1.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Cluster), err
+}
+
+// Delete takes name of the cluster and deletes it. Returns an error if one occurs.
+func (c *FakeClusters) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clustersResource, name), &v1beta1.Cluster{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clustersResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ClusterList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched cluster.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/fake/fake_horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/fake/fake_horizontalpodautoscaler.go
@@ -36,50 +36,7 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "", Kind: "HorizontalPodAutoscaler"}
 
-func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (*autoscaling.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
-
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &autoscaling.HorizontalPodAutoscalerList{})
-	return err
-}
-
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
 func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
@@ -90,6 +47,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (
 	return obj.(*autoscaling.HorizontalPodAutoscaler), err
 }
 
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &autoscaling.HorizontalPodAutoscalerList{})
@@ -116,6 +74,56 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interfa
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (*autoscaling.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &autoscaling.HorizontalPodAutoscalerList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -59,6 +59,41 @@ func newHorizontalPodAutoscalers(c *AutoscalingClient, namespace string) *horizo
 	}
 }
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	result = &autoscaling.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
+	result = &autoscaling.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}
@@ -120,41 +155,6 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, l
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
-func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	result = &autoscaling.HorizontalPodAutoscaler{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
-	result = &autoscaling.HorizontalPodAutoscalerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -85,7 +85,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.H
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/fake/fake_job.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/fake/fake_job.go
@@ -36,50 +36,7 @@ var jobsResource = schema.GroupVersionResource{Group: "batch", Version: "", Reso
 
 var jobsKind = schema.GroupVersionKind{Group: "batch", Version: "", Kind: "Job"}
 
-func (c *FakeJobs) Create(job *batch.Job) (result *batch.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) Update(job *batch.Job) (result *batch.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) UpdateStatus(job *batch.Job) (*batch.Job, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch.Job{})
-
-	return err
-}
-
-func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &batch.JobList{})
-	return err
-}
-
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
 func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &batch.Job{})
@@ -90,6 +47,7 @@ func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch.Job, e
 	return obj.(*batch.Job), err
 }
 
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
 func (c *FakeJobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &batch.JobList{})
@@ -116,6 +74,56 @@ func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(jobsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Create(job *batch.Job) (result *batch.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Update(job *batch.Job) (result *batch.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeJobs) UpdateStatus(job *batch.Job) (*batch.Job, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// Delete takes name of the job and deletes it. Returns an error if one occurs.
+func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch.Job{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch.JobList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched job.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
@@ -59,6 +59,41 @@ func newJobs(c *BatchClient, namespace string) *jobs {
 	}
 }
 
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *jobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
+	result = &batch.Job{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
+	result = &batch.JobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Create(job *batch.Job) (result *batch.Job, err error) {
 	result = &batch.Job{}
@@ -120,41 +155,6 @@ func (c *jobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
-func (c *jobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
-	result = &batch.Job{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Jobs that match those selectors.
-func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
-	result = &batch.JobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested jobs.
-func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched job.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/batch/internalversion/job.go
@@ -85,7 +85,7 @@ func (c *jobs) Update(job *batch.Job) (result *batch.Job, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *jobs) UpdateStatus(job *batch.Job) (result *batch.Job, err error) {
 	result = &batch.Job{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/configmap.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/configmap.go
@@ -58,6 +58,41 @@ func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	}
 }
 
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
+func (c *configMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
+	result = &api.ConfigMap{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
+	result = &api.ConfigMapList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested configMaps.
+func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
 	result = &api.ConfigMap{}
@@ -103,41 +138,6 @@ func (c *configMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
-func (c *configMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
-	result = &api.ConfigMap{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
-func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
-	result = &api.ConfigMapList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested configMaps.
-func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/event.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/event.go
@@ -58,6 +58,41 @@ func newEvents(c *CoreClient, namespace string) *events {
 	}
 }
 
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *events) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
+	result = &api.EventList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *api.Event) (result *api.Event, err error) {
 	result = &api.Event{}
@@ -103,41 +138,6 @@ func (c *events) DeleteCollection(options *v1.DeleteOptions, listOptions v1.List
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
-func (c *events) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
-	result = &api.Event{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Events that match those selectors.
-func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
-	result = &api.EventList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested events.
-func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched event.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_configmap.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_configmap.go
@@ -36,40 +36,7 @@ var configmapsResource = schema.GroupVersionResource{Group: "", Version: "", Res
 
 var configmapsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ConfigMap"}
 
-func (c *FakeConfigMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Update(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &api.ConfigMap{})
-
-	return err
-}
-
-func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ConfigMapList{})
-	return err
-}
-
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
 func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &api.ConfigMap{})
@@ -80,6 +47,7 @@ func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *api.Co
 	return obj.(*api.ConfigMap), err
 }
 
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
 func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &api.ConfigMapList{})
@@ -106,6 +74,44 @@ func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(configmapsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ConfigMap), err
+}
+
+// Update takes the representation of a configMap and updates it. Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Update(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ConfigMap), err
+}
+
+// Delete takes name of the configMap and deletes it. Returns an error if one occurs.
+func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &api.ConfigMap{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ConfigMapList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_event.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_event.go
@@ -36,40 +36,7 @@ var eventsResource = schema.GroupVersionResource{Group: "", Version: "", Resourc
 
 var eventsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Event"}
 
-func (c *FakeEvents) Create(event *api.Event) (result *api.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &api.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Event), err
-}
-
-func (c *FakeEvents) Update(event *api.Event) (result *api.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &api.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Event), err
-}
-
-func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &api.Event{})
-
-	return err
-}
-
-func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.EventList{})
-	return err
-}
-
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
 func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &api.Event{})
@@ -80,6 +47,7 @@ func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *api.Event,
 	return obj.(*api.Event), err
 }
 
+// List takes label and field selectors, and returns the list of Events that match those selectors.
 func (c *FakeEvents) List(opts v1.ListOptions) (result *api.EventList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &api.EventList{})
@@ -106,6 +74,44 @@ func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(eventsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Create(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Update(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+// Delete takes name of the event and deletes it. Returns an error if one occurs.
+func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &api.Event{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.EventList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched event.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_namespace.go
@@ -35,46 +35,7 @@ var namespacesResource = schema.GroupVersionResource{Group: "", Version: "", Res
 
 var namespacesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Namespace"}
 
-func (c *FakeNamespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &api.Namespace{})
-	return err
-}
-
-func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
-	return err
-}
-
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
 func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(namespacesResource, name), &api.Namespace{})
@@ -84,6 +45,7 @@ func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *api.Na
 	return obj.(*api.Namespace), err
 }
 
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
 func (c *FakeNamespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &api.NamespaceList{})
@@ -108,6 +70,52 @@ func (c *FakeNamespaces) List(opts v1.ListOptions) (result *api.NamespaceList, e
 func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(namespacesResource, opts))
+}
+
+// Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeNamespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// Delete takes name of the namespace and deletes it. Returns an error if one occurs.
+func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &api.Namespace{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_secret.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_secret.go
@@ -36,40 +36,7 @@ var secretsResource = schema.GroupVersionResource{Group: "", Version: "", Resour
 
 var secretsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Secret"}
 
-func (c *FakeSecrets) Create(secret *api.Secret) (result *api.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &api.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Secret), err
-}
-
-func (c *FakeSecrets) Update(secret *api.Secret) (result *api.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &api.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Secret), err
-}
-
-func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &api.Secret{})
-
-	return err
-}
-
-func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.SecretList{})
-	return err
-}
-
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
 func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &api.Secret{})
@@ -80,6 +47,7 @@ func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *api.Secre
 	return obj.(*api.Secret), err
 }
 
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
 func (c *FakeSecrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &api.SecretList{})
@@ -106,6 +74,44 @@ func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(secretsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Create(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+// Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Update(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+// Delete takes name of the secret and deletes it. Returns an error if one occurs.
+func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &api.Secret{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.SecretList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/fake/fake_service.go
@@ -36,50 +36,7 @@ var servicesResource = schema.GroupVersionResource{Group: "", Version: "", Resou
 
 var servicesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Service"}
 
-func (c *FakeServices) Create(service *api.Service) (result *api.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) Update(service *api.Service) (result *api.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) UpdateStatus(service *api.Service) (*api.Service, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &api.Service{})
-
-	return err
-}
-
-func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ServiceList{})
-	return err
-}
-
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
 func (c *FakeServices) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &api.Service{})
@@ -90,6 +47,7 @@ func (c *FakeServices) Get(name string, options v1.GetOptions) (result *api.Serv
 	return obj.(*api.Service), err
 }
 
+// List takes label and field selectors, and returns the list of Services that match those selectors.
 func (c *FakeServices) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &api.ServiceList{})
@@ -116,6 +74,56 @@ func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Create(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Update(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeServices) UpdateStatus(service *api.Service) (*api.Service, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// Delete takes name of the service and deletes it. Returns an error if one occurs.
+func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &api.Service{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ServiceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched service.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
@@ -57,6 +57,38 @@ func newNamespaces(c *CoreClient) *namespaces {
 	}
 }
 
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *namespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Get().
+		Resource("namespaces").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
+	result = &api.NamespaceList{}
+	err = c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
@@ -113,38 +145,6 @@ func (c *namespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
-func (c *namespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
-	result = &api.Namespace{}
-	err = c.client.Get().
-		Resource("namespaces").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
-func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
-	result = &api.NamespaceList{}
-	err = c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested namespaces.
-func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/namespace.go
@@ -81,7 +81,7 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *namespaces) UpdateStatus(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/secret.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/secret.go
@@ -58,6 +58,41 @@ func newSecrets(c *CoreClient, namespace string) *secrets {
 	}
 }
 
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *secrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
+	result = &api.SecretList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Create(secret *api.Secret) (result *api.Secret, err error) {
 	result = &api.Secret{}
@@ -103,41 +138,6 @@ func (c *secrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
-func (c *secrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
-	result = &api.Secret{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Secrets that match those selectors.
-func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
-	result = &api.SecretList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested secrets.
-func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
@@ -59,6 +59,41 @@ func newServices(c *CoreClient, namespace string) *services {
 	}
 }
 
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *services) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
+	result = &api.ServiceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Create(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
@@ -120,41 +155,6 @@ func (c *services) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
-func (c *services) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
-	result = &api.Service{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Services that match those selectors.
-func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
-	result = &api.ServiceList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested services.
-func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched service.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/core/internalversion/service.go
@@ -85,7 +85,7 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *services) UpdateStatus(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
@@ -85,7 +85,7 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/daemonset.go
@@ -59,6 +59,41 @@ func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	}
 }
 
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
+func (c *daemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
+	result = &extensions.DaemonSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
@@ -120,41 +155,6 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
-func (c *daemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
-	result = &extensions.DaemonSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
-func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
-	result = &extensions.DaemonSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
+	result = &extensions.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
-	result = &extensions.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
-	result = &extensions.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/deployment.go
@@ -85,7 +85,7 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_daemonset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_daemonset.go
@@ -36,50 +36,7 @@ var daemonsetsResource = schema.GroupVersionResource{Group: "extensions", Versio
 
 var daemonsetsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "DaemonSet"}
 
-func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
-
-	return err
-}
-
-func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
-	return err
-}
-
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
 func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
@@ -90,6 +47,7 @@ func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *extens
 	return obj.(*extensions.DaemonSet), err
 }
 
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &extensions.DaemonSetList{})
@@ -116,6 +74,56 @@ func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(daemonsetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
+func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
@@ -36,50 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var deploymentsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "Deployment"}
 
-func (c *FakeDeployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
-
-	return err
-}
-
-func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
-	return err
-}
-
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
@@ -90,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *exten
 	return obj.(*extensions.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &extensions.DeploymentList{})
@@ -116,6 +74,56 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_ingress.go
@@ -36,50 +36,7 @@ var ingressesResource = schema.GroupVersionResource{Group: "extensions", Version
 
 var ingressesKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "Ingress"}
 
-func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &extensions.Ingress{})
-
-	return err
-}
-
-func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
-	return err
-}
-
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
 func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &extensions.Ingress{})
@@ -90,6 +47,7 @@ func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *extensi
 	return obj.(*extensions.Ingress), err
 }
 
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *FakeIngresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &extensions.IngressList{})
@@ -116,6 +74,56 @@ func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(ingressesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// Delete takes name of the ingress and deletes it. Returns an error if one occurs.
+func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &extensions.Ingress{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
@@ -36,50 +36,7 @@ var replicasetsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var replicasetsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "ReplicaSet"}
 
-func (c *FakeReplicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (*extensions.ReplicaSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
-
-	return err
-}
-
-func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.ReplicaSetList{})
-	return err
-}
-
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
 func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
@@ -90,6 +47,7 @@ func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *exten
 	return obj.(*extensions.ReplicaSet), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
 func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &extensions.ReplicaSetList{})
@@ -116,6 +74,56 @@ func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(replicasetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeReplicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (*extensions.ReplicaSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// Delete takes name of the replicaSet and deletes it. Returns an error if one occurs.
+func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.ReplicaSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
@@ -85,7 +85,7 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/ingress.go
@@ -59,6 +59,41 @@ func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	}
 }
 
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
+func (c *ingresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
+	result = &extensions.IngressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
@@ -120,41 +155,6 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
-	result = &extensions.Ingress{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
-func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
-	result = &extensions.IngressList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
@@ -85,7 +85,7 @@ func (c *replicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensi
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/extensions/internalversion/replicaset.go
@@ -59,6 +59,41 @@ func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	}
 }
 
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
+func (c *replicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
+	result = &extensions.ReplicaSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
+func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
+	result = &extensions.ReplicaSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicaSets.
+func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}
@@ -120,41 +155,6 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
-func (c *replicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
-	result = &extensions.ReplicaSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
-func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
-	result = &extensions.ReplicaSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
@@ -57,6 +57,38 @@ func newClusters(c *FederationClient) *clusters {
 	}
 }
 
+// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
+func (c *clusters) Get(name string, options v1.GetOptions) (result *federation.Cluster, err error) {
+	result = &federation.Cluster{}
+	err = c.client.Get().
+		Resource("clusters").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Clusters that match those selectors.
+func (c *clusters) List(opts v1.ListOptions) (result *federation.ClusterList, err error) {
+	result = &federation.ClusterList{}
+	err = c.client.Get().
+		Resource("clusters").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusters.
+func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusters").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a cluster and creates it.  Returns the server's representation of the cluster, and an error, if there is any.
 func (c *clusters) Create(cluster *federation.Cluster) (result *federation.Cluster, err error) {
 	result = &federation.Cluster{}
@@ -113,38 +145,6 @@ func (c *clusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
-func (c *clusters) Get(name string, options v1.GetOptions) (result *federation.Cluster, err error) {
-	result = &federation.Cluster{}
-	err = c.client.Get().
-		Resource("clusters").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Clusters that match those selectors.
-func (c *clusters) List(opts v1.ListOptions) (result *federation.ClusterList, err error) {
-	result = &federation.ClusterList{}
-	err = c.client.Get().
-		Resource("clusters").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusters.
-func (c *clusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusters").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched cluster.

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/cluster.go
@@ -81,7 +81,7 @@ func (c *clusters) Update(cluster *federation.Cluster) (result *federation.Clust
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *clusters) UpdateStatus(cluster *federation.Cluster) (result *federation.Cluster, err error) {
 	result = &federation.Cluster{}

--- a/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/fake/fake_cluster.go
+++ b/federation/client/clientset_generated/federation_internalclientset/typed/federation/internalversion/fake/fake_cluster.go
@@ -35,46 +35,7 @@ var clustersResource = schema.GroupVersionResource{Group: "federation", Version:
 
 var clustersKind = schema.GroupVersionKind{Group: "federation", Version: "", Kind: "Cluster"}
 
-func (c *FakeClusters) Create(cluster *federation.Cluster) (result *federation.Cluster, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clustersResource, cluster), &federation.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*federation.Cluster), err
-}
-
-func (c *FakeClusters) Update(cluster *federation.Cluster) (result *federation.Cluster, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clustersResource, cluster), &federation.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*federation.Cluster), err
-}
-
-func (c *FakeClusters) UpdateStatus(cluster *federation.Cluster) (*federation.Cluster, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(clustersResource, "status", cluster), &federation.Cluster{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*federation.Cluster), err
-}
-
-func (c *FakeClusters) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clustersResource, name), &federation.Cluster{})
-	return err
-}
-
-func (c *FakeClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clustersResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &federation.ClusterList{})
-	return err
-}
-
+// Get takes name of the cluster, and returns the corresponding cluster object, and an error if there is any.
 func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *federation.Cluster, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clustersResource, name), &federation.Cluster{})
@@ -84,6 +45,7 @@ func (c *FakeClusters) Get(name string, options v1.GetOptions) (result *federati
 	return obj.(*federation.Cluster), err
 }
 
+// List takes label and field selectors, and returns the list of Clusters that match those selectors.
 func (c *FakeClusters) List(opts v1.ListOptions) (result *federation.ClusterList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clustersResource, clustersKind, opts), &federation.ClusterList{})
@@ -108,6 +70,52 @@ func (c *FakeClusters) List(opts v1.ListOptions) (result *federation.ClusterList
 func (c *FakeClusters) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clustersResource, opts))
+}
+
+// Create takes the representation of a cluster and creates it.  Returns the server's representation of the cluster, and an error, if there is any.
+func (c *FakeClusters) Create(cluster *federation.Cluster) (result *federation.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clustersResource, cluster), &federation.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*federation.Cluster), err
+}
+
+// Update takes the representation of a cluster and updates it. Returns the server's representation of the cluster, and an error, if there is any.
+func (c *FakeClusters) Update(cluster *federation.Cluster) (result *federation.Cluster, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clustersResource, cluster), &federation.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*federation.Cluster), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeClusters) UpdateStatus(cluster *federation.Cluster) (*federation.Cluster, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(clustersResource, "status", cluster), &federation.Cluster{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*federation.Cluster), err
+}
+
+// Delete takes name of the cluster and deletes it. Returns an error if one occurs.
+func (c *FakeClusters) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clustersResource, name), &federation.Cluster{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeClusters) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clustersResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &federation.ClusterList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched cluster.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -415,8 +415,8 @@ const (
 	AlphaStorageNodeAffinityAnnotation = "volume.alpha.kubernetes.io/node-affinity"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type PersistentVolume struct {
@@ -493,7 +493,7 @@ type PersistentVolumeList struct {
 	Items []PersistentVolume
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
@@ -2377,7 +2377,7 @@ type PodStatusResult struct {
 	Status PodStatus
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Pod is a collection of containers, used as either input (create, update) or as output (list, get).
@@ -2407,7 +2407,7 @@ type PodTemplateSpec struct {
 	Spec PodSpec
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodTemplate describes a template for creating copies of a predefined pod.
@@ -2515,7 +2515,7 @@ type ReplicationControllerCondition struct {
 	Message string
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationController represents the configuration of a replication controller.
@@ -2750,7 +2750,7 @@ type ServicePort struct {
 	NodePort int32
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -2770,7 +2770,7 @@ type Service struct {
 	Status ServiceStatus
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceAccount binds together:
@@ -2808,7 +2808,7 @@ type ServiceAccountList struct {
 	Items []ServiceAccount
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Endpoints is a collection of endpoints that implement the actual service.  Example:
@@ -3150,8 +3150,8 @@ const (
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Node is a worker node in Kubernetes
@@ -3213,8 +3213,8 @@ const (
 	NamespaceTerminating NamespacePhase = "Terminating"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // A namespace provides a scope for Names.
@@ -3532,7 +3532,7 @@ const (
 	EventTypeWarning string = "Warning"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Event is a report of an event somewhere in the cluster.
@@ -3641,7 +3641,7 @@ type LimitRangeSpec struct {
 	Limits []LimitRangeItem
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace
@@ -3734,7 +3734,7 @@ type ResourceQuotaStatus struct {
 	Used ResourceList
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
@@ -3764,7 +3764,7 @@ type ResourceQuotaList struct {
 	Items []ResourceQuota
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Secret holds secret data of a certain type.  The total bytes of the values in
@@ -3884,7 +3884,7 @@ type SecretList struct {
 	Items []Secret
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ConfigMap holds configuration data for components or applications to consume.
@@ -3969,8 +3969,8 @@ type ComponentCondition struct {
 	Error string
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.

--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // InitializerConfiguration describes the configuration of initializers.
@@ -121,8 +121,8 @@ const (
 	Fail FailurePolicyType = "Fail"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ExternalAdmissionHookConfiguration describes the configuration of initializers.

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StatefulSet represents a set of pods with consistent identities.
@@ -199,7 +199,7 @@ type StatefulSetList struct {
 	Items []StatefulSet
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ControllerRevision implements an immutable snapshot of state data. Clients

--- a/pkg/apis/authentication/types.go
+++ b/pkg/apis/authentication/types.go
@@ -35,9 +35,9 @@ const (
 	ImpersonateUserExtraHeaderPrefix = "Impersonate-Extra-"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TokenReview attempts to authenticate a token to a known user.

--- a/pkg/apis/authorization/types.go
+++ b/pkg/apis/authorization/types.go
@@ -20,9 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.  Not filling in a
@@ -38,9 +38,9 @@ type SubjectAccessReview struct {
 	Status SubjectAccessReviewStatus
 }
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
@@ -57,8 +57,8 @@ type SelfSubjectAccessReview struct {
 	Status SubjectAccessReviewStatus
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.

--- a/pkg/apis/autoscaling/types.go
+++ b/pkg/apis/autoscaling/types.go
@@ -326,7 +326,7 @@ type ResourceMetricStatus struct {
 	CurrentAverageValue resource.Quantity
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // HorizontalPodAutoscaler is the configuration for a horizontal pod

--- a/pkg/apis/batch/types.go
+++ b/pkg/apis/batch/types.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Job represents the configuration of a single job.
@@ -192,7 +192,7 @@ type JobCondition struct {
 	Message string
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CronJob represents the configuration of a single cron job.

--- a/pkg/apis/certificates/types.go
+++ b/pkg/apis/certificates/types.go
@@ -18,8 +18,8 @@ package certificates
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Describes a certificate signing request

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -60,8 +60,8 @@ type ScaleStatus struct {
 	Selector *metav1.LabelSelector
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // represents a scaling request for a resource.
@@ -110,8 +110,8 @@ type CustomMetricCurrentStatusList struct {
 	Items []CustomMetricCurrentStatus
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
@@ -165,7 +165,7 @@ type ThirdPartyResourceData struct {
 	Data []byte
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Deployment struct {
@@ -519,7 +519,7 @@ type DaemonSetStatus struct {
 	CollisionCount *int64
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DaemonSet represents the configuration of a daemon set.
@@ -578,7 +578,7 @@ type ThirdPartyResourceDataList struct {
 	Items []ThirdPartyResourceData
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Ingress is a collection of rules that allow inbound connections to reach the
@@ -747,7 +747,7 @@ type IngressBackend struct {
 	ServicePort intstr.IntOrString
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicaSet represents the configuration of a replica set.
@@ -856,8 +856,8 @@ type ReplicaSetCondition struct {
 	Message string
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodSecurityPolicy governs the ability to make requests that affect the SecurityContext
@@ -1081,7 +1081,7 @@ type PodSecurityPolicyList struct {
 	Items []PodSecurityPolicy
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NetworkPolicy describes what network traffic is allowed for a set of Pods

--- a/pkg/apis/imagepolicy/types.go
+++ b/pkg/apis/imagepolicy/types.go
@@ -20,9 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageReview checks if the set of images in a pod are allowed.

--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NetworkPolicy describes what network traffic is allowed for a set of Pods

--- a/pkg/apis/policy/types.go
+++ b/pkg/apis/policy/types.go
@@ -77,7 +77,7 @@ type PodDisruptionBudgetStatus struct {
 	ExpectedPods int32
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -104,8 +104,8 @@ type PodDisruptionBudgetList struct {
 	Items []PodDisruptionBudget
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Eviction evicts a pod from its node subject to certain policies and safety constraints.

--- a/pkg/apis/policy/v1alpha1/types.go
+++ b/pkg/apis/policy/v1alpha1/types.go
@@ -52,7 +52,7 @@ type PodDisruptionBudgetStatus struct {
 	ExpectedPods int32 `json:"expectedPods" protobuf:"varint,4,opt,name=expectedPods"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods

--- a/pkg/apis/rbac/types.go
+++ b/pkg/apis/rbac/types.go
@@ -87,7 +87,7 @@ type RoleRef struct {
 	Name string
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
@@ -100,7 +100,7 @@ type Role struct {
 	Rules []PolicyRule
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace.
@@ -142,8 +142,8 @@ type RoleList struct {
 	Items []Role
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -156,8 +156,8 @@ type ClusterRole struct {
 	Rules []PolicyRule
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace,

--- a/pkg/apis/scheduling/types.go
+++ b/pkg/apis/scheduling/types.go
@@ -18,8 +18,8 @@ package scheduling
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PriorityClass defines the mapping from a priority class name to the priority

--- a/pkg/apis/settings/types.go
+++ b/pkg/apis/settings/types.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodPreset is a policy resource that defines additional runtime

--- a/pkg/apis/storage/types.go
+++ b/pkg/apis/storage/types.go
@@ -18,8 +18,8 @@ package storage
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageClass describes a named "class" of storage offered in a cluster.

--- a/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -56,6 +56,38 @@ func newExternalAdmissionHookConfigurations(c *AdmissionregistrationClient) *ext
 	}
 }
 
+// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
+func (c *externalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
+	result = &admissionregistration.ExternalAdmissionHookConfiguration{}
+	err = c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
+func (c *externalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *admissionregistration.ExternalAdmissionHookConfigurationList, err error) {
+	result = &admissionregistration.ExternalAdmissionHookConfigurationList{}
+	err = c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested externalAdmissionHookConfigurations.
+func (c *externalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a externalAdmissionHookConfiguration and creates it.  Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
 func (c *externalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *admissionregistration.ExternalAdmissionHookConfiguration) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
 	result = &admissionregistration.ExternalAdmissionHookConfiguration{}
@@ -97,38 +129,6 @@ func (c *externalAdmissionHookConfigurations) DeleteCollection(options *v1.Delet
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
-func (c *externalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
-	result = &admissionregistration.ExternalAdmissionHookConfiguration{}
-	err = c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
-func (c *externalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *admissionregistration.ExternalAdmissionHookConfigurationList, err error) {
-	result = &admissionregistration.ExternalAdmissionHookConfigurationList{}
-	err = c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested externalAdmissionHookConfigurations.
-func (c *externalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched externalAdmissionHookConfiguration.

--- a/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/fake/fake_externaladmissionhookconfiguration.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/fake/fake_externaladmissionhookconfiguration.go
@@ -35,37 +35,7 @@ var externaladmissionhookconfigurationsResource = schema.GroupVersionResource{Gr
 
 var externaladmissionhookconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "", Kind: "ExternalAdmissionHookConfiguration"}
 
-func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *admissionregistration.ExternalAdmissionHookConfiguration) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &admissionregistration.ExternalAdmissionHookConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*admissionregistration.ExternalAdmissionHookConfiguration), err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookConfiguration *admissionregistration.ExternalAdmissionHookConfiguration) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &admissionregistration.ExternalAdmissionHookConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*admissionregistration.ExternalAdmissionHookConfiguration), err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(externaladmissionhookconfigurationsResource, name), &admissionregistration.ExternalAdmissionHookConfiguration{})
-	return err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(externaladmissionhookconfigurationsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &admissionregistration.ExternalAdmissionHookConfigurationList{})
-	return err
-}
-
+// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
 func (c *FakeExternalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(externaladmissionhookconfigurationsResource, name), &admissionregistration.ExternalAdmissionHookConfiguration{})
@@ -75,6 +45,7 @@ func (c *FakeExternalAdmissionHookConfigurations) Get(name string, options v1.Ge
 	return obj.(*admissionregistration.ExternalAdmissionHookConfiguration), err
 }
 
+// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
 func (c *FakeExternalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *admissionregistration.ExternalAdmissionHookConfigurationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(externaladmissionhookconfigurationsResource, externaladmissionhookconfigurationsKind, opts), &admissionregistration.ExternalAdmissionHookConfigurationList{})
@@ -99,6 +70,41 @@ func (c *FakeExternalAdmissionHookConfigurations) List(opts v1.ListOptions) (res
 func (c *FakeExternalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(externaladmissionhookconfigurationsResource, opts))
+}
+
+// Create takes the representation of a externalAdmissionHookConfiguration and creates it.  Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
+func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *admissionregistration.ExternalAdmissionHookConfiguration) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &admissionregistration.ExternalAdmissionHookConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*admissionregistration.ExternalAdmissionHookConfiguration), err
+}
+
+// Update takes the representation of a externalAdmissionHookConfiguration and updates it. Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
+func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookConfiguration *admissionregistration.ExternalAdmissionHookConfiguration) (result *admissionregistration.ExternalAdmissionHookConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &admissionregistration.ExternalAdmissionHookConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*admissionregistration.ExternalAdmissionHookConfiguration), err
+}
+
+// Delete takes name of the externalAdmissionHookConfiguration and deletes it. Returns an error if one occurs.
+func (c *FakeExternalAdmissionHookConfigurations) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(externaladmissionhookconfigurationsResource, name), &admissionregistration.ExternalAdmissionHookConfiguration{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeExternalAdmissionHookConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(externaladmissionhookconfigurationsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &admissionregistration.ExternalAdmissionHookConfigurationList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched externalAdmissionHookConfiguration.

--- a/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/fake/fake_initializerconfiguration.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/fake/fake_initializerconfiguration.go
@@ -35,37 +35,7 @@ var initializerconfigurationsResource = schema.GroupVersionResource{Group: "admi
 
 var initializerconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "", Kind: "InitializerConfiguration"}
 
-func (c *FakeInitializerConfigurations) Create(initializerConfiguration *admissionregistration.InitializerConfiguration) (result *admissionregistration.InitializerConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(initializerconfigurationsResource, initializerConfiguration), &admissionregistration.InitializerConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*admissionregistration.InitializerConfiguration), err
-}
-
-func (c *FakeInitializerConfigurations) Update(initializerConfiguration *admissionregistration.InitializerConfiguration) (result *admissionregistration.InitializerConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(initializerconfigurationsResource, initializerConfiguration), &admissionregistration.InitializerConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*admissionregistration.InitializerConfiguration), err
-}
-
-func (c *FakeInitializerConfigurations) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(initializerconfigurationsResource, name), &admissionregistration.InitializerConfiguration{})
-	return err
-}
-
-func (c *FakeInitializerConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(initializerconfigurationsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &admissionregistration.InitializerConfigurationList{})
-	return err
-}
-
+// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
 func (c *FakeInitializerConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.InitializerConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(initializerconfigurationsResource, name), &admissionregistration.InitializerConfiguration{})
@@ -75,6 +45,7 @@ func (c *FakeInitializerConfigurations) Get(name string, options v1.GetOptions) 
 	return obj.(*admissionregistration.InitializerConfiguration), err
 }
 
+// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
 func (c *FakeInitializerConfigurations) List(opts v1.ListOptions) (result *admissionregistration.InitializerConfigurationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(initializerconfigurationsResource, initializerconfigurationsKind, opts), &admissionregistration.InitializerConfigurationList{})
@@ -99,6 +70,41 @@ func (c *FakeInitializerConfigurations) List(opts v1.ListOptions) (result *admis
 func (c *FakeInitializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(initializerconfigurationsResource, opts))
+}
+
+// Create takes the representation of a initializerConfiguration and creates it.  Returns the server's representation of the initializerConfiguration, and an error, if there is any.
+func (c *FakeInitializerConfigurations) Create(initializerConfiguration *admissionregistration.InitializerConfiguration) (result *admissionregistration.InitializerConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(initializerconfigurationsResource, initializerConfiguration), &admissionregistration.InitializerConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*admissionregistration.InitializerConfiguration), err
+}
+
+// Update takes the representation of a initializerConfiguration and updates it. Returns the server's representation of the initializerConfiguration, and an error, if there is any.
+func (c *FakeInitializerConfigurations) Update(initializerConfiguration *admissionregistration.InitializerConfiguration) (result *admissionregistration.InitializerConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(initializerconfigurationsResource, initializerConfiguration), &admissionregistration.InitializerConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*admissionregistration.InitializerConfiguration), err
+}
+
+// Delete takes name of the initializerConfiguration and deletes it. Returns an error if one occurs.
+func (c *FakeInitializerConfigurations) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(initializerconfigurationsResource, name), &admissionregistration.InitializerConfiguration{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeInitializerConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(initializerconfigurationsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &admissionregistration.InitializerConfigurationList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched initializerConfiguration.

--- a/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/admissionregistration/internalversion/initializerconfiguration.go
@@ -56,6 +56,38 @@ func newInitializerConfigurations(c *AdmissionregistrationClient) *initializerCo
 	}
 }
 
+// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
+func (c *initializerConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.InitializerConfiguration, err error) {
+	result = &admissionregistration.InitializerConfiguration{}
+	err = c.client.Get().
+		Resource("initializerconfigurations").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
+func (c *initializerConfigurations) List(opts v1.ListOptions) (result *admissionregistration.InitializerConfigurationList, err error) {
+	result = &admissionregistration.InitializerConfigurationList{}
+	err = c.client.Get().
+		Resource("initializerconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested initializerConfigurations.
+func (c *initializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("initializerconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a initializerConfiguration and creates it.  Returns the server's representation of the initializerConfiguration, and an error, if there is any.
 func (c *initializerConfigurations) Create(initializerConfiguration *admissionregistration.InitializerConfiguration) (result *admissionregistration.InitializerConfiguration, err error) {
 	result = &admissionregistration.InitializerConfiguration{}
@@ -97,38 +129,6 @@ func (c *initializerConfigurations) DeleteCollection(options *v1.DeleteOptions, 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
-func (c *initializerConfigurations) Get(name string, options v1.GetOptions) (result *admissionregistration.InitializerConfiguration, err error) {
-	result = &admissionregistration.InitializerConfiguration{}
-	err = c.client.Get().
-		Resource("initializerconfigurations").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
-func (c *initializerConfigurations) List(opts v1.ListOptions) (result *admissionregistration.InitializerConfigurationList, err error) {
-	result = &admissionregistration.InitializerConfigurationList{}
-	err = c.client.Get().
-		Resource("initializerconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested initializerConfigurations.
-func (c *initializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("initializerconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched initializerConfiguration.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/controllerrevision.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/controllerrevision.go
@@ -58,6 +58,41 @@ func newControllerRevisions(c *AppsClient, namespace string) *controllerRevision
 	}
 }
 
+// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
+func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *apps.ControllerRevision, err error) {
+	result = &apps.ControllerRevision{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
+func (c *controllerRevisions) List(opts v1.ListOptions) (result *apps.ControllerRevisionList, err error) {
+	result = &apps.ControllerRevisionList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested controllerRevisions.
+func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Create(controllerRevision *apps.ControllerRevision) (result *apps.ControllerRevision, err error) {
 	result = &apps.ControllerRevision{}
@@ -103,41 +138,6 @@ func (c *controllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
-func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *apps.ControllerRevision, err error) {
-	result = &apps.ControllerRevision{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
-func (c *controllerRevisions) List(opts v1.ListOptions) (result *apps.ControllerRevisionList, err error) {
-	result = &apps.ControllerRevisionList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched controllerRevision.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_controllerrevision.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_controllerrevision.go
@@ -36,40 +36,7 @@ var controllerrevisionsResource = schema.GroupVersionResource{Group: "apps", Ver
 
 var controllerrevisionsKind = schema.GroupVersionKind{Group: "apps", Version: "", Kind: "ControllerRevision"}
 
-func (c *FakeControllerRevisions) Create(controllerRevision *apps.ControllerRevision) (result *apps.ControllerRevision, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(controllerrevisionsResource, c.ns, controllerRevision), &apps.ControllerRevision{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apps.ControllerRevision), err
-}
-
-func (c *FakeControllerRevisions) Update(controllerRevision *apps.ControllerRevision) (result *apps.ControllerRevision, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(controllerrevisionsResource, c.ns, controllerRevision), &apps.ControllerRevision{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apps.ControllerRevision), err
-}
-
-func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(controllerrevisionsResource, c.ns, name), &apps.ControllerRevision{})
-
-	return err
-}
-
-func (c *FakeControllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(controllerrevisionsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &apps.ControllerRevisionList{})
-	return err
-}
-
+// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
 func (c *FakeControllerRevisions) Get(name string, options v1.GetOptions) (result *apps.ControllerRevision, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(controllerrevisionsResource, c.ns, name), &apps.ControllerRevision{})
@@ -80,6 +47,7 @@ func (c *FakeControllerRevisions) Get(name string, options v1.GetOptions) (resul
 	return obj.(*apps.ControllerRevision), err
 }
 
+// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
 func (c *FakeControllerRevisions) List(opts v1.ListOptions) (result *apps.ControllerRevisionList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(controllerrevisionsResource, controllerrevisionsKind, c.ns, opts), &apps.ControllerRevisionList{})
@@ -106,6 +74,44 @@ func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, e
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(controllerrevisionsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
+func (c *FakeControllerRevisions) Create(controllerRevision *apps.ControllerRevision) (result *apps.ControllerRevision, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(controllerrevisionsResource, c.ns, controllerRevision), &apps.ControllerRevision{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.ControllerRevision), err
+}
+
+// Update takes the representation of a controllerRevision and updates it. Returns the server's representation of the controllerRevision, and an error, if there is any.
+func (c *FakeControllerRevisions) Update(controllerRevision *apps.ControllerRevision) (result *apps.ControllerRevision, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(controllerrevisionsResource, c.ns, controllerRevision), &apps.ControllerRevision{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.ControllerRevision), err
+}
+
+// Delete takes name of the controllerRevision and deletes it. Returns an error if one occurs.
+func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(controllerrevisionsResource, c.ns, name), &apps.ControllerRevision{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeControllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(controllerrevisionsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &apps.ControllerRevisionList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched controllerRevision.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_statefulset.go
@@ -36,50 +36,7 @@ var statefulsetsResource = schema.GroupVersionResource{Group: "apps", Version: "
 
 var statefulsetsKind = schema.GroupVersionKind{Group: "apps", Version: "", Kind: "StatefulSet"}
 
-func (c *FakeStatefulSets) Create(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &apps.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apps.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) Update(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(statefulsetsResource, c.ns, statefulSet), &apps.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apps.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) UpdateStatus(statefulSet *apps.StatefulSet) (*apps.StatefulSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "status", c.ns, statefulSet), &apps.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apps.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(statefulsetsResource, c.ns, name), &apps.StatefulSet{})
-
-	return err
-}
-
-func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(statefulsetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &apps.StatefulSetList{})
-	return err
-}
-
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
 func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *apps.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(statefulsetsResource, c.ns, name), &apps.StatefulSet{})
@@ -90,6 +47,7 @@ func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *apps
 	return obj.(*apps.StatefulSet), err
 }
 
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *apps.StatefulSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(statefulsetsResource, statefulsetsKind, c.ns, opts), &apps.StatefulSetList{})
@@ -116,6 +74,56 @@ func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(statefulsetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
+func (c *FakeStatefulSets) Create(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &apps.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.StatefulSet), err
+}
+
+// Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
+func (c *FakeStatefulSets) Update(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(statefulsetsResource, c.ns, statefulSet), &apps.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.StatefulSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeStatefulSets) UpdateStatus(statefulSet *apps.StatefulSet) (*apps.StatefulSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "status", c.ns, statefulSet), &apps.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apps.StatefulSet), err
+}
+
+// Delete takes name of the statefulSet and deletes it. Returns an error if one occurs.
+func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(statefulsetsResource, c.ns, name), &apps.StatefulSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(statefulsetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &apps.StatefulSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
@@ -59,6 +59,41 @@ func newStatefulSets(c *AppsClient, namespace string) *statefulSets {
 	}
 }
 
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
+func (c *statefulSets) Get(name string, options v1.GetOptions) (result *apps.StatefulSet, err error) {
+	result = &apps.StatefulSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) List(opts v1.ListOptions) (result *apps.StatefulSetList, err error) {
+	result = &apps.StatefulSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested statefulSets.
+func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
 	result = &apps.StatefulSet{}
@@ -120,41 +155,6 @@ func (c *statefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
-func (c *statefulSets) Get(name string, options v1.GetOptions) (result *apps.StatefulSet, err error) {
-	result = &apps.StatefulSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
-func (c *statefulSets) List(opts v1.ListOptions) (result *apps.StatefulSetList, err error) {
-	result = &apps.StatefulSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
@@ -85,7 +85,7 @@ func (c *statefulSets) Update(statefulSet *apps.StatefulSet) (result *apps.State
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *statefulSets) UpdateStatus(statefulSet *apps.StatefulSet) (result *apps.StatefulSet, err error) {
 	result = &apps.StatefulSet{}

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/fake/fake_horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/fake/fake_horizontalpodautoscaler.go
@@ -36,50 +36,7 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "", Kind: "HorizontalPodAutoscaler"}
 
-func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (*autoscaling.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*autoscaling.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
-
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &autoscaling.HorizontalPodAutoscalerList{})
-	return err
-}
-
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
 func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
@@ -90,6 +47,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (
 	return obj.(*autoscaling.HorizontalPodAutoscaler), err
 }
 
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &autoscaling.HorizontalPodAutoscalerList{})
@@ -116,6 +74,56 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interfa
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
+func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (*autoscaling.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling.HorizontalPodAutoscaler), err
+}
+
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling.HorizontalPodAutoscaler{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &autoscaling.HorizontalPodAutoscalerList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -59,6 +59,41 @@ func newHorizontalPodAutoscalers(c *AutoscalingClient, namespace string) *horizo
 	}
 }
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
+	result = &autoscaling.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
+	result = &autoscaling.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}
@@ -120,41 +155,6 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, l
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
-func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling.HorizontalPodAutoscaler, err error) {
-	result = &autoscaling.HorizontalPodAutoscaler{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling.HorizontalPodAutoscalerList, err error) {
-	result = &autoscaling.HorizontalPodAutoscalerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -85,7 +85,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling.H
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling.HorizontalPodAutoscaler) (result *autoscaling.HorizontalPodAutoscaler, err error) {
 	result = &autoscaling.HorizontalPodAutoscaler{}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
@@ -85,7 +85,7 @@ func (c *cronJobs) Update(cronJob *batch.CronJob) (result *batch.CronJob, err er
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *cronJobs) UpdateStatus(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
 	result = &batch.CronJob{}

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/cronjob.go
@@ -59,6 +59,41 @@ func newCronJobs(c *BatchClient, namespace string) *cronJobs {
 	}
 }
 
+// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
+func (c *cronJobs) Get(name string, options v1.GetOptions) (result *batch.CronJob, err error) {
+	result = &batch.CronJob{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
+func (c *cronJobs) List(opts v1.ListOptions) (result *batch.CronJobList, err error) {
+	result = &batch.CronJobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested cronJobs.
+func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Create(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
 	result = &batch.CronJob{}
@@ -120,41 +155,6 @@ func (c *cronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
-func (c *cronJobs) Get(name string, options v1.GetOptions) (result *batch.CronJob, err error) {
-	result = &batch.CronJob{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
-func (c *cronJobs) List(opts v1.ListOptions) (result *batch.CronJobList, err error) {
-	result = &batch.CronJobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched cronJob.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake/fake_cronjob.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake/fake_cronjob.go
@@ -36,50 +36,7 @@ var cronjobsResource = schema.GroupVersionResource{Group: "batch", Version: "", 
 
 var cronjobsKind = schema.GroupVersionKind{Group: "batch", Version: "", Kind: "CronJob"}
 
-func (c *FakeCronJobs) Create(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(cronjobsResource, c.ns, cronJob), &batch.CronJob{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.CronJob), err
-}
-
-func (c *FakeCronJobs) Update(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(cronjobsResource, c.ns, cronJob), &batch.CronJob{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.CronJob), err
-}
-
-func (c *FakeCronJobs) UpdateStatus(cronJob *batch.CronJob) (*batch.CronJob, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(cronjobsResource, "status", c.ns, cronJob), &batch.CronJob{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.CronJob), err
-}
-
-func (c *FakeCronJobs) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(cronjobsResource, c.ns, name), &batch.CronJob{})
-
-	return err
-}
-
-func (c *FakeCronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(cronjobsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &batch.CronJobList{})
-	return err
-}
-
+// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
 func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *batch.CronJob, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(cronjobsResource, c.ns, name), &batch.CronJob{})
@@ -90,6 +47,7 @@ func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *batch.Cr
 	return obj.(*batch.CronJob), err
 }
 
+// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
 func (c *FakeCronJobs) List(opts v1.ListOptions) (result *batch.CronJobList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(cronjobsResource, cronjobsKind, c.ns, opts), &batch.CronJobList{})
@@ -116,6 +74,56 @@ func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(cronjobsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
+func (c *FakeCronJobs) Create(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(cronjobsResource, c.ns, cronJob), &batch.CronJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.CronJob), err
+}
+
+// Update takes the representation of a cronJob and updates it. Returns the server's representation of the cronJob, and an error, if there is any.
+func (c *FakeCronJobs) Update(cronJob *batch.CronJob) (result *batch.CronJob, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(cronjobsResource, c.ns, cronJob), &batch.CronJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.CronJob), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCronJobs) UpdateStatus(cronJob *batch.CronJob) (*batch.CronJob, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(cronjobsResource, "status", c.ns, cronJob), &batch.CronJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.CronJob), err
+}
+
+// Delete takes name of the cronJob and deletes it. Returns an error if one occurs.
+func (c *FakeCronJobs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(cronjobsResource, c.ns, name), &batch.CronJob{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeCronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(cronjobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch.CronJobList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched cronJob.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake/fake_job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/fake/fake_job.go
@@ -36,50 +36,7 @@ var jobsResource = schema.GroupVersionResource{Group: "batch", Version: "", Reso
 
 var jobsKind = schema.GroupVersionKind{Group: "batch", Version: "", Kind: "Job"}
 
-func (c *FakeJobs) Create(job *batch.Job) (result *batch.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) Update(job *batch.Job) (result *batch.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) UpdateStatus(job *batch.Job) (*batch.Job, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*batch.Job), err
-}
-
-func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch.Job{})
-
-	return err
-}
-
-func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &batch.JobList{})
-	return err
-}
-
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
 func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &batch.Job{})
@@ -90,6 +47,7 @@ func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch.Job, e
 	return obj.(*batch.Job), err
 }
 
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
 func (c *FakeJobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &batch.JobList{})
@@ -116,6 +74,56 @@ func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(jobsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Create(job *batch.Job) (result *batch.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
+func (c *FakeJobs) Update(job *batch.Job) (result *batch.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeJobs) UpdateStatus(job *batch.Job) (*batch.Job, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch.Job), err
+}
+
+// Delete takes name of the job and deletes it. Returns an error if one occurs.
+func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch.Job{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch.JobList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched job.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
@@ -59,6 +59,41 @@ func newJobs(c *BatchClient, namespace string) *jobs {
 	}
 }
 
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *jobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
+	result = &batch.Job{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
+	result = &batch.JobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Create(job *batch.Job) (result *batch.Job, err error) {
 	result = &batch.Job{}
@@ -120,41 +155,6 @@ func (c *jobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
-func (c *jobs) Get(name string, options v1.GetOptions) (result *batch.Job, err error) {
-	result = &batch.Job{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Jobs that match those selectors.
-func (c *jobs) List(opts v1.ListOptions) (result *batch.JobList, err error) {
-	result = &batch.JobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested jobs.
-func (c *jobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched job.

--- a/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/batch/internalversion/job.go
@@ -85,7 +85,7 @@ func (c *jobs) Update(job *batch.Job) (result *batch.Job, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *jobs) UpdateStatus(job *batch.Job) (result *batch.Job, err error) {
 	result = &batch.Job{}

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
@@ -57,6 +57,38 @@ func newCertificateSigningRequests(c *CertificatesClient) *certificateSigningReq
 	}
 }
 
+// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
+func (c *certificateSigningRequests) Get(name string, options v1.GetOptions) (result *certificates.CertificateSigningRequest, err error) {
+	result = &certificates.CertificateSigningRequest{}
+	err = c.client.Get().
+		Resource("certificatesigningrequests").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
+func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *certificates.CertificateSigningRequestList, err error) {
+	result = &certificates.CertificateSigningRequestList{}
+	err = c.client.Get().
+		Resource("certificatesigningrequests").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
+func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("certificatesigningrequests").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *certificateSigningRequests) Create(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}
@@ -113,38 +145,6 @@ func (c *certificateSigningRequests) DeleteCollection(options *v1.DeleteOptions,
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
-func (c *certificateSigningRequests) Get(name string, options v1.GetOptions) (result *certificates.CertificateSigningRequest, err error) {
-	result = &certificates.CertificateSigningRequest{}
-	err = c.client.Get().
-		Resource("certificatesigningrequests").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
-func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *certificates.CertificateSigningRequestList, err error) {
-	result = &certificates.CertificateSigningRequestList{}
-	err = c.client.Get().
-		Resource("certificatesigningrequests").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
-func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("certificatesigningrequests").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/certificatesigningrequest.go
@@ -81,7 +81,7 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *certifica
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}

--- a/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/fake/fake_certificatesigningrequest.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/certificates/internalversion/fake/fake_certificatesigningrequest.go
@@ -35,46 +35,7 @@ var certificatesigningrequestsResource = schema.GroupVersionResource{Group: "cer
 
 var certificatesigningrequestsKind = schema.GroupVersionKind{Group: "certificates.k8s.io", Version: "", Kind: "CertificateSigningRequest"}
 
-func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(certificatesigningrequestsResource, certificateSigningRequest), &certificates.CertificateSigningRequest{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*certificates.CertificateSigningRequest), err
-}
-
-func (c *FakeCertificateSigningRequests) Update(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(certificatesigningrequestsResource, certificateSigningRequest), &certificates.CertificateSigningRequest{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*certificates.CertificateSigningRequest), err
-}
-
-func (c *FakeCertificateSigningRequests) UpdateStatus(certificateSigningRequest *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(certificatesigningrequestsResource, "status", certificateSigningRequest), &certificates.CertificateSigningRequest{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*certificates.CertificateSigningRequest), err
-}
-
-func (c *FakeCertificateSigningRequests) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(certificatesigningrequestsResource, name), &certificates.CertificateSigningRequest{})
-	return err
-}
-
-func (c *FakeCertificateSigningRequests) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(certificatesigningrequestsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &certificates.CertificateSigningRequestList{})
-	return err
-}
-
+// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
 func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions) (result *certificates.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(certificatesigningrequestsResource, name), &certificates.CertificateSigningRequest{})
@@ -84,6 +45,7 @@ func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions)
 	return obj.(*certificates.CertificateSigningRequest), err
 }
 
+// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
 func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *certificates.CertificateSigningRequestList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(certificatesigningrequestsResource, certificatesigningrequestsKind, opts), &certificates.CertificateSigningRequestList{})
@@ -108,6 +70,52 @@ func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *cert
 func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(certificatesigningrequestsResource, opts))
+}
+
+// Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
+func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(certificatesigningrequestsResource, certificateSigningRequest), &certificates.CertificateSigningRequest{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*certificates.CertificateSigningRequest), err
+}
+
+// Update takes the representation of a certificateSigningRequest and updates it. Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
+func (c *FakeCertificateSigningRequests) Update(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(certificatesigningrequestsResource, certificateSigningRequest), &certificates.CertificateSigningRequest{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*certificates.CertificateSigningRequest), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCertificateSigningRequests) UpdateStatus(certificateSigningRequest *certificates.CertificateSigningRequest) (*certificates.CertificateSigningRequest, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(certificatesigningrequestsResource, "status", certificateSigningRequest), &certificates.CertificateSigningRequest{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*certificates.CertificateSigningRequest), err
+}
+
+// Delete takes name of the certificateSigningRequest and deletes it. Returns an error if one occurs.
+func (c *FakeCertificateSigningRequests) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(certificatesigningrequestsResource, name), &certificates.CertificateSigningRequest{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeCertificateSigningRequests) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(certificatesigningrequestsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &certificates.CertificateSigningRequestList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/componentstatus.go
@@ -56,6 +56,38 @@ func newComponentStatuses(c *CoreClient) *componentStatuses {
 	}
 }
 
+// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
+func (c *componentStatuses) Get(name string, options v1.GetOptions) (result *api.ComponentStatus, err error) {
+	result = &api.ComponentStatus{}
+	err = c.client.Get().
+		Resource("componentstatuses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
+func (c *componentStatuses) List(opts v1.ListOptions) (result *api.ComponentStatusList, err error) {
+	result = &api.ComponentStatusList{}
+	err = c.client.Get().
+		Resource("componentstatuses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested componentStatuses.
+func (c *componentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("componentstatuses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *componentStatuses) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
 	result = &api.ComponentStatus{}
@@ -97,38 +129,6 @@ func (c *componentStatuses) DeleteCollection(options *v1.DeleteOptions, listOpti
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
-func (c *componentStatuses) Get(name string, options v1.GetOptions) (result *api.ComponentStatus, err error) {
-	result = &api.ComponentStatus{}
-	err = c.client.Get().
-		Resource("componentstatuses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
-func (c *componentStatuses) List(opts v1.ListOptions) (result *api.ComponentStatusList, err error) {
-	result = &api.ComponentStatusList{}
-	err = c.client.Get().
-		Resource("componentstatuses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested componentStatuses.
-func (c *componentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("componentstatuses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched componentStatus.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/configmap.go
@@ -58,6 +58,41 @@ func newConfigMaps(c *CoreClient, namespace string) *configMaps {
 	}
 }
 
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
+func (c *configMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
+	result = &api.ConfigMap{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
+	result = &api.ConfigMapList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested configMaps.
+func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
 	result = &api.ConfigMap{}
@@ -103,41 +138,6 @@ func (c *configMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
-func (c *configMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
-	result = &api.ConfigMap{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
-func (c *configMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
-	result = &api.ConfigMapList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested configMaps.
-func (c *configMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/endpoints.go
@@ -58,6 +58,41 @@ func newEndpoints(c *CoreClient, namespace string) *endpoints {
 	}
 }
 
+// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
+func (c *endpoints) Get(name string, options v1.GetOptions) (result *api.Endpoints, err error) {
+	result = &api.Endpoints{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
+func (c *endpoints) List(opts v1.ListOptions) (result *api.EndpointsList, err error) {
+	result = &api.EndpointsList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints.
+func (c *endpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *endpoints) Create(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
 	result = &api.Endpoints{}
@@ -103,41 +138,6 @@ func (c *endpoints) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
-func (c *endpoints) Get(name string, options v1.GetOptions) (result *api.Endpoints, err error) {
-	result = &api.Endpoints{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
-func (c *endpoints) List(opts v1.ListOptions) (result *api.EndpointsList, err error) {
-	result = &api.EndpointsList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested endpoints.
-func (c *endpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched endpoints.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/event.go
@@ -58,6 +58,41 @@ func newEvents(c *CoreClient, namespace string) *events {
 	}
 }
 
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *events) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
+	result = &api.Event{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
+	result = &api.EventList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *api.Event) (result *api.Event, err error) {
 	result = &api.Event{}
@@ -103,41 +138,6 @@ func (c *events) DeleteCollection(options *v1.DeleteOptions, listOptions v1.List
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
-func (c *events) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
-	result = &api.Event{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Events that match those selectors.
-func (c *events) List(opts v1.ListOptions) (result *api.EventList, err error) {
-	result = &api.EventList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested events.
-func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched event.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_componentstatus.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_componentstatus.go
@@ -35,37 +35,7 @@ var componentstatusesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var componentstatusesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ComponentStatus"}
 
-func (c *FakeComponentStatuses) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(componentstatusesResource, componentStatus), &api.ComponentStatus{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ComponentStatus), err
-}
-
-func (c *FakeComponentStatuses) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(componentstatusesResource, componentStatus), &api.ComponentStatus{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ComponentStatus), err
-}
-
-func (c *FakeComponentStatuses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(componentstatusesResource, name), &api.ComponentStatus{})
-	return err
-}
-
-func (c *FakeComponentStatuses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(componentstatusesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ComponentStatusList{})
-	return err
-}
-
+// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
 func (c *FakeComponentStatuses) Get(name string, options v1.GetOptions) (result *api.ComponentStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(componentstatusesResource, name), &api.ComponentStatus{})
@@ -75,6 +45,7 @@ func (c *FakeComponentStatuses) Get(name string, options v1.GetOptions) (result 
 	return obj.(*api.ComponentStatus), err
 }
 
+// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
 func (c *FakeComponentStatuses) List(opts v1.ListOptions) (result *api.ComponentStatusList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(componentstatusesResource, componentstatusesKind, opts), &api.ComponentStatusList{})
@@ -99,6 +70,41 @@ func (c *FakeComponentStatuses) List(opts v1.ListOptions) (result *api.Component
 func (c *FakeComponentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(componentstatusesResource, opts))
+}
+
+// Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
+func (c *FakeComponentStatuses) Create(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(componentstatusesResource, componentStatus), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}
+
+// Update takes the representation of a componentStatus and updates it. Returns the server's representation of the componentStatus, and an error, if there is any.
+func (c *FakeComponentStatuses) Update(componentStatus *api.ComponentStatus) (result *api.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(componentstatusesResource, componentStatus), &api.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ComponentStatus), err
+}
+
+// Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
+func (c *FakeComponentStatuses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(componentstatusesResource, name), &api.ComponentStatus{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeComponentStatuses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(componentstatusesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ComponentStatusList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched componentStatus.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_configmap.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_configmap.go
@@ -36,40 +36,7 @@ var configmapsResource = schema.GroupVersionResource{Group: "", Version: "", Res
 
 var configmapsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ConfigMap"}
 
-func (c *FakeConfigMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Update(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &api.ConfigMap{})
-
-	return err
-}
-
-func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ConfigMapList{})
-	return err
-}
-
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
 func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *api.ConfigMap, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &api.ConfigMap{})
@@ -80,6 +47,7 @@ func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *api.Co
 	return obj.(*api.ConfigMap), err
 }
 
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
 func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *api.ConfigMapList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &api.ConfigMapList{})
@@ -106,6 +74,44 @@ func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(configmapsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Create(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ConfigMap), err
+}
+
+// Update takes the representation of a configMap and updates it. Returns the server's representation of the configMap, and an error, if there is any.
+func (c *FakeConfigMaps) Update(configMap *api.ConfigMap) (result *api.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &api.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ConfigMap), err
+}
+
+// Delete takes name of the configMap and deletes it. Returns an error if one occurs.
+func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &api.ConfigMap{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ConfigMapList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_endpoints.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_endpoints.go
@@ -36,40 +36,7 @@ var endpointsResource = schema.GroupVersionResource{Group: "", Version: "", Reso
 
 var endpointsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Endpoints"}
 
-func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoints), &api.Endpoints{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Endpoints), err
-}
-
-func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoints), &api.Endpoints{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Endpoints), err
-}
-
-func (c *FakeEndpoints) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &api.Endpoints{})
-
-	return err
-}
-
-func (c *FakeEndpoints) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.EndpointsList{})
-	return err
-}
-
+// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
 func (c *FakeEndpoints) Get(name string, options v1.GetOptions) (result *api.Endpoints, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(endpointsResource, c.ns, name), &api.Endpoints{})
@@ -80,6 +47,7 @@ func (c *FakeEndpoints) Get(name string, options v1.GetOptions) (result *api.End
 	return obj.(*api.Endpoints), err
 }
 
+// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
 func (c *FakeEndpoints) List(opts v1.ListOptions) (result *api.EndpointsList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(endpointsResource, endpointsKind, c.ns, opts), &api.EndpointsList{})
@@ -106,6 +74,44 @@ func (c *FakeEndpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(endpointsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
+func (c *FakeEndpoints) Create(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoints), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}
+
+// Update takes the representation of a endpoints and updates it. Returns the server's representation of the endpoints, and an error, if there is any.
+func (c *FakeEndpoints) Update(endpoints *api.Endpoints) (result *api.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoints), &api.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), err
+}
+
+// Delete takes name of the endpoints and deletes it. Returns an error if one occurs.
+func (c *FakeEndpoints) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &api.Endpoints{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeEndpoints) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.EndpointsList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched endpoints.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_event.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_event.go
@@ -36,40 +36,7 @@ var eventsResource = schema.GroupVersionResource{Group: "", Version: "", Resourc
 
 var eventsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Event"}
 
-func (c *FakeEvents) Create(event *api.Event) (result *api.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &api.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Event), err
-}
-
-func (c *FakeEvents) Update(event *api.Event) (result *api.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &api.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Event), err
-}
-
-func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &api.Event{})
-
-	return err
-}
-
-func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.EventList{})
-	return err
-}
-
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
 func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *api.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &api.Event{})
@@ -80,6 +47,7 @@ func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *api.Event,
 	return obj.(*api.Event), err
 }
 
+// List takes label and field selectors, and returns the list of Events that match those selectors.
 func (c *FakeEvents) List(opts v1.ListOptions) (result *api.EventList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &api.EventList{})
@@ -106,6 +74,44 @@ func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(eventsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Create(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
+func (c *FakeEvents) Update(event *api.Event) (result *api.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &api.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Event), err
+}
+
+// Delete takes name of the event and deletes it. Returns an error if one occurs.
+func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &api.Event{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.EventList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched event.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_limitrange.go
@@ -36,40 +36,7 @@ var limitrangesResource = schema.GroupVersionResource{Group: "", Version: "", Re
 
 var limitrangesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "LimitRange"}
 
-func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(limitrangesResource, c.ns, limitRange), &api.LimitRange{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.LimitRange), err
-}
-
-func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(limitrangesResource, c.ns, limitRange), &api.LimitRange{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.LimitRange), err
-}
-
-func (c *FakeLimitRanges) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(limitrangesResource, c.ns, name), &api.LimitRange{})
-
-	return err
-}
-
-func (c *FakeLimitRanges) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(limitrangesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.LimitRangeList{})
-	return err
-}
-
+// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
 func (c *FakeLimitRanges) Get(name string, options v1.GetOptions) (result *api.LimitRange, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(limitrangesResource, c.ns, name), &api.LimitRange{})
@@ -80,6 +47,7 @@ func (c *FakeLimitRanges) Get(name string, options v1.GetOptions) (result *api.L
 	return obj.(*api.LimitRange), err
 }
 
+// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
 func (c *FakeLimitRanges) List(opts v1.ListOptions) (result *api.LimitRangeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(limitrangesResource, limitrangesKind, c.ns, opts), &api.LimitRangeList{})
@@ -106,6 +74,44 @@ func (c *FakeLimitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(limitrangesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
+func (c *FakeLimitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(limitrangesResource, c.ns, limitRange), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}
+
+// Update takes the representation of a limitRange and updates it. Returns the server's representation of the limitRange, and an error, if there is any.
+func (c *FakeLimitRanges) Update(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(limitrangesResource, c.ns, limitRange), &api.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.LimitRange), err
+}
+
+// Delete takes name of the limitRange and deletes it. Returns an error if one occurs.
+func (c *FakeLimitRanges) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(limitrangesResource, c.ns, name), &api.LimitRange{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeLimitRanges) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(limitrangesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.LimitRangeList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched limitRange.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_namespace.go
@@ -35,46 +35,7 @@ var namespacesResource = schema.GroupVersionResource{Group: "", Version: "", Res
 
 var namespacesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Namespace"}
 
-func (c *FakeNamespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &api.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Namespace), err
-}
-
-func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &api.Namespace{})
-	return err
-}
-
-func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
-	return err
-}
-
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
 func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(namespacesResource, name), &api.Namespace{})
@@ -84,6 +45,7 @@ func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *api.Na
 	return obj.(*api.Namespace), err
 }
 
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
 func (c *FakeNamespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &api.NamespaceList{})
@@ -108,6 +70,52 @@ func (c *FakeNamespaces) List(opts v1.ListOptions) (result *api.NamespaceList, e
 func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(namespacesResource, opts))
+}
+
+// Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
+func (c *FakeNamespaces) Update(namespace *api.Namespace) (result *api.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeNamespaces) UpdateStatus(namespace *api.Namespace) (*api.Namespace, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &api.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Namespace), err
+}
+
+// Delete takes name of the namespace and deletes it. Returns an error if one occurs.
+func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &api.Namespace{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.NamespaceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_node.go
@@ -35,46 +35,7 @@ var nodesResource = schema.GroupVersionResource{Group: "", Version: "", Resource
 
 var nodesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Node"}
 
-func (c *FakeNodes) Create(node *api.Node) (result *api.Node, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(nodesResource, node), &api.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Node), err
-}
-
-func (c *FakeNodes) Update(node *api.Node) (result *api.Node, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(nodesResource, node), &api.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Node), err
-}
-
-func (c *FakeNodes) UpdateStatus(node *api.Node) (*api.Node, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(nodesResource, "status", node), &api.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Node), err
-}
-
-func (c *FakeNodes) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(nodesResource, name), &api.Node{})
-	return err
-}
-
-func (c *FakeNodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(nodesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.NodeList{})
-	return err
-}
-
+// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
 func (c *FakeNodes) Get(name string, options v1.GetOptions) (result *api.Node, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(nodesResource, name), &api.Node{})
@@ -84,6 +45,7 @@ func (c *FakeNodes) Get(name string, options v1.GetOptions) (result *api.Node, e
 	return obj.(*api.Node), err
 }
 
+// List takes label and field selectors, and returns the list of Nodes that match those selectors.
 func (c *FakeNodes) List(opts v1.ListOptions) (result *api.NodeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(nodesResource, nodesKind, opts), &api.NodeList{})
@@ -108,6 +70,52 @@ func (c *FakeNodes) List(opts v1.ListOptions) (result *api.NodeList, err error) 
 func (c *FakeNodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(nodesResource, opts))
+}
+
+// Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
+func (c *FakeNodes) Create(node *api.Node) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(nodesResource, node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+// Update takes the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
+func (c *FakeNodes) Update(node *api.Node) (result *api.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(nodesResource, node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeNodes) UpdateStatus(node *api.Node) (*api.Node, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(nodesResource, "status", node), &api.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Node), err
+}
+
+// Delete takes name of the node and deletes it. Returns an error if one occurs.
+func (c *FakeNodes) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(nodesResource, name), &api.Node{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(nodesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.NodeList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched node.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_persistentvolume.go
@@ -35,46 +35,7 @@ var persistentvolumesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var persistentvolumesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "PersistentVolume"}
 
-func (c *FakePersistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(persistentvolumesResource, persistentVolume), &api.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(persistentvolumesResource, persistentVolume), &api.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(persistentvolumesResource, "status", persistentVolume), &api.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(persistentvolumesResource, name), &api.PersistentVolume{})
-	return err
-}
-
-func (c *FakePersistentVolumes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(persistentvolumesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.PersistentVolumeList{})
-	return err
-}
-
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
 func (c *FakePersistentVolumes) Get(name string, options v1.GetOptions) (result *api.PersistentVolume, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(persistentvolumesResource, name), &api.PersistentVolume{})
@@ -84,6 +45,7 @@ func (c *FakePersistentVolumes) Get(name string, options v1.GetOptions) (result 
 	return obj.(*api.PersistentVolume), err
 }
 
+// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
 func (c *FakePersistentVolumes) List(opts v1.ListOptions) (result *api.PersistentVolumeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(persistentvolumesResource, persistentvolumesKind, opts), &api.PersistentVolumeList{})
@@ -108,6 +70,52 @@ func (c *FakePersistentVolumes) List(opts v1.ListOptions) (result *api.Persisten
 func (c *FakePersistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(persistentvolumesResource, opts))
+}
+
+// Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
+func (c *FakePersistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(persistentvolumesResource, persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+// Update takes the representation of a persistentVolume and updates it. Returns the server's representation of the persistentVolume, and an error, if there is any.
+func (c *FakePersistentVolumes) Update(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(persistentvolumesResource, persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (*api.PersistentVolume, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(persistentvolumesResource, "status", persistentVolume), &api.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolume), err
+}
+
+// Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
+func (c *FakePersistentVolumes) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(persistentvolumesResource, name), &api.PersistentVolume{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePersistentVolumes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(persistentvolumesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PersistentVolumeList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched persistentVolume.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_persistentvolumeclaim.go
@@ -36,50 +36,7 @@ var persistentvolumeclaimsResource = schema.GroupVersionResource{Group: "", Vers
 
 var persistentvolumeclaimsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "PersistentVolumeClaim"}
 
-func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &api.PersistentVolumeClaim{})
-
-	return err
-}
-
-func (c *FakePersistentVolumeClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.PersistentVolumeClaimList{})
-	return err
-}
-
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
 func (c *FakePersistentVolumeClaims) Get(name string, options v1.GetOptions) (result *api.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(persistentvolumeclaimsResource, c.ns, name), &api.PersistentVolumeClaim{})
@@ -90,6 +47,7 @@ func (c *FakePersistentVolumeClaims) Get(name string, options v1.GetOptions) (re
 	return obj.(*api.PersistentVolumeClaim), err
 }
 
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
 func (c *FakePersistentVolumeClaims) List(opts v1.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(persistentvolumeclaimsResource, persistentvolumeclaimsKind, c.ns, opts), &api.PersistentVolumeClaimList{})
@@ -116,6 +74,56 @@ func (c *FakePersistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(persistentvolumeclaimsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+// Update takes the representation of a persistentVolumeClaim and updates it. Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
+func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (*api.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &api.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PersistentVolumeClaim), err
+}
+
+// Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.
+func (c *FakePersistentVolumeClaims) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &api.PersistentVolumeClaim{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePersistentVolumeClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PersistentVolumeClaimList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched persistentVolumeClaim.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_pod.go
@@ -36,50 +36,7 @@ var podsResource = schema.GroupVersionResource{Group: "", Version: "", Resource:
 
 var podsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Pod"}
 
-func (c *FakePods) Create(pod *api.Pod) (result *api.Pod, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &api.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Pod), err
-}
-
-func (c *FakePods) Update(pod *api.Pod) (result *api.Pod, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podsResource, c.ns, pod), &api.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Pod), err
-}
-
-func (c *FakePods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(podsResource, "status", c.ns, pod), &api.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Pod), err
-}
-
-func (c *FakePods) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podsResource, c.ns, name), &api.Pod{})
-
-	return err
-}
-
-func (c *FakePods) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.PodList{})
-	return err
-}
-
+// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
 func (c *FakePods) Get(name string, options v1.GetOptions) (result *api.Pod, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podsResource, c.ns, name), &api.Pod{})
@@ -90,6 +47,7 @@ func (c *FakePods) Get(name string, options v1.GetOptions) (result *api.Pod, err
 	return obj.(*api.Pod), err
 }
 
+// List takes label and field selectors, and returns the list of Pods that match those selectors.
 func (c *FakePods) List(opts v1.ListOptions) (result *api.PodList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podsResource, podsKind, c.ns, opts), &api.PodList{})
@@ -116,6 +74,56 @@ func (c *FakePods) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
+func (c *FakePods) Create(pod *api.Pod) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+// Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
+func (c *FakePods) Update(pod *api.Pod) (result *api.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podsResource, c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakePods) UpdateStatus(pod *api.Pod) (*api.Pod, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(podsResource, "status", c.ns, pod), &api.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Pod), err
+}
+
+// Delete takes name of the pod and deletes it. Returns an error if one occurs.
+func (c *FakePods) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podsResource, c.ns, name), &api.Pod{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePods) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PodList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched pod.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_podtemplate.go
@@ -36,40 +36,7 @@ var podtemplatesResource = schema.GroupVersionResource{Group: "", Version: "", R
 
 var podtemplatesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "PodTemplate"}
 
-func (c *FakePodTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podtemplatesResource, c.ns, podTemplate), &api.PodTemplate{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PodTemplate), err
-}
-
-func (c *FakePodTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podtemplatesResource, c.ns, podTemplate), &api.PodTemplate{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.PodTemplate), err
-}
-
-func (c *FakePodTemplates) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podtemplatesResource, c.ns, name), &api.PodTemplate{})
-
-	return err
-}
-
-func (c *FakePodTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podtemplatesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.PodTemplateList{})
-	return err
-}
-
+// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
 func (c *FakePodTemplates) Get(name string, options v1.GetOptions) (result *api.PodTemplate, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podtemplatesResource, c.ns, name), &api.PodTemplate{})
@@ -80,6 +47,7 @@ func (c *FakePodTemplates) Get(name string, options v1.GetOptions) (result *api.
 	return obj.(*api.PodTemplate), err
 }
 
+// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
 func (c *FakePodTemplates) List(opts v1.ListOptions) (result *api.PodTemplateList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podtemplatesResource, podtemplatesKind, c.ns, opts), &api.PodTemplateList{})
@@ -106,6 +74,44 @@ func (c *FakePodTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podtemplatesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
+func (c *FakePodTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(podtemplatesResource, c.ns, podTemplate), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}
+
+// Update takes the representation of a podTemplate and updates it. Returns the server's representation of the podTemplate, and an error, if there is any.
+func (c *FakePodTemplates) Update(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podtemplatesResource, c.ns, podTemplate), &api.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.PodTemplate), err
+}
+
+// Delete takes name of the podTemplate and deletes it. Returns an error if one occurs.
+func (c *FakePodTemplates) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podtemplatesResource, c.ns, name), &api.PodTemplate{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePodTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podtemplatesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.PodTemplateList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podTemplate.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_replicationcontroller.go
@@ -36,50 +36,7 @@ var replicationcontrollersResource = schema.GroupVersionResource{Group: "", Vers
 
 var replicationcontrollersKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ReplicationController"}
 
-func (c *FakeReplicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(replicationcontrollersResource, c.ns, replicationController), &api.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) Update(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(replicationcontrollersResource, c.ns, replicationController), &api.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) UpdateStatus(replicationController *api.ReplicationController) (*api.ReplicationController, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "status", c.ns, replicationController), &api.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(replicationcontrollersResource, c.ns, name), &api.ReplicationController{})
-
-	return err
-}
-
-func (c *FakeReplicationControllers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicationcontrollersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ReplicationControllerList{})
-	return err
-}
-
+// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
 func (c *FakeReplicationControllers) Get(name string, options v1.GetOptions) (result *api.ReplicationController, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicationcontrollersResource, c.ns, name), &api.ReplicationController{})
@@ -90,6 +47,7 @@ func (c *FakeReplicationControllers) Get(name string, options v1.GetOptions) (re
 	return obj.(*api.ReplicationController), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
 func (c *FakeReplicationControllers) List(opts v1.ListOptions) (result *api.ReplicationControllerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicationcontrollersResource, replicationcontrollersKind, c.ns, opts), &api.ReplicationControllerList{})
@@ -116,6 +74,56 @@ func (c *FakeReplicationControllers) Watch(opts v1.ListOptions) (watch.Interface
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(replicationcontrollersResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
+func (c *FakeReplicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(replicationcontrollersResource, c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+// Update takes the representation of a replicationController and updates it. Returns the server's representation of the replicationController, and an error, if there is any.
+func (c *FakeReplicationControllers) Update(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(replicationcontrollersResource, c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeReplicationControllers) UpdateStatus(replicationController *api.ReplicationController) (*api.ReplicationController, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "status", c.ns, replicationController), &api.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ReplicationController), err
+}
+
+// Delete takes name of the replicationController and deletes it. Returns an error if one occurs.
+func (c *FakeReplicationControllers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(replicationcontrollersResource, c.ns, name), &api.ReplicationController{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeReplicationControllers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicationcontrollersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ReplicationControllerList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched replicationController.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_resourcequota.go
@@ -36,50 +36,7 @@ var resourcequotasResource = schema.GroupVersionResource{Group: "", Version: "",
 
 var resourcequotasKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ResourceQuota"}
 
-func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(resourcequotasResource, c.ns, resourceQuota), &api.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(resourcequotasResource, c.ns, resourceQuota), &api.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(resourcequotasResource, "status", c.ns, resourceQuota), &api.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourcequotasResource, c.ns, name), &api.ResourceQuota{})
-
-	return err
-}
-
-func (c *FakeResourceQuotas) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(resourcequotasResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ResourceQuotaList{})
-	return err
-}
-
+// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
 func (c *FakeResourceQuotas) Get(name string, options v1.GetOptions) (result *api.ResourceQuota, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(resourcequotasResource, c.ns, name), &api.ResourceQuota{})
@@ -90,6 +47,7 @@ func (c *FakeResourceQuotas) Get(name string, options v1.GetOptions) (result *ap
 	return obj.(*api.ResourceQuota), err
 }
 
+// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
 func (c *FakeResourceQuotas) List(opts v1.ListOptions) (result *api.ResourceQuotaList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(resourcequotasResource, resourcequotasKind, c.ns, opts), &api.ResourceQuotaList{})
@@ -116,6 +74,56 @@ func (c *FakeResourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error)
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(resourcequotasResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
+func (c *FakeResourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(resourcequotasResource, c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+// Update takes the representation of a resourceQuota and updates it. Returns the server's representation of the resourceQuota, and an error, if there is any.
+func (c *FakeResourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(resourcequotasResource, c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (*api.ResourceQuota, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(resourcequotasResource, "status", c.ns, resourceQuota), &api.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ResourceQuota), err
+}
+
+// Delete takes name of the resourceQuota and deletes it. Returns an error if one occurs.
+func (c *FakeResourceQuotas) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(resourcequotasResource, c.ns, name), &api.ResourceQuota{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeResourceQuotas) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(resourcequotasResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ResourceQuotaList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched resourceQuota.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_secret.go
@@ -36,40 +36,7 @@ var secretsResource = schema.GroupVersionResource{Group: "", Version: "", Resour
 
 var secretsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Secret"}
 
-func (c *FakeSecrets) Create(secret *api.Secret) (result *api.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &api.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Secret), err
-}
-
-func (c *FakeSecrets) Update(secret *api.Secret) (result *api.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &api.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Secret), err
-}
-
-func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &api.Secret{})
-
-	return err
-}
-
-func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.SecretList{})
-	return err
-}
-
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
 func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &api.Secret{})
@@ -80,6 +47,7 @@ func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *api.Secre
 	return obj.(*api.Secret), err
 }
 
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
 func (c *FakeSecrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &api.SecretList{})
@@ -106,6 +74,44 @@ func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(secretsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Create(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+// Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
+func (c *FakeSecrets) Update(secret *api.Secret) (result *api.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &api.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Secret), err
+}
+
+// Delete takes name of the secret and deletes it. Returns an error if one occurs.
+func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &api.Secret{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.SecretList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_service.go
@@ -36,50 +36,7 @@ var servicesResource = schema.GroupVersionResource{Group: "", Version: "", Resou
 
 var servicesKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "Service"}
 
-func (c *FakeServices) Create(service *api.Service) (result *api.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) Update(service *api.Service) (result *api.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) UpdateStatus(service *api.Service) (*api.Service, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &api.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.Service), err
-}
-
-func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &api.Service{})
-
-	return err
-}
-
-func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ServiceList{})
-	return err
-}
-
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
 func (c *FakeServices) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &api.Service{})
@@ -90,6 +47,7 @@ func (c *FakeServices) Get(name string, options v1.GetOptions) (result *api.Serv
 	return obj.(*api.Service), err
 }
 
+// List takes label and field selectors, and returns the list of Services that match those selectors.
 func (c *FakeServices) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &api.ServiceList{})
@@ -116,6 +74,56 @@ func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Create(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
+func (c *FakeServices) Update(service *api.Service) (result *api.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeServices) UpdateStatus(service *api.Service) (*api.Service, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &api.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.Service), err
+}
+
+// Delete takes name of the service and deletes it. Returns an error if one occurs.
+func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &api.Service{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ServiceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched service.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_serviceaccount.go
@@ -36,40 +36,7 @@ var serviceaccountsResource = schema.GroupVersionResource{Group: "", Version: ""
 
 var serviceaccountsKind = schema.GroupVersionKind{Group: "", Version: "", Kind: "ServiceAccount"}
 
-func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(serviceaccountsResource, c.ns, serviceAccount), &api.ServiceAccount{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ServiceAccount), err
-}
-
-func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(serviceaccountsResource, c.ns, serviceAccount), &api.ServiceAccount{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*api.ServiceAccount), err
-}
-
-func (c *FakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(serviceaccountsResource, c.ns, name), &api.ServiceAccount{})
-
-	return err
-}
-
-func (c *FakeServiceAccounts) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(serviceaccountsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &api.ServiceAccountList{})
-	return err
-}
-
+// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
 func (c *FakeServiceAccounts) Get(name string, options v1.GetOptions) (result *api.ServiceAccount, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(serviceaccountsResource, c.ns, name), &api.ServiceAccount{})
@@ -80,6 +47,7 @@ func (c *FakeServiceAccounts) Get(name string, options v1.GetOptions) (result *a
 	return obj.(*api.ServiceAccount), err
 }
 
+// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
 func (c *FakeServiceAccounts) List(opts v1.ListOptions) (result *api.ServiceAccountList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(serviceaccountsResource, serviceaccountsKind, c.ns, opts), &api.ServiceAccountList{})
@@ -106,6 +74,44 @@ func (c *FakeServiceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(serviceaccountsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
+func (c *FakeServiceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(serviceaccountsResource, c.ns, serviceAccount), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}
+
+// Update takes the representation of a serviceAccount and updates it. Returns the server's representation of the serviceAccount, and an error, if there is any.
+func (c *FakeServiceAccounts) Update(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(serviceaccountsResource, c.ns, serviceAccount), &api.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*api.ServiceAccount), err
+}
+
+// Delete takes name of the serviceAccount and deletes it. Returns an error if one occurs.
+func (c *FakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(serviceaccountsResource, c.ns, name), &api.ServiceAccount{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeServiceAccounts) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(serviceaccountsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &api.ServiceAccountList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched serviceAccount.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/limitrange.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/limitrange.go
@@ -58,6 +58,41 @@ func newLimitRanges(c *CoreClient, namespace string) *limitRanges {
 	}
 }
 
+// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
+func (c *limitRanges) Get(name string, options v1.GetOptions) (result *api.LimitRange, err error) {
+	result = &api.LimitRange{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
+func (c *limitRanges) List(opts v1.ListOptions) (result *api.LimitRangeList, err error) {
+	result = &api.LimitRangeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested limitRanges.
+func (c *limitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *limitRanges) Create(limitRange *api.LimitRange) (result *api.LimitRange, err error) {
 	result = &api.LimitRange{}
@@ -103,41 +138,6 @@ func (c *limitRanges) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
-func (c *limitRanges) Get(name string, options v1.GetOptions) (result *api.LimitRange, err error) {
-	result = &api.LimitRange{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
-func (c *limitRanges) List(opts v1.ListOptions) (result *api.LimitRangeList, err error) {
-	result = &api.LimitRangeList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested limitRanges.
-func (c *limitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched limitRange.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
@@ -57,6 +57,38 @@ func newNamespaces(c *CoreClient) *namespaces {
 	}
 }
 
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *namespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
+	result = &api.Namespace{}
+	err = c.client.Get().
+		Resource("namespaces").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
+	result = &api.NamespaceList{}
+	err = c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Create(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}
@@ -113,38 +145,6 @@ func (c *namespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
-func (c *namespaces) Get(name string, options v1.GetOptions) (result *api.Namespace, err error) {
-	result = &api.Namespace{}
-	err = c.client.Get().
-		Resource("namespaces").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
-func (c *namespaces) List(opts v1.ListOptions) (result *api.NamespaceList, err error) {
-	result = &api.NamespaceList{}
-	err = c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested namespaces.
-func (c *namespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/namespace.go
@@ -81,7 +81,7 @@ func (c *namespaces) Update(namespace *api.Namespace) (result *api.Namespace, er
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *namespaces) UpdateStatus(namespace *api.Namespace) (result *api.Namespace, err error) {
 	result = &api.Namespace{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
@@ -57,6 +57,38 @@ func newNodes(c *CoreClient) *nodes {
 	}
 }
 
+// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
+func (c *nodes) Get(name string, options v1.GetOptions) (result *api.Node, err error) {
+	result = &api.Node{}
+	err = c.client.Get().
+		Resource("nodes").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Nodes that match those selectors.
+func (c *nodes) List(opts v1.ListOptions) (result *api.NodeList, err error) {
+	result = &api.NodeList{}
+	err = c.client.Get().
+		Resource("nodes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested nodes.
+func (c *nodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("nodes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
 func (c *nodes) Create(node *api.Node) (result *api.Node, err error) {
 	result = &api.Node{}
@@ -113,38 +145,6 @@ func (c *nodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
-func (c *nodes) Get(name string, options v1.GetOptions) (result *api.Node, err error) {
-	result = &api.Node{}
-	err = c.client.Get().
-		Resource("nodes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Nodes that match those selectors.
-func (c *nodes) List(opts v1.ListOptions) (result *api.NodeList, err error) {
-	result = &api.NodeList{}
-	err = c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested nodes.
-func (c *nodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched node.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/node.go
@@ -81,7 +81,7 @@ func (c *nodes) Update(node *api.Node) (result *api.Node, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *nodes) UpdateStatus(node *api.Node) (result *api.Node, err error) {
 	result = &api.Node{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
@@ -57,6 +57,38 @@ func newPersistentVolumes(c *CoreClient) *persistentVolumes {
 	}
 }
 
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
+func (c *persistentVolumes) Get(name string, options v1.GetOptions) (result *api.PersistentVolume, err error) {
+	result = &api.PersistentVolume{}
+	err = c.client.Get().
+		Resource("persistentvolumes").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
+func (c *persistentVolumes) List(opts v1.ListOptions) (result *api.PersistentVolumeList, err error) {
+	result = &api.PersistentVolumeList{}
+	err = c.client.Get().
+		Resource("persistentvolumes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumes.
+func (c *persistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("persistentvolumes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *persistentVolumes) Create(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}
@@ -113,38 +145,6 @@ func (c *persistentVolumes) DeleteCollection(options *v1.DeleteOptions, listOpti
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
-func (c *persistentVolumes) Get(name string, options v1.GetOptions) (result *api.PersistentVolume, err error) {
-	result = &api.PersistentVolume{}
-	err = c.client.Get().
-		Resource("persistentvolumes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
-func (c *persistentVolumes) List(opts v1.ListOptions) (result *api.PersistentVolumeList, err error) {
-	result = &api.PersistentVolumeList{}
-	err = c.client.Get().
-		Resource("persistentvolumes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested persistentVolumes.
-func (c *persistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("persistentvolumes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched persistentVolume.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolume.go
@@ -81,7 +81,7 @@ func (c *persistentVolumes) Update(persistentVolume *api.PersistentVolume) (resu
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *persistentVolumes) UpdateStatus(persistentVolume *api.PersistentVolume) (result *api.PersistentVolume, err error) {
 	result = &api.PersistentVolume{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
@@ -85,7 +85,7 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *api.PersistentVol
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/persistentvolumeclaim.go
@@ -59,6 +59,41 @@ func newPersistentVolumeClaims(c *CoreClient, namespace string) *persistentVolum
 	}
 }
 
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
+func (c *persistentVolumeClaims) Get(name string, options v1.GetOptions) (result *api.PersistentVolumeClaim, err error) {
+	result = &api.PersistentVolumeClaim{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
+func (c *persistentVolumeClaims) List(opts v1.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
+	result = &api.PersistentVolumeClaimList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *persistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *persistentVolumeClaims) Create(persistentVolumeClaim *api.PersistentVolumeClaim) (result *api.PersistentVolumeClaim, err error) {
 	result = &api.PersistentVolumeClaim{}
@@ -120,41 +155,6 @@ func (c *persistentVolumeClaims) DeleteCollection(options *v1.DeleteOptions, lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
-func (c *persistentVolumeClaims) Get(name string, options v1.GetOptions) (result *api.PersistentVolumeClaim, err error) {
-	result = &api.PersistentVolumeClaim{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
-func (c *persistentVolumeClaims) List(opts v1.ListOptions) (result *api.PersistentVolumeClaimList, err error) {
-	result = &api.PersistentVolumeClaimList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
-func (c *persistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched persistentVolumeClaim.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
@@ -59,6 +59,41 @@ func newPods(c *CoreClient, namespace string) *pods {
 	}
 }
 
+// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
+func (c *pods) Get(name string, options v1.GetOptions) (result *api.Pod, err error) {
+	result = &api.Pod{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Pods that match those selectors.
+func (c *pods) List(opts v1.ListOptions) (result *api.PodList, err error) {
+	result = &api.PodList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *pods) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
 func (c *pods) Create(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}
@@ -120,41 +155,6 @@ func (c *pods) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
-func (c *pods) Get(name string, options v1.GetOptions) (result *api.Pod, err error) {
-	result = &api.Pod{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Pods that match those selectors.
-func (c *pods) List(opts v1.ListOptions) (result *api.PodList, err error) {
-	result = &api.PodList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested pods.
-func (c *pods) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched pod.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/pod.go
@@ -85,7 +85,7 @@ func (c *pods) Update(pod *api.Pod) (result *api.Pod, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *pods) UpdateStatus(pod *api.Pod) (result *api.Pod, err error) {
 	result = &api.Pod{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/podtemplate.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/podtemplate.go
@@ -58,6 +58,41 @@ func newPodTemplates(c *CoreClient, namespace string) *podTemplates {
 	}
 }
 
+// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
+func (c *podTemplates) Get(name string, options v1.GetOptions) (result *api.PodTemplate, err error) {
+	result = &api.PodTemplate{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
+func (c *podTemplates) List(opts v1.ListOptions) (result *api.PodTemplateList, err error) {
+	result = &api.PodTemplateList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *podTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *podTemplates) Create(podTemplate *api.PodTemplate) (result *api.PodTemplate, err error) {
 	result = &api.PodTemplate{}
@@ -103,41 +138,6 @@ func (c *podTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
-func (c *podTemplates) Get(name string, options v1.GetOptions) (result *api.PodTemplate, err error) {
-	result = &api.PodTemplate{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
-func (c *podTemplates) List(opts v1.ListOptions) (result *api.PodTemplateList, err error) {
-	result = &api.PodTemplateList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podTemplates.
-func (c *podTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podTemplate.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
@@ -59,6 +59,41 @@ func newReplicationControllers(c *CoreClient, namespace string) *replicationCont
 	}
 }
 
+// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
+func (c *replicationControllers) Get(name string, options v1.GetOptions) (result *api.ReplicationController, err error) {
+	result = &api.ReplicationController{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
+func (c *replicationControllers) List(opts v1.ListOptions) (result *api.ReplicationControllerList, err error) {
+	result = &api.ReplicationControllerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicationControllers.
+func (c *replicationControllers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *replicationControllers) Create(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}
@@ -120,41 +155,6 @@ func (c *replicationControllers) DeleteCollection(options *v1.DeleteOptions, lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
-func (c *replicationControllers) Get(name string, options v1.GetOptions) (result *api.ReplicationController, err error) {
-	result = &api.ReplicationController{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
-func (c *replicationControllers) List(opts v1.ListOptions) (result *api.ReplicationControllerList, err error) {
-	result = &api.ReplicationControllerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicationControllers.
-func (c *replicationControllers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicationController.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/replicationcontroller.go
@@ -85,7 +85,7 @@ func (c *replicationControllers) Update(replicationController *api.ReplicationCo
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicationControllers) UpdateStatus(replicationController *api.ReplicationController) (result *api.ReplicationController, err error) {
 	result = &api.ReplicationController{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
@@ -59,6 +59,41 @@ func newResourceQuotas(c *CoreClient, namespace string) *resourceQuotas {
 	}
 }
 
+// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
+func (c *resourceQuotas) Get(name string, options v1.GetOptions) (result *api.ResourceQuota, err error) {
+	result = &api.ResourceQuota{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
+func (c *resourceQuotas) List(opts v1.ListOptions) (result *api.ResourceQuotaList, err error) {
+	result = &api.ResourceQuotaList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested resourceQuotas.
+func (c *resourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *resourceQuotas) Create(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}
@@ -120,41 +155,6 @@ func (c *resourceQuotas) DeleteCollection(options *v1.DeleteOptions, listOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
-func (c *resourceQuotas) Get(name string, options v1.GetOptions) (result *api.ResourceQuota, err error) {
-	result = &api.ResourceQuota{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
-func (c *resourceQuotas) List(opts v1.ListOptions) (result *api.ResourceQuotaList, err error) {
-	result = &api.ResourceQuotaList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested resourceQuotas.
-func (c *resourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched resourceQuota.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/resourcequota.go
@@ -85,7 +85,7 @@ func (c *resourceQuotas) Update(resourceQuota *api.ResourceQuota) (result *api.R
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *resourceQuotas) UpdateStatus(resourceQuota *api.ResourceQuota) (result *api.ResourceQuota, err error) {
 	result = &api.ResourceQuota{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/secret.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/secret.go
@@ -58,6 +58,41 @@ func newSecrets(c *CoreClient, namespace string) *secrets {
 	}
 }
 
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *secrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
+	result = &api.Secret{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
+	result = &api.SecretList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Create(secret *api.Secret) (result *api.Secret, err error) {
 	result = &api.Secret{}
@@ -103,41 +138,6 @@ func (c *secrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
-func (c *secrets) Get(name string, options v1.GetOptions) (result *api.Secret, err error) {
-	result = &api.Secret{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Secrets that match those selectors.
-func (c *secrets) List(opts v1.ListOptions) (result *api.SecretList, err error) {
-	result = &api.SecretList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested secrets.
-func (c *secrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
@@ -59,6 +59,41 @@ func newServices(c *CoreClient, namespace string) *services {
 	}
 }
 
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *services) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
+	result = &api.Service{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
+	result = &api.ServiceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Create(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}
@@ -120,41 +155,6 @@ func (c *services) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
-func (c *services) Get(name string, options v1.GetOptions) (result *api.Service, err error) {
-	result = &api.Service{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Services that match those selectors.
-func (c *services) List(opts v1.ListOptions) (result *api.ServiceList, err error) {
-	result = &api.ServiceList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested services.
-func (c *services) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched service.

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/service.go
@@ -85,7 +85,7 @@ func (c *services) Update(service *api.Service) (result *api.Service, err error)
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *services) UpdateStatus(service *api.Service) (result *api.Service, err error) {
 	result = &api.Service{}

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/serviceaccount.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/serviceaccount.go
@@ -58,6 +58,41 @@ func newServiceAccounts(c *CoreClient, namespace string) *serviceAccounts {
 	}
 }
 
+// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
+func (c *serviceAccounts) Get(name string, options v1.GetOptions) (result *api.ServiceAccount, err error) {
+	result = &api.ServiceAccount{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
+func (c *serviceAccounts) List(opts v1.ListOptions) (result *api.ServiceAccountList, err error) {
+	result = &api.ServiceAccountList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested serviceAccounts.
+func (c *serviceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *serviceAccounts) Create(serviceAccount *api.ServiceAccount) (result *api.ServiceAccount, err error) {
 	result = &api.ServiceAccount{}
@@ -103,41 +138,6 @@ func (c *serviceAccounts) DeleteCollection(options *v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
-func (c *serviceAccounts) Get(name string, options v1.GetOptions) (result *api.ServiceAccount, err error) {
-	result = &api.ServiceAccount{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
-func (c *serviceAccounts) List(opts v1.ListOptions) (result *api.ServiceAccountList, err error) {
-	result = &api.ServiceAccountList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested serviceAccounts.
-func (c *serviceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched serviceAccount.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
@@ -85,7 +85,7 @@ func (c *daemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *daemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/daemonset.go
@@ -59,6 +59,41 @@ func newDaemonSets(c *ExtensionsClient, namespace string) *daemonSets {
 	}
 }
 
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
+func (c *daemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
+	result = &extensions.DaemonSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
+	result = &extensions.DaemonSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
 	result = &extensions.DaemonSet{}
@@ -120,41 +155,6 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
-func (c *daemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
-	result = &extensions.DaemonSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
-func (c *daemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
-	result = &extensions.DaemonSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *ExtensionsClient, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
+	result = &extensions.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
+	result = &extensions.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
-	result = &extensions.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
-	result = &extensions.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
@@ -85,7 +85,7 @@ func (c *deployments) Update(deployment *extensions.Deployment) (result *extensi
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
 	result = &extensions.Deployment{}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_daemonset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_daemonset.go
@@ -36,50 +36,7 @@ var daemonsetsResource = schema.GroupVersionResource{Group: "extensions", Versio
 
 var daemonsetsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "DaemonSet"}
 
-func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &extensions.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
-
-	return err
-}
-
-func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
-	return err
-}
-
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
 func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *extensions.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
@@ -90,6 +47,7 @@ func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *extens
 	return obj.(*extensions.DaemonSet), err
 }
 
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *extensions.DaemonSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &extensions.DaemonSetList{})
@@ -116,6 +74,56 @@ func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(daemonsetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Create(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
+func (c *FakeDaemonSets) Update(daemonSet *extensions.DaemonSet) (result *extensions.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDaemonSets) UpdateStatus(daemonSet *extensions.DaemonSet) (*extensions.DaemonSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &extensions.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.DaemonSet), err
+}
+
+// Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
+func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &extensions.DaemonSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DaemonSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
@@ -36,50 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var deploymentsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "Deployment"}
 
-func (c *FakeDeployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &extensions.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Deployment), err
-}
-
-func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
-
-	return err
-}
-
-func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
-	return err
-}
-
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *extensions.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
@@ -90,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *exten
 	return obj.(*extensions.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *extensions.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &extensions.DeploymentList{})
@@ -116,6 +74,56 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Create(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Update(deployment *extensions.Deployment) (result *extensions.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDeployments) UpdateStatus(deployment *extensions.Deployment) (*extensions.Deployment, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &extensions.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Deployment), err
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &extensions.Deployment{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.DeploymentList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_ingress.go
@@ -36,50 +36,7 @@ var ingressesResource = schema.GroupVersionResource{Group: "extensions", Version
 
 var ingressesKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "Ingress"}
 
-func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &extensions.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.Ingress), err
-}
-
-func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &extensions.Ingress{})
-
-	return err
-}
-
-func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
-	return err
-}
-
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
 func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &extensions.Ingress{})
@@ -90,6 +47,7 @@ func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *extensi
 	return obj.(*extensions.Ingress), err
 }
 
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *FakeIngresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &extensions.IngressList{})
@@ -116,6 +74,56 @@ func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(ingressesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
+func (c *FakeIngresses) Update(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeIngresses) UpdateStatus(ingress *extensions.Ingress) (*extensions.Ingress, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &extensions.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Ingress), err
+}
+
+// Delete takes name of the ingress and deletes it. Returns an error if one occurs.
+func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &extensions.Ingress{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.IngressList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_networkpolicy.go
@@ -36,40 +36,7 @@ var networkpoliciesResource = schema.GroupVersionResource{Group: "extensions", V
 
 var networkpoliciesKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "NetworkPolicy"}
 
-func (c *FakeNetworkPolicies) Create(networkPolicy *extensions.NetworkPolicy) (result *extensions.NetworkPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &extensions.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) Update(networkPolicy *extensions.NetworkPolicy) (result *extensions.NetworkPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &extensions.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &extensions.NetworkPolicy{})
-
-	return err
-}
-
-func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.NetworkPolicyList{})
-	return err
-}
-
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
 func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *extensions.NetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &extensions.NetworkPolicy{})
@@ -80,6 +47,7 @@ func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *e
 	return obj.(*extensions.NetworkPolicy), err
 }
 
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *extensions.NetworkPolicyList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &extensions.NetworkPolicyList{})
@@ -106,6 +74,44 @@ func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(networkpoliciesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
+func (c *FakeNetworkPolicies) Create(networkPolicy *extensions.NetworkPolicy) (result *extensions.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &extensions.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.NetworkPolicy), err
+}
+
+// Update takes the representation of a networkPolicy and updates it. Returns the server's representation of the networkPolicy, and an error, if there is any.
+func (c *FakeNetworkPolicies) Update(networkPolicy *extensions.NetworkPolicy) (result *extensions.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &extensions.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.NetworkPolicy), err
+}
+
+// Delete takes name of the networkPolicy and deletes it. Returns an error if one occurs.
+func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &extensions.NetworkPolicy{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.NetworkPolicyList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched networkPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_podsecuritypolicy.go
@@ -35,37 +35,7 @@ var podsecuritypoliciesResource = schema.GroupVersionResource{Group: "extensions
 
 var podsecuritypoliciesKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "PodSecurityPolicy"}
 
-func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *extensions.PodSecurityPolicy) (result *extensions.PodSecurityPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(podsecuritypoliciesResource, podSecurityPolicy), &extensions.PodSecurityPolicy{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.PodSecurityPolicy), err
-}
-
-func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *extensions.PodSecurityPolicy) (result *extensions.PodSecurityPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(podsecuritypoliciesResource, podSecurityPolicy), &extensions.PodSecurityPolicy{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.PodSecurityPolicy), err
-}
-
-func (c *FakePodSecurityPolicies) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(podsecuritypoliciesResource, name), &extensions.PodSecurityPolicy{})
-	return err
-}
-
-func (c *FakePodSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(podsecuritypoliciesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.PodSecurityPolicyList{})
-	return err
-}
-
+// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
 func (c *FakePodSecurityPolicies) Get(name string, options v1.GetOptions) (result *extensions.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(podsecuritypoliciesResource, name), &extensions.PodSecurityPolicy{})
@@ -75,6 +45,7 @@ func (c *FakePodSecurityPolicies) Get(name string, options v1.GetOptions) (resul
 	return obj.(*extensions.PodSecurityPolicy), err
 }
 
+// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
 func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *extensions.PodSecurityPolicyList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(podsecuritypoliciesResource, podsecuritypoliciesKind, opts), &extensions.PodSecurityPolicyList{})
@@ -99,6 +70,41 @@ func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *extensions.
 func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(podsecuritypoliciesResource, opts))
+}
+
+// Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
+func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *extensions.PodSecurityPolicy) (result *extensions.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(podsecuritypoliciesResource, podSecurityPolicy), &extensions.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.PodSecurityPolicy), err
+}
+
+// Update takes the representation of a podSecurityPolicy and updates it. Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
+func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *extensions.PodSecurityPolicy) (result *extensions.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(podsecuritypoliciesResource, podSecurityPolicy), &extensions.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.PodSecurityPolicy), err
+}
+
+// Delete takes name of the podSecurityPolicy and deletes it. Returns an error if one occurs.
+func (c *FakePodSecurityPolicies) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(podsecuritypoliciesResource, name), &extensions.PodSecurityPolicy{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePodSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(podsecuritypoliciesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.PodSecurityPolicyList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
@@ -36,50 +36,7 @@ var replicasetsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var replicasetsKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "ReplicaSet"}
 
-func (c *FakeReplicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (*extensions.ReplicaSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &extensions.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
-
-	return err
-}
-
-func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.ReplicaSetList{})
-	return err
-}
-
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
 func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
@@ -90,6 +47,7 @@ func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *exten
 	return obj.(*extensions.ReplicaSet), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
 func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &extensions.ReplicaSetList{})
@@ -116,6 +74,56 @@ func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(replicasetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
+func (c *FakeReplicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeReplicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (*extensions.ReplicaSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &extensions.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ReplicaSet), err
+}
+
+// Delete takes name of the replicaSet and deletes it. Returns an error if one occurs.
+func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &extensions.ReplicaSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.ReplicaSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_thirdpartyresource.go
@@ -35,37 +35,7 @@ var thirdpartyresourcesResource = schema.GroupVersionResource{Group: "extensions
 
 var thirdpartyresourcesKind = schema.GroupVersionKind{Group: "extensions", Version: "", Kind: "ThirdPartyResource"}
 
-func (c *FakeThirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(thirdpartyresourcesResource, thirdPartyResource), &extensions.ThirdPartyResource{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ThirdPartyResource), err
-}
-
-func (c *FakeThirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(thirdpartyresourcesResource, thirdPartyResource), &extensions.ThirdPartyResource{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*extensions.ThirdPartyResource), err
-}
-
-func (c *FakeThirdPartyResources) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(thirdpartyresourcesResource, name), &extensions.ThirdPartyResource{})
-	return err
-}
-
-func (c *FakeThirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(thirdpartyresourcesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &extensions.ThirdPartyResourceList{})
-	return err
-}
-
+// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
 func (c *FakeThirdPartyResources) Get(name string, options v1.GetOptions) (result *extensions.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(thirdpartyresourcesResource, name), &extensions.ThirdPartyResource{})
@@ -75,6 +45,7 @@ func (c *FakeThirdPartyResources) Get(name string, options v1.GetOptions) (resul
 	return obj.(*extensions.ThirdPartyResource), err
 }
 
+// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
 func (c *FakeThirdPartyResources) List(opts v1.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(thirdpartyresourcesResource, thirdpartyresourcesKind, opts), &extensions.ThirdPartyResourceList{})
@@ -99,6 +70,41 @@ func (c *FakeThirdPartyResources) List(opts v1.ListOptions) (result *extensions.
 func (c *FakeThirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(thirdpartyresourcesResource, opts))
+}
+
+// Create takes the representation of a thirdPartyResource and creates it.  Returns the server's representation of the thirdPartyResource, and an error, if there is any.
+func (c *FakeThirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(thirdpartyresourcesResource, thirdPartyResource), &extensions.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}
+
+// Update takes the representation of a thirdPartyResource and updates it. Returns the server's representation of the thirdPartyResource, and an error, if there is any.
+func (c *FakeThirdPartyResources) Update(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(thirdpartyresourcesResource, thirdPartyResource), &extensions.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.ThirdPartyResource), err
+}
+
+// Delete takes name of the thirdPartyResource and deletes it. Returns an error if one occurs.
+func (c *FakeThirdPartyResources) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(thirdpartyresourcesResource, name), &extensions.ThirdPartyResource{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeThirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(thirdpartyresourcesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &extensions.ThirdPartyResourceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
@@ -85,7 +85,7 @@ func (c *ingresses) Update(ingress *extensions.Ingress) (result *extensions.Ingr
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *ingresses) UpdateStatus(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/ingress.go
@@ -59,6 +59,41 @@ func newIngresses(c *ExtensionsClient, namespace string) *ingresses {
 	}
 }
 
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
+func (c *ingresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
+	result = &extensions.Ingress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
+	result = &extensions.IngressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *extensions.Ingress) (result *extensions.Ingress, err error) {
 	result = &extensions.Ingress{}
@@ -120,41 +155,6 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingresses) Get(name string, options v1.GetOptions) (result *extensions.Ingress, err error) {
-	result = &extensions.Ingress{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
-func (c *ingresses) List(opts v1.ListOptions) (result *extensions.IngressList, err error) {
-	result = &extensions.IngressList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/networkpolicy.go
@@ -58,6 +58,41 @@ func newNetworkPolicies(c *ExtensionsClient, namespace string) *networkPolicies 
 	}
 }
 
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
+func (c *networkPolicies) Get(name string, options v1.GetOptions) (result *extensions.NetworkPolicy, err error) {
+	result = &extensions.NetworkPolicy{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
+func (c *networkPolicies) List(opts v1.ListOptions) (result *extensions.NetworkPolicyList, err error) {
+	result = &extensions.NetworkPolicyList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested networkPolicies.
+func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Create(networkPolicy *extensions.NetworkPolicy) (result *extensions.NetworkPolicy, err error) {
 	result = &extensions.NetworkPolicy{}
@@ -103,41 +138,6 @@ func (c *networkPolicies) DeleteCollection(options *v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
-func (c *networkPolicies) Get(name string, options v1.GetOptions) (result *extensions.NetworkPolicy, err error) {
-	result = &extensions.NetworkPolicy{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
-func (c *networkPolicies) List(opts v1.ListOptions) (result *extensions.NetworkPolicyList, err error) {
-	result = &extensions.NetworkPolicyList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched networkPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/podsecuritypolicy.go
@@ -56,6 +56,38 @@ func newPodSecurityPolicies(c *ExtensionsClient) *podSecurityPolicies {
 	}
 }
 
+// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
+func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *extensions.PodSecurityPolicy, err error) {
+	result = &extensions.PodSecurityPolicy{}
+	err = c.client.Get().
+		Resource("podsecuritypolicies").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
+func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *extensions.PodSecurityPolicyList, err error) {
+	result = &extensions.PodSecurityPolicyList{}
+	err = c.client.Get().
+		Resource("podsecuritypolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
+func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("podsecuritypolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Create(podSecurityPolicy *extensions.PodSecurityPolicy) (result *extensions.PodSecurityPolicy, err error) {
 	result = &extensions.PodSecurityPolicy{}
@@ -97,38 +129,6 @@ func (c *podSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
-func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *extensions.PodSecurityPolicy, err error) {
-	result = &extensions.PodSecurityPolicy{}
-	err = c.client.Get().
-		Resource("podsecuritypolicies").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
-func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *extensions.PodSecurityPolicyList, err error) {
-	result = &extensions.PodSecurityPolicyList{}
-	err = c.client.Get().
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
-func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
@@ -85,7 +85,7 @@ func (c *replicaSets) Update(replicaSet *extensions.ReplicaSet) (result *extensi
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicaSets) UpdateStatus(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
@@ -59,6 +59,41 @@ func newReplicaSets(c *ExtensionsClient, namespace string) *replicaSets {
 	}
 }
 
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
+func (c *replicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
+	result = &extensions.ReplicaSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
+func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
+	result = &extensions.ReplicaSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicaSets.
+func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *extensions.ReplicaSet) (result *extensions.ReplicaSet, err error) {
 	result = &extensions.ReplicaSet{}
@@ -120,41 +155,6 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
-func (c *replicaSets) Get(name string, options v1.GetOptions) (result *extensions.ReplicaSet, err error) {
-	result = &extensions.ReplicaSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
-func (c *replicaSets) List(opts v1.ListOptions) (result *extensions.ReplicaSetList, err error) {
-	result = &extensions.ReplicaSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/thirdpartyresource.go
@@ -56,6 +56,38 @@ func newThirdPartyResources(c *ExtensionsClient) *thirdPartyResources {
 	}
 }
 
+// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
+func (c *thirdPartyResources) Get(name string, options v1.GetOptions) (result *extensions.ThirdPartyResource, err error) {
+	result = &extensions.ThirdPartyResource{}
+	err = c.client.Get().
+		Resource("thirdpartyresources").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
+func (c *thirdPartyResources) List(opts v1.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
+	result = &extensions.ThirdPartyResourceList{}
+	err = c.client.Get().
+		Resource("thirdpartyresources").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested thirdPartyResources.
+func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("thirdpartyresources").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a thirdPartyResource and creates it.  Returns the server's representation of the thirdPartyResource, and an error, if there is any.
 func (c *thirdPartyResources) Create(thirdPartyResource *extensions.ThirdPartyResource) (result *extensions.ThirdPartyResource, err error) {
 	result = &extensions.ThirdPartyResource{}
@@ -97,38 +129,6 @@ func (c *thirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
-func (c *thirdPartyResources) Get(name string, options v1.GetOptions) (result *extensions.ThirdPartyResource, err error) {
-	result = &extensions.ThirdPartyResource{}
-	err = c.client.Get().
-		Resource("thirdpartyresources").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
-func (c *thirdPartyResources) List(opts v1.ListOptions) (result *extensions.ThirdPartyResourceList, err error) {
-	result = &extensions.ThirdPartyResourceList{}
-	err = c.client.Get().
-		Resource("thirdpartyresources").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested thirdPartyResources.
-func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("thirdpartyresources").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.

--- a/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion/fake/fake_networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion/fake/fake_networkpolicy.go
@@ -36,40 +36,7 @@ var networkpoliciesResource = schema.GroupVersionResource{Group: "networking.k8s
 
 var networkpoliciesKind = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "", Kind: "NetworkPolicy"}
 
-func (c *FakeNetworkPolicies) Create(networkPolicy *networking.NetworkPolicy) (result *networking.NetworkPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &networking.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*networking.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) Update(networkPolicy *networking.NetworkPolicy) (result *networking.NetworkPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &networking.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*networking.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &networking.NetworkPolicy{})
-
-	return err
-}
-
-func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &networking.NetworkPolicyList{})
-	return err
-}
-
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
 func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *networking.NetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &networking.NetworkPolicy{})
@@ -80,6 +47,7 @@ func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *n
 	return obj.(*networking.NetworkPolicy), err
 }
 
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *networking.NetworkPolicyList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &networking.NetworkPolicyList{})
@@ -106,6 +74,44 @@ func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(networkpoliciesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
+func (c *FakeNetworkPolicies) Create(networkPolicy *networking.NetworkPolicy) (result *networking.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &networking.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*networking.NetworkPolicy), err
+}
+
+// Update takes the representation of a networkPolicy and updates it. Returns the server's representation of the networkPolicy, and an error, if there is any.
+func (c *FakeNetworkPolicies) Update(networkPolicy *networking.NetworkPolicy) (result *networking.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &networking.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*networking.NetworkPolicy), err
+}
+
+// Delete takes name of the networkPolicy and deletes it. Returns an error if one occurs.
+func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &networking.NetworkPolicy{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &networking.NetworkPolicyList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched networkPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion/networkpolicy.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/networking/internalversion/networkpolicy.go
@@ -58,6 +58,41 @@ func newNetworkPolicies(c *NetworkingClient, namespace string) *networkPolicies 
 	}
 }
 
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
+func (c *networkPolicies) Get(name string, options v1.GetOptions) (result *networking.NetworkPolicy, err error) {
+	result = &networking.NetworkPolicy{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
+func (c *networkPolicies) List(opts v1.ListOptions) (result *networking.NetworkPolicyList, err error) {
+	result = &networking.NetworkPolicyList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested networkPolicies.
+func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Create(networkPolicy *networking.NetworkPolicy) (result *networking.NetworkPolicy, err error) {
 	result = &networking.NetworkPolicy{}
@@ -103,41 +138,6 @@ func (c *networkPolicies) DeleteCollection(options *v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
-func (c *networkPolicies) Get(name string, options v1.GetOptions) (result *networking.NetworkPolicy, err error) {
-	result = &networking.NetworkPolicy{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
-func (c *networkPolicies) List(opts v1.ListOptions) (result *networking.NetworkPolicyList, err error) {
-	result = &networking.NetworkPolicyList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched networkPolicy.

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/fake/fake_poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/fake/fake_poddisruptionbudget.go
@@ -36,50 +36,7 @@ var poddisruptionbudgetsResource = schema.GroupVersionResource{Group: "policy", 
 
 var poddisruptionbudgetsKind = schema.GroupVersionKind{Group: "policy", Version: "", Kind: "PodDisruptionBudget"}
 
-func (c *FakePodDisruptionBudgets) Create(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*policy.PodDisruptionBudget), err
-}
-
-func (c *FakePodDisruptionBudgets) Update(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*policy.PodDisruptionBudget), err
-}
-
-func (c *FakePodDisruptionBudgets) UpdateStatus(podDisruptionBudget *policy.PodDisruptionBudget) (*policy.PodDisruptionBudget, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(poddisruptionbudgetsResource, "status", c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*policy.PodDisruptionBudget), err
-}
-
-func (c *FakePodDisruptionBudgets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(poddisruptionbudgetsResource, c.ns, name), &policy.PodDisruptionBudget{})
-
-	return err
-}
-
-func (c *FakePodDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(poddisruptionbudgetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &policy.PodDisruptionBudgetList{})
-	return err
-}
-
+// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
 func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (result *policy.PodDisruptionBudget, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(poddisruptionbudgetsResource, c.ns, name), &policy.PodDisruptionBudget{})
@@ -90,6 +47,7 @@ func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (resu
 	return obj.(*policy.PodDisruptionBudget), err
 }
 
+// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
 func (c *FakePodDisruptionBudgets) List(opts v1.ListOptions) (result *policy.PodDisruptionBudgetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(poddisruptionbudgetsResource, poddisruptionbudgetsKind, c.ns, opts), &policy.PodDisruptionBudgetList{})
@@ -116,6 +74,56 @@ func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, 
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(poddisruptionbudgetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
+func (c *FakePodDisruptionBudgets) Create(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*policy.PodDisruptionBudget), err
+}
+
+// Update takes the representation of a podDisruptionBudget and updates it. Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
+func (c *FakePodDisruptionBudgets) Update(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*policy.PodDisruptionBudget), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakePodDisruptionBudgets) UpdateStatus(podDisruptionBudget *policy.PodDisruptionBudget) (*policy.PodDisruptionBudget, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(poddisruptionbudgetsResource, "status", c.ns, podDisruptionBudget), &policy.PodDisruptionBudget{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*policy.PodDisruptionBudget), err
+}
+
+// Delete takes name of the podDisruptionBudget and deletes it. Returns an error if one occurs.
+func (c *FakePodDisruptionBudgets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(poddisruptionbudgetsResource, c.ns, name), &policy.PodDisruptionBudget{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePodDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(poddisruptionbudgetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &policy.PodDisruptionBudgetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podDisruptionBudget.

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
@@ -85,7 +85,7 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *policy.PodDisruptionB
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
 	result = &policy.PodDisruptionBudget{}

--- a/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/policy/internalversion/poddisruptionbudget.go
@@ -59,6 +59,41 @@ func newPodDisruptionBudgets(c *PolicyClient, namespace string) *podDisruptionBu
 	}
 }
 
+// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
+func (c *podDisruptionBudgets) Get(name string, options v1.GetOptions) (result *policy.PodDisruptionBudget, err error) {
+	result = &policy.PodDisruptionBudget{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
+func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *policy.PodDisruptionBudgetList, err error) {
+	result = &policy.PodDisruptionBudgetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
+func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *podDisruptionBudgets) Create(podDisruptionBudget *policy.PodDisruptionBudget) (result *policy.PodDisruptionBudget, err error) {
 	result = &policy.PodDisruptionBudget{}
@@ -120,41 +155,6 @@ func (c *podDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
-func (c *podDisruptionBudgets) Get(name string, options v1.GetOptions) (result *policy.PodDisruptionBudget, err error) {
-	result = &policy.PodDisruptionBudget{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
-func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *policy.PodDisruptionBudgetList, err error) {
-	result = &policy.PodDisruptionBudgetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
-func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podDisruptionBudget.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrole.go
@@ -56,6 +56,38 @@ func newClusterRoles(c *RbacClient) *clusterRoles {
 	}
 }
 
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
+func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *rbac.ClusterRole, err error) {
+	result = &rbac.ClusterRole{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
+func (c *clusterRoles) List(opts v1.ListOptions) (result *rbac.ClusterRoleList, err error) {
+	result = &rbac.ClusterRoleList{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoles.
+func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
 	result = &rbac.ClusterRole{}
@@ -97,38 +129,6 @@ func (c *clusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
-func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *rbac.ClusterRole, err error) {
-	result = &rbac.ClusterRole{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
-func (c *clusterRoles) List(opts v1.ListOptions) (result *rbac.ClusterRoleList, err error) {
-	result = &rbac.ClusterRoleList{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/clusterrolebinding.go
@@ -56,6 +56,38 @@ func newClusterRoleBindings(c *RbacClient) *clusterRoleBindings {
 	}
 }
 
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
+func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *rbac.ClusterRoleBinding, err error) {
+	result = &rbac.ClusterRoleBinding{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *rbac.ClusterRoleBindingList, err error) {
+	result = &rbac.ClusterRoleBindingList{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
+func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
 	result = &rbac.ClusterRoleBinding{}
@@ -97,38 +129,6 @@ func (c *clusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
-func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *rbac.ClusterRoleBinding, err error) {
-	result = &rbac.ClusterRoleBinding{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
-func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *rbac.ClusterRoleBindingList, err error) {
-	result = &rbac.ClusterRoleBindingList{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrole.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrole.go
@@ -35,37 +35,7 @@ var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var clusterrolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "", Kind: "ClusterRole"}
 
-func (c *FakeClusterRoles) Create(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &rbac.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Update(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &rbac.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &rbac.ClusterRole{})
-	return err
-}
-
-func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &rbac.ClusterRoleList{})
-	return err
-}
-
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
 func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *rbac.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolesResource, name), &rbac.ClusterRole{})
@@ -75,6 +45,7 @@ func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *rbac
 	return obj.(*rbac.ClusterRole), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
 func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *rbac.ClusterRoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolesResource, clusterrolesKind, opts), &rbac.ClusterRoleList{})
@@ -99,6 +70,41 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *rbac.ClusterRoleLi
 func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+}
+
+// Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
+func (c *FakeClusterRoles) Create(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &rbac.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRole), err
+}
+
+// Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
+func (c *FakeClusterRoles) Update(clusterRole *rbac.ClusterRole) (result *rbac.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &rbac.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRole), err
+}
+
+// Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
+func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &rbac.ClusterRole{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &rbac.ClusterRoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_clusterrolebinding.go
@@ -35,37 +35,7 @@ var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.autho
 
 var clusterrolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "", Kind: "ClusterRoleBinding"}
 
-func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &rbac.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &rbac.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &rbac.ClusterRoleBinding{})
-	return err
-}
-
-func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &rbac.ClusterRoleBindingList{})
-	return err
-}
-
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
 func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (result *rbac.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolebindingsResource, name), &rbac.ClusterRoleBinding{})
@@ -75,6 +45,7 @@ func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (resul
 	return obj.(*rbac.ClusterRoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *rbac.ClusterRoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolebindingsResource, clusterrolebindingsKind, opts), &rbac.ClusterRoleBindingList{})
@@ -99,6 +70,41 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *rbac.Cluste
 func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+}
+
+// Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
+func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &rbac.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRoleBinding), err
+}
+
+// Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
+func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *rbac.ClusterRoleBinding) (result *rbac.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &rbac.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.ClusterRoleBinding), err
+}
+
+// Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
+func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &rbac.ClusterRoleBinding{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &rbac.ClusterRoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_role.go
@@ -36,40 +36,7 @@ var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.i
 
 var rolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "", Kind: "Role"}
 
-func (c *FakeRoles) Create(role *rbac.Role) (result *rbac.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &rbac.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.Role), err
-}
-
-func (c *FakeRoles) Update(role *rbac.Role) (result *rbac.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &rbac.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.Role), err
-}
-
-func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &rbac.Role{})
-
-	return err
-}
-
-func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &rbac.RoleList{})
-	return err
-}
-
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
 func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *rbac.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolesResource, c.ns, name), &rbac.Role{})
@@ -80,6 +47,7 @@ func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *rbac.Role, 
 	return obj.(*rbac.Role), err
 }
 
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *FakeRoles) List(opts v1.ListOptions) (result *rbac.RoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolesResource, rolesKind, c.ns, opts), &rbac.RoleList{})
@@ -106,6 +74,44 @@ func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolesResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
+func (c *FakeRoles) Create(role *rbac.Role) (result *rbac.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &rbac.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.Role), err
+}
+
+// Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
+func (c *FakeRoles) Update(role *rbac.Role) (result *rbac.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &rbac.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.Role), err
+}
+
+// Delete takes name of the role and deletes it. Returns an error if one occurs.
+func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &rbac.Role{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &rbac.RoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched role.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/fake/fake_rolebinding.go
@@ -36,40 +36,7 @@ var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var rolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "", Kind: "RoleBinding"}
 
-func (c *FakeRoleBindings) Create(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &rbac.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Update(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &rbac.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*rbac.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &rbac.RoleBinding{})
-
-	return err
-}
-
-func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &rbac.RoleBindingList{})
-	return err
-}
-
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
 func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *rbac.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolebindingsResource, c.ns, name), &rbac.RoleBinding{})
@@ -80,6 +47,7 @@ func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *rbac
 	return obj.(*rbac.RoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *rbac.RoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolebindingsResource, rolebindingsKind, c.ns, opts), &rbac.RoleBindingList{})
@@ -106,6 +74,44 @@ func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolebindingsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
+func (c *FakeRoleBindings) Create(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &rbac.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.RoleBinding), err
+}
+
+// Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
+func (c *FakeRoleBindings) Update(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &rbac.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*rbac.RoleBinding), err
+}
+
+// Delete takes name of the roleBinding and deletes it. Returns an error if one occurs.
+func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &rbac.RoleBinding{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &rbac.RoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/role.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/role.go
@@ -58,6 +58,41 @@ func newRoles(c *RbacClient, namespace string) *roles {
 	}
 }
 
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
+func (c *roles) Get(name string, options v1.GetOptions) (result *rbac.Role, err error) {
+	result = &rbac.Role{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) List(opts v1.ListOptions) (result *rbac.RoleList, err error) {
+	result = &rbac.RoleList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roles.
+func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *rbac.Role) (result *rbac.Role, err error) {
 	result = &rbac.Role{}
@@ -103,41 +138,6 @@ func (c *roles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
-func (c *roles) Get(name string, options v1.GetOptions) (result *rbac.Role, err error) {
-	result = &rbac.Role{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Roles that match those selectors.
-func (c *roles) List(opts v1.ListOptions) (result *rbac.RoleList, err error) {
-	result = &rbac.RoleList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched role.

--- a/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/rolebinding.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/rbac/internalversion/rolebinding.go
@@ -58,6 +58,41 @@ func newRoleBindings(c *RbacClient, namespace string) *roleBindings {
 	}
 }
 
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
+func (c *roleBindings) Get(name string, options v1.GetOptions) (result *rbac.RoleBinding, err error) {
+	result = &rbac.RoleBinding{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) List(opts v1.ListOptions) (result *rbac.RoleBindingList, err error) {
+	result = &rbac.RoleBindingList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roleBindings.
+func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *rbac.RoleBinding) (result *rbac.RoleBinding, err error) {
 	result = &rbac.RoleBinding{}
@@ -103,41 +138,6 @@ func (c *roleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
-func (c *roleBindings) Get(name string, options v1.GetOptions) (result *rbac.RoleBinding, err error) {
-	result = &rbac.RoleBinding{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
-func (c *roleBindings) List(opts v1.ListOptions) (result *rbac.RoleBindingList, err error) {
-	result = &rbac.RoleBindingList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion/fake/fake_priorityclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion/fake/fake_priorityclass.go
@@ -35,37 +35,7 @@ var priorityclassesResource = schema.GroupVersionResource{Group: "scheduling.k8s
 
 var priorityclassesKind = schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: "", Kind: "PriorityClass"}
 
-func (c *FakePriorityClasses) Create(priorityClass *scheduling.PriorityClass) (result *scheduling.PriorityClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(priorityclassesResource, priorityClass), &scheduling.PriorityClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*scheduling.PriorityClass), err
-}
-
-func (c *FakePriorityClasses) Update(priorityClass *scheduling.PriorityClass) (result *scheduling.PriorityClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(priorityclassesResource, priorityClass), &scheduling.PriorityClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*scheduling.PriorityClass), err
-}
-
-func (c *FakePriorityClasses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(priorityclassesResource, name), &scheduling.PriorityClass{})
-	return err
-}
-
-func (c *FakePriorityClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(priorityclassesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &scheduling.PriorityClassList{})
-	return err
-}
-
+// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
 func (c *FakePriorityClasses) Get(name string, options v1.GetOptions) (result *scheduling.PriorityClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(priorityclassesResource, name), &scheduling.PriorityClass{})
@@ -75,6 +45,7 @@ func (c *FakePriorityClasses) Get(name string, options v1.GetOptions) (result *s
 	return obj.(*scheduling.PriorityClass), err
 }
 
+// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
 func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *scheduling.PriorityClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(priorityclassesResource, priorityclassesKind, opts), &scheduling.PriorityClassList{})
@@ -99,6 +70,41 @@ func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *scheduling.Prio
 func (c *FakePriorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(priorityclassesResource, opts))
+}
+
+// Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
+func (c *FakePriorityClasses) Create(priorityClass *scheduling.PriorityClass) (result *scheduling.PriorityClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(priorityclassesResource, priorityClass), &scheduling.PriorityClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*scheduling.PriorityClass), err
+}
+
+// Update takes the representation of a priorityClass and updates it. Returns the server's representation of the priorityClass, and an error, if there is any.
+func (c *FakePriorityClasses) Update(priorityClass *scheduling.PriorityClass) (result *scheduling.PriorityClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(priorityclassesResource, priorityClass), &scheduling.PriorityClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*scheduling.PriorityClass), err
+}
+
+// Delete takes name of the priorityClass and deletes it. Returns an error if one occurs.
+func (c *FakePriorityClasses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(priorityclassesResource, name), &scheduling.PriorityClass{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePriorityClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(priorityclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &scheduling.PriorityClassList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched priorityClass.

--- a/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion/priorityclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/scheduling/internalversion/priorityclass.go
@@ -56,6 +56,38 @@ func newPriorityClasses(c *SchedulingClient) *priorityClasses {
 	}
 }
 
+// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
+func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *scheduling.PriorityClass, err error) {
+	result = &scheduling.PriorityClass{}
+	err = c.client.Get().
+		Resource("priorityclasses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
+func (c *priorityClasses) List(opts v1.ListOptions) (result *scheduling.PriorityClassList, err error) {
+	result = &scheduling.PriorityClassList{}
+	err = c.client.Get().
+		Resource("priorityclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested priorityClasses.
+func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("priorityclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Create(priorityClass *scheduling.PriorityClass) (result *scheduling.PriorityClass, err error) {
 	result = &scheduling.PriorityClass{}
@@ -97,38 +129,6 @@ func (c *priorityClasses) DeleteCollection(options *v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
-func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *scheduling.PriorityClass, err error) {
-	result = &scheduling.PriorityClass{}
-	err = c.client.Get().
-		Resource("priorityclasses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
-func (c *priorityClasses) List(opts v1.ListOptions) (result *scheduling.PriorityClassList, err error) {
-	result = &scheduling.PriorityClassList{}
-	err = c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched priorityClass.

--- a/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/fake/fake_podpreset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/fake/fake_podpreset.go
@@ -36,40 +36,7 @@ var podpresetsResource = schema.GroupVersionResource{Group: "settings.k8s.io", V
 
 var podpresetsKind = schema.GroupVersionKind{Group: "settings.k8s.io", Version: "", Kind: "PodPreset"}
 
-func (c *FakePodPresets) Create(podPreset *settings.PodPreset) (result *settings.PodPreset, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podpresetsResource, c.ns, podPreset), &settings.PodPreset{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*settings.PodPreset), err
-}
-
-func (c *FakePodPresets) Update(podPreset *settings.PodPreset) (result *settings.PodPreset, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podpresetsResource, c.ns, podPreset), &settings.PodPreset{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*settings.PodPreset), err
-}
-
-func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podpresetsResource, c.ns, name), &settings.PodPreset{})
-
-	return err
-}
-
-func (c *FakePodPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podpresetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &settings.PodPresetList{})
-	return err
-}
-
+// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
 func (c *FakePodPresets) Get(name string, options v1.GetOptions) (result *settings.PodPreset, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podpresetsResource, c.ns, name), &settings.PodPreset{})
@@ -80,6 +47,7 @@ func (c *FakePodPresets) Get(name string, options v1.GetOptions) (result *settin
 	return obj.(*settings.PodPreset), err
 }
 
+// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
 func (c *FakePodPresets) List(opts v1.ListOptions) (result *settings.PodPresetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podpresetsResource, podpresetsKind, c.ns, opts), &settings.PodPresetList{})
@@ -106,6 +74,44 @@ func (c *FakePodPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podpresetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
+func (c *FakePodPresets) Create(podPreset *settings.PodPreset) (result *settings.PodPreset, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(podpresetsResource, c.ns, podPreset), &settings.PodPreset{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*settings.PodPreset), err
+}
+
+// Update takes the representation of a podPreset and updates it. Returns the server's representation of the podPreset, and an error, if there is any.
+func (c *FakePodPresets) Update(podPreset *settings.PodPreset) (result *settings.PodPreset, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podpresetsResource, c.ns, podPreset), &settings.PodPreset{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*settings.PodPreset), err
+}
+
+// Delete takes name of the podPreset and deletes it. Returns an error if one occurs.
+func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podpresetsResource, c.ns, name), &settings.PodPreset{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePodPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podpresetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &settings.PodPresetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podPreset.

--- a/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/podpreset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/settings/internalversion/podpreset.go
@@ -58,6 +58,41 @@ func newPodPresets(c *SettingsClient, namespace string) *podPresets {
 	}
 }
 
+// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
+func (c *podPresets) Get(name string, options v1.GetOptions) (result *settings.PodPreset, err error) {
+	result = &settings.PodPreset{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
+func (c *podPresets) List(opts v1.ListOptions) (result *settings.PodPresetList, err error) {
+	result = &settings.PodPresetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podPresets.
+func (c *podPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *podPresets) Create(podPreset *settings.PodPreset) (result *settings.PodPreset, err error) {
 	result = &settings.PodPreset{}
@@ -103,41 +138,6 @@ func (c *podPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
-func (c *podPresets) Get(name string, options v1.GetOptions) (result *settings.PodPreset, err error) {
-	result = &settings.PodPreset{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
-func (c *podPresets) List(opts v1.ListOptions) (result *settings.PodPresetList, err error) {
-	result = &settings.PodPresetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podPresets.
-func (c *podPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podPreset.

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/fake/fake_storageclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/fake/fake_storageclass.go
@@ -35,37 +35,7 @@ var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io"
 
 var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Version: "", Kind: "StorageClass"}
 
-func (c *FakeStorageClasses) Create(storageClass *storage.StorageClass) (result *storage.StorageClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &storage.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*storage.StorageClass), err
-}
-
-func (c *FakeStorageClasses) Update(storageClass *storage.StorageClass) (result *storage.StorageClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &storage.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*storage.StorageClass), err
-}
-
-func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &storage.StorageClass{})
-	return err
-}
-
-func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &storage.StorageClassList{})
-	return err
-}
-
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *storage.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(storageclassesResource, name), &storage.StorageClass{})
@@ -75,6 +45,7 @@ func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *st
 	return obj.(*storage.StorageClass), err
 }
 
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storage.StorageClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &storage.StorageClassList{})
@@ -99,6 +70,41 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storage.StorageC
 func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+}
+
+// Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *FakeStorageClasses) Create(storageClass *storage.StorageClass) (result *storage.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &storage.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*storage.StorageClass), err
+}
+
+// Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
+func (c *FakeStorageClasses) Update(storageClass *storage.StorageClass) (result *storage.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &storage.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*storage.StorageClass), err
+}
+
+// Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
+func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &storage.StorageClass{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &storage.StorageClassList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched storageClass.

--- a/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/storageclass.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/storage/internalversion/storageclass.go
@@ -56,6 +56,38 @@ func newStorageClasses(c *StorageClient) *storageClasses {
 	}
 }
 
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
+func (c *storageClasses) Get(name string, options v1.GetOptions) (result *storage.StorageClass, err error) {
+	result = &storage.StorageClass{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) List(opts v1.ListOptions) (result *storage.StorageClassList, err error) {
+	result = &storage.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Create(storageClass *storage.StorageClass) (result *storage.StorageClass, err error) {
 	result = &storage.StorageClass{}
@@ -97,38 +129,6 @@ func (c *storageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
-func (c *storageClasses) Get(name string, options v1.GetOptions) (result *storage.StorageClass, err error) {
-	result = &storage.StorageClass{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
-func (c *storageClasses) List(opts v1.ListOptions) (result *storage.StorageClassList, err error) {
-	result = &storage.StorageClassList{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched storageClass.

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // InitializerConfiguration describes the configuration of initializers.
@@ -123,8 +123,8 @@ const (
 	Fail FailurePolicyType = "Fail"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ExternalAdmissionHookConfiguration describes the configuration of initializers.

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -56,8 +56,8 @@ type ScaleStatus struct {
 	TargetSelector string `json:"targetSelector,omitempty" protobuf:"bytes,3,opt,name=targetSelector"`
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Scale represents a scaling request for a resource.
@@ -76,7 +76,7 @@ type Scale struct {
 	Status ScaleStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StatefulSet represents a set of pods with consistent identities.
@@ -253,7 +253,7 @@ type StatefulSetList struct {
 	Items           []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
@@ -487,7 +487,7 @@ type DeploymentList struct {
 	Items []Deployment `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ControllerRevision implements an immutable snapshot of state data. Clients

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -57,7 +57,7 @@ type ScaleStatus struct {
 	TargetSelector string `json:"targetSelector,omitempty" protobuf:"bytes,3,opt,name=targetSelector"`
 }
 
-// +genclient=true
+// +genclient
 // +noMethods=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -78,7 +78,7 @@ type Scale struct {
 	Status ScaleStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WIP: This is not ready to be used and we plan to make breaking changes to it.
@@ -261,7 +261,7 @@ type StatefulSetList struct {
 	Items           []StatefulSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WIP: This is not ready to be used and we plan to make breaking changes to it.

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -58,7 +58,7 @@ type ScaleStatus struct {
 }
 
 // +genclient
-// +noMethods=true
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WIP: This is not ready to be used and we plan to make breaking changes to it.

--- a/staging/src/k8s.io/api/authentication/v1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1/types.go
@@ -37,9 +37,9 @@ const (
 	ImpersonateUserExtraHeaderPrefix = "Impersonate-Extra-"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TokenReview attempts to authenticate a token to a known user.

--- a/staging/src/k8s.io/api/authentication/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/types.go
@@ -22,9 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // TokenReview attempts to authenticate a token to a known user.

--- a/staging/src/k8s.io/api/authorization/v1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1/types.go
@@ -22,9 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
@@ -41,9 +41,9 @@ type SubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
@@ -62,8 +62,8 @@ type SelfSubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -22,9 +22,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
@@ -41,9 +41,9 @@ type SubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
@@ -62,8 +62,8 @@ type SelfSubjectAccessReview struct {
 	Status SubjectAccessReviewStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.

--- a/staging/src/k8s.io/api/autoscaling/v1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/types.go
@@ -72,7 +72,7 @@ type HorizontalPodAutoscalerStatus struct {
 	CurrentCPUUtilizationPercentage *int32 `json:"currentCPUUtilizationPercentage,omitempty" protobuf:"varint,5,opt,name=currentCPUUtilizationPercentage"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // configuration of a horizontal pod autoscaler.

--- a/staging/src/k8s.io/api/autoscaling/v2alpha1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2alpha1/types.go
@@ -275,7 +275,7 @@ type ResourceMetricStatus struct {
 	CurrentAverageValue resource.Quantity `json:"currentAverageValue" protobuf:"bytes,3,name=currentAverageValue"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // HorizontalPodAutoscaler is the configuration for a horizontal pod

--- a/staging/src/k8s.io/api/batch/v1/types.go
+++ b/staging/src/k8s.io/api/batch/v1/types.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Job represents the configuration of a single job.

--- a/staging/src/k8s.io/api/batch/v2alpha1/types.go
+++ b/staging/src/k8s.io/api/batch/v2alpha1/types.go
@@ -51,7 +51,7 @@ type JobTemplateSpec struct {
 	Spec batchv1.JobSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CronJob represents the configuration of a single cron job.

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -22,8 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Describes a certificate signing request

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -464,8 +464,8 @@ const (
 	AlphaStorageNodeAffinityAnnotation = "volume.alpha.kubernetes.io/node-affinity"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PersistentVolume (PV) is a storage resource provisioned by an administrator.
@@ -566,7 +566,7 @@ type PersistentVolumeList struct {
 	Items []PersistentVolume `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PersistentVolumeClaim is a user's request for and claim to a persistent volume
@@ -2677,7 +2677,7 @@ type PodStatusResult struct {
 	Status PodStatus `json:"status,omitempty" protobuf:"bytes,2,opt,name=status"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Pod is a collection of containers that can run on a host. This resource is created
@@ -2731,7 +2731,7 @@ type PodTemplateSpec struct {
 	Spec PodSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodTemplate describes a template for creating copies of a predefined pod.
@@ -2855,7 +2855,7 @@ type ReplicationControllerCondition struct {
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationController represents the configuration of a replication controller.
@@ -3109,7 +3109,7 @@ type ServicePort struct {
 	NodePort int32 `json:"nodePort,omitempty" protobuf:"varint,5,opt,name=nodePort"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Service is a named abstraction of software service (for example, mysql) consisting of local port
@@ -3155,7 +3155,7 @@ type ServiceList struct {
 	Items []Service `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceAccount binds together:
@@ -3204,7 +3204,7 @@ type ServiceAccountList struct {
 	Items []ServiceAccount `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Endpoints is a collection of endpoints that implement the actual service. Example:
@@ -3587,8 +3587,8 @@ const (
 // ResourceList is a set of (resource name, quantity) pairs.
 type ResourceList map[ResourceName]resource.Quantity
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Node is a worker node in Kubernetes.
@@ -3662,8 +3662,8 @@ const (
 	NamespaceTerminating NamespacePhase = "Terminating"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Namespace provides a scope for Names.
@@ -4057,7 +4057,7 @@ const (
 	EventTypeWarning string = "Warning"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Event is a report of an event somewhere in the cluster.
@@ -4171,7 +4171,7 @@ type LimitRangeSpec struct {
 	Limits []LimitRangeItem `json:"limits" protobuf:"bytes,1,rep,name=limits"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // LimitRange sets resource usage limits for each kind of resource in a Namespace.
@@ -4272,7 +4272,7 @@ type ResourceQuotaStatus struct {
 	Used ResourceList `json:"used,omitempty" protobuf:"bytes,2,rep,name=used,casttype=ResourceList,castkey=ResourceName"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ResourceQuota sets aggregate quota restrictions enforced per namespace
@@ -4309,7 +4309,7 @@ type ResourceQuotaList struct {
 	Items []ResourceQuota `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Secret holds secret data of a certain type. The total bytes of the values in
@@ -4439,7 +4439,7 @@ type SecretList struct {
 	Items []Secret `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ConfigMap holds configuration data for pods to consume.
@@ -4496,8 +4496,8 @@ type ComponentCondition struct {
 	Error string `json:"error,omitempty" protobuf:"bytes,4,opt,name=error"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ComponentStatus (and ComponentStatusList) holds the cluster validation info.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -50,8 +50,8 @@ type ScaleStatus struct {
 	TargetSelector string `json:"targetSelector,omitempty" protobuf:"bytes,3,opt,name=targetSelector"`
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // represents a scaling request for a resource.
@@ -100,8 +100,8 @@ type CustomMetricCurrentStatusList struct {
 	Items []CustomMetricCurrentStatus `json:"items" protobuf:"bytes,1,rep,name=items"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
@@ -157,7 +157,7 @@ type ThirdPartyResourceData struct {
 	Data []byte `json:"data,omitempty" protobuf:"bytes,2,opt,name=data"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
@@ -524,7 +524,7 @@ type DaemonSetStatus struct {
 	CollisionCount *int64 `json:"collisionCount,omitempty" protobuf:"varint,9,opt,name=collisionCount"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DaemonSet represents the configuration of a daemon set.
@@ -590,7 +590,7 @@ type ThirdPartyResourceDataList struct {
 	Items []ThirdPartyResourceData `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Ingress is a collection of rules that allow inbound connections to reach the
@@ -759,7 +759,7 @@ type IngressBackend struct {
 	ServicePort intstr.IntOrString `json:"servicePort" protobuf:"bytes,2,opt,name=servicePort"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicaSet represents the configuration of a ReplicaSet.
@@ -886,8 +886,8 @@ type ReplicaSetCondition struct {
 	Message string `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Pod Security Policy governs the ability to make requests that affect the Security Context

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/types.go
@@ -20,9 +20,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
-// +noMethods=true
+// +genclient
+// +genclient:nonNamespaced
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ImageReview checks if the set of images in a pod are allowed.

--- a/staging/src/k8s.io/api/networking/v1/types.go
+++ b/staging/src/k8s.io/api/networking/v1/types.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // NetworkPolicy describes what network traffic is allowed for a set of Pods

--- a/staging/src/k8s.io/api/policy/v1beta1/types.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/types.go
@@ -74,7 +74,7 @@ type PodDisruptionBudgetStatus struct {
 	ExpectedPods int32 `json:"expectedPods" protobuf:"varint,6,opt,name=expectedPods"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods
@@ -97,8 +97,8 @@ type PodDisruptionBudgetList struct {
 	Items           []PodDisruptionBudget `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
-// +noMethods=true
+// +genclient
+// +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Eviction evicts a pod from its node subject to certain policies and safety constraints.

--- a/staging/src/k8s.io/api/rbac/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/types.go
@@ -99,7 +99,7 @@ type RoleRef struct {
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
@@ -113,7 +113,7 @@ type Role struct {
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace.
@@ -159,8 +159,8 @@ type RoleList struct {
 	Items []Role `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -174,8 +174,8 @@ type ClusterRole struct {
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace,

--- a/staging/src/k8s.io/api/rbac/v1beta1/types.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/types.go
@@ -97,7 +97,7 @@ type RoleRef struct {
 	Name string `json:"name" protobuf:"bytes,3,opt,name=name"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.
@@ -111,7 +111,7 @@ type Role struct {
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace.
@@ -157,8 +157,8 @@ type RoleList struct {
 	Items []Role `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.
@@ -172,8 +172,8 @@ type ClusterRole struct {
 	Rules []PolicyRule `json:"rules" protobuf:"bytes,2,rep,name=rules"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace,

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PriorityClass defines mapping from a priority class name to the priority

--- a/staging/src/k8s.io/api/settings/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/settings/v1alpha1/types.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // PodPreset is a policy resource that defines additional runtime

--- a/staging/src/k8s.io/api/storage/v1/types.go
+++ b/staging/src/k8s.io/api/storage/v1/types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageClass describes the parameters for a class of storage for

--- a/staging/src/k8s.io/api/storage/v1beta1/types.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/types.go
@@ -20,8 +20,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StorageClass describes the parameters for a class of storage for

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/types.go
@@ -113,8 +113,8 @@ type CustomResourceDefinitionStatus struct {
 // a CustomResourceDefinition
 const CustomResourceCleanupFinalizer = "customresourcecleanup.apiextensions.k8s.io"
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -113,8 +113,8 @@ type CustomResourceDefinitionStatus struct {
 // a CustomResourceDefinition
 const CustomResourceCleanupFinalizer = "customresourcecleanup.apiextensions.k8s.io"
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -81,7 +81,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *v1beta1.Cus
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -57,6 +57,38 @@ func newCustomResourceDefinitions(c *ApiextensionsV1beta1Client) *customResource
 	}
 }
 
+// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
+func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (result *v1beta1.CustomResourceDefinition, err error) {
+	result = &v1beta1.CustomResourceDefinition{}
+	err = c.client.Get().
+		Resource("customresourcedefinitions").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
+func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
+	result = &v1beta1.CustomResourceDefinitionList{}
+	err = c.client.Get().
+		Resource("customresourcedefinitions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
+func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("customresourcedefinitions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Create(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
 	result = &v1beta1.CustomResourceDefinition{}
@@ -113,38 +145,6 @@ func (c *customResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
-func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (result *v1beta1.CustomResourceDefinition, err error) {
-	result = &v1beta1.CustomResourceDefinition{}
-	err = c.client.Get().
-		Resource("customresourcedefinitions").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
-func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
-	result = &v1beta1.CustomResourceDefinitionList{}
-	err = c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched customResourceDefinition.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
@@ -35,46 +35,7 @@ var customresourcedefinitionsResource = schema.GroupVersionResource{Group: "apie
 
 var customresourcedefinitionsKind = schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "v1beta1", Kind: "CustomResourceDefinition"}
 
-func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &v1beta1.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &v1beta1.CustomResourceDefinition{})
-	return err
-}
-
-func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.CustomResourceDefinitionList{})
-	return err
-}
-
+// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
 func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) (result *v1beta1.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(customresourcedefinitionsResource, name), &v1beta1.CustomResourceDefinition{})
@@ -84,6 +45,7 @@ func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) 
 	return obj.(*v1beta1.CustomResourceDefinition), err
 }
 
+// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
 func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.CustomResourceDefinitionList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts), &v1beta1.CustomResourceDefinitionList{})
@@ -108,6 +70,52 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *v1bet
 func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+}
+
+// Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
+func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.CustomResourceDefinition), err
+}
+
+// Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
+func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *v1beta1.CustomResourceDefinition) (result *v1beta1.CustomResourceDefinition, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.CustomResourceDefinition), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *v1beta1.CustomResourceDefinition) (*v1beta1.CustomResourceDefinition, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &v1beta1.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.CustomResourceDefinition), err
+}
+
+// Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
+func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &v1beta1.CustomResourceDefinition{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.CustomResourceDefinitionList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched customResourceDefinition.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -81,7 +81,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *apiextensio
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/customresourcedefinition.go
@@ -57,6 +57,38 @@ func newCustomResourceDefinitions(c *ApiextensionsClient) *customResourceDefinit
 	}
 }
 
+// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
+func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (result *apiextensions.CustomResourceDefinition, err error) {
+	result = &apiextensions.CustomResourceDefinition{}
+	err = c.client.Get().
+		Resource("customresourcedefinitions").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
+func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextensions.CustomResourceDefinitionList, err error) {
+	result = &apiextensions.CustomResourceDefinitionList{}
+	err = c.client.Get().
+		Resource("customresourcedefinitions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
+func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("customresourcedefinitions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
 func (c *customResourceDefinitions) Create(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
 	result = &apiextensions.CustomResourceDefinition{}
@@ -113,38 +145,6 @@ func (c *customResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
-func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (result *apiextensions.CustomResourceDefinition, err error) {
-	result = &apiextensions.CustomResourceDefinition{}
-	err = c.client.Get().
-		Resource("customresourcedefinitions").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
-func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *apiextensions.CustomResourceDefinitionList, err error) {
-	result = &apiextensions.CustomResourceDefinitionList{}
-	err = c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested customResourceDefinitions.
-func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("customresourcedefinitions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched customResourceDefinition.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/fake/fake_customresourcedefinition.go
@@ -35,46 +35,7 @@ var customresourcedefinitionsResource = schema.GroupVersionResource{Group: "apie
 
 var customresourcedefinitionsKind = schema.GroupVersionKind{Group: "apiextensions.k8s.io", Version: "", Kind: "CustomResourceDefinition"}
 
-func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiextensions.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiextensions.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &apiextensions.CustomResourceDefinition{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiextensions.CustomResourceDefinition), err
-}
-
-func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &apiextensions.CustomResourceDefinition{})
-	return err
-}
-
-func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &apiextensions.CustomResourceDefinitionList{})
-	return err
-}
-
+// Get takes name of the customResourceDefinition, and returns the corresponding customResourceDefinition object, and an error if there is any.
 func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) (result *apiextensions.CustomResourceDefinition, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(customresourcedefinitionsResource, name), &apiextensions.CustomResourceDefinition{})
@@ -84,6 +45,7 @@ func (c *FakeCustomResourceDefinitions) Get(name string, options v1.GetOptions) 
 	return obj.(*apiextensions.CustomResourceDefinition), err
 }
 
+// List takes label and field selectors, and returns the list of CustomResourceDefinitions that match those selectors.
 func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *apiextensions.CustomResourceDefinitionList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(customresourcedefinitionsResource, customresourcedefinitionsKind, opts), &apiextensions.CustomResourceDefinitionList{})
@@ -108,6 +70,52 @@ func (c *FakeCustomResourceDefinitions) List(opts v1.ListOptions) (result *apiex
 func (c *FakeCustomResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(customresourcedefinitionsResource, opts))
+}
+
+// Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
+func (c *FakeCustomResourceDefinitions) Create(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiextensions.CustomResourceDefinition), err
+}
+
+// Update takes the representation of a customResourceDefinition and updates it. Returns the server's representation of the customResourceDefinition, and an error, if there is any.
+func (c *FakeCustomResourceDefinitions) Update(customResourceDefinition *apiextensions.CustomResourceDefinition) (result *apiextensions.CustomResourceDefinition, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(customresourcedefinitionsResource, customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiextensions.CustomResourceDefinition), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeCustomResourceDefinitions) UpdateStatus(customResourceDefinition *apiextensions.CustomResourceDefinition) (*apiextensions.CustomResourceDefinition, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(customresourcedefinitionsResource, "status", customResourceDefinition), &apiextensions.CustomResourceDefinition{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiextensions.CustomResourceDefinition), err
+}
+
+// Delete takes name of the customResourceDefinition and deletes it. Returns an error if one occurs.
+func (c *FakeCustomResourceDefinitions) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(customresourcedefinitionsResource, name), &apiextensions.CustomResourceDefinition{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeCustomResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(customresourcedefinitionsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &apiextensions.CustomResourceDefinitionList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched customResourceDefinition.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -56,6 +56,38 @@ func newExternalAdmissionHookConfigurations(c *AdmissionregistrationV1alpha1Clie
 	}
 }
 
+// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
+func (c *externalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
+	result = &v1alpha1.ExternalAdmissionHookConfiguration{}
+	err = c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
+func (c *externalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *v1alpha1.ExternalAdmissionHookConfigurationList, err error) {
+	result = &v1alpha1.ExternalAdmissionHookConfigurationList{}
+	err = c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested externalAdmissionHookConfigurations.
+func (c *externalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("externaladmissionhookconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a externalAdmissionHookConfiguration and creates it.  Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
 func (c *externalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	result = &v1alpha1.ExternalAdmissionHookConfiguration{}
@@ -97,38 +129,6 @@ func (c *externalAdmissionHookConfigurations) DeleteCollection(options *v1.Delet
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
-func (c *externalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
-	result = &v1alpha1.ExternalAdmissionHookConfiguration{}
-	err = c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
-func (c *externalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *v1alpha1.ExternalAdmissionHookConfigurationList, err error) {
-	result = &v1alpha1.ExternalAdmissionHookConfigurationList{}
-	err = c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested externalAdmissionHookConfigurations.
-func (c *externalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("externaladmissionhookconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched externalAdmissionHookConfiguration.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_externaladmissionhookconfiguration.go
@@ -35,6 +35,7 @@ var externaladmissionhookconfigurationsResource = schema.GroupVersionResource{Gr
 
 var externaladmissionhookconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Kind: "ExternalAdmissionHookConfiguration"}
 
+// Get takes name of the externalAdmissionHookConfiguration, and returns the corresponding externalAdmissionHookConfiguration object, and an error if there is any.
 func (c *FakeExternalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(externaladmissionhookconfigurationsResource, name), &v1alpha1.ExternalAdmissionHookConfiguration{})
@@ -44,6 +45,7 @@ func (c *FakeExternalAdmissionHookConfigurations) Get(name string, options v1.Ge
 	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
 }
 
+// List takes label and field selectors, and returns the list of ExternalAdmissionHookConfigurations that match those selectors.
 func (c *FakeExternalAdmissionHookConfigurations) List(opts v1.ListOptions) (result *v1alpha1.ExternalAdmissionHookConfigurationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(externaladmissionhookconfigurationsResource, externaladmissionhookconfigurationsKind, opts), &v1alpha1.ExternalAdmissionHookConfigurationList{})
@@ -70,6 +72,7 @@ func (c *FakeExternalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (wa
 		InvokesWatch(testing.NewRootWatchAction(externaladmissionhookconfigurationsResource, opts))
 }
 
+// Create takes the representation of a externalAdmissionHookConfiguration and creates it.  Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
 func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
@@ -79,6 +82,7 @@ func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookCo
 	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
 }
 
+// Update takes the representation of a externalAdmissionHookConfiguration and updates it. Returns the server's representation of the externalAdmissionHookConfiguration, and an error, if there is any.
 func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
@@ -88,12 +92,14 @@ func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookCo
 	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
 }
 
+// Delete takes name of the externalAdmissionHookConfiguration and deletes it. Returns an error if one occurs.
 func (c *FakeExternalAdmissionHookConfigurations) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(externaladmissionhookconfigurationsResource, name), &v1alpha1.ExternalAdmissionHookConfiguration{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeExternalAdmissionHookConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(externaladmissionhookconfigurationsResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_externaladmissionhookconfiguration.go
@@ -35,37 +35,6 @@ var externaladmissionhookconfigurationsResource = schema.GroupVersionResource{Gr
 
 var externaladmissionhookconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Kind: "ExternalAdmissionHookConfiguration"}
 
-func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(externaladmissionhookconfigurationsResource, name), &v1alpha1.ExternalAdmissionHookConfiguration{})
-	return err
-}
-
-func (c *FakeExternalAdmissionHookConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(externaladmissionhookconfigurationsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.ExternalAdmissionHookConfigurationList{})
-	return err
-}
-
 func (c *FakeExternalAdmissionHookConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(externaladmissionhookconfigurationsResource, name), &v1alpha1.ExternalAdmissionHookConfiguration{})
@@ -99,6 +68,37 @@ func (c *FakeExternalAdmissionHookConfigurations) List(opts v1.ListOptions) (res
 func (c *FakeExternalAdmissionHookConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(externaladmissionhookconfigurationsResource, opts))
+}
+
+func (c *FakeExternalAdmissionHookConfigurations) Create(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
+}
+
+func (c *FakeExternalAdmissionHookConfigurations) Update(externalAdmissionHookConfiguration *v1alpha1.ExternalAdmissionHookConfiguration) (result *v1alpha1.ExternalAdmissionHookConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(externaladmissionhookconfigurationsResource, externalAdmissionHookConfiguration), &v1alpha1.ExternalAdmissionHookConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ExternalAdmissionHookConfiguration), err
+}
+
+func (c *FakeExternalAdmissionHookConfigurations) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(externaladmissionhookconfigurationsResource, name), &v1alpha1.ExternalAdmissionHookConfiguration{})
+	return err
+}
+
+func (c *FakeExternalAdmissionHookConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(externaladmissionhookconfigurationsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.ExternalAdmissionHookConfigurationList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched externalAdmissionHookConfiguration.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_initializerconfiguration.go
@@ -35,6 +35,7 @@ var initializerconfigurationsResource = schema.GroupVersionResource{Group: "admi
 
 var initializerconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Kind: "InitializerConfiguration"}
 
+// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
 func (c *FakeInitializerConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.InitializerConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(initializerconfigurationsResource, name), &v1alpha1.InitializerConfiguration{})
@@ -44,6 +45,7 @@ func (c *FakeInitializerConfigurations) Get(name string, options v1.GetOptions) 
 	return obj.(*v1alpha1.InitializerConfiguration), err
 }
 
+// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
 func (c *FakeInitializerConfigurations) List(opts v1.ListOptions) (result *v1alpha1.InitializerConfigurationList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(initializerconfigurationsResource, initializerconfigurationsKind, opts), &v1alpha1.InitializerConfigurationList{})
@@ -70,6 +72,7 @@ func (c *FakeInitializerConfigurations) Watch(opts v1.ListOptions) (watch.Interf
 		InvokesWatch(testing.NewRootWatchAction(initializerconfigurationsResource, opts))
 }
 
+// Create takes the representation of a initializerConfiguration and creates it.  Returns the server's representation of the initializerConfiguration, and an error, if there is any.
 func (c *FakeInitializerConfigurations) Create(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
@@ -79,6 +82,7 @@ func (c *FakeInitializerConfigurations) Create(initializerConfiguration *v1alpha
 	return obj.(*v1alpha1.InitializerConfiguration), err
 }
 
+// Update takes the representation of a initializerConfiguration and updates it. Returns the server's representation of the initializerConfiguration, and an error, if there is any.
 func (c *FakeInitializerConfigurations) Update(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
@@ -88,12 +92,14 @@ func (c *FakeInitializerConfigurations) Update(initializerConfiguration *v1alpha
 	return obj.(*v1alpha1.InitializerConfiguration), err
 }
 
+// Delete takes name of the initializerConfiguration and deletes it. Returns an error if one occurs.
 func (c *FakeInitializerConfigurations) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(initializerconfigurationsResource, name), &v1alpha1.InitializerConfiguration{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeInitializerConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(initializerconfigurationsResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/fake/fake_initializerconfiguration.go
@@ -35,37 +35,6 @@ var initializerconfigurationsResource = schema.GroupVersionResource{Group: "admi
 
 var initializerconfigurationsKind = schema.GroupVersionKind{Group: "admissionregistration.k8s.io", Version: "v1alpha1", Kind: "InitializerConfiguration"}
 
-func (c *FakeInitializerConfigurations) Create(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.InitializerConfiguration), err
-}
-
-func (c *FakeInitializerConfigurations) Update(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.InitializerConfiguration), err
-}
-
-func (c *FakeInitializerConfigurations) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(initializerconfigurationsResource, name), &v1alpha1.InitializerConfiguration{})
-	return err
-}
-
-func (c *FakeInitializerConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(initializerconfigurationsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.InitializerConfigurationList{})
-	return err
-}
-
 func (c *FakeInitializerConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.InitializerConfiguration, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(initializerconfigurationsResource, name), &v1alpha1.InitializerConfiguration{})
@@ -99,6 +68,37 @@ func (c *FakeInitializerConfigurations) List(opts v1.ListOptions) (result *v1alp
 func (c *FakeInitializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(initializerconfigurationsResource, opts))
+}
+
+func (c *FakeInitializerConfigurations) Create(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.InitializerConfiguration), err
+}
+
+func (c *FakeInitializerConfigurations) Update(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(initializerconfigurationsResource, initializerConfiguration), &v1alpha1.InitializerConfiguration{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.InitializerConfiguration), err
+}
+
+func (c *FakeInitializerConfigurations) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(initializerconfigurationsResource, name), &v1alpha1.InitializerConfiguration{})
+	return err
+}
+
+func (c *FakeInitializerConfigurations) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(initializerconfigurationsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.InitializerConfigurationList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched initializerConfiguration.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -56,6 +56,38 @@ func newInitializerConfigurations(c *AdmissionregistrationV1alpha1Client) *initi
 	}
 }
 
+// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
+func (c *initializerConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.InitializerConfiguration, err error) {
+	result = &v1alpha1.InitializerConfiguration{}
+	err = c.client.Get().
+		Resource("initializerconfigurations").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
+func (c *initializerConfigurations) List(opts v1.ListOptions) (result *v1alpha1.InitializerConfigurationList, err error) {
+	result = &v1alpha1.InitializerConfigurationList{}
+	err = c.client.Get().
+		Resource("initializerconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested initializerConfigurations.
+func (c *initializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("initializerconfigurations").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a initializerConfiguration and creates it.  Returns the server's representation of the initializerConfiguration, and an error, if there is any.
 func (c *initializerConfigurations) Create(initializerConfiguration *v1alpha1.InitializerConfiguration) (result *v1alpha1.InitializerConfiguration, err error) {
 	result = &v1alpha1.InitializerConfiguration{}
@@ -97,38 +129,6 @@ func (c *initializerConfigurations) DeleteCollection(options *v1.DeleteOptions, 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the initializerConfiguration, and returns the corresponding initializerConfiguration object, and an error if there is any.
-func (c *initializerConfigurations) Get(name string, options v1.GetOptions) (result *v1alpha1.InitializerConfiguration, err error) {
-	result = &v1alpha1.InitializerConfiguration{}
-	err = c.client.Get().
-		Resource("initializerconfigurations").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of InitializerConfigurations that match those selectors.
-func (c *initializerConfigurations) List(opts v1.ListOptions) (result *v1alpha1.InitializerConfigurationList, err error) {
-	result = &v1alpha1.InitializerConfigurationList{}
-	err = c.client.Get().
-		Resource("initializerconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested initializerConfigurations.
-func (c *initializerConfigurations) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("initializerconfigurations").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched initializerConfiguration.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -58,6 +58,41 @@ func newControllerRevisions(c *AppsV1beta1Client, namespace string) *controllerR
 	}
 }
 
+// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
+func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *v1beta1.ControllerRevision, err error) {
+	result = &v1beta1.ControllerRevision{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
+func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.ControllerRevisionList, err error) {
+	result = &v1beta1.ControllerRevisionList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested controllerRevisions.
+func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("controllerrevisions").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *controllerRevisions) Create(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
 	result = &v1beta1.ControllerRevision{}
@@ -103,41 +138,6 @@ func (c *controllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
-func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *v1beta1.ControllerRevision, err error) {
-	result = &v1beta1.ControllerRevision{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
-func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.ControllerRevisionList, err error) {
-	result = &v1beta1.ControllerRevisionList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested controllerRevisions.
-func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("controllerrevisions").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched controllerRevision.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *AppsV1beta1Client, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
+	result = &v1beta1.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	result = &v1beta1.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
@@ -85,7 +120,7 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
-	result = &v1beta1.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
-	result = &v1beta1.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
@@ -36,6 +36,7 @@ var controllerrevisionsResource = schema.GroupVersionResource{Group: "apps", Ver
 
 var controllerrevisionsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "ControllerRevision"}
 
+// Get takes name of the controllerRevision, and returns the corresponding controllerRevision object, and an error if there is any.
 func (c *FakeControllerRevisions) Get(name string, options v1.GetOptions) (result *v1beta1.ControllerRevision, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(controllerrevisionsResource, c.ns, name), &v1beta1.ControllerRevision{})
@@ -46,6 +47,7 @@ func (c *FakeControllerRevisions) Get(name string, options v1.GetOptions) (resul
 	return obj.(*v1beta1.ControllerRevision), err
 }
 
+// List takes label and field selectors, and returns the list of ControllerRevisions that match those selectors.
 func (c *FakeControllerRevisions) List(opts v1.ListOptions) (result *v1beta1.ControllerRevisionList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(controllerrevisionsResource, controllerrevisionsKind, c.ns, opts), &v1beta1.ControllerRevisionList{})
@@ -74,6 +76,7 @@ func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, e
 
 }
 
+// Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *FakeControllerRevisions) Create(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
@@ -84,6 +87,7 @@ func (c *FakeControllerRevisions) Create(controllerRevision *v1beta1.ControllerR
 	return obj.(*v1beta1.ControllerRevision), err
 }
 
+// Update takes the representation of a controllerRevision and updates it. Returns the server's representation of the controllerRevision, and an error, if there is any.
 func (c *FakeControllerRevisions) Update(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
@@ -94,6 +98,7 @@ func (c *FakeControllerRevisions) Update(controllerRevision *v1beta1.ControllerR
 	return obj.(*v1beta1.ControllerRevision), err
 }
 
+// Delete takes name of the controllerRevision and deletes it. Returns an error if one occurs.
 func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(controllerrevisionsResource, c.ns, name), &v1beta1.ControllerRevision{})
@@ -101,6 +106,7 @@ func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions)
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeControllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(controllerrevisionsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
@@ -36,40 +36,6 @@ var controllerrevisionsResource = schema.GroupVersionResource{Group: "apps", Ver
 
 var controllerrevisionsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "ControllerRevision"}
 
-func (c *FakeControllerRevisions) Create(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ControllerRevision), err
-}
-
-func (c *FakeControllerRevisions) Update(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ControllerRevision), err
-}
-
-func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(controllerrevisionsResource, c.ns, name), &v1beta1.ControllerRevision{})
-
-	return err
-}
-
-func (c *FakeControllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(controllerrevisionsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ControllerRevisionList{})
-	return err
-}
-
 func (c *FakeControllerRevisions) Get(name string, options v1.GetOptions) (result *v1beta1.ControllerRevision, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(controllerrevisionsResource, c.ns, name), &v1beta1.ControllerRevision{})
@@ -106,6 +72,40 @@ func (c *FakeControllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, e
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(controllerrevisionsResource, c.ns, opts))
 
+}
+
+func (c *FakeControllerRevisions) Create(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ControllerRevision), err
+}
+
+func (c *FakeControllerRevisions) Update(controllerRevision *v1beta1.ControllerRevision) (result *v1beta1.ControllerRevision, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(controllerrevisionsResource, c.ns, controllerRevision), &v1beta1.ControllerRevision{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ControllerRevision), err
+}
+
+func (c *FakeControllerRevisions) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(controllerrevisionsResource, c.ns, name), &v1beta1.ControllerRevision{})
+
+	return err
+}
+
+func (c *FakeControllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(controllerrevisionsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ControllerRevisionList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched controllerRevision.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
@@ -36,6 +36,44 @@ var deploymentsResource = schema.GroupVersionResource{Group: "apps", Version: "v
 
 var deploymentsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"}
 
+func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}
+
+func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.DeploymentList{}
+	for _, item := range obj.(*v1beta1.DeploymentList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
+
+}
+
 func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -78,44 +116,6 @@ func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOption
 
 	_, err := c.Fake.Invokes(action, &v1beta1.DeploymentList{})
 	return err
-}
-
-func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Deployment), err
-}
-
-func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.DeploymentList{}
-	for _, item := range obj.(*v1beta1.DeploymentList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
@@ -36,6 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "apps", Version: "v
 
 var deploymentsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "Deployment"}
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
@@ -46,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
@@ -74,6 +76,7 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -84,6 +87,7 @@ func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta
 	return obj.(*v1beta1.Deployment), err
 }
 
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -94,6 +98,8 @@ func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta
 	return obj.(*v1beta1.Deployment), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta1.Deployment{})
@@ -104,6 +110,7 @@ func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1
 	return obj.(*v1beta1.Deployment), err
 }
 
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
 func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
@@ -111,6 +118,7 @@ func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -36,6 +36,7 @@ var statefulsetsResource = schema.GroupVersionResource{Group: "apps", Version: "
 
 var statefulsetsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "StatefulSet"}
 
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
 func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(statefulsetsResource, c.ns, name), &v1beta1.StatefulSet{})
@@ -46,6 +47,7 @@ func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1be
 	return obj.(*v1beta1.StatefulSet), err
 }
 
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(statefulsetsResource, statefulsetsKind, c.ns, opts), &v1beta1.StatefulSetList{})
@@ -74,6 +76,7 @@ func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *FakeStatefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &v1beta1.StatefulSet{})
@@ -84,6 +87,7 @@ func (c *FakeStatefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1b
 	return obj.(*v1beta1.StatefulSet), err
 }
 
+// Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *FakeStatefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(statefulsetsResource, c.ns, statefulSet), &v1beta1.StatefulSet{})
@@ -94,6 +98,8 @@ func (c *FakeStatefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1b
 	return obj.(*v1beta1.StatefulSet), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeStatefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (*v1beta1.StatefulSet, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "status", c.ns, statefulSet), &v1beta1.StatefulSet{})
@@ -104,6 +110,7 @@ func (c *FakeStatefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (*v1be
 	return obj.(*v1beta1.StatefulSet), err
 }
 
+// Delete takes name of the statefulSet and deletes it. Returns an error if one occurs.
 func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(statefulsetsResource, c.ns, name), &v1beta1.StatefulSet{})
@@ -111,6 +118,7 @@ func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error 
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(statefulsetsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -36,6 +36,44 @@ var statefulsetsResource = schema.GroupVersionResource{Group: "apps", Version: "
 
 var statefulsetsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta1", Kind: "StatefulSet"}
 
+func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.StatefulSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(statefulsetsResource, c.ns, name), &v1beta1.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StatefulSet), err
+}
+
+func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(statefulsetsResource, statefulsetsKind, c.ns, opts), &v1beta1.StatefulSetList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.StatefulSetList{}
+	for _, item := range obj.(*v1beta1.StatefulSetList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested statefulSets.
+func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(statefulsetsResource, c.ns, opts))
+
+}
+
 func (c *FakeStatefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &v1beta1.StatefulSet{})
@@ -78,44 +116,6 @@ func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptio
 
 	_, err := c.Fake.Invokes(action, &v1beta1.StatefulSetList{})
 	return err
-}
-
-func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.StatefulSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(statefulsetsResource, c.ns, name), &v1beta1.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(statefulsetsResource, statefulsetsKind, c.ns, opts), &v1beta1.StatefulSetList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.StatefulSetList{}
-	for _, item := range obj.(*v1beta1.StatefulSetList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(statefulsetsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -59,6 +59,41 @@ func newStatefulSets(c *AppsV1beta1Client, namespace string) *statefulSets {
 	}
 }
 
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
+func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.StatefulSet, err error) {
+	result = &v1beta1.StatefulSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
+	result = &v1beta1.StatefulSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested statefulSets.
+func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
@@ -85,7 +120,7 @@ func (c *statefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *statefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (result *v1beta1.StatefulSet, err error) {
 	result = &v1beta1.StatefulSet{}
@@ -120,41 +155,6 @@ func (c *statefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
-func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.StatefulSet, err error) {
-	result = &v1beta1.StatefulSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
-func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetList, err error) {
-	result = &v1beta1.StatefulSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *AppsV1beta2Client, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta2.Deployment, err error) {
+	result = &v1beta2.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList, err error) {
+	result = &v1beta2.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
 	result = &v1beta2.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta2.Deployment, err error) {
-	result = &v1beta2.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList, err error) {
-	result = &v1beta2.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -85,7 +85,7 @@ func (c *deployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.De
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
 	result = &v1beta2.Deployment{}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
@@ -36,50 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "apps", Version: "v
 
 var deploymentsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta2", Kind: "Deployment"}
 
-func (c *FakeDeployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta2.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.Deployment), err
-}
-
-func (c *FakeDeployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta2.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.Deployment), err
-}
-
-func (c *FakeDeployments) UpdateStatus(deployment *v1beta2.Deployment) (*v1beta2.Deployment, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta2.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.Deployment), err
-}
-
-func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta2.Deployment{})
-
-	return err
-}
-
-func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta2.DeploymentList{})
-	return err
-}
-
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta2.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta2.Deployment{})
@@ -90,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta2.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta2.DeploymentList{})
@@ -116,6 +74,56 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta2.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.Deployment), err
+}
+
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
+func (c *FakeDeployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta2.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.Deployment), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeDeployments) UpdateStatus(deployment *v1beta2.Deployment) (*v1beta2.Deployment, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta2.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.Deployment), err
+}
+
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
+func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta2.Deployment{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta2.DeploymentList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
@@ -36,50 +36,7 @@ var statefulsetsResource = schema.GroupVersionResource{Group: "apps", Version: "
 
 var statefulsetsKind = schema.GroupVersionKind{Group: "apps", Version: "v1beta2", Kind: "StatefulSet"}
 
-func (c *FakeStatefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &v1beta2.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(statefulsetsResource, c.ns, statefulSet), &v1beta2.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) UpdateStatus(statefulSet *v1beta2.StatefulSet) (*v1beta2.StatefulSet, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "status", c.ns, statefulSet), &v1beta2.StatefulSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta2.StatefulSet), err
-}
-
-func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(statefulsetsResource, c.ns, name), &v1beta2.StatefulSet{})
-
-	return err
-}
-
-func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(statefulsetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta2.StatefulSetList{})
-	return err
-}
-
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
 func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1beta2.StatefulSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(statefulsetsResource, c.ns, name), &v1beta2.StatefulSet{})
@@ -90,6 +47,7 @@ func (c *FakeStatefulSets) Get(name string, options v1.GetOptions) (result *v1be
 	return obj.(*v1beta2.StatefulSet), err
 }
 
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
 func (c *FakeStatefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(statefulsetsResource, statefulsetsKind, c.ns, opts), &v1beta2.StatefulSetList{})
@@ -116,6 +74,56 @@ func (c *FakeStatefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(statefulsetsResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
+func (c *FakeStatefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(statefulsetsResource, c.ns, statefulSet), &v1beta2.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.StatefulSet), err
+}
+
+// Update takes the representation of a statefulSet and updates it. Returns the server's representation of the statefulSet, and an error, if there is any.
+func (c *FakeStatefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(statefulsetsResource, c.ns, statefulSet), &v1beta2.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.StatefulSet), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeStatefulSets) UpdateStatus(statefulSet *v1beta2.StatefulSet) (*v1beta2.StatefulSet, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "status", c.ns, statefulSet), &v1beta2.StatefulSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.StatefulSet), err
+}
+
+// Delete takes name of the statefulSet and deletes it. Returns an error if one occurs.
+func (c *FakeStatefulSets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(statefulsetsResource, c.ns, name), &v1beta2.StatefulSet{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeStatefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(statefulsetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta2.StatefulSetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -85,7 +85,7 @@ func (c *statefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *statefulSets) UpdateStatus(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
 	result = &v1beta2.StatefulSet{}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -59,6 +59,41 @@ func newStatefulSets(c *AppsV1beta2Client, namespace string) *statefulSets {
 	}
 }
 
+// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
+func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta2.StatefulSet, err error) {
+	result = &v1beta2.StatefulSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
+func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetList, err error) {
+	result = &v1beta2.StatefulSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested statefulSets.
+func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
 func (c *statefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2.StatefulSet, err error) {
 	result = &v1beta2.StatefulSet{}
@@ -120,41 +155,6 @@ func (c *statefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the statefulSet, and returns the corresponding statefulSet object, and an error if there is any.
-func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta2.StatefulSet, err error) {
-	result = &v1beta2.StatefulSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StatefulSets that match those selectors.
-func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetList, err error) {
-	result = &v1beta2.StatefulSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested statefulSets.
-func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("statefulsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched statefulSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -36,6 +36,7 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"}
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
 func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
@@ -46,6 +47,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (
 	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling_v1.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &autoscaling_v1.HorizontalPodAutoscalerList{})
@@ -74,6 +76,7 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interfa
 
 }
 
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
@@ -84,6 +87,7 @@ func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscali
 	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
@@ -94,6 +98,8 @@ func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscali
 	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (*autoscaling_v1.HorizontalPodAutoscaler, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
@@ -104,6 +110,7 @@ func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *aut
 	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
 func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
@@ -111,6 +118,7 @@ func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOpt
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/autoscaling/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	autoscaling_v1 "k8s.io/api/autoscaling/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"}
 
-func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }
 
-func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *autoscaling_v1.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (*v1.HorizontalPodAutoscaler, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &v1.HorizontalPodAutoscaler{})
-
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.HorizontalPodAutoscalerList{})
-	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &v1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &v1.HorizontalPodAutoscalerList{})
+		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &autoscaling_v1.HorizontalPodAutoscalerList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.HorizontalPodAutoscalerList{}
-	for _, item := range obj.(*v1.HorizontalPodAutoscalerList).Items {
+	list := &autoscaling_v1.HorizontalPodAutoscalerList{}
+	for _, item := range obj.(*autoscaling_v1.HorizontalPodAutoscalerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakeHorizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v
 }
 
 // Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched horizontalPodAutoscaler.
-func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.HorizontalPodAutoscaler, err error) {
+func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &v1.HorizontalPodAutoscaler{})
+		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.HorizontalPodAutoscaler), err
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *autoscaling_v1.HorizontalPodAutoscaler) (*autoscaling_v1.HorizontalPodAutoscaler, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	return err
+}
+
+func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &autoscaling_v1.HorizontalPodAutoscalerList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched horizontalPodAutoscaler.
+func (c *FakeHorizontalPodAutoscalers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *autoscaling_v1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(horizontalpodautoscalersResource, c.ns, name, data, subresources...), &autoscaling_v1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*autoscaling_v1.HorizontalPodAutoscaler), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -59,6 +59,41 @@ func newHorizontalPodAutoscalers(c *AutoscalingV1Client, namespace string) *hori
 	}
 }
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
+	result = &v1.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
+	result = &v1.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
@@ -85,7 +120,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.Horizontal
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.HorizontalPodAutoscaler) (result *v1.HorizontalPodAutoscaler, err error) {
 	result = &v1.HorizontalPodAutoscaler{}
@@ -120,41 +155,6 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *meta_v1.DeleteOptio
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
-func (c *horizontalPodAutoscalers) Get(name string, options meta_v1.GetOptions) (result *v1.HorizontalPodAutoscaler, err error) {
-	result = &v1.HorizontalPodAutoscaler{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(opts meta_v1.ListOptions) (result *v1.HorizontalPodAutoscalerList, err error) {
-	result = &v1.HorizontalPodAutoscalerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/fake/fake_horizontalpodautoscaler.go
@@ -36,6 +36,7 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "v2alpha1", Kind: "HorizontalPodAutoscaler"}
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
 func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &v2alpha1.HorizontalPodAutoscaler{})
@@ -46,6 +47,7 @@ func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
 }
 
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
 func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.HorizontalPodAutoscalerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &v2alpha1.HorizontalPodAutoscalerList{})
@@ -74,6 +76,7 @@ func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interfa
 
 }
 
+// Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v2alpha1.HorizontalPodAutoscaler{})
@@ -84,6 +87,7 @@ func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2alpha1.
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
 }
 
+// Update takes the representation of a horizontalPodAutoscaler and updates it. Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v2alpha1.HorizontalPodAutoscaler{})
@@ -94,6 +98,8 @@ func (c *FakeHorizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2alpha1.
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (*v2alpha1.HorizontalPodAutoscaler, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(horizontalpodautoscalersResource, "status", c.ns, horizontalPodAutoscaler), &v2alpha1.HorizontalPodAutoscaler{})
@@ -104,6 +110,7 @@ func (c *FakeHorizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2a
 	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
 }
 
+// Delete takes name of the horizontalPodAutoscaler and deletes it. Returns an error if one occurs.
 func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(horizontalpodautoscalersResource, c.ns, name), &v2alpha1.HorizontalPodAutoscaler{})
@@ -111,6 +118,7 @@ func (c *FakeHorizontalPodAutoscalers) Delete(name string, options *v1.DeleteOpt
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(horizontalpodautoscalersResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/fake/fake_horizontalpodautoscaler.go
@@ -36,6 +36,44 @@ var horizontalpodautoscalersResource = schema.GroupVersionResource{Group: "autos
 
 var horizontalpodautoscalersKind = schema.GroupVersionKind{Group: "autoscaling", Version: "v2alpha1", Kind: "HorizontalPodAutoscaler"}
 
+func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &v2alpha1.HorizontalPodAutoscaler{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
+}
+
+func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.HorizontalPodAutoscalerList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &v2alpha1.HorizontalPodAutoscalerList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v2alpha1.HorizontalPodAutoscalerList{}
+	for _, item := range obj.(*v2alpha1.HorizontalPodAutoscalerList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
+
+}
+
 func (c *FakeHorizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(horizontalpodautoscalersResource, c.ns, horizontalPodAutoscaler), &v2alpha1.HorizontalPodAutoscaler{})
@@ -78,44 +116,6 @@ func (c *FakeHorizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOption
 
 	_, err := c.Fake.Invokes(action, &v2alpha1.HorizontalPodAutoscalerList{})
 	return err
-}
-
-func (c *FakeHorizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(horizontalpodautoscalersResource, c.ns, name), &v2alpha1.HorizontalPodAutoscaler{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v2alpha1.HorizontalPodAutoscaler), err
-}
-
-func (c *FakeHorizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.HorizontalPodAutoscalerList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(horizontalpodautoscalersResource, horizontalpodautoscalersKind, c.ns, opts), &v2alpha1.HorizontalPodAutoscalerList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v2alpha1.HorizontalPodAutoscalerList{}
-	for _, item := range obj.(*v2alpha1.HorizontalPodAutoscalerList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *FakeHorizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(horizontalpodautoscalersResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -59,6 +59,41 @@ func newHorizontalPodAutoscalers(c *AutoscalingV2alpha1Client, namespace string)
 	}
 }
 
+// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
+func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
+	result = &v2alpha1.HorizontalPodAutoscaler{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
+func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.HorizontalPodAutoscalerList, err error) {
+	result = &v2alpha1.HorizontalPodAutoscalerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
+func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("horizontalpodautoscalers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
 func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	result = &v2alpha1.HorizontalPodAutoscaler{}
@@ -85,7 +120,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2alpha1.Hori
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2alpha1.HorizontalPodAutoscaler) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
 	result = &v2alpha1.HorizontalPodAutoscaler{}
@@ -120,41 +155,6 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, l
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the horizontalPodAutoscaler, and returns the corresponding horizontalPodAutoscaler object, and an error if there is any.
-func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (result *v2alpha1.HorizontalPodAutoscaler, err error) {
-	result = &v2alpha1.HorizontalPodAutoscaler{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of HorizontalPodAutoscalers that match those selectors.
-func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2alpha1.HorizontalPodAutoscalerList, err error) {
-	result = &v2alpha1.HorizontalPodAutoscalerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested horizontalPodAutoscalers.
-func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("horizontalpodautoscalers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched horizontalPodAutoscaler.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/batch/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	batch_v1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var jobsResource = schema.GroupVersionResource{Group: "batch", Version: "v1", Re
 
 var jobsKind = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 
-func (c *FakeJobs) Create(job *v1.Job) (result *v1.Job, err error) {
+func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &v1.Job{})
+		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &batch_v1.Job{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Job), err
+	return obj.(*batch_v1.Job), err
 }
 
-func (c *FakeJobs) Update(job *v1.Job) (result *v1.Job, err error) {
+func (c *FakeJobs) List(opts v1.ListOptions) (result *batch_v1.JobList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) UpdateStatus(job *v1.Job) (*v1.Job, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &v1.Job{})
-
-	return err
-}
-
-func (c *FakeJobs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.JobList{})
-	return err
-}
-
-func (c *FakeJobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &v1.Job{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Job), err
-}
-
-func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &v1.JobList{})
+		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &batch_v1.JobList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.JobList{}
-	for _, item := range obj.(*v1.JobList).Items {
+	list := &batch_v1.JobList{}
+	for _, item := range obj.(*batch_v1.JobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakeJobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error
 }
 
 // Watch returns a watch.Interface that watches the requested jobs.
-func (c *FakeJobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(jobsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched job.
-func (c *FakeJobs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Job, err error) {
+func (c *FakeJobs) Create(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &v1.Job{})
+		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch_v1.Job{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Job), err
+	return obj.(*batch_v1.Job), err
+}
+
+func (c *FakeJobs) Update(job *batch_v1.Job) (result *batch_v1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
+}
+
+func (c *FakeJobs) UpdateStatus(job *batch_v1.Job) (*batch_v1.Job, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
+}
+
+func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch_v1.Job{})
+
+	return err
+}
+
+func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &batch_v1.JobList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched job.
+func (c *FakeJobs) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *batch_v1.Job, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(jobsResource, c.ns, name, data, subresources...), &batch_v1.Job{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*batch_v1.Job), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
@@ -36,6 +36,7 @@ var jobsResource = schema.GroupVersionResource{Group: "batch", Version: "v1", Re
 
 var jobsKind = schema.GroupVersionKind{Group: "batch", Version: "v1", Kind: "Job"}
 
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
 func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(jobsResource, c.ns, name), &batch_v1.Job{})
@@ -46,6 +47,7 @@ func (c *FakeJobs) Get(name string, options v1.GetOptions) (result *batch_v1.Job
 	return obj.(*batch_v1.Job), err
 }
 
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
 func (c *FakeJobs) List(opts v1.ListOptions) (result *batch_v1.JobList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(jobsResource, jobsKind, c.ns, opts), &batch_v1.JobList{})
@@ -74,6 +76,7 @@ func (c *FakeJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *FakeJobs) Create(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(jobsResource, c.ns, job), &batch_v1.Job{})
@@ -84,6 +87,7 @@ func (c *FakeJobs) Create(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	return obj.(*batch_v1.Job), err
 }
 
+// Update takes the representation of a job and updates it. Returns the server's representation of the job, and an error, if there is any.
 func (c *FakeJobs) Update(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(jobsResource, c.ns, job), &batch_v1.Job{})
@@ -94,6 +98,8 @@ func (c *FakeJobs) Update(job *batch_v1.Job) (result *batch_v1.Job, err error) {
 	return obj.(*batch_v1.Job), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeJobs) UpdateStatus(job *batch_v1.Job) (*batch_v1.Job, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(jobsResource, "status", c.ns, job), &batch_v1.Job{})
@@ -104,6 +110,7 @@ func (c *FakeJobs) UpdateStatus(job *batch_v1.Job) (*batch_v1.Job, error) {
 	return obj.(*batch_v1.Job), err
 }
 
+// Delete takes name of the job and deletes it. Returns an error if one occurs.
 func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(jobsResource, c.ns, name), &batch_v1.Job{})
@@ -111,6 +118,7 @@ func (c *FakeJobs) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(jobsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -59,6 +59,41 @@ func newJobs(c *BatchV1Client, namespace string) *jobs {
 	}
 }
 
+// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
+func (c *jobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
+	result = &v1.Job{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Jobs that match those selectors.
+func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
+	result = &v1.JobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested jobs.
+func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("jobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
 func (c *jobs) Create(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
@@ -85,7 +120,7 @@ func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *jobs) UpdateStatus(job *v1.Job) (result *v1.Job, err error) {
 	result = &v1.Job{}
@@ -120,41 +155,6 @@ func (c *jobs) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the job, and returns the corresponding job object, and an error if there is any.
-func (c *jobs) Get(name string, options meta_v1.GetOptions) (result *v1.Job, err error) {
-	result = &v1.Job{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Jobs that match those selectors.
-func (c *jobs) List(opts meta_v1.ListOptions) (result *v1.JobList, err error) {
-	result = &v1.JobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested jobs.
-func (c *jobs) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("jobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched job.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -59,6 +59,41 @@ func newCronJobs(c *BatchV2alpha1Client, namespace string) *cronJobs {
 	}
 }
 
+// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
+func (c *cronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.CronJob, err error) {
+	result = &v2alpha1.CronJob{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
+func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err error) {
+	result = &v2alpha1.CronJobList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested cronJobs.
+func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("cronjobs").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *cronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
@@ -85,7 +120,7 @@ func (c *cronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *cronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	result = &v2alpha1.CronJob{}
@@ -120,41 +155,6 @@ func (c *cronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
-func (c *cronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.CronJob, err error) {
-	result = &v2alpha1.CronJob{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
-func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err error) {
-	result = &v2alpha1.CronJobList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("cronjobs").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched cronJob.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
@@ -36,6 +36,7 @@ var cronjobsResource = schema.GroupVersionResource{Group: "batch", Version: "v2a
 
 var cronjobsKind = schema.GroupVersionKind{Group: "batch", Version: "v2alpha1", Kind: "CronJob"}
 
+// Get takes name of the cronJob, and returns the corresponding cronJob object, and an error if there is any.
 func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.CronJob, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(cronjobsResource, c.ns, name), &v2alpha1.CronJob{})
@@ -46,6 +47,7 @@ func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1
 	return obj.(*v2alpha1.CronJob), err
 }
 
+// List takes label and field selectors, and returns the list of CronJobs that match those selectors.
 func (c *FakeCronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(cronjobsResource, cronjobsKind, c.ns, opts), &v2alpha1.CronJobList{})
@@ -74,6 +76,7 @@ func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *FakeCronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(cronjobsResource, c.ns, cronJob), &v2alpha1.CronJob{})
@@ -84,6 +87,7 @@ func (c *FakeCronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJ
 	return obj.(*v2alpha1.CronJob), err
 }
 
+// Update takes the representation of a cronJob and updates it. Returns the server's representation of the cronJob, and an error, if there is any.
 func (c *FakeCronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(cronjobsResource, c.ns, cronJob), &v2alpha1.CronJob{})
@@ -94,6 +98,8 @@ func (c *FakeCronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJ
 	return obj.(*v2alpha1.CronJob), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (*v2alpha1.CronJob, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(cronjobsResource, "status", c.ns, cronJob), &v2alpha1.CronJob{})
@@ -104,6 +110,7 @@ func (c *FakeCronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (*v2alpha1.CronJo
 	return obj.(*v2alpha1.CronJob), err
 }
 
+// Delete takes name of the cronJob and deletes it. Returns an error if one occurs.
 func (c *FakeCronJobs) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(cronjobsResource, c.ns, name), &v2alpha1.CronJob{})
@@ -111,6 +118,7 @@ func (c *FakeCronJobs) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeCronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(cronjobsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
@@ -36,6 +36,44 @@ var cronjobsResource = schema.GroupVersionResource{Group: "batch", Version: "v2a
 
 var cronjobsKind = schema.GroupVersionKind{Group: "batch", Version: "v2alpha1", Kind: "CronJob"}
 
+func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.CronJob, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(cronjobsResource, c.ns, name), &v2alpha1.CronJob{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v2alpha1.CronJob), err
+}
+
+func (c *FakeCronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(cronjobsResource, cronjobsKind, c.ns, opts), &v2alpha1.CronJobList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v2alpha1.CronJobList{}
+	for _, item := range obj.(*v2alpha1.CronJobList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested cronJobs.
+func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(cronjobsResource, c.ns, opts))
+
+}
+
 func (c *FakeCronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(cronjobsResource, c.ns, cronJob), &v2alpha1.CronJob{})
@@ -78,44 +116,6 @@ func (c *FakeCronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v
 
 	_, err := c.Fake.Invokes(action, &v2alpha1.CronJobList{})
 	return err
-}
-
-func (c *FakeCronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.CronJob, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(cronjobsResource, c.ns, name), &v2alpha1.CronJob{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v2alpha1.CronJob), err
-}
-
-func (c *FakeCronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(cronjobsResource, cronjobsKind, c.ns, opts), &v2alpha1.CronJobList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v2alpha1.CronJobList{}
-	for _, item := range obj.(*v2alpha1.CronJobList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested cronJobs.
-func (c *FakeCronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(cronjobsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched cronJob.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -57,6 +57,38 @@ func newCertificateSigningRequests(c *CertificatesV1beta1Client) *certificateSig
 	}
 }
 
+// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
+func (c *certificateSigningRequests) Get(name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
+	result = &v1beta1.CertificateSigningRequest{}
+	err = c.client.Get().
+		Resource("certificatesigningrequests").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
+func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.CertificateSigningRequestList, err error) {
+	result = &v1beta1.CertificateSigningRequestList{}
+	err = c.client.Get().
+		Resource("certificatesigningrequests").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
+func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("certificatesigningrequests").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *certificateSigningRequests) Create(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
@@ -81,7 +113,7 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *v1beta1.C
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	result = &v1beta1.CertificateSigningRequest{}
@@ -113,38 +145,6 @@ func (c *certificateSigningRequests) DeleteCollection(options *v1.DeleteOptions,
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
-func (c *certificateSigningRequests) Get(name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
-	result = &v1beta1.CertificateSigningRequest{}
-	err = c.client.Get().
-		Resource("certificatesigningrequests").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
-func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.CertificateSigningRequestList, err error) {
-	result = &v1beta1.CertificateSigningRequestList{}
-	err = c.client.Get().
-		Resource("certificatesigningrequests").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
-func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("certificatesigningrequests").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
@@ -35,6 +35,7 @@ var certificatesigningrequestsResource = schema.GroupVersionResource{Group: "cer
 
 var certificatesigningrequestsKind = schema.GroupVersionKind{Group: "certificates.k8s.io", Version: "v1beta1", Kind: "CertificateSigningRequest"}
 
+// Get takes name of the certificateSigningRequest, and returns the corresponding certificateSigningRequest object, and an error if there is any.
 func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(certificatesigningrequestsResource, name), &v1beta1.CertificateSigningRequest{})
@@ -44,6 +45,7 @@ func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions)
 	return obj.(*v1beta1.CertificateSigningRequest), err
 }
 
+// List takes label and field selectors, and returns the list of CertificateSigningRequests that match those selectors.
 func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.CertificateSigningRequestList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(certificatesigningrequestsResource, certificatesigningrequestsKind, opts), &v1beta1.CertificateSigningRequestList{})
@@ -70,6 +72,7 @@ func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) (watch.Inter
 		InvokesWatch(testing.NewRootWatchAction(certificatesigningrequestsResource, opts))
 }
 
+// Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(certificatesigningrequestsResource, certificateSigningRequest), &v1beta1.CertificateSigningRequest{})
@@ -79,6 +82,7 @@ func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *v1bet
 	return obj.(*v1beta1.CertificateSigningRequest), err
 }
 
+// Update takes the representation of a certificateSigningRequest and updates it. Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
 func (c *FakeCertificateSigningRequests) Update(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(certificatesigningrequestsResource, certificateSigningRequest), &v1beta1.CertificateSigningRequest{})
@@ -88,6 +92,8 @@ func (c *FakeCertificateSigningRequests) Update(certificateSigningRequest *v1bet
 	return obj.(*v1beta1.CertificateSigningRequest), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeCertificateSigningRequests) UpdateStatus(certificateSigningRequest *v1beta1.CertificateSigningRequest) (*v1beta1.CertificateSigningRequest, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(certificatesigningrequestsResource, "status", certificateSigningRequest), &v1beta1.CertificateSigningRequest{})
@@ -97,12 +103,14 @@ func (c *FakeCertificateSigningRequests) UpdateStatus(certificateSigningRequest 
 	return obj.(*v1beta1.CertificateSigningRequest), err
 }
 
+// Delete takes name of the certificateSigningRequest and deletes it. Returns an error if one occurs.
 func (c *FakeCertificateSigningRequests) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(certificatesigningrequestsResource, name), &v1beta1.CertificateSigningRequest{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeCertificateSigningRequests) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(certificatesigningrequestsResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
@@ -35,6 +35,41 @@ var certificatesigningrequestsResource = schema.GroupVersionResource{Group: "cer
 
 var certificatesigningrequestsKind = schema.GroupVersionKind{Group: "certificates.k8s.io", Version: "v1beta1", Kind: "CertificateSigningRequest"}
 
+func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootGetAction(certificatesigningrequestsResource, name), &v1beta1.CertificateSigningRequest{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.CertificateSigningRequest), err
+}
+
+func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.CertificateSigningRequestList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootListAction(certificatesigningrequestsResource, certificatesigningrequestsKind, opts), &v1beta1.CertificateSigningRequestList{})
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.CertificateSigningRequestList{}
+	for _, item := range obj.(*v1beta1.CertificateSigningRequestList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
+func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewRootWatchAction(certificatesigningrequestsResource, opts))
+}
+
 func (c *FakeCertificateSigningRequests) Create(certificateSigningRequest *v1beta1.CertificateSigningRequest) (result *v1beta1.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(certificatesigningrequestsResource, certificateSigningRequest), &v1beta1.CertificateSigningRequest{})
@@ -73,41 +108,6 @@ func (c *FakeCertificateSigningRequests) DeleteCollection(options *v1.DeleteOpti
 
 	_, err := c.Fake.Invokes(action, &v1beta1.CertificateSigningRequestList{})
 	return err
-}
-
-func (c *FakeCertificateSigningRequests) Get(name string, options v1.GetOptions) (result *v1beta1.CertificateSigningRequest, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(certificatesigningrequestsResource, name), &v1beta1.CertificateSigningRequest{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.CertificateSigningRequest), err
-}
-
-func (c *FakeCertificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.CertificateSigningRequestList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(certificatesigningrequestsResource, certificatesigningrequestsKind, opts), &v1beta1.CertificateSigningRequestList{})
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.CertificateSigningRequestList{}
-	for _, item := range obj.(*v1beta1.CertificateSigningRequestList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested certificateSigningRequests.
-func (c *FakeCertificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewRootWatchAction(certificatesigningrequestsResource, opts))
 }
 
 // Patch applies the patch and returns the patched certificateSigningRequest.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -56,6 +56,38 @@ func newComponentStatuses(c *CoreV1Client) *componentStatuses {
 	}
 }
 
+// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
+func (c *componentStatuses) Get(name string, options meta_v1.GetOptions) (result *v1.ComponentStatus, err error) {
+	result = &v1.ComponentStatus{}
+	err = c.client.Get().
+		Resource("componentstatuses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
+func (c *componentStatuses) List(opts meta_v1.ListOptions) (result *v1.ComponentStatusList, err error) {
+	result = &v1.ComponentStatusList{}
+	err = c.client.Get().
+		Resource("componentstatuses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested componentStatuses.
+func (c *componentStatuses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("componentstatuses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *componentStatuses) Create(componentStatus *v1.ComponentStatus) (result *v1.ComponentStatus, err error) {
 	result = &v1.ComponentStatus{}
@@ -97,38 +129,6 @@ func (c *componentStatuses) DeleteCollection(options *meta_v1.DeleteOptions, lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
-func (c *componentStatuses) Get(name string, options meta_v1.GetOptions) (result *v1.ComponentStatus, err error) {
-	result = &v1.ComponentStatus{}
-	err = c.client.Get().
-		Resource("componentstatuses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
-func (c *componentStatuses) List(opts meta_v1.ListOptions) (result *v1.ComponentStatusList, err error) {
-	result = &v1.ComponentStatusList{}
-	err = c.client.Get().
-		Resource("componentstatuses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested componentStatuses.
-func (c *componentStatuses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("componentstatuses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched componentStatus.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -58,6 +58,41 @@ func newConfigMaps(c *CoreV1Client, namespace string) *configMaps {
 	}
 }
 
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
+func (c *configMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
+	result = &v1.ConfigMap{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
+func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
+	result = &v1.ConfigMapList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested configMaps.
+func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("configmaps").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *configMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
 	result = &v1.ConfigMap{}
@@ -103,41 +138,6 @@ func (c *configMaps) DeleteCollection(options *meta_v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
-func (c *configMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
-	result = &v1.ConfigMap{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
-func (c *configMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
-	result = &v1.ConfigMapList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested configMaps.
-func (c *configMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("configmaps").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched configMap.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -58,6 +58,41 @@ func newEndpoints(c *CoreV1Client, namespace string) *endpoints {
 	}
 }
 
+// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
+func (c *endpoints) Get(name string, options meta_v1.GetOptions) (result *v1.Endpoints, err error) {
+	result = &v1.Endpoints{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
+func (c *endpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList, err error) {
+	result = &v1.EndpointsList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested endpoints.
+func (c *endpoints) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("endpoints").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *endpoints) Create(endpoints *v1.Endpoints) (result *v1.Endpoints, err error) {
 	result = &v1.Endpoints{}
@@ -103,41 +138,6 @@ func (c *endpoints) DeleteCollection(options *meta_v1.DeleteOptions, listOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
-func (c *endpoints) Get(name string, options meta_v1.GetOptions) (result *v1.Endpoints, err error) {
-	result = &v1.Endpoints{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
-func (c *endpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList, err error) {
-	result = &v1.EndpointsList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested endpoints.
-func (c *endpoints) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("endpoints").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched endpoints.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -58,6 +58,41 @@ func newEvents(c *CoreV1Client, namespace string) *events {
 	}
 }
 
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
+func (c *events) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
+	result = &v1.Event{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Events that match those selectors.
+func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
+	result = &v1.EventList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested events.
+func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("events").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *events) Create(event *v1.Event) (result *v1.Event, err error) {
 	result = &v1.Event{}
@@ -103,41 +138,6 @@ func (c *events) DeleteCollection(options *meta_v1.DeleteOptions, listOptions me
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
-func (c *events) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
-	result = &v1.Event{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Events that match those selectors.
-func (c *events) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
-	result = &v1.EventList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested events.
-func (c *events) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("events").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched event.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
@@ -35,6 +35,7 @@ var componentstatusesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var componentstatusesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ComponentStatus"}
 
+// Get takes name of the componentStatus, and returns the corresponding componentStatus object, and an error if there is any.
 func (c *FakeComponentStatuses) Get(name string, options v1.GetOptions) (result *core_v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(componentstatusesResource, name), &core_v1.ComponentStatus{})
@@ -44,6 +45,7 @@ func (c *FakeComponentStatuses) Get(name string, options v1.GetOptions) (result 
 	return obj.(*core_v1.ComponentStatus), err
 }
 
+// List takes label and field selectors, and returns the list of ComponentStatuses that match those selectors.
 func (c *FakeComponentStatuses) List(opts v1.ListOptions) (result *core_v1.ComponentStatusList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(componentstatusesResource, componentstatusesKind, opts), &core_v1.ComponentStatusList{})
@@ -70,6 +72,7 @@ func (c *FakeComponentStatuses) Watch(opts v1.ListOptions) (watch.Interface, err
 		InvokesWatch(testing.NewRootWatchAction(componentstatusesResource, opts))
 }
 
+// Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *FakeComponentStatuses) Create(componentStatus *core_v1.ComponentStatus) (result *core_v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(componentstatusesResource, componentStatus), &core_v1.ComponentStatus{})
@@ -79,6 +82,7 @@ func (c *FakeComponentStatuses) Create(componentStatus *core_v1.ComponentStatus)
 	return obj.(*core_v1.ComponentStatus), err
 }
 
+// Update takes the representation of a componentStatus and updates it. Returns the server's representation of the componentStatus, and an error, if there is any.
 func (c *FakeComponentStatuses) Update(componentStatus *core_v1.ComponentStatus) (result *core_v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(componentstatusesResource, componentStatus), &core_v1.ComponentStatus{})
@@ -88,12 +92,14 @@ func (c *FakeComponentStatuses) Update(componentStatus *core_v1.ComponentStatus)
 	return obj.(*core_v1.ComponentStatus), err
 }
 
+// Delete takes name of the componentStatus and deletes it. Returns an error if one occurs.
 func (c *FakeComponentStatuses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(componentstatusesResource, name), &core_v1.ComponentStatus{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeComponentStatuses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(componentstatusesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,49 +35,18 @@ var componentstatusesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var componentstatusesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ComponentStatus"}
 
-func (c *FakeComponentStatuses) Create(componentStatus *v1.ComponentStatus) (result *v1.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Get(name string, options v1.GetOptions) (result *core_v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(componentstatusesResource, componentStatus), &v1.ComponentStatus{})
+		Invokes(testing.NewRootGetAction(componentstatusesResource, name), &core_v1.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ComponentStatus), err
+	return obj.(*core_v1.ComponentStatus), err
 }
 
-func (c *FakeComponentStatuses) Update(componentStatus *v1.ComponentStatus) (result *v1.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) List(opts v1.ListOptions) (result *core_v1.ComponentStatusList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(componentstatusesResource, componentStatus), &v1.ComponentStatus{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ComponentStatus), err
-}
-
-func (c *FakeComponentStatuses) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(componentstatusesResource, name), &v1.ComponentStatus{})
-	return err
-}
-
-func (c *FakeComponentStatuses) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(componentstatusesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ComponentStatusList{})
-	return err
-}
-
-func (c *FakeComponentStatuses) Get(name string, options meta_v1.GetOptions) (result *v1.ComponentStatus, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(componentstatusesResource, name), &v1.ComponentStatus{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ComponentStatus), err
-}
-
-func (c *FakeComponentStatuses) List(opts meta_v1.ListOptions) (result *v1.ComponentStatusList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(componentstatusesResource, componentstatusesKind, opts), &v1.ComponentStatusList{})
+		Invokes(testing.NewRootListAction(componentstatusesResource, componentstatusesKind, opts), &core_v1.ComponentStatusList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -86,8 +55,8 @@ func (c *FakeComponentStatuses) List(opts meta_v1.ListOptions) (result *v1.Compo
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ComponentStatusList{}
-	for _, item := range obj.(*v1.ComponentStatusList).Items {
+	list := &core_v1.ComponentStatusList{}
+	for _, item := range obj.(*core_v1.ComponentStatusList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -96,17 +65,48 @@ func (c *FakeComponentStatuses) List(opts meta_v1.ListOptions) (result *v1.Compo
 }
 
 // Watch returns a watch.Interface that watches the requested componentStatuses.
-func (c *FakeComponentStatuses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeComponentStatuses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(componentstatusesResource, opts))
 }
 
-// Patch applies the patch and returns the patched componentStatus.
-func (c *FakeComponentStatuses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ComponentStatus, err error) {
+func (c *FakeComponentStatuses) Create(componentStatus *core_v1.ComponentStatus) (result *core_v1.ComponentStatus, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(componentstatusesResource, name, data, subresources...), &v1.ComponentStatus{})
+		Invokes(testing.NewRootCreateAction(componentstatusesResource, componentStatus), &core_v1.ComponentStatus{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ComponentStatus), err
+	return obj.(*core_v1.ComponentStatus), err
+}
+
+func (c *FakeComponentStatuses) Update(componentStatus *core_v1.ComponentStatus) (result *core_v1.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(componentstatusesResource, componentStatus), &core_v1.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ComponentStatus), err
+}
+
+func (c *FakeComponentStatuses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(componentstatusesResource, name), &core_v1.ComponentStatus{})
+	return err
+}
+
+func (c *FakeComponentStatuses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(componentstatusesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ComponentStatusList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched componentStatus.
+func (c *FakeComponentStatuses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ComponentStatus, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(componentstatusesResource, name, data, subresources...), &core_v1.ComponentStatus{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ComponentStatus), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
@@ -36,6 +36,7 @@ var configmapsResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var configmapsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 
+// Get takes name of the configMap, and returns the corresponding configMap object, and an error if there is any.
 func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
@@ -46,6 +47,7 @@ func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *core_v
 	return obj.(*core_v1.ConfigMap), err
 }
 
+// List takes label and field selectors, and returns the list of ConfigMaps that match those selectors.
 func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *core_v1.ConfigMapList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &core_v1.ConfigMapList{})
@@ -74,6 +76,7 @@ func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
 func (c *FakeConfigMaps) Create(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
@@ -84,6 +87,7 @@ func (c *FakeConfigMaps) Create(configMap *core_v1.ConfigMap) (result *core_v1.C
 	return obj.(*core_v1.ConfigMap), err
 }
 
+// Update takes the representation of a configMap and updates it. Returns the server's representation of the configMap, and an error, if there is any.
 func (c *FakeConfigMaps) Update(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
@@ -94,6 +98,7 @@ func (c *FakeConfigMaps) Update(configMap *core_v1.ConfigMap) (result *core_v1.C
 	return obj.(*core_v1.ConfigMap), err
 }
 
+// Delete takes name of the configMap and deletes it. Returns an error if one occurs.
 func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
@@ -101,6 +106,7 @@ func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var configmapsResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var configmapsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}
 
-func (c *FakeConfigMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
+func (c *FakeConfigMaps) Get(name string, options v1.GetOptions) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &v1.ConfigMap{})
+		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ConfigMap), err
+	return obj.(*core_v1.ConfigMap), err
 }
 
-func (c *FakeConfigMaps) Update(configMap *v1.ConfigMap) (result *v1.ConfigMap, err error) {
+func (c *FakeConfigMaps) List(opts v1.ListOptions) (result *core_v1.ConfigMapList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &v1.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &v1.ConfigMap{})
-
-	return err
-}
-
-func (c *FakeConfigMaps) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ConfigMapList{})
-	return err
-}
-
-func (c *FakeConfigMaps) Get(name string, options meta_v1.GetOptions) (result *v1.ConfigMap, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(configmapsResource, c.ns, name), &v1.ConfigMap{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ConfigMap), err
-}
-
-func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &v1.ConfigMapList{})
+		Invokes(testing.NewListAction(configmapsResource, configmapsKind, c.ns, opts), &core_v1.ConfigMapList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapLis
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ConfigMapList{}
-	for _, item := range obj.(*v1.ConfigMapList).Items {
+	list := &core_v1.ConfigMapList{}
+	for _, item := range obj.(*core_v1.ConfigMapList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeConfigMaps) List(opts meta_v1.ListOptions) (result *v1.ConfigMapLis
 }
 
 // Watch returns a watch.Interface that watches the requested configMaps.
-func (c *FakeConfigMaps) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeConfigMaps) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(configmapsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched configMap.
-func (c *FakeConfigMaps) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ConfigMap, err error) {
+func (c *FakeConfigMaps) Create(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &v1.ConfigMap{})
+		Invokes(testing.NewCreateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ConfigMap), err
+	return obj.(*core_v1.ConfigMap), err
+}
+
+func (c *FakeConfigMaps) Update(configMap *core_v1.ConfigMap) (result *core_v1.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(configmapsResource, c.ns, configMap), &core_v1.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ConfigMap), err
+}
+
+func (c *FakeConfigMaps) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(configmapsResource, c.ns, name), &core_v1.ConfigMap{})
+
+	return err
+}
+
+func (c *FakeConfigMaps) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(configmapsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ConfigMapList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched configMap.
+func (c *FakeConfigMaps) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ConfigMap, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(configmapsResource, c.ns, name, data, subresources...), &core_v1.ConfigMap{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ConfigMap), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
@@ -36,6 +36,7 @@ var endpointsResource = schema.GroupVersionResource{Group: "", Version: "v1", Re
 
 var endpointsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
 
+// Get takes name of the endpoints, and returns the corresponding endpoints object, and an error if there is any.
 func (c *FakeEndpoints) Get(name string, options v1.GetOptions) (result *core_v1.Endpoints, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(endpointsResource, c.ns, name), &core_v1.Endpoints{})
@@ -46,6 +47,7 @@ func (c *FakeEndpoints) Get(name string, options v1.GetOptions) (result *core_v1
 	return obj.(*core_v1.Endpoints), err
 }
 
+// List takes label and field selectors, and returns the list of Endpoints that match those selectors.
 func (c *FakeEndpoints) List(opts v1.ListOptions) (result *core_v1.EndpointsList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(endpointsResource, endpointsKind, c.ns, opts), &core_v1.EndpointsList{})
@@ -74,6 +76,7 @@ func (c *FakeEndpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *FakeEndpoints) Create(endpoints *core_v1.Endpoints) (result *core_v1.Endpoints, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoints), &core_v1.Endpoints{})
@@ -84,6 +87,7 @@ func (c *FakeEndpoints) Create(endpoints *core_v1.Endpoints) (result *core_v1.En
 	return obj.(*core_v1.Endpoints), err
 }
 
+// Update takes the representation of a endpoints and updates it. Returns the server's representation of the endpoints, and an error, if there is any.
 func (c *FakeEndpoints) Update(endpoints *core_v1.Endpoints) (result *core_v1.Endpoints, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoints), &core_v1.Endpoints{})
@@ -94,6 +98,7 @@ func (c *FakeEndpoints) Update(endpoints *core_v1.Endpoints) (result *core_v1.En
 	return obj.(*core_v1.Endpoints), err
 }
 
+// Delete takes name of the endpoints and deletes it. Returns an error if one occurs.
 func (c *FakeEndpoints) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &core_v1.Endpoints{})
@@ -101,6 +106,7 @@ func (c *FakeEndpoints) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeEndpoints) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var endpointsResource = schema.GroupVersionResource{Group: "", Version: "v1", Re
 
 var endpointsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Endpoints"}
 
-func (c *FakeEndpoints) Create(endpoints *v1.Endpoints) (result *v1.Endpoints, err error) {
+func (c *FakeEndpoints) Get(name string, options v1.GetOptions) (result *core_v1.Endpoints, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoints), &v1.Endpoints{})
+		Invokes(testing.NewGetAction(endpointsResource, c.ns, name), &core_v1.Endpoints{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Endpoints), err
+	return obj.(*core_v1.Endpoints), err
 }
 
-func (c *FakeEndpoints) Update(endpoints *v1.Endpoints) (result *v1.Endpoints, err error) {
+func (c *FakeEndpoints) List(opts v1.ListOptions) (result *core_v1.EndpointsList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoints), &v1.Endpoints{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Endpoints), err
-}
-
-func (c *FakeEndpoints) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &v1.Endpoints{})
-
-	return err
-}
-
-func (c *FakeEndpoints) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.EndpointsList{})
-	return err
-}
-
-func (c *FakeEndpoints) Get(name string, options meta_v1.GetOptions) (result *v1.Endpoints, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(endpointsResource, c.ns, name), &v1.Endpoints{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Endpoints), err
-}
-
-func (c *FakeEndpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(endpointsResource, endpointsKind, c.ns, opts), &v1.EndpointsList{})
+		Invokes(testing.NewListAction(endpointsResource, endpointsKind, c.ns, opts), &core_v1.EndpointsList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeEndpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.EndpointsList{}
-	for _, item := range obj.(*v1.EndpointsList).Items {
+	list := &core_v1.EndpointsList{}
+	for _, item := range obj.(*core_v1.EndpointsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeEndpoints) List(opts meta_v1.ListOptions) (result *v1.EndpointsList
 }
 
 // Watch returns a watch.Interface that watches the requested endpoints.
-func (c *FakeEndpoints) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeEndpoints) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(endpointsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched endpoints.
-func (c *FakeEndpoints) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Endpoints, err error) {
+func (c *FakeEndpoints) Create(endpoints *core_v1.Endpoints) (result *core_v1.Endpoints, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(endpointsResource, c.ns, name, data, subresources...), &v1.Endpoints{})
+		Invokes(testing.NewCreateAction(endpointsResource, c.ns, endpoints), &core_v1.Endpoints{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Endpoints), err
+	return obj.(*core_v1.Endpoints), err
+}
+
+func (c *FakeEndpoints) Update(endpoints *core_v1.Endpoints) (result *core_v1.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(endpointsResource, c.ns, endpoints), &core_v1.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Endpoints), err
+}
+
+func (c *FakeEndpoints) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(endpointsResource, c.ns, name), &core_v1.Endpoints{})
+
+	return err
+}
+
+func (c *FakeEndpoints) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(endpointsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.EndpointsList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched endpoints.
+func (c *FakeEndpoints) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Endpoints, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(endpointsResource, c.ns, name, data, subresources...), &core_v1.Endpoints{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Endpoints), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var eventsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resou
 
 var eventsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}
 
-func (c *FakeEvents) Create(event *v1.Event) (result *v1.Event, err error) {
+func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &v1.Event{})
+		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &core_v1.Event{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Event), err
+	return obj.(*core_v1.Event), err
 }
 
-func (c *FakeEvents) Update(event *v1.Event) (result *v1.Event, err error) {
+func (c *FakeEvents) List(opts v1.ListOptions) (result *core_v1.EventList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &v1.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Event), err
-}
-
-func (c *FakeEvents) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &v1.Event{})
-
-	return err
-}
-
-func (c *FakeEvents) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.EventList{})
-	return err
-}
-
-func (c *FakeEvents) Get(name string, options meta_v1.GetOptions) (result *v1.Event, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &v1.Event{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Event), err
-}
-
-func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &v1.EventList{})
+		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &core_v1.EventList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err e
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.EventList{}
-	for _, item := range obj.(*v1.EventList).Items {
+	list := &core_v1.EventList{}
+	for _, item := range obj.(*core_v1.EventList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeEvents) List(opts meta_v1.ListOptions) (result *v1.EventList, err e
 }
 
 // Watch returns a watch.Interface that watches the requested events.
-func (c *FakeEvents) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(eventsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched event.
-func (c *FakeEvents) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Event, err error) {
+func (c *FakeEvents) Create(event *core_v1.Event) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &v1.Event{})
+		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &core_v1.Event{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Event), err
+	return obj.(*core_v1.Event), err
+}
+
+func (c *FakeEvents) Update(event *core_v1.Event) (result *core_v1.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &core_v1.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Event), err
+}
+
+func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &core_v1.Event{})
+
+	return err
+}
+
+func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.EventList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched event.
+func (c *FakeEvents) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Event, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(eventsResource, c.ns, name, data, subresources...), &core_v1.Event{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Event), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -36,6 +36,7 @@ var eventsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resou
 
 var eventsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Event"}
 
+// Get takes name of the event, and returns the corresponding event object, and an error if there is any.
 func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(eventsResource, c.ns, name), &core_v1.Event{})
@@ -46,6 +47,7 @@ func (c *FakeEvents) Get(name string, options v1.GetOptions) (result *core_v1.Ev
 	return obj.(*core_v1.Event), err
 }
 
+// List takes label and field selectors, and returns the list of Events that match those selectors.
 func (c *FakeEvents) List(opts v1.ListOptions) (result *core_v1.EventList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(eventsResource, eventsKind, c.ns, opts), &core_v1.EventList{})
@@ -74,6 +76,7 @@ func (c *FakeEvents) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Create(event *core_v1.Event) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(eventsResource, c.ns, event), &core_v1.Event{})
@@ -84,6 +87,7 @@ func (c *FakeEvents) Create(event *core_v1.Event) (result *core_v1.Event, err er
 	return obj.(*core_v1.Event), err
 }
 
+// Update takes the representation of a event and updates it. Returns the server's representation of the event, and an error, if there is any.
 func (c *FakeEvents) Update(event *core_v1.Event) (result *core_v1.Event, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(eventsResource, c.ns, event), &core_v1.Event{})
@@ -94,6 +98,7 @@ func (c *FakeEvents) Update(event *core_v1.Event) (result *core_v1.Event, err er
 	return obj.(*core_v1.Event), err
 }
 
+// Delete takes name of the event and deletes it. Returns an error if one occurs.
 func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(eventsResource, c.ns, name), &core_v1.Event{})
@@ -101,6 +106,7 @@ func (c *FakeEvents) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeEvents) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(eventsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
@@ -36,6 +36,7 @@ var limitrangesResource = schema.GroupVersionResource{Group: "", Version: "v1", 
 
 var limitrangesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "LimitRange"}
 
+// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
 func (c *FakeLimitRanges) Get(name string, options v1.GetOptions) (result *core_v1.LimitRange, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(limitrangesResource, c.ns, name), &core_v1.LimitRange{})
@@ -46,6 +47,7 @@ func (c *FakeLimitRanges) Get(name string, options v1.GetOptions) (result *core_
 	return obj.(*core_v1.LimitRange), err
 }
 
+// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
 func (c *FakeLimitRanges) List(opts v1.ListOptions) (result *core_v1.LimitRangeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(limitrangesResource, limitrangesKind, c.ns, opts), &core_v1.LimitRangeList{})
@@ -74,6 +76,7 @@ func (c *FakeLimitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *FakeLimitRanges) Create(limitRange *core_v1.LimitRange) (result *core_v1.LimitRange, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(limitrangesResource, c.ns, limitRange), &core_v1.LimitRange{})
@@ -84,6 +87,7 @@ func (c *FakeLimitRanges) Create(limitRange *core_v1.LimitRange) (result *core_v
 	return obj.(*core_v1.LimitRange), err
 }
 
+// Update takes the representation of a limitRange and updates it. Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *FakeLimitRanges) Update(limitRange *core_v1.LimitRange) (result *core_v1.LimitRange, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(limitrangesResource, c.ns, limitRange), &core_v1.LimitRange{})
@@ -94,6 +98,7 @@ func (c *FakeLimitRanges) Update(limitRange *core_v1.LimitRange) (result *core_v
 	return obj.(*core_v1.LimitRange), err
 }
 
+// Delete takes name of the limitRange and deletes it. Returns an error if one occurs.
 func (c *FakeLimitRanges) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(limitrangesResource, c.ns, name), &core_v1.LimitRange{})
@@ -101,6 +106,7 @@ func (c *FakeLimitRanges) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeLimitRanges) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(limitrangesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var limitrangesResource = schema.GroupVersionResource{Group: "", Version: "v1", 
 
 var limitrangesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "LimitRange"}
 
-func (c *FakeLimitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
+func (c *FakeLimitRanges) Get(name string, options v1.GetOptions) (result *core_v1.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(limitrangesResource, c.ns, limitRange), &v1.LimitRange{})
+		Invokes(testing.NewGetAction(limitrangesResource, c.ns, name), &core_v1.LimitRange{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.LimitRange), err
+	return obj.(*core_v1.LimitRange), err
 }
 
-func (c *FakeLimitRanges) Update(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
+func (c *FakeLimitRanges) List(opts v1.ListOptions) (result *core_v1.LimitRangeList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(limitrangesResource, c.ns, limitRange), &v1.LimitRange{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.LimitRange), err
-}
-
-func (c *FakeLimitRanges) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(limitrangesResource, c.ns, name), &v1.LimitRange{})
-
-	return err
-}
-
-func (c *FakeLimitRanges) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(limitrangesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.LimitRangeList{})
-	return err
-}
-
-func (c *FakeLimitRanges) Get(name string, options meta_v1.GetOptions) (result *v1.LimitRange, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(limitrangesResource, c.ns, name), &v1.LimitRange{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.LimitRange), err
-}
-
-func (c *FakeLimitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(limitrangesResource, limitrangesKind, c.ns, opts), &v1.LimitRangeList{})
+		Invokes(testing.NewListAction(limitrangesResource, limitrangesKind, c.ns, opts), &core_v1.LimitRangeList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeLimitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeL
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.LimitRangeList{}
-	for _, item := range obj.(*v1.LimitRangeList).Items {
+	list := &core_v1.LimitRangeList{}
+	for _, item := range obj.(*core_v1.LimitRangeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeLimitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeL
 }
 
 // Watch returns a watch.Interface that watches the requested limitRanges.
-func (c *FakeLimitRanges) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeLimitRanges) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(limitrangesResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched limitRange.
-func (c *FakeLimitRanges) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.LimitRange, err error) {
+func (c *FakeLimitRanges) Create(limitRange *core_v1.LimitRange) (result *core_v1.LimitRange, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(limitrangesResource, c.ns, name, data, subresources...), &v1.LimitRange{})
+		Invokes(testing.NewCreateAction(limitrangesResource, c.ns, limitRange), &core_v1.LimitRange{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.LimitRange), err
+	return obj.(*core_v1.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Update(limitRange *core_v1.LimitRange) (result *core_v1.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(limitrangesResource, c.ns, limitRange), &core_v1.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.LimitRange), err
+}
+
+func (c *FakeLimitRanges) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(limitrangesResource, c.ns, name), &core_v1.LimitRange{})
+
+	return err
+}
+
+func (c *FakeLimitRanges) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(limitrangesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.LimitRangeList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched limitRange.
+func (c *FakeLimitRanges) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.LimitRange, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(limitrangesResource, c.ns, name, data, subresources...), &core_v1.LimitRange{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.LimitRange), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -35,6 +35,7 @@ var namespacesResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var namespacesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
 func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(namespacesResource, name), &core_v1.Namespace{})
@@ -44,6 +45,7 @@ func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *core_v
 	return obj.(*core_v1.Namespace), err
 }
 
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
 func (c *FakeNamespaces) List(opts v1.ListOptions) (result *core_v1.NamespaceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &core_v1.NamespaceList{})
@@ -70,6 +72,7 @@ func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		InvokesWatch(testing.NewRootWatchAction(namespacesResource, opts))
 }
 
+// Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *FakeNamespaces) Create(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &core_v1.Namespace{})
@@ -79,6 +82,7 @@ func (c *FakeNamespaces) Create(namespace *core_v1.Namespace) (result *core_v1.N
 	return obj.(*core_v1.Namespace), err
 }
 
+// Update takes the representation of a namespace and updates it. Returns the server's representation of the namespace, and an error, if there is any.
 func (c *FakeNamespaces) Update(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &core_v1.Namespace{})
@@ -88,6 +92,8 @@ func (c *FakeNamespaces) Update(namespace *core_v1.Namespace) (result *core_v1.N
 	return obj.(*core_v1.Namespace), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNamespaces) UpdateStatus(namespace *core_v1.Namespace) (*core_v1.Namespace, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &core_v1.Namespace{})
@@ -97,12 +103,14 @@ func (c *FakeNamespaces) UpdateStatus(namespace *core_v1.Namespace) (*core_v1.Na
 	return obj.(*core_v1.Namespace), err
 }
 
+// Delete takes name of the namespace and deletes it. Returns an error if one occurs.
 func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &core_v1.Namespace{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,58 +35,18 @@ var namespacesResource = schema.GroupVersionResource{Group: "", Version: "v1", R
 
 var namespacesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Namespace"}
 
-func (c *FakeNamespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+func (c *FakeNamespaces) Get(name string, options v1.GetOptions) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &v1.Namespace{})
+		Invokes(testing.NewRootGetAction(namespacesResource, name), &core_v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Namespace), err
+	return obj.(*core_v1.Namespace), err
 }
 
-func (c *FakeNamespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+func (c *FakeNamespaces) List(opts v1.ListOptions) (result *core_v1.NamespaceList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) UpdateStatus(namespace *v1.Namespace) (*v1.Namespace, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &v1.Namespace{})
-	return err
-}
-
-func (c *FakeNamespaces) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.NamespaceList{})
-	return err
-}
-
-func (c *FakeNamespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(namespacesResource, name), &v1.Namespace{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Namespace), err
-}
-
-func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &v1.NamespaceList{})
+		Invokes(testing.NewRootListAction(namespacesResource, namespacesKind, opts), &core_v1.NamespaceList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +55,8 @@ func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceLis
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.NamespaceList{}
-	for _, item := range obj.(*v1.NamespaceList).Items {
+	list := &core_v1.NamespaceList{}
+	for _, item := range obj.(*core_v1.NamespaceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -105,17 +65,57 @@ func (c *FakeNamespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceLis
 }
 
 // Watch returns a watch.Interface that watches the requested namespaces.
-func (c *FakeNamespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeNamespaces) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(namespacesResource, opts))
 }
 
-// Patch applies the patch and returns the patched namespace.
-func (c *FakeNamespaces) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Namespace, err error) {
+func (c *FakeNamespaces) Create(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &v1.Namespace{})
+		Invokes(testing.NewRootCreateAction(namespacesResource, namespace), &core_v1.Namespace{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Namespace), err
+	return obj.(*core_v1.Namespace), err
+}
+
+func (c *FakeNamespaces) Update(namespace *core_v1.Namespace) (result *core_v1.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(namespacesResource, namespace), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
+}
+
+func (c *FakeNamespaces) UpdateStatus(namespace *core_v1.Namespace) (*core_v1.Namespace, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(namespacesResource, "status", namespace), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
+}
+
+func (c *FakeNamespaces) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(namespacesResource, name), &core_v1.Namespace{})
+	return err
+}
+
+func (c *FakeNamespaces) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(namespacesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.NamespaceList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched namespace.
+func (c *FakeNamespaces) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Namespace, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(namespacesResource, name, data, subresources...), &core_v1.Namespace{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Namespace), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,58 +35,18 @@ var nodesResource = schema.GroupVersionResource{Group: "", Version: "v1", Resour
 
 var nodesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
 
-func (c *FakeNodes) Create(node *v1.Node) (result *v1.Node, err error) {
+func (c *FakeNodes) Get(name string, options v1.GetOptions) (result *core_v1.Node, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(nodesResource, node), &v1.Node{})
+		Invokes(testing.NewRootGetAction(nodesResource, name), &core_v1.Node{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Node), err
+	return obj.(*core_v1.Node), err
 }
 
-func (c *FakeNodes) Update(node *v1.Node) (result *v1.Node, err error) {
+func (c *FakeNodes) List(opts v1.ListOptions) (result *core_v1.NodeList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(nodesResource, node), &v1.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Node), err
-}
-
-func (c *FakeNodes) UpdateStatus(node *v1.Node) (*v1.Node, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(nodesResource, "status", node), &v1.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Node), err
-}
-
-func (c *FakeNodes) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(nodesResource, name), &v1.Node{})
-	return err
-}
-
-func (c *FakeNodes) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(nodesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.NodeList{})
-	return err
-}
-
-func (c *FakeNodes) Get(name string, options meta_v1.GetOptions) (result *v1.Node, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(nodesResource, name), &v1.Node{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Node), err
-}
-
-func (c *FakeNodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(nodesResource, nodesKind, opts), &v1.NodeList{})
+		Invokes(testing.NewRootListAction(nodesResource, nodesKind, opts), &core_v1.NodeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +55,8 @@ func (c *FakeNodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err err
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.NodeList{}
-	for _, item := range obj.(*v1.NodeList).Items {
+	list := &core_v1.NodeList{}
+	for _, item := range obj.(*core_v1.NodeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -105,17 +65,57 @@ func (c *FakeNodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err err
 }
 
 // Watch returns a watch.Interface that watches the requested nodes.
-func (c *FakeNodes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeNodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(nodesResource, opts))
 }
 
-// Patch applies the patch and returns the patched node.
-func (c *FakeNodes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Node, err error) {
+func (c *FakeNodes) Create(node *core_v1.Node) (result *core_v1.Node, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(nodesResource, name, data, subresources...), &v1.Node{})
+		Invokes(testing.NewRootCreateAction(nodesResource, node), &core_v1.Node{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Node), err
+	return obj.(*core_v1.Node), err
+}
+
+func (c *FakeNodes) Update(node *core_v1.Node) (result *core_v1.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(nodesResource, node), &core_v1.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Node), err
+}
+
+func (c *FakeNodes) UpdateStatus(node *core_v1.Node) (*core_v1.Node, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(nodesResource, "status", node), &core_v1.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Node), err
+}
+
+func (c *FakeNodes) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(nodesResource, name), &core_v1.Node{})
+	return err
+}
+
+func (c *FakeNodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(nodesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.NodeList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched node.
+func (c *FakeNodes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Node, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(nodesResource, name, data, subresources...), &core_v1.Node{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Node), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -35,6 +35,7 @@ var nodesResource = schema.GroupVersionResource{Group: "", Version: "v1", Resour
 
 var nodesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}
 
+// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
 func (c *FakeNodes) Get(name string, options v1.GetOptions) (result *core_v1.Node, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(nodesResource, name), &core_v1.Node{})
@@ -44,6 +45,7 @@ func (c *FakeNodes) Get(name string, options v1.GetOptions) (result *core_v1.Nod
 	return obj.(*core_v1.Node), err
 }
 
+// List takes label and field selectors, and returns the list of Nodes that match those selectors.
 func (c *FakeNodes) List(opts v1.ListOptions) (result *core_v1.NodeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(nodesResource, nodesKind, opts), &core_v1.NodeList{})
@@ -70,6 +72,7 @@ func (c *FakeNodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		InvokesWatch(testing.NewRootWatchAction(nodesResource, opts))
 }
 
+// Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
 func (c *FakeNodes) Create(node *core_v1.Node) (result *core_v1.Node, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(nodesResource, node), &core_v1.Node{})
@@ -79,6 +82,7 @@ func (c *FakeNodes) Create(node *core_v1.Node) (result *core_v1.Node, err error)
 	return obj.(*core_v1.Node), err
 }
 
+// Update takes the representation of a node and updates it. Returns the server's representation of the node, and an error, if there is any.
 func (c *FakeNodes) Update(node *core_v1.Node) (result *core_v1.Node, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(nodesResource, node), &core_v1.Node{})
@@ -88,6 +92,8 @@ func (c *FakeNodes) Update(node *core_v1.Node) (result *core_v1.Node, err error)
 	return obj.(*core_v1.Node), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeNodes) UpdateStatus(node *core_v1.Node) (*core_v1.Node, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(nodesResource, "status", node), &core_v1.Node{})
@@ -97,12 +103,14 @@ func (c *FakeNodes) UpdateStatus(node *core_v1.Node) (*core_v1.Node, error) {
 	return obj.(*core_v1.Node), err
 }
 
+// Delete takes name of the node and deletes it. Returns an error if one occurs.
 func (c *FakeNodes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(nodesResource, name), &core_v1.Node{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeNodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(nodesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
@@ -35,6 +35,7 @@ var persistentvolumesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var persistentvolumesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"}
 
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
 func (c *FakePersistentVolumes) Get(name string, options v1.GetOptions) (result *core_v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(persistentvolumesResource, name), &core_v1.PersistentVolume{})
@@ -44,6 +45,7 @@ func (c *FakePersistentVolumes) Get(name string, options v1.GetOptions) (result 
 	return obj.(*core_v1.PersistentVolume), err
 }
 
+// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
 func (c *FakePersistentVolumes) List(opts v1.ListOptions) (result *core_v1.PersistentVolumeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(persistentvolumesResource, persistentvolumesKind, opts), &core_v1.PersistentVolumeList{})
@@ -70,6 +72,7 @@ func (c *FakePersistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, err
 		InvokesWatch(testing.NewRootWatchAction(persistentvolumesResource, opts))
 }
 
+// Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *FakePersistentVolumes) Create(persistentVolume *core_v1.PersistentVolume) (result *core_v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(persistentvolumesResource, persistentVolume), &core_v1.PersistentVolume{})
@@ -79,6 +82,7 @@ func (c *FakePersistentVolumes) Create(persistentVolume *core_v1.PersistentVolum
 	return obj.(*core_v1.PersistentVolume), err
 }
 
+// Update takes the representation of a persistentVolume and updates it. Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *FakePersistentVolumes) Update(persistentVolume *core_v1.PersistentVolume) (result *core_v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(persistentvolumesResource, persistentVolume), &core_v1.PersistentVolume{})
@@ -88,6 +92,8 @@ func (c *FakePersistentVolumes) Update(persistentVolume *core_v1.PersistentVolum
 	return obj.(*core_v1.PersistentVolume), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *core_v1.PersistentVolume) (*core_v1.PersistentVolume, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateSubresourceAction(persistentvolumesResource, "status", persistentVolume), &core_v1.PersistentVolume{})
@@ -97,12 +103,14 @@ func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *core_v1.Persisten
 	return obj.(*core_v1.PersistentVolume), err
 }
 
+// Delete takes name of the persistentVolume and deletes it. Returns an error if one occurs.
 func (c *FakePersistentVolumes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(persistentvolumesResource, name), &core_v1.PersistentVolume{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePersistentVolumes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(persistentvolumesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,58 +35,18 @@ var persistentvolumesResource = schema.GroupVersionResource{Group: "", Version: 
 
 var persistentvolumesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"}
 
-func (c *FakePersistentVolumes) Create(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
+func (c *FakePersistentVolumes) Get(name string, options v1.GetOptions) (result *core_v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(persistentvolumesResource, persistentVolume), &v1.PersistentVolume{})
+		Invokes(testing.NewRootGetAction(persistentvolumesResource, name), &core_v1.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PersistentVolume), err
+	return obj.(*core_v1.PersistentVolume), err
 }
 
-func (c *FakePersistentVolumes) Update(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
+func (c *FakePersistentVolumes) List(opts v1.ListOptions) (result *core_v1.PersistentVolumeList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(persistentvolumesResource, persistentVolume), &v1.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *v1.PersistentVolume) (*v1.PersistentVolume, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(persistentvolumesResource, "status", persistentVolume), &v1.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(persistentvolumesResource, name), &v1.PersistentVolume{})
-	return err
-}
-
-func (c *FakePersistentVolumes) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(persistentvolumesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.PersistentVolumeList{})
-	return err
-}
-
-func (c *FakePersistentVolumes) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolume, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(persistentvolumesResource, name), &v1.PersistentVolume{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolume), err
-}
-
-func (c *FakePersistentVolumes) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(persistentvolumesResource, persistentvolumesKind, opts), &v1.PersistentVolumeList{})
+		Invokes(testing.NewRootListAction(persistentvolumesResource, persistentvolumesKind, opts), &core_v1.PersistentVolumeList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -95,8 +55,8 @@ func (c *FakePersistentVolumes) List(opts meta_v1.ListOptions) (result *v1.Persi
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.PersistentVolumeList{}
-	for _, item := range obj.(*v1.PersistentVolumeList).Items {
+	list := &core_v1.PersistentVolumeList{}
+	for _, item := range obj.(*core_v1.PersistentVolumeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -105,17 +65,57 @@ func (c *FakePersistentVolumes) List(opts meta_v1.ListOptions) (result *v1.Persi
 }
 
 // Watch returns a watch.Interface that watches the requested persistentVolumes.
-func (c *FakePersistentVolumes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakePersistentVolumes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(persistentvolumesResource, opts))
 }
 
-// Patch applies the patch and returns the patched persistentVolume.
-func (c *FakePersistentVolumes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolume, err error) {
+func (c *FakePersistentVolumes) Create(persistentVolume *core_v1.PersistentVolume) (result *core_v1.PersistentVolume, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(persistentvolumesResource, name, data, subresources...), &v1.PersistentVolume{})
+		Invokes(testing.NewRootCreateAction(persistentvolumesResource, persistentVolume), &core_v1.PersistentVolume{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PersistentVolume), err
+	return obj.(*core_v1.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Update(persistentVolume *core_v1.PersistentVolume) (result *core_v1.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(persistentvolumesResource, persistentVolume), &core_v1.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) UpdateStatus(persistentVolume *core_v1.PersistentVolume) (*core_v1.PersistentVolume, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(persistentvolumesResource, "status", persistentVolume), &core_v1.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolume), err
+}
+
+func (c *FakePersistentVolumes) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(persistentvolumesResource, name), &core_v1.PersistentVolume{})
+	return err
+}
+
+func (c *FakePersistentVolumes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(persistentvolumesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.PersistentVolumeList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched persistentVolume.
+func (c *FakePersistentVolumes) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.PersistentVolume, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(persistentvolumesResource, name, data, subresources...), &core_v1.PersistentVolume{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolume), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var persistentvolumeclaimsResource = schema.GroupVersionResource{Group: "", Vers
 
 var persistentvolumeclaimsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"}
 
-func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+func (c *FakePersistentVolumeClaims) Get(name string, options v1.GetOptions) (result *core_v1.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
+		Invokes(testing.NewGetAction(persistentvolumeclaimsResource, c.ns, name), &core_v1.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PersistentVolumeClaim), err
+	return obj.(*core_v1.PersistentVolumeClaim), err
 }
 
-func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
+func (c *FakePersistentVolumeClaims) List(opts v1.ListOptions) (result *core_v1.PersistentVolumeClaimList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &v1.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &v1.PersistentVolumeClaim{})
-
-	return err
-}
-
-func (c *FakePersistentVolumeClaims) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.PersistentVolumeClaimList{})
-	return err
-}
-
-func (c *FakePersistentVolumeClaims) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolumeClaim, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(persistentvolumeclaimsResource, c.ns, name), &v1.PersistentVolumeClaim{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PersistentVolumeClaim), err
-}
-
-func (c *FakePersistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(persistentvolumeclaimsResource, persistentvolumeclaimsKind, c.ns, opts), &v1.PersistentVolumeClaimList{})
+		Invokes(testing.NewListAction(persistentvolumeclaimsResource, persistentvolumeclaimsKind, c.ns, opts), &core_v1.PersistentVolumeClaimList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakePersistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.PersistentVolumeClaimList{}
-	for _, item := range obj.(*v1.PersistentVolumeClaimList).Items {
+	list := &core_v1.PersistentVolumeClaimList{}
+	for _, item := range obj.(*core_v1.PersistentVolumeClaimList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakePersistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.
 }
 
 // Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
-func (c *FakePersistentVolumeClaims) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakePersistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(persistentvolumeclaimsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched persistentVolumeClaim.
-func (c *FakePersistentVolumeClaims) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.PersistentVolumeClaim, err error) {
+func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (result *core_v1.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, name, data, subresources...), &v1.PersistentVolumeClaim{})
+		Invokes(testing.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PersistentVolumeClaim), err
+	return obj.(*core_v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (result *core_v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (*core_v1.PersistentVolumeClaim, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolumeClaim), err
+}
+
+func (c *FakePersistentVolumeClaims) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &core_v1.PersistentVolumeClaim{})
+
+	return err
+}
+
+func (c *FakePersistentVolumeClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.PersistentVolumeClaimList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched persistentVolumeClaim.
+func (c *FakePersistentVolumeClaims) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.PersistentVolumeClaim, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(persistentvolumeclaimsResource, c.ns, name, data, subresources...), &core_v1.PersistentVolumeClaim{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PersistentVolumeClaim), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -36,6 +36,7 @@ var persistentvolumeclaimsResource = schema.GroupVersionResource{Group: "", Vers
 
 var persistentvolumeclaimsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"}
 
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
 func (c *FakePersistentVolumeClaims) Get(name string, options v1.GetOptions) (result *core_v1.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(persistentvolumeclaimsResource, c.ns, name), &core_v1.PersistentVolumeClaim{})
@@ -46,6 +47,7 @@ func (c *FakePersistentVolumeClaims) Get(name string, options v1.GetOptions) (re
 	return obj.(*core_v1.PersistentVolumeClaim), err
 }
 
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
 func (c *FakePersistentVolumeClaims) List(opts v1.ListOptions) (result *core_v1.PersistentVolumeClaimList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(persistentvolumeclaimsResource, persistentvolumeclaimsKind, c.ns, opts), &core_v1.PersistentVolumeClaimList{})
@@ -74,6 +76,7 @@ func (c *FakePersistentVolumeClaims) Watch(opts v1.ListOptions) (watch.Interface
 
 }
 
+// Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (result *core_v1.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
@@ -84,6 +87,7 @@ func (c *FakePersistentVolumeClaims) Create(persistentVolumeClaim *core_v1.Persi
 	return obj.(*core_v1.PersistentVolumeClaim), err
 }
 
+// Update takes the representation of a persistentVolumeClaim and updates it. Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (result *core_v1.PersistentVolumeClaim, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(persistentvolumeclaimsResource, c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
@@ -94,6 +98,8 @@ func (c *FakePersistentVolumeClaims) Update(persistentVolumeClaim *core_v1.Persi
 	return obj.(*core_v1.PersistentVolumeClaim), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *core_v1.PersistentVolumeClaim) (*core_v1.PersistentVolumeClaim, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(persistentvolumeclaimsResource, "status", c.ns, persistentVolumeClaim), &core_v1.PersistentVolumeClaim{})
@@ -104,6 +110,7 @@ func (c *FakePersistentVolumeClaims) UpdateStatus(persistentVolumeClaim *core_v1
 	return obj.(*core_v1.PersistentVolumeClaim), err
 }
 
+// Delete takes name of the persistentVolumeClaim and deletes it. Returns an error if one occurs.
 func (c *FakePersistentVolumeClaims) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(persistentvolumeclaimsResource, c.ns, name), &core_v1.PersistentVolumeClaim{})
@@ -111,6 +118,7 @@ func (c *FakePersistentVolumeClaims) Delete(name string, options *v1.DeleteOptio
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePersistentVolumeClaims) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(persistentvolumeclaimsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var podsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resourc
 
 var podsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
-func (c *FakePods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
+func (c *FakePods) Get(name string, options v1.GetOptions) (result *core_v1.Pod, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &v1.Pod{})
+		Invokes(testing.NewGetAction(podsResource, c.ns, name), &core_v1.Pod{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Pod), err
+	return obj.(*core_v1.Pod), err
 }
 
-func (c *FakePods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
+func (c *FakePods) List(opts v1.ListOptions) (result *core_v1.PodList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podsResource, c.ns, pod), &v1.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Pod), err
-}
-
-func (c *FakePods) UpdateStatus(pod *v1.Pod) (*v1.Pod, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(podsResource, "status", c.ns, pod), &v1.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Pod), err
-}
-
-func (c *FakePods) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podsResource, c.ns, name), &v1.Pod{})
-
-	return err
-}
-
-func (c *FakePods) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.PodList{})
-	return err
-}
-
-func (c *FakePods) Get(name string, options meta_v1.GetOptions) (result *v1.Pod, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(podsResource, c.ns, name), &v1.Pod{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Pod), err
-}
-
-func (c *FakePods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(podsResource, podsKind, c.ns, opts), &v1.PodList{})
+		Invokes(testing.NewListAction(podsResource, podsKind, c.ns, opts), &core_v1.PodList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakePods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.PodList{}
-	for _, item := range obj.(*v1.PodList).Items {
+	list := &core_v1.PodList{}
+	for _, item := range obj.(*core_v1.PodList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakePods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error
 }
 
 // Watch returns a watch.Interface that watches the requested pods.
-func (c *FakePods) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakePods) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched pod.
-func (c *FakePods) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Pod, err error) {
+func (c *FakePods) Create(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podsResource, c.ns, name, data, subresources...), &v1.Pod{})
+		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &core_v1.Pod{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Pod), err
+	return obj.(*core_v1.Pod), err
+}
+
+func (c *FakePods) Update(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podsResource, c.ns, pod), &core_v1.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Pod), err
+}
+
+func (c *FakePods) UpdateStatus(pod *core_v1.Pod) (*core_v1.Pod, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(podsResource, "status", c.ns, pod), &core_v1.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Pod), err
+}
+
+func (c *FakePods) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podsResource, c.ns, name), &core_v1.Pod{})
+
+	return err
+}
+
+func (c *FakePods) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.PodList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched pod.
+func (c *FakePods) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Pod, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(podsResource, c.ns, name, data, subresources...), &core_v1.Pod{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Pod), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -36,6 +36,7 @@ var podsResource = schema.GroupVersionResource{Group: "", Version: "v1", Resourc
 
 var podsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 
+// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
 func (c *FakePods) Get(name string, options v1.GetOptions) (result *core_v1.Pod, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podsResource, c.ns, name), &core_v1.Pod{})
@@ -46,6 +47,7 @@ func (c *FakePods) Get(name string, options v1.GetOptions) (result *core_v1.Pod,
 	return obj.(*core_v1.Pod), err
 }
 
+// List takes label and field selectors, and returns the list of Pods that match those selectors.
 func (c *FakePods) List(opts v1.ListOptions) (result *core_v1.PodList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podsResource, podsKind, c.ns, opts), &core_v1.PodList{})
@@ -74,6 +76,7 @@ func (c *FakePods) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
 func (c *FakePods) Create(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(podsResource, c.ns, pod), &core_v1.Pod{})
@@ -84,6 +87,7 @@ func (c *FakePods) Create(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
 	return obj.(*core_v1.Pod), err
 }
 
+// Update takes the representation of a pod and updates it. Returns the server's representation of the pod, and an error, if there is any.
 func (c *FakePods) Update(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(podsResource, c.ns, pod), &core_v1.Pod{})
@@ -94,6 +98,8 @@ func (c *FakePods) Update(pod *core_v1.Pod) (result *core_v1.Pod, err error) {
 	return obj.(*core_v1.Pod), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakePods) UpdateStatus(pod *core_v1.Pod) (*core_v1.Pod, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(podsResource, "status", c.ns, pod), &core_v1.Pod{})
@@ -104,6 +110,7 @@ func (c *FakePods) UpdateStatus(pod *core_v1.Pod) (*core_v1.Pod, error) {
 	return obj.(*core_v1.Pod), err
 }
 
+// Delete takes name of the pod and deletes it. Returns an error if one occurs.
 func (c *FakePods) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(podsResource, c.ns, name), &core_v1.Pod{})
@@ -111,6 +118,7 @@ func (c *FakePods) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePods) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(podsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
@@ -36,6 +36,7 @@ var podtemplatesResource = schema.GroupVersionResource{Group: "", Version: "v1",
 
 var podtemplatesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodTemplate"}
 
+// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
 func (c *FakePodTemplates) Get(name string, options v1.GetOptions) (result *core_v1.PodTemplate, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podtemplatesResource, c.ns, name), &core_v1.PodTemplate{})
@@ -46,6 +47,7 @@ func (c *FakePodTemplates) Get(name string, options v1.GetOptions) (result *core
 	return obj.(*core_v1.PodTemplate), err
 }
 
+// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
 func (c *FakePodTemplates) List(opts v1.ListOptions) (result *core_v1.PodTemplateList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podtemplatesResource, podtemplatesKind, c.ns, opts), &core_v1.PodTemplateList{})
@@ -74,6 +76,7 @@ func (c *FakePodTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *FakePodTemplates) Create(podTemplate *core_v1.PodTemplate) (result *core_v1.PodTemplate, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(podtemplatesResource, c.ns, podTemplate), &core_v1.PodTemplate{})
@@ -84,6 +87,7 @@ func (c *FakePodTemplates) Create(podTemplate *core_v1.PodTemplate) (result *cor
 	return obj.(*core_v1.PodTemplate), err
 }
 
+// Update takes the representation of a podTemplate and updates it. Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *FakePodTemplates) Update(podTemplate *core_v1.PodTemplate) (result *core_v1.PodTemplate, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(podtemplatesResource, c.ns, podTemplate), &core_v1.PodTemplate{})
@@ -94,6 +98,7 @@ func (c *FakePodTemplates) Update(podTemplate *core_v1.PodTemplate) (result *cor
 	return obj.(*core_v1.PodTemplate), err
 }
 
+// Delete takes name of the podTemplate and deletes it. Returns an error if one occurs.
 func (c *FakePodTemplates) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(podtemplatesResource, c.ns, name), &core_v1.PodTemplate{})
@@ -101,6 +106,7 @@ func (c *FakePodTemplates) Delete(name string, options *v1.DeleteOptions) error 
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePodTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(podtemplatesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var podtemplatesResource = schema.GroupVersionResource{Group: "", Version: "v1",
 
 var podtemplatesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodTemplate"}
 
-func (c *FakePodTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
+func (c *FakePodTemplates) Get(name string, options v1.GetOptions) (result *core_v1.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podtemplatesResource, c.ns, podTemplate), &v1.PodTemplate{})
+		Invokes(testing.NewGetAction(podtemplatesResource, c.ns, name), &core_v1.PodTemplate{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PodTemplate), err
+	return obj.(*core_v1.PodTemplate), err
 }
 
-func (c *FakePodTemplates) Update(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
+func (c *FakePodTemplates) List(opts v1.ListOptions) (result *core_v1.PodTemplateList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podtemplatesResource, c.ns, podTemplate), &v1.PodTemplate{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PodTemplate), err
-}
-
-func (c *FakePodTemplates) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podtemplatesResource, c.ns, name), &v1.PodTemplate{})
-
-	return err
-}
-
-func (c *FakePodTemplates) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podtemplatesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.PodTemplateList{})
-	return err
-}
-
-func (c *FakePodTemplates) Get(name string, options meta_v1.GetOptions) (result *v1.PodTemplate, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(podtemplatesResource, c.ns, name), &v1.PodTemplate{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.PodTemplate), err
-}
-
-func (c *FakePodTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplateList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(podtemplatesResource, podtemplatesKind, c.ns, opts), &v1.PodTemplateList{})
+		Invokes(testing.NewListAction(podtemplatesResource, podtemplatesKind, c.ns, opts), &core_v1.PodTemplateList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakePodTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplat
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.PodTemplateList{}
-	for _, item := range obj.(*v1.PodTemplateList).Items {
+	list := &core_v1.PodTemplateList{}
+	for _, item := range obj.(*core_v1.PodTemplateList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakePodTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplat
 }
 
 // Watch returns a watch.Interface that watches the requested podTemplates.
-func (c *FakePodTemplates) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakePodTemplates) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podtemplatesResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched podTemplate.
-func (c *FakePodTemplates) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.PodTemplate, err error) {
+func (c *FakePodTemplates) Create(podTemplate *core_v1.PodTemplate) (result *core_v1.PodTemplate, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(podtemplatesResource, c.ns, name, data, subresources...), &v1.PodTemplate{})
+		Invokes(testing.NewCreateAction(podtemplatesResource, c.ns, podTemplate), &core_v1.PodTemplate{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.PodTemplate), err
+	return obj.(*core_v1.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Update(podTemplate *core_v1.PodTemplate) (result *core_v1.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podtemplatesResource, c.ns, podTemplate), &core_v1.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PodTemplate), err
+}
+
+func (c *FakePodTemplates) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podtemplatesResource, c.ns, name), &core_v1.PodTemplate{})
+
+	return err
+}
+
+func (c *FakePodTemplates) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podtemplatesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.PodTemplateList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched podTemplate.
+func (c *FakePodTemplates) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.PodTemplate, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(podtemplatesResource, c.ns, name, data, subresources...), &core_v1.PodTemplate{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.PodTemplate), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var replicationcontrollersResource = schema.GroupVersionResource{Group: "", Vers
 
 var replicationcontrollersKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}
 
-func (c *FakeReplicationControllers) Create(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
+func (c *FakeReplicationControllers) Get(name string, options v1.GetOptions) (result *core_v1.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(replicationcontrollersResource, c.ns, replicationController), &v1.ReplicationController{})
+		Invokes(testing.NewGetAction(replicationcontrollersResource, c.ns, name), &core_v1.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ReplicationController), err
+	return obj.(*core_v1.ReplicationController), err
 }
 
-func (c *FakeReplicationControllers) Update(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
+func (c *FakeReplicationControllers) List(opts v1.ListOptions) (result *core_v1.ReplicationControllerList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(replicationcontrollersResource, c.ns, replicationController), &v1.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) UpdateStatus(replicationController *v1.ReplicationController) (*v1.ReplicationController, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "status", c.ns, replicationController), &v1.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(replicationcontrollersResource, c.ns, name), &v1.ReplicationController{})
-
-	return err
-}
-
-func (c *FakeReplicationControllers) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(replicationcontrollersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ReplicationControllerList{})
-	return err
-}
-
-func (c *FakeReplicationControllers) Get(name string, options meta_v1.GetOptions) (result *v1.ReplicationController, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(replicationcontrollersResource, c.ns, name), &v1.ReplicationController{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ReplicationController), err
-}
-
-func (c *FakeReplicationControllers) List(opts meta_v1.ListOptions) (result *v1.ReplicationControllerList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(replicationcontrollersResource, replicationcontrollersKind, c.ns, opts), &v1.ReplicationControllerList{})
+		Invokes(testing.NewListAction(replicationcontrollersResource, replicationcontrollersKind, c.ns, opts), &core_v1.ReplicationControllerList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakeReplicationControllers) List(opts meta_v1.ListOptions) (result *v1.
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ReplicationControllerList{}
-	for _, item := range obj.(*v1.ReplicationControllerList).Items {
+	list := &core_v1.ReplicationControllerList{}
+	for _, item := range obj.(*core_v1.ReplicationControllerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakeReplicationControllers) List(opts meta_v1.ListOptions) (result *v1.
 }
 
 // Watch returns a watch.Interface that watches the requested replicationControllers.
-func (c *FakeReplicationControllers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeReplicationControllers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(replicationcontrollersResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched replicationController.
-func (c *FakeReplicationControllers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ReplicationController, err error) {
+func (c *FakeReplicationControllers) Create(replicationController *core_v1.ReplicationController) (result *core_v1.ReplicationController, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, name, data, subresources...), &v1.ReplicationController{})
+		Invokes(testing.NewCreateAction(replicationcontrollersResource, c.ns, replicationController), &core_v1.ReplicationController{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ReplicationController), err
+	return obj.(*core_v1.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Update(replicationController *core_v1.ReplicationController) (result *core_v1.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(replicationcontrollersResource, c.ns, replicationController), &core_v1.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) UpdateStatus(replicationController *core_v1.ReplicationController) (*core_v1.ReplicationController, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "status", c.ns, replicationController), &core_v1.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ReplicationController), err
+}
+
+func (c *FakeReplicationControllers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(replicationcontrollersResource, c.ns, name), &core_v1.ReplicationController{})
+
+	return err
+}
+
+func (c *FakeReplicationControllers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(replicationcontrollersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ReplicationControllerList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched replicationController.
+func (c *FakeReplicationControllers) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ReplicationController, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(replicationcontrollersResource, c.ns, name, data, subresources...), &core_v1.ReplicationController{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ReplicationController), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -36,6 +36,7 @@ var replicationcontrollersResource = schema.GroupVersionResource{Group: "", Vers
 
 var replicationcontrollersKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ReplicationController"}
 
+// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
 func (c *FakeReplicationControllers) Get(name string, options v1.GetOptions) (result *core_v1.ReplicationController, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicationcontrollersResource, c.ns, name), &core_v1.ReplicationController{})
@@ -46,6 +47,7 @@ func (c *FakeReplicationControllers) Get(name string, options v1.GetOptions) (re
 	return obj.(*core_v1.ReplicationController), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
 func (c *FakeReplicationControllers) List(opts v1.ListOptions) (result *core_v1.ReplicationControllerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicationcontrollersResource, replicationcontrollersKind, c.ns, opts), &core_v1.ReplicationControllerList{})
@@ -74,6 +76,7 @@ func (c *FakeReplicationControllers) Watch(opts v1.ListOptions) (watch.Interface
 
 }
 
+// Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *FakeReplicationControllers) Create(replicationController *core_v1.ReplicationController) (result *core_v1.ReplicationController, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(replicationcontrollersResource, c.ns, replicationController), &core_v1.ReplicationController{})
@@ -84,6 +87,7 @@ func (c *FakeReplicationControllers) Create(replicationController *core_v1.Repli
 	return obj.(*core_v1.ReplicationController), err
 }
 
+// Update takes the representation of a replicationController and updates it. Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *FakeReplicationControllers) Update(replicationController *core_v1.ReplicationController) (result *core_v1.ReplicationController, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(replicationcontrollersResource, c.ns, replicationController), &core_v1.ReplicationController{})
@@ -94,6 +98,8 @@ func (c *FakeReplicationControllers) Update(replicationController *core_v1.Repli
 	return obj.(*core_v1.ReplicationController), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeReplicationControllers) UpdateStatus(replicationController *core_v1.ReplicationController) (*core_v1.ReplicationController, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "status", c.ns, replicationController), &core_v1.ReplicationController{})
@@ -104,6 +110,7 @@ func (c *FakeReplicationControllers) UpdateStatus(replicationController *core_v1
 	return obj.(*core_v1.ReplicationController), err
 }
 
+// Delete takes name of the replicationController and deletes it. Returns an error if one occurs.
 func (c *FakeReplicationControllers) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(replicationcontrollersResource, c.ns, name), &core_v1.ReplicationController{})
@@ -111,6 +118,7 @@ func (c *FakeReplicationControllers) Delete(name string, options *v1.DeleteOptio
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeReplicationControllers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(replicationcontrollersResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
@@ -36,6 +36,7 @@ var resourcequotasResource = schema.GroupVersionResource{Group: "", Version: "v1
 
 var resourcequotasKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}
 
+// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
 func (c *FakeResourceQuotas) Get(name string, options v1.GetOptions) (result *core_v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(resourcequotasResource, c.ns, name), &core_v1.ResourceQuota{})
@@ -46,6 +47,7 @@ func (c *FakeResourceQuotas) Get(name string, options v1.GetOptions) (result *co
 	return obj.(*core_v1.ResourceQuota), err
 }
 
+// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
 func (c *FakeResourceQuotas) List(opts v1.ListOptions) (result *core_v1.ResourceQuotaList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(resourcequotasResource, resourcequotasKind, c.ns, opts), &core_v1.ResourceQuotaList{})
@@ -74,6 +76,7 @@ func (c *FakeResourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error)
 
 }
 
+// Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *FakeResourceQuotas) Create(resourceQuota *core_v1.ResourceQuota) (result *core_v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(resourcequotasResource, c.ns, resourceQuota), &core_v1.ResourceQuota{})
@@ -84,6 +87,7 @@ func (c *FakeResourceQuotas) Create(resourceQuota *core_v1.ResourceQuota) (resul
 	return obj.(*core_v1.ResourceQuota), err
 }
 
+// Update takes the representation of a resourceQuota and updates it. Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *FakeResourceQuotas) Update(resourceQuota *core_v1.ResourceQuota) (result *core_v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(resourcequotasResource, c.ns, resourceQuota), &core_v1.ResourceQuota{})
@@ -94,6 +98,8 @@ func (c *FakeResourceQuotas) Update(resourceQuota *core_v1.ResourceQuota) (resul
 	return obj.(*core_v1.ResourceQuota), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *core_v1.ResourceQuota) (*core_v1.ResourceQuota, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(resourcequotasResource, "status", c.ns, resourceQuota), &core_v1.ResourceQuota{})
@@ -104,6 +110,7 @@ func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *core_v1.ResourceQuota) 
 	return obj.(*core_v1.ResourceQuota), err
 }
 
+// Delete takes name of the resourceQuota and deletes it. Returns an error if one occurs.
 func (c *FakeResourceQuotas) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(resourcequotasResource, c.ns, name), &core_v1.ResourceQuota{})
@@ -111,6 +118,7 @@ func (c *FakeResourceQuotas) Delete(name string, options *v1.DeleteOptions) erro
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeResourceQuotas) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(resourcequotasResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var resourcequotasResource = schema.GroupVersionResource{Group: "", Version: "v1
 
 var resourcequotasKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}
 
-func (c *FakeResourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
+func (c *FakeResourceQuotas) Get(name string, options v1.GetOptions) (result *core_v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(resourcequotasResource, c.ns, resourceQuota), &v1.ResourceQuota{})
+		Invokes(testing.NewGetAction(resourcequotasResource, c.ns, name), &core_v1.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ResourceQuota), err
+	return obj.(*core_v1.ResourceQuota), err
 }
 
-func (c *FakeResourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
+func (c *FakeResourceQuotas) List(opts v1.ListOptions) (result *core_v1.ResourceQuotaList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(resourcequotasResource, c.ns, resourceQuota), &v1.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (*v1.ResourceQuota, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(resourcequotasResource, "status", c.ns, resourceQuota), &v1.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(resourcequotasResource, c.ns, name), &v1.ResourceQuota{})
-
-	return err
-}
-
-func (c *FakeResourceQuotas) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(resourcequotasResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ResourceQuotaList{})
-	return err
-}
-
-func (c *FakeResourceQuotas) Get(name string, options meta_v1.GetOptions) (result *v1.ResourceQuota, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(resourcequotasResource, c.ns, name), &v1.ResourceQuota{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ResourceQuota), err
-}
-
-func (c *FakeResourceQuotas) List(opts meta_v1.ListOptions) (result *v1.ResourceQuotaList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(resourcequotasResource, resourcequotasKind, c.ns, opts), &v1.ResourceQuotaList{})
+		Invokes(testing.NewListAction(resourcequotasResource, resourcequotasKind, c.ns, opts), &core_v1.ResourceQuotaList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakeResourceQuotas) List(opts meta_v1.ListOptions) (result *v1.Resource
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ResourceQuotaList{}
-	for _, item := range obj.(*v1.ResourceQuotaList).Items {
+	list := &core_v1.ResourceQuotaList{}
+	for _, item := range obj.(*core_v1.ResourceQuotaList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakeResourceQuotas) List(opts meta_v1.ListOptions) (result *v1.Resource
 }
 
 // Watch returns a watch.Interface that watches the requested resourceQuotas.
-func (c *FakeResourceQuotas) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeResourceQuotas) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(resourcequotasResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched resourceQuota.
-func (c *FakeResourceQuotas) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ResourceQuota, err error) {
+func (c *FakeResourceQuotas) Create(resourceQuota *core_v1.ResourceQuota) (result *core_v1.ResourceQuota, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(resourcequotasResource, c.ns, name, data, subresources...), &v1.ResourceQuota{})
+		Invokes(testing.NewCreateAction(resourcequotasResource, c.ns, resourceQuota), &core_v1.ResourceQuota{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ResourceQuota), err
+	return obj.(*core_v1.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Update(resourceQuota *core_v1.ResourceQuota) (result *core_v1.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(resourcequotasResource, c.ns, resourceQuota), &core_v1.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) UpdateStatus(resourceQuota *core_v1.ResourceQuota) (*core_v1.ResourceQuota, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(resourcequotasResource, "status", c.ns, resourceQuota), &core_v1.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ResourceQuota), err
+}
+
+func (c *FakeResourceQuotas) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(resourcequotasResource, c.ns, name), &core_v1.ResourceQuota{})
+
+	return err
+}
+
+func (c *FakeResourceQuotas) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(resourcequotasResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ResourceQuotaList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched resourceQuota.
+func (c *FakeResourceQuotas) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ResourceQuota, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(resourcequotasResource, c.ns, name, data, subresources...), &core_v1.ResourceQuota{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ResourceQuota), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
@@ -36,6 +36,7 @@ var secretsResource = schema.GroupVersionResource{Group: "", Version: "v1", Reso
 
 var secretsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
 func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &core_v1.Secret{})
@@ -46,6 +47,7 @@ func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *core_v1.S
 	return obj.(*core_v1.Secret), err
 }
 
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
 func (c *FakeSecrets) List(opts v1.ListOptions) (result *core_v1.SecretList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &core_v1.SecretList{})
@@ -74,6 +76,7 @@ func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *FakeSecrets) Create(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
@@ -84,6 +87,7 @@ func (c *FakeSecrets) Create(secret *core_v1.Secret) (result *core_v1.Secret, er
 	return obj.(*core_v1.Secret), err
 }
 
+// Update takes the representation of a secret and updates it. Returns the server's representation of the secret, and an error, if there is any.
 func (c *FakeSecrets) Update(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
@@ -94,6 +98,7 @@ func (c *FakeSecrets) Update(secret *core_v1.Secret) (result *core_v1.Secret, er
 	return obj.(*core_v1.Secret), err
 }
 
+// Delete takes name of the secret and deletes it. Returns an error if one occurs.
 func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &core_v1.Secret{})
@@ -101,6 +106,7 @@ func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var secretsResource = schema.GroupVersionResource{Group: "", Version: "v1", Reso
 
 var secretsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Secret"}
 
-func (c *FakeSecrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
+func (c *FakeSecrets) Get(name string, options v1.GetOptions) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &v1.Secret{})
+		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &core_v1.Secret{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Secret), err
+	return obj.(*core_v1.Secret), err
 }
 
-func (c *FakeSecrets) Update(secret *v1.Secret) (result *v1.Secret, err error) {
+func (c *FakeSecrets) List(opts v1.ListOptions) (result *core_v1.SecretList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &v1.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Secret), err
-}
-
-func (c *FakeSecrets) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &v1.Secret{})
-
-	return err
-}
-
-func (c *FakeSecrets) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.SecretList{})
-	return err
-}
-
-func (c *FakeSecrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(secretsResource, c.ns, name), &v1.Secret{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Secret), err
-}
-
-func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &v1.SecretList{})
+		Invokes(testing.NewListAction(secretsResource, secretsKind, c.ns, opts), &core_v1.SecretList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.SecretList{}
-	for _, item := range obj.(*v1.SecretList).Items {
+	list := &core_v1.SecretList{}
+	for _, item := range obj.(*core_v1.SecretList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeSecrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err
 }
 
 // Watch returns a watch.Interface that watches the requested secrets.
-func (c *FakeSecrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeSecrets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(secretsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched secret.
-func (c *FakeSecrets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Secret, err error) {
+func (c *FakeSecrets) Create(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &v1.Secret{})
+		Invokes(testing.NewCreateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Secret), err
+	return obj.(*core_v1.Secret), err
+}
+
+func (c *FakeSecrets) Update(secret *core_v1.Secret) (result *core_v1.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(secretsResource, c.ns, secret), &core_v1.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Secret), err
+}
+
+func (c *FakeSecrets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(secretsResource, c.ns, name), &core_v1.Secret{})
+
+	return err
+}
+
+func (c *FakeSecrets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(secretsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.SecretList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched secret.
+func (c *FakeSecrets) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Secret, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(secretsResource, c.ns, name, data, subresources...), &core_v1.Secret{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Secret), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,63 +36,19 @@ var servicesResource = schema.GroupVersionResource{Group: "", Version: "v1", Res
 
 var servicesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
 
-func (c *FakeServices) Create(service *v1.Service) (result *v1.Service, err error) {
+func (c *FakeServices) Get(name string, options v1.GetOptions) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &v1.Service{})
+		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &core_v1.Service{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Service), err
+	return obj.(*core_v1.Service), err
 }
 
-func (c *FakeServices) Update(service *v1.Service) (result *v1.Service, err error) {
+func (c *FakeServices) List(opts v1.ListOptions) (result *core_v1.ServiceList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) UpdateStatus(service *v1.Service) (*v1.Service, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &v1.Service{})
-
-	return err
-}
-
-func (c *FakeServices) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ServiceList{})
-	return err
-}
-
-func (c *FakeServices) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &v1.Service{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.Service), err
-}
-
-func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &v1.ServiceList{})
+		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &core_v1.ServiceList{})
 
 	if obj == nil {
 		return nil, err
@@ -102,8 +58,8 @@ func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, e
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ServiceList{}
-	for _, item := range obj.(*v1.ServiceList).Items {
+	list := &core_v1.ServiceList{}
+	for _, item := range obj.(*core_v1.ServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -112,19 +68,63 @@ func (c *FakeServices) List(opts meta_v1.ListOptions) (result *v1.ServiceList, e
 }
 
 // Watch returns a watch.Interface that watches the requested services.
-func (c *FakeServices) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(servicesResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched service.
-func (c *FakeServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.Service, err error) {
+func (c *FakeServices) Create(service *core_v1.Service) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &v1.Service{})
+		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &core_v1.Service{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.Service), err
+	return obj.(*core_v1.Service), err
+}
+
+func (c *FakeServices) Update(service *core_v1.Service) (result *core_v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
+}
+
+func (c *FakeServices) UpdateStatus(service *core_v1.Service) (*core_v1.Service, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
+}
+
+func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &core_v1.Service{})
+
+	return err
+}
+
+func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ServiceList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched service.
+func (c *FakeServices) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.Service, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(servicesResource, c.ns, name, data, subresources...), &core_v1.Service{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.Service), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -36,6 +36,7 @@ var servicesResource = schema.GroupVersionResource{Group: "", Version: "v1", Res
 
 var servicesKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Service"}
 
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
 func (c *FakeServices) Get(name string, options v1.GetOptions) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(servicesResource, c.ns, name), &core_v1.Service{})
@@ -46,6 +47,7 @@ func (c *FakeServices) Get(name string, options v1.GetOptions) (result *core_v1.
 	return obj.(*core_v1.Service), err
 }
 
+// List takes label and field selectors, and returns the list of Services that match those selectors.
 func (c *FakeServices) List(opts v1.ListOptions) (result *core_v1.ServiceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(servicesResource, servicesKind, c.ns, opts), &core_v1.ServiceList{})
@@ -74,6 +76,7 @@ func (c *FakeServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *FakeServices) Create(service *core_v1.Service) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(servicesResource, c.ns, service), &core_v1.Service{})
@@ -84,6 +87,7 @@ func (c *FakeServices) Create(service *core_v1.Service) (result *core_v1.Service
 	return obj.(*core_v1.Service), err
 }
 
+// Update takes the representation of a service and updates it. Returns the server's representation of the service, and an error, if there is any.
 func (c *FakeServices) Update(service *core_v1.Service) (result *core_v1.Service, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(servicesResource, c.ns, service), &core_v1.Service{})
@@ -94,6 +98,8 @@ func (c *FakeServices) Update(service *core_v1.Service) (result *core_v1.Service
 	return obj.(*core_v1.Service), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeServices) UpdateStatus(service *core_v1.Service) (*core_v1.Service, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(servicesResource, "status", c.ns, service), &core_v1.Service{})
@@ -104,6 +110,7 @@ func (c *FakeServices) UpdateStatus(service *core_v1.Service) (*core_v1.Service,
 	return obj.(*core_v1.Service), err
 }
 
+// Delete takes name of the service and deletes it. Returns an error if one occurs.
 func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(servicesResource, c.ns, name), &core_v1.Service{})
@@ -111,6 +118,7 @@ func (c *FakeServices) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(servicesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
@@ -36,6 +36,7 @@ var serviceaccountsResource = schema.GroupVersionResource{Group: "", Version: "v
 
 var serviceaccountsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 
+// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
 func (c *FakeServiceAccounts) Get(name string, options v1.GetOptions) (result *core_v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(serviceaccountsResource, c.ns, name), &core_v1.ServiceAccount{})
@@ -46,6 +47,7 @@ func (c *FakeServiceAccounts) Get(name string, options v1.GetOptions) (result *c
 	return obj.(*core_v1.ServiceAccount), err
 }
 
+// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
 func (c *FakeServiceAccounts) List(opts v1.ListOptions) (result *core_v1.ServiceAccountList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(serviceaccountsResource, serviceaccountsKind, c.ns, opts), &core_v1.ServiceAccountList{})
@@ -74,6 +76,7 @@ func (c *FakeServiceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error
 
 }
 
+// Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *FakeServiceAccounts) Create(serviceAccount *core_v1.ServiceAccount) (result *core_v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(serviceaccountsResource, c.ns, serviceAccount), &core_v1.ServiceAccount{})
@@ -84,6 +87,7 @@ func (c *FakeServiceAccounts) Create(serviceAccount *core_v1.ServiceAccount) (re
 	return obj.(*core_v1.ServiceAccount), err
 }
 
+// Update takes the representation of a serviceAccount and updates it. Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *FakeServiceAccounts) Update(serviceAccount *core_v1.ServiceAccount) (result *core_v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(serviceaccountsResource, c.ns, serviceAccount), &core_v1.ServiceAccount{})
@@ -94,6 +98,7 @@ func (c *FakeServiceAccounts) Update(serviceAccount *core_v1.ServiceAccount) (re
 	return obj.(*core_v1.ServiceAccount), err
 }
 
+// Delete takes name of the serviceAccount and deletes it. Returns an error if one occurs.
 func (c *FakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(serviceaccountsResource, c.ns, name), &core_v1.ServiceAccount{})
@@ -101,6 +106,7 @@ func (c *FakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) err
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeServiceAccounts) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(serviceaccountsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/core/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	core_v1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var serviceaccountsResource = schema.GroupVersionResource{Group: "", Version: "v
 
 var serviceaccountsKind = schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ServiceAccount"}
 
-func (c *FakeServiceAccounts) Create(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
+func (c *FakeServiceAccounts) Get(name string, options v1.GetOptions) (result *core_v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(serviceaccountsResource, c.ns, serviceAccount), &v1.ServiceAccount{})
+		Invokes(testing.NewGetAction(serviceaccountsResource, c.ns, name), &core_v1.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ServiceAccount), err
+	return obj.(*core_v1.ServiceAccount), err
 }
 
-func (c *FakeServiceAccounts) Update(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
+func (c *FakeServiceAccounts) List(opts v1.ListOptions) (result *core_v1.ServiceAccountList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(serviceaccountsResource, c.ns, serviceAccount), &v1.ServiceAccount{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ServiceAccount), err
-}
-
-func (c *FakeServiceAccounts) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(serviceaccountsResource, c.ns, name), &v1.ServiceAccount{})
-
-	return err
-}
-
-func (c *FakeServiceAccounts) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(serviceaccountsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.ServiceAccountList{})
-	return err
-}
-
-func (c *FakeServiceAccounts) Get(name string, options meta_v1.GetOptions) (result *v1.ServiceAccount, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(serviceaccountsResource, c.ns, name), &v1.ServiceAccount{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.ServiceAccount), err
-}
-
-func (c *FakeServiceAccounts) List(opts meta_v1.ListOptions) (result *v1.ServiceAccountList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(serviceaccountsResource, serviceaccountsKind, c.ns, opts), &v1.ServiceAccountList{})
+		Invokes(testing.NewListAction(serviceaccountsResource, serviceaccountsKind, c.ns, opts), &core_v1.ServiceAccountList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeServiceAccounts) List(opts meta_v1.ListOptions) (result *v1.Service
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.ServiceAccountList{}
-	for _, item := range obj.(*v1.ServiceAccountList).Items {
+	list := &core_v1.ServiceAccountList{}
+	for _, item := range obj.(*core_v1.ServiceAccountList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeServiceAccounts) List(opts meta_v1.ListOptions) (result *v1.Service
 }
 
 // Watch returns a watch.Interface that watches the requested serviceAccounts.
-func (c *FakeServiceAccounts) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeServiceAccounts) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(serviceaccountsResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched serviceAccount.
-func (c *FakeServiceAccounts) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.ServiceAccount, err error) {
+func (c *FakeServiceAccounts) Create(serviceAccount *core_v1.ServiceAccount) (result *core_v1.ServiceAccount, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(serviceaccountsResource, c.ns, name, data, subresources...), &v1.ServiceAccount{})
+		Invokes(testing.NewCreateAction(serviceaccountsResource, c.ns, serviceAccount), &core_v1.ServiceAccount{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.ServiceAccount), err
+	return obj.(*core_v1.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Update(serviceAccount *core_v1.ServiceAccount) (result *core_v1.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(serviceaccountsResource, c.ns, serviceAccount), &core_v1.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ServiceAccount), err
+}
+
+func (c *FakeServiceAccounts) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(serviceaccountsResource, c.ns, name), &core_v1.ServiceAccount{})
+
+	return err
+}
+
+func (c *FakeServiceAccounts) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(serviceaccountsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &core_v1.ServiceAccountList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched serviceAccount.
+func (c *FakeServiceAccounts) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *core_v1.ServiceAccount, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(serviceaccountsResource, c.ns, name, data, subresources...), &core_v1.ServiceAccount{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*core_v1.ServiceAccount), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -58,6 +58,41 @@ func newLimitRanges(c *CoreV1Client, namespace string) *limitRanges {
 	}
 }
 
+// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
+func (c *limitRanges) Get(name string, options meta_v1.GetOptions) (result *v1.LimitRange, err error) {
+	result = &v1.LimitRange{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
+func (c *limitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeList, err error) {
+	result = &v1.LimitRangeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested limitRanges.
+func (c *limitRanges) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("limitranges").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
 func (c *limitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, err error) {
 	result = &v1.LimitRange{}
@@ -103,41 +138,6 @@ func (c *limitRanges) DeleteCollection(options *meta_v1.DeleteOptions, listOptio
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the limitRange, and returns the corresponding limitRange object, and an error if there is any.
-func (c *limitRanges) Get(name string, options meta_v1.GetOptions) (result *v1.LimitRange, err error) {
-	result = &v1.LimitRange{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of LimitRanges that match those selectors.
-func (c *limitRanges) List(opts meta_v1.ListOptions) (result *v1.LimitRangeList, err error) {
-	result = &v1.LimitRangeList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested limitRanges.
-func (c *limitRanges) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("limitranges").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched limitRange.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -57,6 +57,38 @@ func newNamespaces(c *CoreV1Client) *namespaces {
 	}
 }
 
+// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
+func (c *namespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
+	result = &v1.Namespace{}
+	err = c.client.Get().
+		Resource("namespaces").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
+func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
+	result = &v1.NamespaceList{}
+	err = c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested namespaces.
+func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("namespaces").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
 func (c *namespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
@@ -81,7 +113,7 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
@@ -113,38 +145,6 @@ func (c *namespaces) DeleteCollection(options *meta_v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the namespace, and returns the corresponding namespace object, and an error if there is any.
-func (c *namespaces) Get(name string, options meta_v1.GetOptions) (result *v1.Namespace, err error) {
-	result = &v1.Namespace{}
-	err = c.client.Get().
-		Resource("namespaces").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Namespaces that match those selectors.
-func (c *namespaces) List(opts meta_v1.ListOptions) (result *v1.NamespaceList, err error) {
-	result = &v1.NamespaceList{}
-	err = c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested namespaces.
-func (c *namespaces) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("namespaces").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched namespace.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -57,6 +57,38 @@ func newNodes(c *CoreV1Client) *nodes {
 	}
 }
 
+// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
+func (c *nodes) Get(name string, options meta_v1.GetOptions) (result *v1.Node, err error) {
+	result = &v1.Node{}
+	err = c.client.Get().
+		Resource("nodes").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Nodes that match those selectors.
+func (c *nodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err error) {
+	result = &v1.NodeList{}
+	err = c.client.Get().
+		Resource("nodes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested nodes.
+func (c *nodes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("nodes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
 func (c *nodes) Create(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
@@ -81,7 +113,7 @@ func (c *nodes) Update(node *v1.Node) (result *v1.Node, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *nodes) UpdateStatus(node *v1.Node) (result *v1.Node, err error) {
 	result = &v1.Node{}
@@ -113,38 +145,6 @@ func (c *nodes) DeleteCollection(options *meta_v1.DeleteOptions, listOptions met
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the node, and returns the corresponding node object, and an error if there is any.
-func (c *nodes) Get(name string, options meta_v1.GetOptions) (result *v1.Node, err error) {
-	result = &v1.Node{}
-	err = c.client.Get().
-		Resource("nodes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Nodes that match those selectors.
-func (c *nodes) List(opts meta_v1.ListOptions) (result *v1.NodeList, err error) {
-	result = &v1.NodeList{}
-	err = c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested nodes.
-func (c *nodes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("nodes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched node.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -57,6 +57,38 @@ func newPersistentVolumes(c *CoreV1Client) *persistentVolumes {
 	}
 }
 
+// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
+func (c *persistentVolumes) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolume, err error) {
+	result = &v1.PersistentVolume{}
+	err = c.client.Get().
+		Resource("persistentvolumes").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
+func (c *persistentVolumes) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeList, err error) {
+	result = &v1.PersistentVolumeList{}
+	err = c.client.Get().
+		Resource("persistentvolumes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumes.
+func (c *persistentVolumes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("persistentvolumes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
 func (c *persistentVolumes) Create(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
@@ -81,7 +113,7 @@ func (c *persistentVolumes) Update(persistentVolume *v1.PersistentVolume) (resul
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *persistentVolumes) UpdateStatus(persistentVolume *v1.PersistentVolume) (result *v1.PersistentVolume, err error) {
 	result = &v1.PersistentVolume{}
@@ -113,38 +145,6 @@ func (c *persistentVolumes) DeleteCollection(options *meta_v1.DeleteOptions, lis
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the persistentVolume, and returns the corresponding persistentVolume object, and an error if there is any.
-func (c *persistentVolumes) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolume, err error) {
-	result = &v1.PersistentVolume{}
-	err = c.client.Get().
-		Resource("persistentvolumes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PersistentVolumes that match those selectors.
-func (c *persistentVolumes) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeList, err error) {
-	result = &v1.PersistentVolumeList{}
-	err = c.client.Get().
-		Resource("persistentvolumes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested persistentVolumes.
-func (c *persistentVolumes) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("persistentvolumes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched persistentVolume.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -59,6 +59,41 @@ func newPersistentVolumeClaims(c *CoreV1Client, namespace string) *persistentVol
 	}
 }
 
+// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
+func (c *persistentVolumeClaims) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolumeClaim, err error) {
+	result = &v1.PersistentVolumeClaim{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
+func (c *persistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
+	result = &v1.PersistentVolumeClaimList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
+func (c *persistentVolumeClaims) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("persistentvolumeclaims").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
 func (c *persistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
@@ -85,7 +120,7 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolu
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.PersistentVolumeClaim) (result *v1.PersistentVolumeClaim, err error) {
 	result = &v1.PersistentVolumeClaim{}
@@ -120,41 +155,6 @@ func (c *persistentVolumeClaims) DeleteCollection(options *meta_v1.DeleteOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the persistentVolumeClaim, and returns the corresponding persistentVolumeClaim object, and an error if there is any.
-func (c *persistentVolumeClaims) Get(name string, options meta_v1.GetOptions) (result *v1.PersistentVolumeClaim, err error) {
-	result = &v1.PersistentVolumeClaim{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PersistentVolumeClaims that match those selectors.
-func (c *persistentVolumeClaims) List(opts meta_v1.ListOptions) (result *v1.PersistentVolumeClaimList, err error) {
-	result = &v1.PersistentVolumeClaimList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested persistentVolumeClaims.
-func (c *persistentVolumeClaims) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("persistentvolumeclaims").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched persistentVolumeClaim.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -59,6 +59,41 @@ func newPods(c *CoreV1Client, namespace string) *pods {
 	}
 }
 
+// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
+func (c *pods) Get(name string, options meta_v1.GetOptions) (result *v1.Pod, err error) {
+	result = &v1.Pod{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Pods that match those selectors.
+func (c *pods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error) {
+	result = &v1.PodList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested pods.
+func (c *pods) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("pods").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
 func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
@@ -85,7 +120,7 @@ func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *pods) UpdateStatus(pod *v1.Pod) (result *v1.Pod, err error) {
 	result = &v1.Pod{}
@@ -120,41 +155,6 @@ func (c *pods) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the pod, and returns the corresponding pod object, and an error if there is any.
-func (c *pods) Get(name string, options meta_v1.GetOptions) (result *v1.Pod, err error) {
-	result = &v1.Pod{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Pods that match those selectors.
-func (c *pods) List(opts meta_v1.ListOptions) (result *v1.PodList, err error) {
-	result = &v1.PodList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested pods.
-func (c *pods) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("pods").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched pod.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -58,6 +58,41 @@ func newPodTemplates(c *CoreV1Client, namespace string) *podTemplates {
 	}
 }
 
+// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
+func (c *podTemplates) Get(name string, options meta_v1.GetOptions) (result *v1.PodTemplate, err error) {
+	result = &v1.PodTemplate{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
+func (c *podTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplateList, err error) {
+	result = &v1.PodTemplateList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podTemplates.
+func (c *podTemplates) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("podtemplates").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
 func (c *podTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTemplate, err error) {
 	result = &v1.PodTemplate{}
@@ -103,41 +138,6 @@ func (c *podTemplates) DeleteCollection(options *meta_v1.DeleteOptions, listOpti
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podTemplate, and returns the corresponding podTemplate object, and an error if there is any.
-func (c *podTemplates) Get(name string, options meta_v1.GetOptions) (result *v1.PodTemplate, err error) {
-	result = &v1.PodTemplate{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodTemplates that match those selectors.
-func (c *podTemplates) List(opts meta_v1.ListOptions) (result *v1.PodTemplateList, err error) {
-	result = &v1.PodTemplateList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podTemplates.
-func (c *podTemplates) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("podtemplates").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podTemplate.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -59,6 +59,41 @@ func newReplicationControllers(c *CoreV1Client, namespace string) *replicationCo
 	}
 }
 
+// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
+func (c *replicationControllers) Get(name string, options meta_v1.GetOptions) (result *v1.ReplicationController, err error) {
+	result = &v1.ReplicationController{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
+func (c *replicationControllers) List(opts meta_v1.ListOptions) (result *v1.ReplicationControllerList, err error) {
+	result = &v1.ReplicationControllerList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicationControllers.
+func (c *replicationControllers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicationcontrollers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
 func (c *replicationControllers) Create(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
@@ -85,7 +120,7 @@ func (c *replicationControllers) Update(replicationController *v1.ReplicationCon
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicationControllers) UpdateStatus(replicationController *v1.ReplicationController) (result *v1.ReplicationController, err error) {
 	result = &v1.ReplicationController{}
@@ -120,41 +155,6 @@ func (c *replicationControllers) DeleteCollection(options *meta_v1.DeleteOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicationController, and returns the corresponding replicationController object, and an error if there is any.
-func (c *replicationControllers) Get(name string, options meta_v1.GetOptions) (result *v1.ReplicationController, err error) {
-	result = &v1.ReplicationController{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicationControllers that match those selectors.
-func (c *replicationControllers) List(opts meta_v1.ListOptions) (result *v1.ReplicationControllerList, err error) {
-	result = &v1.ReplicationControllerList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicationControllers.
-func (c *replicationControllers) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicationcontrollers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicationController.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -59,6 +59,41 @@ func newResourceQuotas(c *CoreV1Client, namespace string) *resourceQuotas {
 	}
 }
 
+// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
+func (c *resourceQuotas) Get(name string, options meta_v1.GetOptions) (result *v1.ResourceQuota, err error) {
+	result = &v1.ResourceQuota{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
+func (c *resourceQuotas) List(opts meta_v1.ListOptions) (result *v1.ResourceQuotaList, err error) {
+	result = &v1.ResourceQuotaList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested resourceQuotas.
+func (c *resourceQuotas) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("resourcequotas").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
 func (c *resourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
@@ -85,7 +120,7 @@ func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.Res
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *resourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (result *v1.ResourceQuota, err error) {
 	result = &v1.ResourceQuota{}
@@ -120,41 +155,6 @@ func (c *resourceQuotas) DeleteCollection(options *meta_v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the resourceQuota, and returns the corresponding resourceQuota object, and an error if there is any.
-func (c *resourceQuotas) Get(name string, options meta_v1.GetOptions) (result *v1.ResourceQuota, err error) {
-	result = &v1.ResourceQuota{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ResourceQuotas that match those selectors.
-func (c *resourceQuotas) List(opts meta_v1.ListOptions) (result *v1.ResourceQuotaList, err error) {
-	result = &v1.ResourceQuotaList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested resourceQuotas.
-func (c *resourceQuotas) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("resourcequotas").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched resourceQuota.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -58,6 +58,41 @@ func newSecrets(c *CoreV1Client, namespace string) *secrets {
 	}
 }
 
+// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
+func (c *secrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
+	result = &v1.Secret{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Secrets that match those selectors.
+func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
+	result = &v1.SecretList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested secrets.
+func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("secrets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
 func (c *secrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
 	result = &v1.Secret{}
@@ -103,41 +138,6 @@ func (c *secrets) DeleteCollection(options *meta_v1.DeleteOptions, listOptions m
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the secret, and returns the corresponding secret object, and an error if there is any.
-func (c *secrets) Get(name string, options meta_v1.GetOptions) (result *v1.Secret, err error) {
-	result = &v1.Secret{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Secrets that match those selectors.
-func (c *secrets) List(opts meta_v1.ListOptions) (result *v1.SecretList, err error) {
-	result = &v1.SecretList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested secrets.
-func (c *secrets) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("secrets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched secret.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -59,6 +59,41 @@ func newServices(c *CoreV1Client, namespace string) *services {
 	}
 }
 
+// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
+func (c *services) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
+	result = &v1.Service{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Services that match those selectors.
+func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
+	result = &v1.ServiceList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested services.
+func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("services").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
 func (c *services) Create(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
@@ -85,7 +120,7 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err error) {
 	result = &v1.Service{}
@@ -120,41 +155,6 @@ func (c *services) DeleteCollection(options *meta_v1.DeleteOptions, listOptions 
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the service, and returns the corresponding service object, and an error if there is any.
-func (c *services) Get(name string, options meta_v1.GetOptions) (result *v1.Service, err error) {
-	result = &v1.Service{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Services that match those selectors.
-func (c *services) List(opts meta_v1.ListOptions) (result *v1.ServiceList, err error) {
-	result = &v1.ServiceList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested services.
-func (c *services) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("services").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched service.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -58,6 +58,41 @@ func newServiceAccounts(c *CoreV1Client, namespace string) *serviceAccounts {
 	}
 }
 
+// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
+func (c *serviceAccounts) Get(name string, options meta_v1.GetOptions) (result *v1.ServiceAccount, err error) {
+	result = &v1.ServiceAccount{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
+func (c *serviceAccounts) List(opts meta_v1.ListOptions) (result *v1.ServiceAccountList, err error) {
+	result = &v1.ServiceAccountList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested serviceAccounts.
+func (c *serviceAccounts) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("serviceaccounts").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
 func (c *serviceAccounts) Create(serviceAccount *v1.ServiceAccount) (result *v1.ServiceAccount, err error) {
 	result = &v1.ServiceAccount{}
@@ -103,41 +138,6 @@ func (c *serviceAccounts) DeleteCollection(options *meta_v1.DeleteOptions, listO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the serviceAccount, and returns the corresponding serviceAccount object, and an error if there is any.
-func (c *serviceAccounts) Get(name string, options meta_v1.GetOptions) (result *v1.ServiceAccount, err error) {
-	result = &v1.ServiceAccount{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ServiceAccounts that match those selectors.
-func (c *serviceAccounts) List(opts meta_v1.ListOptions) (result *v1.ServiceAccountList, err error) {
-	result = &v1.ServiceAccountList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested serviceAccounts.
-func (c *serviceAccounts) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("serviceaccounts").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched serviceAccount.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -59,6 +59,41 @@ func newDaemonSets(c *ExtensionsV1beta1Client, namespace string) *daemonSets {
 	}
 }
 
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
+func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
+	result = &v1beta1.DaemonSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
+func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
+	result = &v1beta1.DaemonSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("daemonsets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *daemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
@@ -85,7 +120,7 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	result = &v1beta1.DaemonSet{}
@@ -120,41 +155,6 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
-func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
-	result = &v1beta1.DaemonSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
-func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
-	result = &v1beta1.DaemonSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("daemonsets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -59,6 +59,41 @@ func newDeployments(c *ExtensionsV1beta1Client, namespace string) *deployments {
 	}
 }
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
+func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
+	result = &v1beta1.Deployment{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
+func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	result = &v1beta1.DeploymentList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
@@ -85,7 +120,7 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	result = &v1beta1.Deployment{}
@@ -120,41 +155,6 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
-func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
-	result = &v1beta1.Deployment{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Deployments that match those selectors.
-func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
-	result = &v1beta1.DeploymentList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("deployments").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -36,6 +36,44 @@ var daemonsetsResource = schema.GroupVersionResource{Group: "extensions", Versio
 
 var daemonsetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "DaemonSet"}
 
+func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.DaemonSet), err
+}
+
+func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &v1beta1.DaemonSetList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.DaemonSetList{}
+	for _, item := range obj.(*v1beta1.DaemonSetList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested daemonSets.
+func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(daemonsetsResource, c.ns, opts))
+
+}
+
 func (c *FakeDaemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
@@ -78,44 +116,6 @@ func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions
 
 	_, err := c.Fake.Invokes(action, &v1beta1.DaemonSetList{})
 	return err
-}
-
-func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.DaemonSet), err
-}
-
-func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &v1beta1.DaemonSetList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.DaemonSetList{}
-	for _, item := range obj.(*v1beta1.DaemonSetList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested daemonSets.
-func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(daemonsetsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched daemonSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -36,6 +36,7 @@ var daemonsetsResource = schema.GroupVersionResource{Group: "extensions", Versio
 
 var daemonsetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "DaemonSet"}
 
+// Get takes name of the daemonSet, and returns the corresponding daemonSet object, and an error if there is any.
 func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
@@ -46,6 +47,7 @@ func (c *FakeDaemonSets) Get(name string, options v1.GetOptions) (result *v1beta
 	return obj.(*v1beta1.DaemonSet), err
 }
 
+// List takes label and field selectors, and returns the list of DaemonSets that match those selectors.
 func (c *FakeDaemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(daemonsetsResource, daemonsetsKind, c.ns, opts), &v1beta1.DaemonSetList{})
@@ -74,6 +76,7 @@ func (c *FakeDaemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *FakeDaemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
@@ -84,6 +87,7 @@ func (c *FakeDaemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.D
 	return obj.(*v1beta1.DaemonSet), err
 }
 
+// Update takes the representation of a daemonSet and updates it. Returns the server's representation of the daemonSet, and an error, if there is any.
 func (c *FakeDaemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.DaemonSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(daemonsetsResource, c.ns, daemonSet), &v1beta1.DaemonSet{})
@@ -94,6 +98,8 @@ func (c *FakeDaemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.D
 	return obj.(*v1beta1.DaemonSet), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeDaemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (*v1beta1.DaemonSet, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(daemonsetsResource, "status", c.ns, daemonSet), &v1beta1.DaemonSet{})
@@ -104,6 +110,7 @@ func (c *FakeDaemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (*v1beta1.Da
 	return obj.(*v1beta1.DaemonSet), err
 }
 
+// Delete takes name of the daemonSet and deletes it. Returns an error if one occurs.
 func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(daemonsetsResource, c.ns, name), &v1beta1.DaemonSet{})
@@ -111,6 +118,7 @@ func (c *FakeDaemonSets) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeDaemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(daemonsetsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -36,6 +36,7 @@ var deploymentsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var deploymentsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}
 
+// Get takes name of the deployment, and returns the corresponding deployment object, and an error if there is any.
 func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
@@ -46,6 +47,7 @@ func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.Deployment), err
 }
 
+// List takes label and field selectors, and returns the list of Deployments that match those selectors.
 func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
@@ -74,6 +76,7 @@ func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
 func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -84,6 +87,7 @@ func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta
 	return obj.(*v1beta1.Deployment), err
 }
 
+// Update takes the representation of a deployment and updates it. Returns the server's representation of the deployment, and an error, if there is any.
 func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -94,6 +98,8 @@ func (c *FakeDeployments) Update(deployment *v1beta1.Deployment) (result *v1beta
 	return obj.(*v1beta1.Deployment), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1.Deployment, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "status", c.ns, deployment), &v1beta1.Deployment{})
@@ -104,6 +110,7 @@ func (c *FakeDeployments) UpdateStatus(deployment *v1beta1.Deployment) (*v1beta1
 	return obj.(*v1beta1.Deployment), err
 }
 
+// Delete takes name of the deployment and deletes it. Returns an error if one occurs.
 func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
@@ -111,6 +118,7 @@ func (c *FakeDeployments) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(deploymentsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -36,6 +36,44 @@ var deploymentsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var deploymentsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"}
 
+func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Deployment), err
+}
+
+func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.DeploymentList{}
+	for _, item := range obj.(*v1beta1.DeploymentList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested deployments.
+func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
+
+}
+
 func (c *FakeDeployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.Deployment, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(deploymentsResource, c.ns, deployment), &v1beta1.Deployment{})
@@ -78,44 +116,6 @@ func (c *FakeDeployments) DeleteCollection(options *v1.DeleteOptions, listOption
 
 	_, err := c.Fake.Invokes(action, &v1beta1.DeploymentList{})
 	return err
-}
-
-func (c *FakeDeployments) Get(name string, options v1.GetOptions) (result *v1beta1.Deployment, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(deploymentsResource, c.ns, name), &v1beta1.Deployment{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Deployment), err
-}
-
-func (c *FakeDeployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(deploymentsResource, deploymentsKind, c.ns, opts), &v1beta1.DeploymentList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.DeploymentList{}
-	for _, item := range obj.(*v1beta1.DeploymentList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested deployments.
-func (c *FakeDeployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(deploymentsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched deployment.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -36,6 +36,7 @@ var ingressesResource = schema.GroupVersionResource{Group: "extensions", Version
 
 var ingressesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
 
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
 func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
@@ -46,6 +47,7 @@ func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1
 	return obj.(*v1beta1.Ingress), err
 }
 
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
 func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &v1beta1.IngressList{})
@@ -74,6 +76,7 @@ func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *FakeIngresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
@@ -84,6 +87,7 @@ func (c *FakeIngresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingres
 	return obj.(*v1beta1.Ingress), err
 }
 
+// Update takes the representation of a ingress and updates it. Returns the server's representation of the ingress, and an error, if there is any.
 func (c *FakeIngresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
@@ -94,6 +98,8 @@ func (c *FakeIngresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingres
 	return obj.(*v1beta1.Ingress), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeIngresses) UpdateStatus(ingress *v1beta1.Ingress) (*v1beta1.Ingress, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(ingressesResource, "status", c.ns, ingress), &v1beta1.Ingress{})
@@ -104,6 +110,7 @@ func (c *FakeIngresses) UpdateStatus(ingress *v1beta1.Ingress) (*v1beta1.Ingress
 	return obj.(*v1beta1.Ingress), err
 }
 
+// Delete takes name of the ingress and deletes it. Returns an error if one occurs.
 func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
@@ -111,6 +118,7 @@ func (c *FakeIngresses) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(ingressesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -36,6 +36,44 @@ var ingressesResource = schema.GroupVersionResource{Group: "extensions", Version
 
 var ingressesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Ingress"}
 
+func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Ingress), err
+}
+
+func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &v1beta1.IngressList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.IngressList{}
+	for _, item := range obj.(*v1beta1.IngressList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(ingressesResource, c.ns, opts))
+
+}
+
 func (c *FakeIngresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(ingressesResource, c.ns, ingress), &v1beta1.Ingress{})
@@ -78,44 +116,6 @@ func (c *FakeIngresses) DeleteCollection(options *v1.DeleteOptions, listOptions 
 
 	_, err := c.Fake.Invokes(action, &v1beta1.IngressList{})
 	return err
-}
-
-func (c *FakeIngresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(ingressesResource, c.ns, name), &v1beta1.Ingress{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Ingress), err
-}
-
-func (c *FakeIngresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(ingressesResource, ingressesKind, c.ns, opts), &v1beta1.IngressList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.IngressList{}
-	for _, item := range obj.(*v1beta1.IngressList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *FakeIngresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(ingressesResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -35,6 +35,7 @@ var podsecuritypoliciesResource = schema.GroupVersionResource{Group: "extensions
 
 var podsecuritypoliciesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"}
 
+// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
 func (c *FakePodSecurityPolicies) Get(name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(podsecuritypoliciesResource, name), &v1beta1.PodSecurityPolicy{})
@@ -44,6 +45,7 @@ func (c *FakePodSecurityPolicies) Get(name string, options v1.GetOptions) (resul
 	return obj.(*v1beta1.PodSecurityPolicy), err
 }
 
+// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
 func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecurityPolicyList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(podsecuritypoliciesResource, podsecuritypoliciesKind, opts), &v1beta1.PodSecurityPolicyList{})
@@ -70,6 +72,7 @@ func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, e
 		InvokesWatch(testing.NewRootWatchAction(podsecuritypoliciesResource, opts))
 }
 
+// Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
@@ -79,6 +82,7 @@ func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityP
 	return obj.(*v1beta1.PodSecurityPolicy), err
 }
 
+// Update takes the representation of a podSecurityPolicy and updates it. Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
@@ -88,12 +92,14 @@ func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityP
 	return obj.(*v1beta1.PodSecurityPolicy), err
 }
 
+// Delete takes name of the podSecurityPolicy and deletes it. Returns an error if one occurs.
 func (c *FakePodSecurityPolicies) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(podsecuritypoliciesResource, name), &v1beta1.PodSecurityPolicy{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePodSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(podsecuritypoliciesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -35,37 +35,6 @@ var podsecuritypoliciesResource = schema.GroupVersionResource{Group: "extensions
 
 var podsecuritypoliciesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "PodSecurityPolicy"}
 
-func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.PodSecurityPolicy), err
-}
-
-func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.PodSecurityPolicy), err
-}
-
-func (c *FakePodSecurityPolicies) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(podsecuritypoliciesResource, name), &v1beta1.PodSecurityPolicy{})
-	return err
-}
-
-func (c *FakePodSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(podsecuritypoliciesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.PodSecurityPolicyList{})
-	return err
-}
-
 func (c *FakePodSecurityPolicies) Get(name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(podsecuritypoliciesResource, name), &v1beta1.PodSecurityPolicy{})
@@ -99,6 +68,37 @@ func (c *FakePodSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.Pod
 func (c *FakePodSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(podsecuritypoliciesResource, opts))
+}
+
+func (c *FakePodSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.PodSecurityPolicy), err
+}
+
+func (c *FakePodSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(podsecuritypoliciesResource, podSecurityPolicy), &v1beta1.PodSecurityPolicy{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.PodSecurityPolicy), err
+}
+
+func (c *FakePodSecurityPolicies) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(podsecuritypoliciesResource, name), &v1beta1.PodSecurityPolicy{})
+	return err
+}
+
+func (c *FakePodSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(podsecuritypoliciesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.PodSecurityPolicyList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -36,6 +36,7 @@ var replicasetsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var replicasetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}
 
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
 func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
@@ -46,6 +47,7 @@ func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.ReplicaSet), err
 }
 
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
 func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &v1beta1.ReplicaSetList{})
@@ -74,6 +76,7 @@ func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *FakeReplicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
@@ -84,6 +87,7 @@ func (c *FakeReplicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta
 	return obj.(*v1beta1.ReplicaSet), err
 }
 
+// Update takes the representation of a replicaSet and updates it. Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *FakeReplicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
@@ -94,6 +98,8 @@ func (c *FakeReplicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta
 	return obj.(*v1beta1.ReplicaSet), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeReplicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (*v1beta1.ReplicaSet, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "status", c.ns, replicaSet), &v1beta1.ReplicaSet{})
@@ -104,6 +110,7 @@ func (c *FakeReplicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (*v1beta1
 	return obj.(*v1beta1.ReplicaSet), err
 }
 
+// Delete takes name of the replicaSet and deletes it. Returns an error if one occurs.
 func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
@@ -111,6 +118,7 @@ func (c *FakeReplicaSets) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(replicasetsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -36,6 +36,44 @@ var replicasetsResource = schema.GroupVersionResource{Group: "extensions", Versi
 
 var replicasetsKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ReplicaSet"}
 
+func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ReplicaSet), err
+}
+
+func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &v1beta1.ReplicaSetList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.ReplicaSetList{}
+	for _, item := range obj.(*v1beta1.ReplicaSetList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested replicaSets.
+func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(replicasetsResource, c.ns, opts))
+
+}
+
 func (c *FakeReplicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(replicasetsResource, c.ns, replicaSet), &v1beta1.ReplicaSet{})
@@ -78,44 +116,6 @@ func (c *FakeReplicaSets) DeleteCollection(options *v1.DeleteOptions, listOption
 
 	_, err := c.Fake.Invokes(action, &v1beta1.ReplicaSetList{})
 	return err
-}
-
-func (c *FakeReplicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(replicasetsResource, c.ns, name), &v1beta1.ReplicaSet{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ReplicaSet), err
-}
-
-func (c *FakeReplicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(replicasetsResource, replicasetsKind, c.ns, opts), &v1beta1.ReplicaSetList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.ReplicaSetList{}
-	for _, item := range obj.(*v1beta1.ReplicaSetList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *FakeReplicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(replicasetsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
@@ -35,37 +35,6 @@ var thirdpartyresourcesResource = schema.GroupVersionResource{Group: "extensions
 
 var thirdpartyresourcesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ThirdPartyResource"}
 
-func (c *FakeThirdPartyResources) Create(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ThirdPartyResource), err
-}
-
-func (c *FakeThirdPartyResources) Update(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ThirdPartyResource), err
-}
-
-func (c *FakeThirdPartyResources) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(thirdpartyresourcesResource, name), &v1beta1.ThirdPartyResource{})
-	return err
-}
-
-func (c *FakeThirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(thirdpartyresourcesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ThirdPartyResourceList{})
-	return err
-}
-
 func (c *FakeThirdPartyResources) Get(name string, options v1.GetOptions) (result *v1beta1.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(thirdpartyresourcesResource, name), &v1beta1.ThirdPartyResource{})
@@ -99,6 +68,37 @@ func (c *FakeThirdPartyResources) List(opts v1.ListOptions) (result *v1beta1.Thi
 func (c *FakeThirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(thirdpartyresourcesResource, opts))
+}
+
+func (c *FakeThirdPartyResources) Create(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ThirdPartyResource), err
+}
+
+func (c *FakeThirdPartyResources) Update(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ThirdPartyResource), err
+}
+
+func (c *FakeThirdPartyResources) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(thirdpartyresourcesResource, name), &v1beta1.ThirdPartyResource{})
+	return err
+}
+
+func (c *FakeThirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(thirdpartyresourcesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ThirdPartyResourceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_thirdpartyresource.go
@@ -35,6 +35,7 @@ var thirdpartyresourcesResource = schema.GroupVersionResource{Group: "extensions
 
 var thirdpartyresourcesKind = schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "ThirdPartyResource"}
 
+// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
 func (c *FakeThirdPartyResources) Get(name string, options v1.GetOptions) (result *v1beta1.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(thirdpartyresourcesResource, name), &v1beta1.ThirdPartyResource{})
@@ -44,6 +45,7 @@ func (c *FakeThirdPartyResources) Get(name string, options v1.GetOptions) (resul
 	return obj.(*v1beta1.ThirdPartyResource), err
 }
 
+// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
 func (c *FakeThirdPartyResources) List(opts v1.ListOptions) (result *v1beta1.ThirdPartyResourceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(thirdpartyresourcesResource, thirdpartyresourcesKind, opts), &v1beta1.ThirdPartyResourceList{})
@@ -70,6 +72,7 @@ func (c *FakeThirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, e
 		InvokesWatch(testing.NewRootWatchAction(thirdpartyresourcesResource, opts))
 }
 
+// Create takes the representation of a thirdPartyResource and creates it.  Returns the server's representation of the thirdPartyResource, and an error, if there is any.
 func (c *FakeThirdPartyResources) Create(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
@@ -79,6 +82,7 @@ func (c *FakeThirdPartyResources) Create(thirdPartyResource *v1beta1.ThirdPartyR
 	return obj.(*v1beta1.ThirdPartyResource), err
 }
 
+// Update takes the representation of a thirdPartyResource and updates it. Returns the server's representation of the thirdPartyResource, and an error, if there is any.
 func (c *FakeThirdPartyResources) Update(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(thirdpartyresourcesResource, thirdPartyResource), &v1beta1.ThirdPartyResource{})
@@ -88,12 +92,14 @@ func (c *FakeThirdPartyResources) Update(thirdPartyResource *v1beta1.ThirdPartyR
 	return obj.(*v1beta1.ThirdPartyResource), err
 }
 
+// Delete takes name of the thirdPartyResource and deletes it. Returns an error if one occurs.
 func (c *FakeThirdPartyResources) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(thirdpartyresourcesResource, name), &v1beta1.ThirdPartyResource{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeThirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(thirdpartyresourcesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -59,6 +59,41 @@ func newIngresses(c *ExtensionsV1beta1Client, namespace string) *ingresses {
 	}
 }
 
+// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
+func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
+	result = &v1beta1.Ingress{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
+func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
+	result = &v1beta1.IngressList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested ingresses.
+func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("ingresses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
 func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
@@ -85,7 +120,7 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, err error) {
 	result = &v1beta1.Ingress{}
@@ -120,41 +155,6 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the ingress, and returns the corresponding ingress object, and an error if there is any.
-func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ingress, err error) {
-	result = &v1beta1.Ingress{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Ingresses that match those selectors.
-func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err error) {
-	result = &v1beta1.IngressList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested ingresses.
-func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("ingresses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched ingress.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -56,6 +56,38 @@ func newPodSecurityPolicies(c *ExtensionsV1beta1Client) *podSecurityPolicies {
 	}
 }
 
+// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
+func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
+	result = &v1beta1.PodSecurityPolicy{}
+	err = c.client.Get().
+		Resource("podsecuritypolicies").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
+func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecurityPolicyList, err error) {
+	result = &v1beta1.PodSecurityPolicyList{}
+	err = c.client.Get().
+		Resource("podsecuritypolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
+func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("podsecuritypolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
 func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolicy) (result *v1beta1.PodSecurityPolicy, err error) {
 	result = &v1beta1.PodSecurityPolicy{}
@@ -97,38 +129,6 @@ func (c *podSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podSecurityPolicy, and returns the corresponding podSecurityPolicy object, and an error if there is any.
-func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *v1beta1.PodSecurityPolicy, err error) {
-	result = &v1beta1.PodSecurityPolicy{}
-	err = c.client.Get().
-		Resource("podsecuritypolicies").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodSecurityPolicies that match those selectors.
-func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecurityPolicyList, err error) {
-	result = &v1beta1.PodSecurityPolicyList{}
-	err = c.client.Get().
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podSecurityPolicies.
-func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("podsecuritypolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podSecurityPolicy.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -59,6 +59,41 @@ func newReplicaSets(c *ExtensionsV1beta1Client, namespace string) *replicaSets {
 	}
 }
 
+// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
+func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
+	result = &v1beta1.ReplicaSet{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
+func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
+	result = &v1beta1.ReplicaSetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested replicaSets.
+func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
 func (c *replicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
@@ -85,7 +120,7 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.ReplicaSet, err error) {
 	result = &v1beta1.ReplicaSet{}
@@ -120,41 +155,6 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the replicaSet, and returns the corresponding replicaSet object, and an error if there is any.
-func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.ReplicaSet, err error) {
-	result = &v1beta1.ReplicaSet{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ReplicaSets that match those selectors.
-func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList, err error) {
-	result = &v1beta1.ReplicaSetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested replicaSets.
-func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("replicasets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched replicaSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/thirdpartyresource.go
@@ -56,6 +56,38 @@ func newThirdPartyResources(c *ExtensionsV1beta1Client) *thirdPartyResources {
 	}
 }
 
+// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
+func (c *thirdPartyResources) Get(name string, options v1.GetOptions) (result *v1beta1.ThirdPartyResource, err error) {
+	result = &v1beta1.ThirdPartyResource{}
+	err = c.client.Get().
+		Resource("thirdpartyresources").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
+func (c *thirdPartyResources) List(opts v1.ListOptions) (result *v1beta1.ThirdPartyResourceList, err error) {
+	result = &v1beta1.ThirdPartyResourceList{}
+	err = c.client.Get().
+		Resource("thirdpartyresources").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested thirdPartyResources.
+func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("thirdpartyresources").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a thirdPartyResource and creates it.  Returns the server's representation of the thirdPartyResource, and an error, if there is any.
 func (c *thirdPartyResources) Create(thirdPartyResource *v1beta1.ThirdPartyResource) (result *v1beta1.ThirdPartyResource, err error) {
 	result = &v1beta1.ThirdPartyResource{}
@@ -97,38 +129,6 @@ func (c *thirdPartyResources) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the thirdPartyResource, and returns the corresponding thirdPartyResource object, and an error if there is any.
-func (c *thirdPartyResources) Get(name string, options v1.GetOptions) (result *v1beta1.ThirdPartyResource, err error) {
-	result = &v1beta1.ThirdPartyResource{}
-	err = c.client.Get().
-		Resource("thirdpartyresources").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ThirdPartyResources that match those selectors.
-func (c *thirdPartyResources) List(opts v1.ListOptions) (result *v1beta1.ThirdPartyResourceList, err error) {
-	result = &v1beta1.ThirdPartyResourceList{}
-	err = c.client.Get().
-		Resource("thirdpartyresources").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested thirdPartyResources.
-func (c *thirdPartyResources) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("thirdpartyresources").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched thirdPartyResource.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/networking/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networking_v1 "k8s.io/api/networking/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -36,53 +36,19 @@ var networkpoliciesResource = schema.GroupVersionResource{Group: "networking.k8s
 
 var networkpoliciesKind = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
 
-func (c *FakeNetworkPolicies) Create(networkPolicy *v1.NetworkPolicy) (result *v1.NetworkPolicy, err error) {
+func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *networking_v1.NetworkPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &v1.NetworkPolicy{})
+		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &networking_v1.NetworkPolicy{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.NetworkPolicy), err
+	return obj.(*networking_v1.NetworkPolicy), err
 }
 
-func (c *FakeNetworkPolicies) Update(networkPolicy *v1.NetworkPolicy) (result *v1.NetworkPolicy, err error) {
+func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *networking_v1.NetworkPolicyList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &v1.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &v1.NetworkPolicy{})
-
-	return err
-}
-
-func (c *FakeNetworkPolicies) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.NetworkPolicyList{})
-	return err
-}
-
-func (c *FakeNetworkPolicies) Get(name string, options meta_v1.GetOptions) (result *v1.NetworkPolicy, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &v1.NetworkPolicy{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.NetworkPolicy), err
-}
-
-func (c *FakeNetworkPolicies) List(opts meta_v1.ListOptions) (result *v1.NetworkPolicyList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &v1.NetworkPolicyList{})
+		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &networking_v1.NetworkPolicyList{})
 
 	if obj == nil {
 		return nil, err
@@ -92,8 +58,8 @@ func (c *FakeNetworkPolicies) List(opts meta_v1.ListOptions) (result *v1.Network
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.NetworkPolicyList{}
-	for _, item := range obj.(*v1.NetworkPolicyList).Items {
+	list := &networking_v1.NetworkPolicyList{}
+	for _, item := range obj.(*networking_v1.NetworkPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -102,19 +68,53 @@ func (c *FakeNetworkPolicies) List(opts meta_v1.ListOptions) (result *v1.Network
 }
 
 // Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *FakeNetworkPolicies) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(networkpoliciesResource, c.ns, opts))
 
 }
 
-// Patch applies the patch and returns the patched networkPolicy.
-func (c *FakeNetworkPolicies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.NetworkPolicy, err error) {
+func (c *FakeNetworkPolicies) Create(networkPolicy *networking_v1.NetworkPolicy) (result *networking_v1.NetworkPolicy, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewPatchSubresourceAction(networkpoliciesResource, c.ns, name, data, subresources...), &v1.NetworkPolicy{})
+		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &networking_v1.NetworkPolicy{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.NetworkPolicy), err
+	return obj.(*networking_v1.NetworkPolicy), err
+}
+
+func (c *FakeNetworkPolicies) Update(networkPolicy *networking_v1.NetworkPolicy) (result *networking_v1.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &networking_v1.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*networking_v1.NetworkPolicy), err
+}
+
+func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &networking_v1.NetworkPolicy{})
+
+	return err
+}
+
+func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &networking_v1.NetworkPolicyList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched networkPolicy.
+func (c *FakeNetworkPolicies) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *networking_v1.NetworkPolicy, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewPatchSubresourceAction(networkpoliciesResource, c.ns, name, data, subresources...), &networking_v1.NetworkPolicy{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*networking_v1.NetworkPolicy), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
@@ -36,6 +36,7 @@ var networkpoliciesResource = schema.GroupVersionResource{Group: "networking.k8s
 
 var networkpoliciesKind = schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}
 
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
 func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *networking_v1.NetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(networkpoliciesResource, c.ns, name), &networking_v1.NetworkPolicy{})
@@ -46,6 +47,7 @@ func (c *FakeNetworkPolicies) Get(name string, options v1.GetOptions) (result *n
 	return obj.(*networking_v1.NetworkPolicy), err
 }
 
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
 func (c *FakeNetworkPolicies) List(opts v1.ListOptions) (result *networking_v1.NetworkPolicyList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(networkpoliciesResource, networkpoliciesKind, c.ns, opts), &networking_v1.NetworkPolicyList{})
@@ -74,6 +76,7 @@ func (c *FakeNetworkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error
 
 }
 
+// Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *FakeNetworkPolicies) Create(networkPolicy *networking_v1.NetworkPolicy) (result *networking_v1.NetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(networkpoliciesResource, c.ns, networkPolicy), &networking_v1.NetworkPolicy{})
@@ -84,6 +87,7 @@ func (c *FakeNetworkPolicies) Create(networkPolicy *networking_v1.NetworkPolicy)
 	return obj.(*networking_v1.NetworkPolicy), err
 }
 
+// Update takes the representation of a networkPolicy and updates it. Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *FakeNetworkPolicies) Update(networkPolicy *networking_v1.NetworkPolicy) (result *networking_v1.NetworkPolicy, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(networkpoliciesResource, c.ns, networkPolicy), &networking_v1.NetworkPolicy{})
@@ -94,6 +98,7 @@ func (c *FakeNetworkPolicies) Update(networkPolicy *networking_v1.NetworkPolicy)
 	return obj.(*networking_v1.NetworkPolicy), err
 }
 
+// Delete takes name of the networkPolicy and deletes it. Returns an error if one occurs.
 func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(networkpoliciesResource, c.ns, name), &networking_v1.NetworkPolicy{})
@@ -101,6 +106,7 @@ func (c *FakeNetworkPolicies) Delete(name string, options *v1.DeleteOptions) err
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeNetworkPolicies) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(networkpoliciesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -58,6 +58,41 @@ func newNetworkPolicies(c *NetworkingV1Client, namespace string) *networkPolicie
 	}
 }
 
+// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
+func (c *networkPolicies) Get(name string, options meta_v1.GetOptions) (result *v1.NetworkPolicy, err error) {
+	result = &v1.NetworkPolicy{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
+func (c *networkPolicies) List(opts meta_v1.ListOptions) (result *v1.NetworkPolicyList, err error) {
+	result = &v1.NetworkPolicyList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested networkPolicies.
+func (c *networkPolicies) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("networkpolicies").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
 func (c *networkPolicies) Create(networkPolicy *v1.NetworkPolicy) (result *v1.NetworkPolicy, err error) {
 	result = &v1.NetworkPolicy{}
@@ -103,41 +138,6 @@ func (c *networkPolicies) DeleteCollection(options *meta_v1.DeleteOptions, listO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the networkPolicy, and returns the corresponding networkPolicy object, and an error if there is any.
-func (c *networkPolicies) Get(name string, options meta_v1.GetOptions) (result *v1.NetworkPolicy, err error) {
-	result = &v1.NetworkPolicy{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of NetworkPolicies that match those selectors.
-func (c *networkPolicies) List(opts meta_v1.ListOptions) (result *v1.NetworkPolicyList, err error) {
-	result = &v1.NetworkPolicyList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested networkPolicies.
-func (c *networkPolicies) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("networkpolicies").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched networkPolicy.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
@@ -36,6 +36,44 @@ var poddisruptionbudgetsResource = schema.GroupVersionResource{Group: "policy", 
 
 var poddisruptionbudgetsKind = schema.GroupVersionKind{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"}
 
+func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (result *v1beta1.PodDisruptionBudget, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(poddisruptionbudgetsResource, c.ns, name), &v1beta1.PodDisruptionBudget{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.PodDisruptionBudget), err
+}
+
+func (c *FakePodDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDisruptionBudgetList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(poddisruptionbudgetsResource, poddisruptionbudgetsKind, c.ns, opts), &v1beta1.PodDisruptionBudgetList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &v1beta1.PodDisruptionBudgetList{}
+	for _, item := range obj.(*v1beta1.PodDisruptionBudgetList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
+func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(poddisruptionbudgetsResource, c.ns, opts))
+
+}
+
 func (c *FakePodDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &v1beta1.PodDisruptionBudget{})
@@ -78,44 +116,6 @@ func (c *FakePodDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, l
 
 	_, err := c.Fake.Invokes(action, &v1beta1.PodDisruptionBudgetList{})
 	return err
-}
-
-func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (result *v1beta1.PodDisruptionBudget, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(poddisruptionbudgetsResource, c.ns, name), &v1beta1.PodDisruptionBudget{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.PodDisruptionBudget), err
-}
-
-func (c *FakePodDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDisruptionBudgetList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(poddisruptionbudgetsResource, poddisruptionbudgetsKind, c.ns, opts), &v1beta1.PodDisruptionBudgetList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &v1beta1.PodDisruptionBudgetList{}
-	for _, item := range obj.(*v1beta1.PodDisruptionBudgetList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
-func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(poddisruptionbudgetsResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched podDisruptionBudget.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
@@ -36,6 +36,7 @@ var poddisruptionbudgetsResource = schema.GroupVersionResource{Group: "policy", 
 
 var poddisruptionbudgetsKind = schema.GroupVersionKind{Group: "policy", Version: "v1beta1", Kind: "PodDisruptionBudget"}
 
+// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
 func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (result *v1beta1.PodDisruptionBudget, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(poddisruptionbudgetsResource, c.ns, name), &v1beta1.PodDisruptionBudget{})
@@ -46,6 +47,7 @@ func (c *FakePodDisruptionBudgets) Get(name string, options v1.GetOptions) (resu
 	return obj.(*v1beta1.PodDisruptionBudget), err
 }
 
+// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
 func (c *FakePodDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDisruptionBudgetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(poddisruptionbudgetsResource, poddisruptionbudgetsKind, c.ns, opts), &v1beta1.PodDisruptionBudgetList{})
@@ -74,6 +76,7 @@ func (c *FakePodDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, 
 
 }
 
+// Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *FakePodDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &v1beta1.PodDisruptionBudget{})
@@ -84,6 +87,7 @@ func (c *FakePodDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisrup
 	return obj.(*v1beta1.PodDisruptionBudget), err
 }
 
+// Update takes the representation of a podDisruptionBudget and updates it. Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *FakePodDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(poddisruptionbudgetsResource, c.ns, podDisruptionBudget), &v1beta1.PodDisruptionBudget{})
@@ -94,6 +98,8 @@ func (c *FakePodDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisrup
 	return obj.(*v1beta1.PodDisruptionBudget), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakePodDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.PodDisruptionBudget) (*v1beta1.PodDisruptionBudget, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(poddisruptionbudgetsResource, "status", c.ns, podDisruptionBudget), &v1beta1.PodDisruptionBudget{})
@@ -104,6 +110,7 @@ func (c *FakePodDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.Pod
 	return obj.(*v1beta1.PodDisruptionBudget), err
 }
 
+// Delete takes name of the podDisruptionBudget and deletes it. Returns an error if one occurs.
 func (c *FakePodDisruptionBudgets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(poddisruptionbudgetsResource, c.ns, name), &v1beta1.PodDisruptionBudget{})
@@ -111,6 +118,7 @@ func (c *FakePodDisruptionBudgets) Delete(name string, options *v1.DeleteOptions
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePodDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(poddisruptionbudgetsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -59,6 +59,41 @@ func newPodDisruptionBudgets(c *PolicyV1beta1Client, namespace string) *podDisru
 	}
 }
 
+// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
+func (c *podDisruptionBudgets) Get(name string, options v1.GetOptions) (result *v1beta1.PodDisruptionBudget, err error) {
+	result = &v1beta1.PodDisruptionBudget{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
+func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDisruptionBudgetList, err error) {
+	result = &v1beta1.PodDisruptionBudgetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
+func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("poddisruptionbudgets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
 func (c *podDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
@@ -85,7 +120,7 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruption
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.PodDisruptionBudget) (result *v1beta1.PodDisruptionBudget, err error) {
 	result = &v1beta1.PodDisruptionBudget{}
@@ -120,41 +155,6 @@ func (c *podDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podDisruptionBudget, and returns the corresponding podDisruptionBudget object, and an error if there is any.
-func (c *podDisruptionBudgets) Get(name string, options v1.GetOptions) (result *v1beta1.PodDisruptionBudget, err error) {
-	result = &v1beta1.PodDisruptionBudget{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodDisruptionBudgets that match those selectors.
-func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDisruptionBudgetList, err error) {
-	result = &v1beta1.PodDisruptionBudgetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podDisruptionBudgets.
-func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("poddisruptionbudgets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podDisruptionBudget.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -56,6 +56,38 @@ func newClusterRoles(c *RbacV1alpha1Client) *clusterRoles {
 	}
 }
 
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
+func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRole, err error) {
+	result = &v1alpha1.ClusterRole{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
+func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleList, err error) {
+	result = &v1alpha1.ClusterRoleList{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoles.
+func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	result = &v1alpha1.ClusterRole{}
@@ -97,38 +129,6 @@ func (c *clusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
-func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRole, err error) {
-	result = &v1alpha1.ClusterRole{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
-func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleList, err error) {
-	result = &v1alpha1.ClusterRoleList{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -56,6 +56,38 @@ func newClusterRoleBindings(c *RbacV1alpha1Client) *clusterRoleBindings {
 	}
 }
 
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
+func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
+	result = &v1alpha1.ClusterRoleBinding{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleBindingList, err error) {
+	result = &v1alpha1.ClusterRoleBindingList{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
+func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	result = &v1alpha1.ClusterRoleBinding{}
@@ -97,38 +129,6 @@ func (c *clusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
-func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
-	result = &v1alpha1.ClusterRoleBinding{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
-func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleBindingList, err error) {
-	result = &v1alpha1.ClusterRoleBindingList{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -35,37 +35,6 @@ var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var clusterrolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "ClusterRole"}
 
-func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1alpha1.ClusterRole{})
-	return err
-}
-
-func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.ClusterRoleList{})
-	return err
-}
-
 func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolesResource, name), &v1alpha1.ClusterRole{})
@@ -99,6 +68,37 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRo
 func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+}
+
+func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1alpha1.ClusterRole{})
+	return err
+}
+
+func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.ClusterRoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -35,6 +35,7 @@ var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var clusterrolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "ClusterRole"}
 
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
 func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolesResource, name), &v1alpha1.ClusterRole{})
@@ -44,6 +45,7 @@ func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1al
 	return obj.(*v1alpha1.ClusterRole), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
 func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolesResource, clusterrolesKind, opts), &v1alpha1.ClusterRoleList{})
@@ -70,6 +72,7 @@ func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
 }
 
+// Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
@@ -79,6 +82,7 @@ func (c *FakeClusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1
 	return obj.(*v1alpha1.ClusterRole), err
 }
 
+// Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *FakeClusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1alpha1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1alpha1.ClusterRole{})
@@ -88,12 +92,14 @@ func (c *FakeClusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1
 	return obj.(*v1alpha1.ClusterRole), err
 }
 
+// Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
 func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1alpha1.ClusterRole{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -35,6 +35,7 @@ var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.autho
 
 var clusterrolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "ClusterRoleBinding"}
 
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
 func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolebindingsResource, name), &v1alpha1.ClusterRoleBinding{})
@@ -44,6 +45,7 @@ func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (resul
 	return obj.(*v1alpha1.ClusterRoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolebindingsResource, clusterrolebindingsKind, opts), &v1alpha1.ClusterRoleBindingList{})
@@ -70,6 +72,7 @@ func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, e
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
 }
 
+// Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
@@ -79,6 +82,7 @@ func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRol
 	return obj.(*v1alpha1.ClusterRoleBinding), err
 }
 
+// Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
@@ -88,12 +92,14 @@ func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRol
 	return obj.(*v1alpha1.ClusterRoleBinding), err
 }
 
+// Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
 func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1alpha1.ClusterRoleBinding{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -35,37 +35,6 @@ var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.autho
 
 var clusterrolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "ClusterRoleBinding"}
 
-func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1alpha1.ClusterRoleBinding{})
-	return err
-}
-
-func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.ClusterRoleBindingList{})
-	return err
-}
-
 func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolebindingsResource, name), &v1alpha1.ClusterRoleBinding{})
@@ -99,6 +68,37 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cl
 func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+}
+
+func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRoleBinding) (result *v1alpha1.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1alpha1.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1alpha1.ClusterRoleBinding{})
+	return err
+}
+
+func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.ClusterRoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -36,40 +36,6 @@ var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.i
 
 var rolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "Role"}
 
-func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Role), err
-}
-
-func (c *FakeRoles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Role), err
-}
-
-func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1alpha1.Role{})
-
-	return err
-}
-
-func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.RoleList{})
-	return err
-}
-
 func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolesResource, c.ns, name), &v1alpha1.Role{})
@@ -106,6 +72,40 @@ func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolesResource, c.ns, opts))
 
+}
+
+func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Role), err
+}
+
+func (c *FakeRoles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Role), err
+}
+
+func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1alpha1.Role{})
+
+	return err
+}
+
+func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.RoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched role.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -36,6 +36,7 @@ var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.i
 
 var rolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "Role"}
 
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
 func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolesResource, c.ns, name), &v1alpha1.Role{})
@@ -46,6 +47,7 @@ func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1alpha1.Ro
 	return obj.(*v1alpha1.Role), err
 }
 
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *FakeRoles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolesResource, rolesKind, c.ns, opts), &v1alpha1.RoleList{})
@@ -74,6 +76,7 @@ func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
@@ -84,6 +87,7 @@ func (c *FakeRoles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err erro
 	return obj.(*v1alpha1.Role), err
 }
 
+// Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
 func (c *FakeRoles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1alpha1.Role{})
@@ -94,6 +98,7 @@ func (c *FakeRoles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err erro
 	return obj.(*v1alpha1.Role), err
 }
 
+// Delete takes name of the role and deletes it. Returns an error if one occurs.
 func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1alpha1.Role{})
@@ -101,6 +106,7 @@ func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -36,40 +36,6 @@ var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var rolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "RoleBinding"}
 
-func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1alpha1.RoleBinding{})
-
-	return err
-}
-
-func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.RoleBindingList{})
-	return err
-}
-
 func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolebindingsResource, c.ns, name), &v1alpha1.RoleBinding{})
@@ -106,6 +72,40 @@ func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolebindingsResource, c.ns, opts))
 
+}
+
+func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.RoleBinding), err
+}
+
+func (c *FakeRoleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.RoleBinding), err
+}
+
+func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1alpha1.RoleBinding{})
+
+	return err
+}
+
+func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.RoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -36,6 +36,7 @@ var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var rolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1alpha1", Kind: "RoleBinding"}
 
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
 func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolebindingsResource, c.ns, name), &v1alpha1.RoleBinding{})
@@ -46,6 +47,7 @@ func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1al
 	return obj.(*v1alpha1.RoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolebindingsResource, rolebindingsKind, c.ns, opts), &v1alpha1.RoleBindingList{})
@@ -74,6 +76,7 @@ func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
@@ -84,6 +87,7 @@ func (c *FakeRoleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1
 	return obj.(*v1alpha1.RoleBinding), err
 }
 
+// Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *FakeRoleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1alpha1.RoleBinding{})
@@ -94,6 +98,7 @@ func (c *FakeRoleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1
 	return obj.(*v1alpha1.RoleBinding), err
 }
 
+// Delete takes name of the roleBinding and deletes it. Returns an error if one occurs.
 func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1alpha1.RoleBinding{})
@@ -101,6 +106,7 @@ func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error 
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -58,6 +58,41 @@ func newRoles(c *RbacV1alpha1Client, namespace string) *roles {
 	}
 }
 
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
+func (c *roles) Get(name string, options v1.GetOptions) (result *v1alpha1.Role, err error) {
+	result = &v1alpha1.Role{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error) {
+	result = &v1alpha1.RoleList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roles.
+func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 	result = &v1alpha1.Role{}
@@ -103,41 +138,6 @@ func (c *roles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
-func (c *roles) Get(name string, options v1.GetOptions) (result *v1alpha1.Role, err error) {
-	result = &v1alpha1.Role{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Roles that match those selectors.
-func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error) {
-	result = &v1alpha1.RoleList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched role.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -58,6 +58,41 @@ func newRoleBindings(c *RbacV1alpha1Client, namespace string) *roleBindings {
 	}
 }
 
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
+func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.RoleBinding, err error) {
+	result = &v1alpha1.RoleBinding{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingList, err error) {
+	result = &v1alpha1.RoleBindingList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roleBindings.
+func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alpha1.RoleBinding, err error) {
 	result = &v1alpha1.RoleBinding{}
@@ -103,41 +138,6 @@ func (c *roleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
-func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1.RoleBinding, err error) {
-	result = &v1alpha1.RoleBinding{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
-func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingList, err error) {
-	result = &v1alpha1.RoleBindingList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -56,6 +56,38 @@ func newClusterRoles(c *RbacV1beta1Client) *clusterRoles {
 	}
 }
 
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
+func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRole, err error) {
+	result = &v1beta1.ClusterRole{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
+func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleList, err error) {
+	result = &v1beta1.ClusterRoleList{}
+	err = c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoles.
+func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterroles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *clusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	result = &v1beta1.ClusterRole{}
@@ -97,38 +129,6 @@ func (c *clusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
-func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRole, err error) {
-	result = &v1beta1.ClusterRole{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
-func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleList, err error) {
-	result = &v1beta1.ClusterRoleList{}
-	err = c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoles.
-func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterroles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -56,6 +56,38 @@ func newClusterRoleBindings(c *RbacV1beta1Client) *clusterRoleBindings {
 	}
 }
 
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
+func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRoleBinding, err error) {
+	result = &v1beta1.ClusterRoleBinding{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
+func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleBindingList, err error) {
+	result = &v1beta1.ClusterRoleBindingList{}
+	err = c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
+func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("clusterrolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *clusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	result = &v1beta1.ClusterRoleBinding{}
@@ -97,38 +129,6 @@ func (c *clusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
-func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRoleBinding, err error) {
-	result = &v1beta1.ClusterRoleBinding{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
-func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleBindingList, err error) {
-	result = &v1beta1.ClusterRoleBindingList{}
-	err = c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested clusterRoleBindings.
-func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("clusterrolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -35,37 +35,6 @@ var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var clusterrolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "ClusterRole"}
 
-func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ClusterRole), err
-}
-
-func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1beta1.ClusterRole{})
-	return err
-}
-
-func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ClusterRoleList{})
-	return err
-}
-
 func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolesResource, name), &v1beta1.ClusterRole{})
@@ -99,6 +68,37 @@ func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRol
 func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
+}
+
+func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ClusterRole), err
+}
+
+func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1beta1.ClusterRole{})
+	return err
+}
+
+func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ClusterRoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRole.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -35,6 +35,7 @@ var clusterrolesResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var clusterrolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "ClusterRole"}
 
+// Get takes name of the clusterRole, and returns the corresponding clusterRole object, and an error if there is any.
 func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolesResource, name), &v1beta1.ClusterRole{})
@@ -44,6 +45,7 @@ func (c *FakeClusterRoles) Get(name string, options v1.GetOptions) (result *v1be
 	return obj.(*v1beta1.ClusterRole), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoles that match those selectors.
 func (c *FakeClusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolesResource, clusterrolesKind, opts), &v1beta1.ClusterRoleList{})
@@ -70,6 +72,7 @@ func (c *FakeClusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		InvokesWatch(testing.NewRootWatchAction(clusterrolesResource, opts))
 }
 
+// Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
@@ -79,6 +82,7 @@ func (c *FakeClusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1b
 	return obj.(*v1beta1.ClusterRole), err
 }
 
+// Update takes the representation of a clusterRole and updates it. Returns the server's representation of the clusterRole, and an error, if there is any.
 func (c *FakeClusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1beta1.ClusterRole, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterrolesResource, clusterRole), &v1beta1.ClusterRole{})
@@ -88,12 +92,14 @@ func (c *FakeClusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1b
 	return obj.(*v1beta1.ClusterRole), err
 }
 
+// Delete takes name of the clusterRole and deletes it. Returns an error if one occurs.
 func (c *FakeClusterRoles) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterrolesResource, name), &v1beta1.ClusterRole{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeClusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterrolesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -35,37 +35,6 @@ var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.autho
 
 var clusterrolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "ClusterRoleBinding"}
 
-func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.ClusterRoleBinding), err
-}
-
-func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1beta1.ClusterRoleBinding{})
-	return err
-}
-
-func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.ClusterRoleBindingList{})
-	return err
-}
-
 func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolebindingsResource, name), &v1beta1.ClusterRoleBinding{})
@@ -99,6 +68,37 @@ func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Clu
 func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
+}
+
+func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.ClusterRoleBinding), err
+}
+
+func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1beta1.ClusterRoleBinding{})
+	return err
+}
+
+func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.ClusterRoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched clusterRoleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -35,6 +35,7 @@ var clusterrolebindingsResource = schema.GroupVersionResource{Group: "rbac.autho
 
 var clusterrolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "ClusterRoleBinding"}
 
+// Get takes name of the clusterRoleBinding, and returns the corresponding clusterRoleBinding object, and an error if there is any.
 func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(clusterrolebindingsResource, name), &v1beta1.ClusterRoleBinding{})
@@ -44,6 +45,7 @@ func (c *FakeClusterRoleBindings) Get(name string, options v1.GetOptions) (resul
 	return obj.(*v1beta1.ClusterRoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of ClusterRoleBindings that match those selectors.
 func (c *FakeClusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(clusterrolebindingsResource, clusterrolebindingsKind, opts), &v1beta1.ClusterRoleBindingList{})
@@ -70,6 +72,7 @@ func (c *FakeClusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, e
 		InvokesWatch(testing.NewRootWatchAction(clusterrolebindingsResource, opts))
 }
 
+// Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
@@ -79,6 +82,7 @@ func (c *FakeClusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRole
 	return obj.(*v1beta1.ClusterRoleBinding), err
 }
 
+// Update takes the representation of a clusterRoleBinding and updates it. Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
 func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRoleBinding) (result *v1beta1.ClusterRoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(clusterrolebindingsResource, clusterRoleBinding), &v1beta1.ClusterRoleBinding{})
@@ -88,12 +92,14 @@ func (c *FakeClusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRole
 	return obj.(*v1beta1.ClusterRoleBinding), err
 }
 
+// Delete takes name of the clusterRoleBinding and deletes it. Returns an error if one occurs.
 func (c *FakeClusterRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(clusterrolebindingsResource, name), &v1beta1.ClusterRoleBinding{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeClusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(clusterrolebindingsResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -36,6 +36,7 @@ var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.i
 
 var rolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "Role"}
 
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
 func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolesResource, c.ns, name), &v1beta1.Role{})
@@ -46,6 +47,7 @@ func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1beta1.Rol
 	return obj.(*v1beta1.Role), err
 }
 
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
 func (c *FakeRoles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolesResource, rolesKind, c.ns, opts), &v1beta1.RoleList{})
@@ -74,6 +76,7 @@ func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1beta1.Role{})
@@ -84,6 +87,7 @@ func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error)
 	return obj.(*v1beta1.Role), err
 }
 
+// Update takes the representation of a role and updates it. Returns the server's representation of the role, and an error, if there is any.
 func (c *FakeRoles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1beta1.Role{})
@@ -94,6 +98,7 @@ func (c *FakeRoles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error)
 	return obj.(*v1beta1.Role), err
 }
 
+// Delete takes name of the role and deletes it. Returns an error if one occurs.
 func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1beta1.Role{})
@@ -101,6 +106,7 @@ func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -36,40 +36,6 @@ var rolesResource = schema.GroupVersionResource{Group: "rbac.authorization.k8s.i
 
 var rolesKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "Role"}
 
-func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1beta1.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Role), err
-}
-
-func (c *FakeRoles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1beta1.Role{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.Role), err
-}
-
-func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1beta1.Role{})
-
-	return err
-}
-
-func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.RoleList{})
-	return err
-}
-
 func (c *FakeRoles) Get(name string, options v1.GetOptions) (result *v1beta1.Role, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolesResource, c.ns, name), &v1beta1.Role{})
@@ -106,6 +72,40 @@ func (c *FakeRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolesResource, c.ns, opts))
 
+}
+
+func (c *FakeRoles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolesResource, c.ns, role), &v1beta1.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Role), err
+}
+
+func (c *FakeRoles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolesResource, c.ns, role), &v1beta1.Role{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Role), err
+}
+
+func (c *FakeRoles) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolesResource, c.ns, name), &v1beta1.Role{})
+
+	return err
+}
+
+func (c *FakeRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolesResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.RoleList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched role.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -36,40 +36,6 @@ var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var rolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "RoleBinding"}
 
-func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.RoleBinding), err
-}
-
-func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1beta1.RoleBinding{})
-
-	return err
-}
-
-func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.RoleBindingList{})
-	return err
-}
-
 func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolebindingsResource, c.ns, name), &v1beta1.RoleBinding{})
@@ -106,6 +72,40 @@ func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(rolebindingsResource, c.ns, opts))
 
+}
+
+func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.RoleBinding), err
+}
+
+func (c *FakeRoleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.RoleBinding), err
+}
+
+func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1beta1.RoleBinding{})
+
+	return err
+}
+
+func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.RoleBindingList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -36,6 +36,7 @@ var rolebindingsResource = schema.GroupVersionResource{Group: "rbac.authorizatio
 
 var rolebindingsKind = schema.GroupVersionKind{Group: "rbac.authorization.k8s.io", Version: "v1beta1", Kind: "RoleBinding"}
 
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
 func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(rolebindingsResource, c.ns, name), &v1beta1.RoleBinding{})
@@ -46,6 +47,7 @@ func (c *FakeRoleBindings) Get(name string, options v1.GetOptions) (result *v1be
 	return obj.(*v1beta1.RoleBinding), err
 }
 
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
 func (c *FakeRoleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(rolebindingsResource, rolebindingsKind, c.ns, opts), &v1beta1.RoleBindingList{})
@@ -74,6 +76,7 @@ func (c *FakeRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
@@ -84,6 +87,7 @@ func (c *FakeRoleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1b
 	return obj.(*v1beta1.RoleBinding), err
 }
 
+// Update takes the representation of a roleBinding and updates it. Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *FakeRoleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(rolebindingsResource, c.ns, roleBinding), &v1beta1.RoleBinding{})
@@ -94,6 +98,7 @@ func (c *FakeRoleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1b
 	return obj.(*v1beta1.RoleBinding), err
 }
 
+// Delete takes name of the roleBinding and deletes it. Returns an error if one occurs.
 func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(rolebindingsResource, c.ns, name), &v1beta1.RoleBinding{})
@@ -101,6 +106,7 @@ func (c *FakeRoleBindings) Delete(name string, options *v1.DeleteOptions) error 
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(rolebindingsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -58,6 +58,41 @@ func newRoles(c *RbacV1beta1Client, namespace string) *roles {
 	}
 }
 
+// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
+func (c *roles) Get(name string, options v1.GetOptions) (result *v1beta1.Role, err error) {
+	result = &v1beta1.Role{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Roles that match those selectors.
+func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) {
+	result = &v1beta1.RoleList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roles.
+func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("roles").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
 func (c *roles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 	result = &v1beta1.Role{}
@@ -103,41 +138,6 @@ func (c *roles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the role, and returns the corresponding role object, and an error if there is any.
-func (c *roles) Get(name string, options v1.GetOptions) (result *v1beta1.Role, err error) {
-	result = &v1beta1.Role{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Roles that match those selectors.
-func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) {
-	result = &v1beta1.RoleList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roles.
-func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("roles").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched role.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -58,6 +58,41 @@ func newRoleBindings(c *RbacV1beta1Client, namespace string) *roleBindings {
 	}
 }
 
+// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
+func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.RoleBinding, err error) {
+	result = &v1beta1.RoleBinding{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
+func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingList, err error) {
+	result = &v1beta1.RoleBindingList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested roleBindings.
+func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("rolebindings").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
 func (c *roleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1.RoleBinding, err error) {
 	result = &v1beta1.RoleBinding{}
@@ -103,41 +138,6 @@ func (c *roleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the roleBinding, and returns the corresponding roleBinding object, and an error if there is any.
-func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.RoleBinding, err error) {
-	result = &v1beta1.RoleBinding{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of RoleBindings that match those selectors.
-func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingList, err error) {
-	result = &v1beta1.RoleBindingList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested roleBindings.
-func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("rolebindings").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched roleBinding.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
@@ -35,37 +35,7 @@ var priorityclassesResource = schema.GroupVersionResource{Group: "scheduling.k8s
 
 var priorityclassesKind = schema.GroupVersionKind{Group: "scheduling.k8s.io", Version: "v1alpha1", Kind: "PriorityClass"}
 
-func (c *FakePriorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(priorityclassesResource, priorityClass), &v1alpha1.PriorityClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.PriorityClass), err
-}
-
-func (c *FakePriorityClasses) Update(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(priorityclassesResource, priorityClass), &v1alpha1.PriorityClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.PriorityClass), err
-}
-
-func (c *FakePriorityClasses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(priorityclassesResource, name), &v1alpha1.PriorityClass{})
-	return err
-}
-
-func (c *FakePriorityClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(priorityclassesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.PriorityClassList{})
-	return err
-}
-
+// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
 func (c *FakePriorityClasses) Get(name string, options v1.GetOptions) (result *v1alpha1.PriorityClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(priorityclassesResource, name), &v1alpha1.PriorityClass{})
@@ -75,6 +45,7 @@ func (c *FakePriorityClasses) Get(name string, options v1.GetOptions) (result *v
 	return obj.(*v1alpha1.PriorityClass), err
 }
 
+// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
 func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(priorityclassesResource, priorityclassesKind, opts), &v1alpha1.PriorityClassList{})
@@ -99,6 +70,41 @@ func (c *FakePriorityClasses) List(opts v1.ListOptions) (result *v1alpha1.Priori
 func (c *FakePriorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(priorityclassesResource, opts))
+}
+
+// Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
+func (c *FakePriorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(priorityclassesResource, priorityClass), &v1alpha1.PriorityClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.PriorityClass), err
+}
+
+// Update takes the representation of a priorityClass and updates it. Returns the server's representation of the priorityClass, and an error, if there is any.
+func (c *FakePriorityClasses) Update(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(priorityclassesResource, priorityClass), &v1alpha1.PriorityClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.PriorityClass), err
+}
+
+// Delete takes name of the priorityClass and deletes it. Returns an error if one occurs.
+func (c *FakePriorityClasses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(priorityclassesResource, name), &v1alpha1.PriorityClass{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakePriorityClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(priorityclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.PriorityClassList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched priorityClass.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -56,6 +56,38 @@ func newPriorityClasses(c *SchedulingV1alpha1Client) *priorityClasses {
 	}
 }
 
+// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
+func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *v1alpha1.PriorityClass, err error) {
+	result = &v1alpha1.PriorityClass{}
+	err = c.client.Get().
+		Resource("priorityclasses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
+func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityClassList, err error) {
+	result = &v1alpha1.PriorityClassList{}
+	err = c.client.Get().
+		Resource("priorityclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested priorityClasses.
+func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("priorityclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
 func (c *priorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result *v1alpha1.PriorityClass, err error) {
 	result = &v1alpha1.PriorityClass{}
@@ -97,38 +129,6 @@ func (c *priorityClasses) DeleteCollection(options *v1.DeleteOptions, listOption
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the priorityClass, and returns the corresponding priorityClass object, and an error if there is any.
-func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *v1alpha1.PriorityClass, err error) {
-	result = &v1alpha1.PriorityClass{}
-	err = c.client.Get().
-		Resource("priorityclasses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PriorityClasses that match those selectors.
-func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityClassList, err error) {
-	result = &v1alpha1.PriorityClassList{}
-	err = c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested priorityClasses.
-func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("priorityclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched priorityClass.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
@@ -36,6 +36,7 @@ var podpresetsResource = schema.GroupVersionResource{Group: "settings.k8s.io", V
 
 var podpresetsKind = schema.GroupVersionKind{Group: "settings.k8s.io", Version: "v1alpha1", Kind: "PodPreset"}
 
+// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
 func (c *FakePodPresets) Get(name string, options v1.GetOptions) (result *v1alpha1.PodPreset, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podpresetsResource, c.ns, name), &v1alpha1.PodPreset{})
@@ -46,6 +47,7 @@ func (c *FakePodPresets) Get(name string, options v1.GetOptions) (result *v1alph
 	return obj.(*v1alpha1.PodPreset), err
 }
 
+// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
 func (c *FakePodPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podpresetsResource, podpresetsKind, c.ns, opts), &v1alpha1.PodPresetList{})
@@ -74,6 +76,7 @@ func (c *FakePodPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *FakePodPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
@@ -84,6 +87,7 @@ func (c *FakePodPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1
 	return obj.(*v1alpha1.PodPreset), err
 }
 
+// Update takes the representation of a podPreset and updates it. Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *FakePodPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
@@ -94,6 +98,7 @@ func (c *FakePodPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1
 	return obj.(*v1alpha1.PodPreset), err
 }
 
+// Delete takes name of the podPreset and deletes it. Returns an error if one occurs.
 func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(podpresetsResource, c.ns, name), &v1alpha1.PodPreset{})
@@ -101,6 +106,7 @@ func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakePodPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(podpresetsResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
@@ -36,40 +36,6 @@ var podpresetsResource = schema.GroupVersionResource{Group: "settings.k8s.io", V
 
 var podpresetsKind = schema.GroupVersionKind{Group: "settings.k8s.io", Version: "v1alpha1", Kind: "PodPreset"}
 
-func (c *FakePodPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.PodPreset), err
-}
-
-func (c *FakePodPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.PodPreset), err
-}
-
-func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(podpresetsResource, c.ns, name), &v1alpha1.PodPreset{})
-
-	return err
-}
-
-func (c *FakePodPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(podpresetsResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.PodPresetList{})
-	return err
-}
-
 func (c *FakePodPresets) Get(name string, options v1.GetOptions) (result *v1alpha1.PodPreset, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podpresetsResource, c.ns, name), &v1alpha1.PodPreset{})
@@ -106,6 +72,40 @@ func (c *FakePodPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(podpresetsResource, c.ns, opts))
 
+}
+
+func (c *FakePodPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.PodPreset), err
+}
+
+func (c *FakePodPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(podpresetsResource, c.ns, podPreset), &v1alpha1.PodPreset{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.PodPreset), err
+}
+
+func (c *FakePodPresets) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(podpresetsResource, c.ns, name), &v1alpha1.PodPreset{})
+
+	return err
+}
+
+func (c *FakePodPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(podpresetsResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.PodPresetList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched podPreset.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
@@ -58,6 +58,41 @@ func newPodPresets(c *SettingsV1alpha1Client, namespace string) *podPresets {
 	}
 }
 
+// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
+func (c *podPresets) Get(name string, options v1.GetOptions) (result *v1alpha1.PodPreset, err error) {
+	result = &v1alpha1.PodPreset{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
+func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, err error) {
+	result = &v1alpha1.PodPresetList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested podPresets.
+func (c *podPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("podpresets").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
 func (c *podPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.PodPreset, err error) {
 	result = &v1alpha1.PodPreset{}
@@ -103,41 +138,6 @@ func (c *podPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the podPreset, and returns the corresponding podPreset object, and an error if there is any.
-func (c *podPresets) Get(name string, options v1.GetOptions) (result *v1alpha1.PodPreset, err error) {
-	result = &v1alpha1.PodPreset{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of PodPresets that match those selectors.
-func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, err error) {
-	result = &v1alpha1.PodPresetList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested podPresets.
-func (c *podPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("podpresets").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched podPreset.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -17,8 +17,8 @@ limitations under the License.
 package fake
 
 import (
-	v1 "k8s.io/api/storage/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	storage_v1 "k8s.io/api/storage/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
@@ -35,49 +35,18 @@ var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io"
 
 var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"}
 
-func (c *FakeStorageClasses) Create(storageClass *v1.StorageClass) (result *v1.StorageClass, err error) {
+func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *storage_v1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &v1.StorageClass{})
+		Invokes(testing.NewRootGetAction(storageclassesResource, name), &storage_v1.StorageClass{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.StorageClass), err
+	return obj.(*storage_v1.StorageClass), err
 }
 
-func (c *FakeStorageClasses) Update(storageClass *v1.StorageClass) (result *v1.StorageClass, err error) {
+func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storage_v1.StorageClassList, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &v1.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.StorageClass), err
-}
-
-func (c *FakeStorageClasses) Delete(name string, options *meta_v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &v1.StorageClass{})
-	return err
-}
-
-func (c *FakeStorageClasses) DeleteCollection(options *meta_v1.DeleteOptions, listOptions meta_v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1.StorageClassList{})
-	return err
-}
-
-func (c *FakeStorageClasses) Get(name string, options meta_v1.GetOptions) (result *v1.StorageClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootGetAction(storageclassesResource, name), &v1.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1.StorageClass), err
-}
-
-func (c *FakeStorageClasses) List(opts meta_v1.ListOptions) (result *v1.StorageClassList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &v1.StorageClassList{})
+		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &storage_v1.StorageClassList{})
 	if obj == nil {
 		return nil, err
 	}
@@ -86,8 +55,8 @@ func (c *FakeStorageClasses) List(opts meta_v1.ListOptions) (result *v1.StorageC
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1.StorageClassList{}
-	for _, item := range obj.(*v1.StorageClassList).Items {
+	list := &storage_v1.StorageClassList{}
+	for _, item := range obj.(*storage_v1.StorageClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)
 		}
@@ -96,17 +65,48 @@ func (c *FakeStorageClasses) List(opts meta_v1.ListOptions) (result *v1.StorageC
 }
 
 // Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *FakeStorageClasses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
 }
 
-// Patch applies the patch and returns the patched storageClass.
-func (c *FakeStorageClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1.StorageClass, err error) {
+func (c *FakeStorageClasses) Create(storageClass *storage_v1.StorageClass) (result *storage_v1.StorageClass, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, name, data, subresources...), &v1.StorageClass{})
+		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &storage_v1.StorageClass{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*v1.StorageClass), err
+	return obj.(*storage_v1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Update(storageClass *storage_v1.StorageClass) (result *storage_v1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &storage_v1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*storage_v1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &storage_v1.StorageClass{})
+	return err
+}
+
+func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &storage_v1.StorageClassList{})
+	return err
+}
+
+// Patch applies the patch and returns the patched storageClass.
+func (c *FakeStorageClasses) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *storage_v1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootPatchSubresourceAction(storageclassesResource, name, data, subresources...), &storage_v1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*storage_v1.StorageClass), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -35,6 +35,7 @@ var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io"
 
 var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1", Kind: "StorageClass"}
 
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *storage_v1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(storageclassesResource, name), &storage_v1.StorageClass{})
@@ -44,6 +45,7 @@ func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *st
 	return obj.(*storage_v1.StorageClass), err
 }
 
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *storage_v1.StorageClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &storage_v1.StorageClassList{})
@@ -70,6 +72,7 @@ func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error)
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
 }
 
+// Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Create(storageClass *storage_v1.StorageClass) (result *storage_v1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &storage_v1.StorageClass{})
@@ -79,6 +82,7 @@ func (c *FakeStorageClasses) Create(storageClass *storage_v1.StorageClass) (resu
 	return obj.(*storage_v1.StorageClass), err
 }
 
+// Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Update(storageClass *storage_v1.StorageClass) (result *storage_v1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &storage_v1.StorageClass{})
@@ -88,12 +92,14 @@ func (c *FakeStorageClasses) Update(storageClass *storage_v1.StorageClass) (resu
 	return obj.(*storage_v1.StorageClass), err
 }
 
+// Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &storage_v1.StorageClass{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -56,6 +56,38 @@ func newStorageClasses(c *StorageV1Client) *storageClasses {
 	}
 }
 
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
+func (c *storageClasses) Get(name string, options meta_v1.GetOptions) (result *v1.StorageClass, err error) {
+	result = &v1.StorageClass{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) List(opts meta_v1.ListOptions) (result *v1.StorageClassList, err error) {
+	result = &v1.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *storageClasses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Create(storageClass *v1.StorageClass) (result *v1.StorageClass, err error) {
 	result = &v1.StorageClass{}
@@ -97,38 +129,6 @@ func (c *storageClasses) DeleteCollection(options *meta_v1.DeleteOptions, listOp
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
-func (c *storageClasses) Get(name string, options meta_v1.GetOptions) (result *v1.StorageClass, err error) {
-	result = &v1.StorageClass{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
-func (c *storageClasses) List(opts meta_v1.ListOptions) (result *v1.StorageClassList, err error) {
-	result = &v1.StorageClassList{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *storageClasses) Watch(opts meta_v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched storageClass.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -35,6 +35,7 @@ var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io"
 
 var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClass"}
 
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(storageclassesResource, name), &v1beta1.StorageClass{})
@@ -44,6 +45,7 @@ func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *v1
 	return obj.(*v1beta1.StorageClass), err
 }
 
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
 func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClassList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(storageclassesResource, storageclassesKind, opts), &v1beta1.StorageClassList{})
@@ -70,6 +72,7 @@ func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error)
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
 }
 
+// Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
@@ -79,6 +82,7 @@ func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result 
 	return obj.(*v1beta1.StorageClass), err
 }
 
+// Update takes the representation of a storageClass and updates it. Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
@@ -88,12 +92,14 @@ func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result 
 	return obj.(*v1beta1.StorageClass), err
 }
 
+// Delete takes name of the storageClass and deletes it. Returns an error if one occurs.
 func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &v1beta1.StorageClass{})
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
 

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -35,37 +35,6 @@ var storageclassesResource = schema.GroupVersionResource{Group: "storage.k8s.io"
 
 var storageclassesKind = schema.GroupVersionKind{Group: "storage.k8s.io", Version: "v1beta1", Kind: "StorageClass"}
 
-func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.StorageClass), err
-}
-
-func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.StorageClass), err
-}
-
-func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &v1beta1.StorageClass{})
-	return err
-}
-
-func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.StorageClassList{})
-	return err
-}
-
 func (c *FakeStorageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(storageclassesResource, name), &v1beta1.StorageClass{})
@@ -99,6 +68,37 @@ func (c *FakeStorageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageC
 func (c *FakeStorageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(storageclassesResource, opts))
+}
+
+func (c *FakeStorageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(storageclassesResource, storageClass), &v1beta1.StorageClass{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.StorageClass), err
+}
+
+func (c *FakeStorageClasses) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(storageclassesResource, name), &v1beta1.StorageClass{})
+	return err
+}
+
+func (c *FakeStorageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(storageclassesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.StorageClassList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched storageClass.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -56,6 +56,38 @@ func newStorageClasses(c *StorageV1beta1Client) *storageClasses {
 	}
 }
 
+// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
+func (c *storageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
+	result = &v1beta1.StorageClass{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
+func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClassList, err error) {
+	result = &v1beta1.StorageClassList{}
+	err = c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested storageClasses.
+func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("storageclasses").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
 func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1beta1.StorageClass, err error) {
 	result = &v1beta1.StorageClass{}
@@ -97,38 +129,6 @@ func (c *storageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the storageClass, and returns the corresponding storageClass object, and an error if there is any.
-func (c *storageClasses) Get(name string, options v1.GetOptions) (result *v1beta1.StorageClass, err error) {
-	result = &v1beta1.StorageClass{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of StorageClasses that match those selectors.
-func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClassList, err error) {
-	result = &v1beta1.StorageClassList{}
-	err = c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested storageClasses.
-func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("storageclasses").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched storageClass.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/types.go
@@ -111,8 +111,8 @@ type APIServiceStatus struct {
 	Conditions []APIServiceCondition
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // APIService represents a server for a particular GroupVersion.

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/types.go
@@ -119,8 +119,8 @@ type APIServiceStatus struct {
 	Conditions []APIServiceCondition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type" protobuf:"bytes,1,rep,name=conditions"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // APIService represents a server for a particular GroupVersion.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -57,6 +57,38 @@ func newAPIServices(c *ApiregistrationV1beta1Client) *aPIServices {
 	}
 }
 
+// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
+func (c *aPIServices) Get(name string, options v1.GetOptions) (result *v1beta1.APIService, err error) {
+	result = &v1beta1.APIService{}
+	err = c.client.Get().
+		Resource("apiservices").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of APIServices that match those selectors.
+func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList, err error) {
+	result = &v1beta1.APIServiceList{}
+	err = c.client.Get().
+		Resource("apiservices").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested aPIServices.
+func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("apiservices").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}
@@ -113,38 +145,6 @@ func (c *aPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
-func (c *aPIServices) Get(name string, options v1.GetOptions) (result *v1beta1.APIService, err error) {
-	result = &v1beta1.APIService{}
-	err = c.client.Get().
-		Resource("apiservices").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of APIServices that match those selectors.
-func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList, err error) {
-	result = &v1beta1.APIServiceList{}
-	err = c.client.Get().
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched aPIService.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -81,7 +81,7 @@ func (c *aPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.AP
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *aPIServices) UpdateStatus(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
 	result = &v1beta1.APIService{}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
@@ -35,46 +35,7 @@ var apiservicesResource = schema.GroupVersionResource{Group: "apiregistration.k8
 
 var apiservicesKind = schema.GroupVersionKind{Group: "apiregistration.k8s.io", Version: "v1beta1", Kind: "APIService"}
 
-func (c *FakeAPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(apiservicesResource, aPIService), &v1beta1.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.APIService), err
-}
-
-func (c *FakeAPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(apiservicesResource, aPIService), &v1beta1.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.APIService), err
-}
-
-func (c *FakeAPIServices) UpdateStatus(aPIService *v1beta1.APIService) (*v1beta1.APIService, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(apiservicesResource, "status", aPIService), &v1beta1.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1beta1.APIService), err
-}
-
-func (c *FakeAPIServices) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(apiservicesResource, name), &v1beta1.APIService{})
-	return err
-}
-
-func (c *FakeAPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(apiservicesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1beta1.APIServiceList{})
-	return err
-}
-
+// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
 func (c *FakeAPIServices) Get(name string, options v1.GetOptions) (result *v1beta1.APIService, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(apiservicesResource, name), &v1beta1.APIService{})
@@ -84,6 +45,7 @@ func (c *FakeAPIServices) Get(name string, options v1.GetOptions) (result *v1bet
 	return obj.(*v1beta1.APIService), err
 }
 
+// List takes label and field selectors, and returns the list of APIServices that match those selectors.
 func (c *FakeAPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(apiservicesResource, apiservicesKind, opts), &v1beta1.APIServiceList{})
@@ -108,6 +70,52 @@ func (c *FakeAPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceL
 func (c *FakeAPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(apiservicesResource, opts))
+}
+
+// Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
+func (c *FakeAPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(apiservicesResource, aPIService), &v1beta1.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.APIService), err
+}
+
+// Update takes the representation of a aPIService and updates it. Returns the server's representation of the aPIService, and an error, if there is any.
+func (c *FakeAPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.APIService, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(apiservicesResource, aPIService), &v1beta1.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.APIService), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeAPIServices) UpdateStatus(aPIService *v1beta1.APIService) (*v1beta1.APIService, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(apiservicesResource, "status", aPIService), &v1beta1.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.APIService), err
+}
+
+// Delete takes name of the aPIService and deletes it. Returns an error if one occurs.
+func (c *FakeAPIServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(apiservicesResource, name), &v1beta1.APIService{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeAPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(apiservicesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1beta1.APIServiceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched aPIService.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -81,7 +81,7 @@ func (c *aPIServices) Update(aPIService *apiregistration.APIService) (result *ap
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *aPIServices) UpdateStatus(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
 	result = &apiregistration.APIService{}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/apiservice.go
@@ -57,6 +57,38 @@ func newAPIServices(c *ApiregistrationClient) *aPIServices {
 	}
 }
 
+// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
+func (c *aPIServices) Get(name string, options v1.GetOptions) (result *apiregistration.APIService, err error) {
+	result = &apiregistration.APIService{}
+	err = c.client.Get().
+		Resource("apiservices").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of APIServices that match those selectors.
+func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServiceList, err error) {
+	result = &apiregistration.APIServiceList{}
+	err = c.client.Get().
+		Resource("apiservices").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested aPIServices.
+func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("apiservices").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
 func (c *aPIServices) Create(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
 	result = &apiregistration.APIService{}
@@ -113,38 +145,6 @@ func (c *aPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
-func (c *aPIServices) Get(name string, options v1.GetOptions) (result *apiregistration.APIService, err error) {
-	result = &apiregistration.APIService{}
-	err = c.client.Get().
-		Resource("apiservices").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of APIServices that match those selectors.
-func (c *aPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServiceList, err error) {
-	result = &apiregistration.APIServiceList{}
-	err = c.client.Get().
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested aPIServices.
-func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("apiservices").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched aPIService.

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/typed/apiregistration/internalversion/fake/fake_apiservice.go
@@ -35,46 +35,7 @@ var apiservicesResource = schema.GroupVersionResource{Group: "apiregistration.k8
 
 var apiservicesKind = schema.GroupVersionKind{Group: "apiregistration.k8s.io", Version: "", Kind: "APIService"}
 
-func (c *FakeAPIServices) Create(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(apiservicesResource, aPIService), &apiregistration.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiregistration.APIService), err
-}
-
-func (c *FakeAPIServices) Update(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(apiservicesResource, aPIService), &apiregistration.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiregistration.APIService), err
-}
-
-func (c *FakeAPIServices) UpdateStatus(aPIService *apiregistration.APIService) (*apiregistration.APIService, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(apiservicesResource, "status", aPIService), &apiregistration.APIService{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*apiregistration.APIService), err
-}
-
-func (c *FakeAPIServices) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(apiservicesResource, name), &apiregistration.APIService{})
-	return err
-}
-
-func (c *FakeAPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(apiservicesResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &apiregistration.APIServiceList{})
-	return err
-}
-
+// Get takes name of the aPIService, and returns the corresponding aPIService object, and an error if there is any.
 func (c *FakeAPIServices) Get(name string, options v1.GetOptions) (result *apiregistration.APIService, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(apiservicesResource, name), &apiregistration.APIService{})
@@ -84,6 +45,7 @@ func (c *FakeAPIServices) Get(name string, options v1.GetOptions) (result *apire
 	return obj.(*apiregistration.APIService), err
 }
 
+// List takes label and field selectors, and returns the list of APIServices that match those selectors.
 func (c *FakeAPIServices) List(opts v1.ListOptions) (result *apiregistration.APIServiceList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(apiservicesResource, apiservicesKind, opts), &apiregistration.APIServiceList{})
@@ -108,6 +70,52 @@ func (c *FakeAPIServices) List(opts v1.ListOptions) (result *apiregistration.API
 func (c *FakeAPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(apiservicesResource, opts))
+}
+
+// Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
+func (c *FakeAPIServices) Create(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(apiservicesResource, aPIService), &apiregistration.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiregistration.APIService), err
+}
+
+// Update takes the representation of a aPIService and updates it. Returns the server's representation of the aPIService, and an error, if there is any.
+func (c *FakeAPIServices) Update(aPIService *apiregistration.APIService) (result *apiregistration.APIService, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(apiservicesResource, aPIService), &apiregistration.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiregistration.APIService), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeAPIServices) UpdateStatus(aPIService *apiregistration.APIService) (*apiregistration.APIService, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateSubresourceAction(apiservicesResource, "status", aPIService), &apiregistration.APIService{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*apiregistration.APIService), err
+}
+
+// Delete takes name of the aPIService and deletes it. Returns an error if one occurs.
+func (c *FakeAPIServices) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(apiservicesResource, name), &apiregistration.APIService{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeAPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(apiservicesResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &apiregistration.APIServiceList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched aPIService.

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/BUILD
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/kube-gen/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/fake:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/scheme:go_default_library",
+        "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/path:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/types:go_default_library",
     ],

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/client_generator.go
@@ -29,6 +29,7 @@ import (
 	clientgenargs "k8s.io/kube-gen/cmd/client-gen/args"
 	"k8s.io/kube-gen/cmd/client-gen/generators/fake"
 	"k8s.io/kube-gen/cmd/client-gen/generators/scheme"
+	"k8s.io/kube-gen/cmd/client-gen/generators/util"
 	"k8s.io/kube-gen/cmd/client-gen/path"
 	clientgentypes "k8s.io/kube-gen/cmd/client-gen/types"
 
@@ -169,7 +170,7 @@ func packageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, cli
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == true
+			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
 		},
 	}
 }
@@ -342,7 +343,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			} else {
 				// User has not specified any override for this group version.
 				// filter out types which dont have genclient=true.
-				if extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == false {
+				if tags := util.MustParseClientGenTags(t.SecondClosestCommentLines); !tags.GenerateClient {
 					continue
 				}
 			}

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/client_generator.go
@@ -342,7 +342,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				}
 			} else {
 				// User has not specified any override for this group version.
-				// filter out types which dont have genclient=true.
+				// filter out types which dont have genclient.
 				if tags := util.MustParseClientGenTags(t.SecondClosestCommentLines); !tags.GenerateClient {
 					continue
 				}

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/BUILD
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/BUILD
@@ -17,12 +17,12 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",
         "//vendor/k8s.io/gengo/types:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/scheme:go_default_library",
+        "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/path:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/types:go_default_library",
     ],

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/fake_client_generator.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/fake_client_generator.go
@@ -20,12 +20,12 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/golang/glog"
-
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
+
 	clientgenargs "k8s.io/kube-gen/cmd/client-gen/args"
 	scheme "k8s.io/kube-gen/cmd/client-gen/generators/scheme"
+	"k8s.io/kube-gen/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/kube-gen/cmd/client-gen/types"
 )
 
@@ -78,17 +78,9 @@ func PackageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, cli
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == true
+			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
 		},
 	}
-}
-
-func extractBoolTagOrDie(key string, lines []string) bool {
-	val, err := types.ExtractSingleBoolCommentTag("+", key, false, lines)
-	if err != nil {
-		glog.Fatalf(err.Error())
-	}
-	return val
 }
 
 func PackageForClientset(customArgs clientgenargs.Args, fakeClientsetPackage string, boilerplate []byte, generatedBy string) generator.Package {

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/tags.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/tags.go
@@ -17,20 +17,8 @@ limitations under the License.
 package generators
 
 import (
-	"github.com/golang/glog"
 	"k8s.io/gengo/types"
 )
-
-// extractBoolTagOrDie gets the comment-tags for the key and asserts that, if
-// it exists, the value is boolean.  If the tag did not exist, it returns
-// false.
-func extractBoolTagOrDie(key string, lines []string) bool {
-	val, err := types.ExtractSingleBoolCommentTag("+", key, false, lines)
-	if err != nil {
-		glog.Fatalf(err.Error())
-	}
-	return val
-}
 
 // extractTag gets the comment-tags for the key.  If the tag did not exist, it
 // returns the empty string.

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/BUILD
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/BUILD
@@ -1,0 +1,23 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["tags_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["tags.go"],
+    tags = ["automanaged"],
+    deps = ["//vendor/k8s.io/gengo/types:go_default_library"],
+)

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/tags.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/tags.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"k8s.io/gengo/types"
+)
+
+var supportedTags = []string{
+	"genclient",
+	"genclient:nonNamespaced",
+	"genclient:noVerbs",
+	"genclient:onlyVerbs",
+	"genclient:skipVerbs",
+	"genclient:noStatus",
+	"genclient:readonly",
+}
+
+// SupportedVerbs is a list of supported verbs for +onlyVerbs and +skipVerbs.
+var SupportedVerbs = []string{
+	"create",
+	"update",
+	"updateStatus",
+	"delete",
+	"deleteCollection",
+	"get",
+	"list",
+	"watch",
+	"patch",
+}
+
+// ReadonlyVerbs represents a list of read-only verbs.
+var ReadonlyVerbs = []string{
+	"get",
+	"list",
+	"watch",
+}
+
+// Tags represents a genclient configuration for a single type.
+type Tags struct {
+	// +genclient
+	GenerateClient bool
+	// +genclient:nonNamespaced
+	NonNamespaced bool
+	// +genclient:noStatus
+	NoStatus bool
+	// +genclient:noVerbs
+	NoVerbs bool
+	// +genclient:skipVerbs=get,update
+	// +genclient:onlyVerbs=create,delete
+	SkipVerbs []string
+}
+
+// HasVerb returns true if we should include the given verb in final client interface and
+// generate the function for it.
+func (t Tags) HasVerb(verb string) bool {
+	if len(t.SkipVerbs) == 0 {
+		return true
+	}
+	for _, s := range t.SkipVerbs {
+		if verb == s {
+			return false
+		}
+	}
+	return true
+}
+
+// MustParseClientGenTags calls ParseClientGenTags but instead of returning error it panics.
+func MustParseClientGenTags(lines []string) Tags {
+	tags, err := ParseClientGenTags(lines)
+	if err != nil {
+		panic(err.Error())
+	}
+	return tags
+}
+
+// ParseClientGenTags parse the provided genclient tags and validates that no unknown
+// tags are provided.
+func ParseClientGenTags(lines []string) (Tags, error) {
+	ret := Tags{}
+	values := types.ExtractCommentTags("+", lines)
+	value := []string{}
+	value, ret.GenerateClient = values["genclient"]
+	// Check the old format and error when used to avoid generating client when //+genclient=false
+	if len(value) > 0 && len(value[0]) > 0 {
+		return ret, fmt.Errorf("+genclient=%s is invalid, use //+genclient if you want to generate client or omit it when you want to disable generation", value)
+	}
+	_, ret.NonNamespaced = values["genclient:nonNamespaced"]
+	// Check the old format and error when used
+	if value := values["nonNamespaced"]; len(value) > 0 && len(value[0]) > 0 {
+		return ret, fmt.Errorf("+nonNamespaced=%s is invalid, use //+genclient:nonNamespaced instead", value[0])
+	}
+	_, ret.NoVerbs = values["genclient:noVerbs"]
+	_, ret.NoStatus = values["genclient:noStatus"]
+	onlyVerbs := []string{}
+	if _, isReadonly := values["genclient:readonly"]; isReadonly {
+		onlyVerbs = ReadonlyVerbs
+	}
+	// Check the old format and error when used
+	if value := values["readonly"]; len(value) > 0 && len(value[0]) > 0 {
+		return ret, fmt.Errorf("+readonly=%s is invalid, use //+genclient:readonly instead", value[0])
+	}
+	if v, exists := values["genclient:skipVerbs"]; exists {
+		ret.SkipVerbs = strings.Split(v[0], ",")
+	}
+	if v, exists := values["genclient:onlyVerbs"]; exists || len(onlyVerbs) > 0 {
+		if len(v) > 0 {
+			onlyVerbs = append(onlyVerbs, strings.Split(v[0], ",")...)
+		}
+		skipVerbs := []string{}
+		for _, m := range SupportedVerbs {
+			skip := true
+			for _, o := range onlyVerbs {
+				if o == m {
+					skip = false
+					break
+				}
+			}
+			// Check for conflicts
+			for _, v := range skipVerbs {
+				if v == m {
+					return ret, fmt.Errorf("verb %q used both in genclient:skipVerbs and genclient:onlyVerbs", v)
+				}
+			}
+			if skip {
+				skipVerbs = append(skipVerbs, m)
+			}
+		}
+		ret.SkipVerbs = skipVerbs
+	}
+	return ret, validateClientGenTags(values)
+}
+
+// validateTags validates that only supported genclient tags were provided.
+func validateClientGenTags(values map[string][]string) error {
+	for _, k := range supportedTags {
+		delete(values, k)
+	}
+	for key := range values {
+		if strings.HasPrefix(key, "genclient") {
+			return errors.New("unknown tag detected: " + key)
+		}
+	}
+	return nil
+}

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/tags_test.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/util/tags_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseTags(t *testing.T) {
+	testCases := map[string]struct {
+		lines       []string
+		expectTags  Tags
+		expectError bool
+	}{
+		"genclient": {
+			lines:      []string{`+genclient`},
+			expectTags: Tags{GenerateClient: true},
+		},
+		"genclient=true": {
+			lines:       []string{`+genclient=true`},
+			expectError: true,
+		},
+		"nonNamespaced=true": {
+			lines:       []string{`+genclient=true`, `+nonNamespaced=true`},
+			expectError: true,
+		},
+		"readonly=true": {
+			lines:       []string{`+genclient=true`, `+readonly=true`},
+			expectError: true,
+		},
+		"genclient:nonNamespaced": {
+			lines:      []string{`+genclient`, `+genclient:nonNamespaced`},
+			expectTags: Tags{GenerateClient: true, NonNamespaced: true},
+		},
+		"genclient:noVerbs": {
+			lines:      []string{`+genclient`, `+genclient:noVerbs`},
+			expectTags: Tags{GenerateClient: true, NoVerbs: true},
+		},
+		"genclient:noStatus": {
+			lines:      []string{`+genclient`, `+genclient:noStatus`},
+			expectTags: Tags{GenerateClient: true, NoStatus: true},
+		},
+		"genclient:onlyVerbs": {
+			lines:      []string{`+genclient`, `+genclient:onlyVerbs=create,delete`},
+			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"update", "updateStatus", "deleteCollection", "get", "list", "watch", "patch"}},
+		},
+		"genclient:readonly": {
+			lines:      []string{`+genclient`, `+genclient:readonly`},
+			expectTags: Tags{GenerateClient: true, SkipVerbs: []string{"create", "update", "updateStatus", "delete", "deleteCollection", "patch"}},
+		},
+		"genclient:conflict": {
+			lines:       []string{`+genclient`, `+genclient:onlyVerbs=create`, `+genclient:skipVerbs=create`},
+			expectError: true,
+		},
+		"genclient:invalid": {
+			lines:       []string{`+genclient`, `+genclient:invalid`},
+			expectError: true,
+		},
+	}
+	for key, c := range testCases {
+		result, err := ParseClientGenTags(c.lines)
+		if err != nil && !c.expectError {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !c.expectError && !reflect.DeepEqual(result, c.expectTags) {
+			t.Errorf("[%s] expected %#v to be %#v", key, result, c.expectTags)
+		}
+	}
+}

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/main.go
@@ -51,7 +51,7 @@ var (
 		"settings/",
 		"networking/",
 	}, "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\".")
-	includedTypesOverrides = flag.StringSlice("included-types-overrides", []string{}, "list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient=true in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient=true will be used for other group versions.")
+	includedTypesOverrides = flag.StringSlice("included-types-overrides", []string{}, "list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient will be used for other group versions.")
 	basePath               = flag.String("input-base", "k8s.io/kubernetes/pkg/apis", "base path to look for the api group.")
 	clientsetName          = flag.StringP("clientset-name", "n", "internalclientset", "the name of the generated clientset package.")
 	clientsetAPIPath       = flag.StringP("clientset-api-path", "", "", "the value of default API path.")

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/test_apis/testgroup/types.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/test_apis/testgroup/types.go
@@ -18,7 +18,7 @@ package testgroup
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type TestType struct {

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/test_apis/testgroup/v1/types.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/test_apis/testgroup/v1/types.go
@@ -18,7 +18,7 @@ package v1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type TestType struct {

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/fake/fake_testtype.go
@@ -36,6 +36,44 @@ var testtypesResource = schema.GroupVersionResource{Group: "testgroup.k8s.io", V
 
 var testtypesKind = schema.GroupVersionKind{Group: "testgroup.k8s.io", Version: "", Kind: "TestType"}
 
+func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *testgroup.TestType, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetAction(testtypesResource, c.ns, name), &testgroup.TestType{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*testgroup.TestType), err
+}
+
+func (c *FakeTestTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewListAction(testtypesResource, testtypesKind, c.ns, opts), &testgroup.TestTypeList{})
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+	list := &testgroup.TestTypeList{}
+	for _, item := range obj.(*testgroup.TestTypeList).Items {
+		if label.Matches(labels.Set(item.Labels)) {
+			list.Items = append(list.Items, item)
+		}
+	}
+	return list, err
+}
+
+// Watch returns a watch.Interface that watches the requested testTypes.
+func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	return c.Fake.
+		InvokesWatch(testing.NewWatchAction(testtypesResource, c.ns, opts))
+
+}
+
 func (c *FakeTestTypes) Create(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(testtypesResource, c.ns, testType), &testgroup.TestType{})
@@ -78,44 +116,6 @@ func (c *FakeTestTypes) DeleteCollection(options *v1.DeleteOptions, listOptions 
 
 	_, err := c.Fake.Invokes(action, &testgroup.TestTypeList{})
 	return err
-}
-
-func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *testgroup.TestType, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewGetAction(testtypesResource, c.ns, name), &testgroup.TestType{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*testgroup.TestType), err
-}
-
-func (c *FakeTestTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewListAction(testtypesResource, testtypesKind, c.ns, opts), &testgroup.TestTypeList{})
-
-	if obj == nil {
-		return nil, err
-	}
-
-	label, _, _ := testing.ExtractFromListOptions(opts)
-	if label == nil {
-		label = labels.Everything()
-	}
-	list := &testgroup.TestTypeList{}
-	for _, item := range obj.(*testgroup.TestTypeList).Items {
-		if label.Matches(labels.Set(item.Labels)) {
-			list.Items = append(list.Items, item)
-		}
-	}
-	return list, err
-}
-
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	return c.Fake.
-		InvokesWatch(testing.NewWatchAction(testtypesResource, c.ns, opts))
-
 }
 
 // Patch applies the patch and returns the patched testType.

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/fake/fake_testtype.go
@@ -36,6 +36,7 @@ var testtypesResource = schema.GroupVersionResource{Group: "testgroup.k8s.io", V
 
 var testtypesKind = schema.GroupVersionKind{Group: "testgroup.k8s.io", Version: "", Kind: "TestType"}
 
+// Get takes name of the testType, and returns the corresponding testType object, and an error if there is any.
 func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *testgroup.TestType, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(testtypesResource, c.ns, name), &testgroup.TestType{})
@@ -46,6 +47,7 @@ func (c *FakeTestTypes) Get(name string, options v1.GetOptions) (result *testgro
 	return obj.(*testgroup.TestType), err
 }
 
+// List takes label and field selectors, and returns the list of TestTypes that match those selectors.
 func (c *FakeTestTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(testtypesResource, testtypesKind, c.ns, opts), &testgroup.TestTypeList{})
@@ -74,6 +76,7 @@ func (c *FakeTestTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 
 }
 
+// Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *FakeTestTypes) Create(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewCreateAction(testtypesResource, c.ns, testType), &testgroup.TestType{})
@@ -84,6 +87,7 @@ func (c *FakeTestTypes) Create(testType *testgroup.TestType) (result *testgroup.
 	return obj.(*testgroup.TestType), err
 }
 
+// Update takes the representation of a testType and updates it. Returns the server's representation of the testType, and an error, if there is any.
 func (c *FakeTestTypes) Update(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateAction(testtypesResource, c.ns, testType), &testgroup.TestType{})
@@ -94,6 +98,8 @@ func (c *FakeTestTypes) Update(testType *testgroup.TestType) (result *testgroup.
 	return obj.(*testgroup.TestType), err
 }
 
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 func (c *FakeTestTypes) UpdateStatus(testType *testgroup.TestType) (*testgroup.TestType, error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewUpdateSubresourceAction(testtypesResource, "status", c.ns, testType), &testgroup.TestType{})
@@ -104,6 +110,7 @@ func (c *FakeTestTypes) UpdateStatus(testType *testgroup.TestType) (*testgroup.T
 	return obj.(*testgroup.TestType), err
 }
 
+// Delete takes name of the testType and deletes it. Returns an error if one occurs.
 func (c *FakeTestTypes) Delete(name string, options *v1.DeleteOptions) error {
 	_, err := c.Fake.
 		Invokes(testing.NewDeleteAction(testtypesResource, c.ns, name), &testgroup.TestType{})
@@ -111,6 +118,7 @@ func (c *FakeTestTypes) Delete(name string, options *v1.DeleteOptions) error {
 	return err
 }
 
+// DeleteCollection deletes a collection of objects.
 func (c *FakeTestTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
 	action := testing.NewDeleteCollectionAction(testtypesResource, c.ns, listOptions)
 

--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/testoutput/clientset_generated/test_internalclientset/typed/testgroup/internalversion/testtype.go
@@ -59,6 +59,41 @@ func newTestTypes(c *TestgroupClient, namespace string) *testTypes {
 	}
 }
 
+// Get takes name of the testType, and returns the corresponding testType object, and an error if there is any.
+func (c *testTypes) Get(name string, options v1.GetOptions) (result *testgroup.TestType, err error) {
+	result = &testgroup.TestType{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("testtypes").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of TestTypes that match those selectors.
+func (c *testTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, err error) {
+	result = &testgroup.TestTypeList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("testtypes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested testTypes.
+func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("testtypes").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
 func (c *testTypes) Create(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	result = &testgroup.TestType{}
@@ -85,7 +120,7 @@ func (c *testTypes) Update(testType *testgroup.TestType) (result *testgroup.Test
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *testTypes) UpdateStatus(testType *testgroup.TestType) (result *testgroup.TestType, err error) {
 	result = &testgroup.TestType{}
@@ -120,41 +155,6 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the testType, and returns the corresponding testType object, and an error if there is any.
-func (c *testTypes) Get(name string, options v1.GetOptions) (result *testgroup.TestType, err error) {
-	result = &testgroup.TestType{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("testtypes").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of TestTypes that match those selectors.
-func (c *testTypes) List(opts v1.ListOptions) (result *testgroup.TestTypeList, err error) {
-	result = &testgroup.TestTypeList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested testTypes.
-func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("testtypes").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched testType.

--- a/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/BUILD
+++ b/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",
         "//vendor/k8s.io/gengo/types:go_default_library",
+        "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/types:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/informer.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+
+	"k8s.io/kube-gen/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/kube-gen/cmd/client-gen/types"
 
 	"github.com/golang/glog"
@@ -69,6 +71,11 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 	clientSetInterface := c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"})
 	informerFor := "InformerFor"
 
+	tags, err := util.ParseClientGenTags(t.SecondClosestCommentLines)
+	if err != nil {
+		return err
+	}
+
 	m := map[string]interface{}{
 		"apiScheme":                       c.Universe.Type(apiScheme),
 		"cacheIndexers":                   c.Universe.Type(cacheIndexers),
@@ -84,7 +91,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 		"listOptions":                     c.Universe.Type(listOptions),
 		"lister":                          c.Universe.Type(types.Name{Package: listerPackage, Name: t.Name.Name + "Lister"}),
 		"namespaceAll":                    c.Universe.Type(metav1NamespaceAll),
-		"namespaced":                      !extractBoolTagOrDie("nonNamespaced", t.SecondClosestCommentLines),
+		"namespaced":                      !tags.NonNamespaced,
 		"newLister":                       c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
 		"runtimeObject":                   c.Universe.Type(runtimeObject),
 		"timeDuration":                    c.Universe.Type(timeDuration),

--- a/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/BUILD
+++ b/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",
         "//vendor/k8s.io/gengo/types:go_default_library",
+        "//vendor/k8s.io/kube-gen/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/kube-gen/cmd/client-gen/types:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/expansion.go
+++ b/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/expansion.go
@@ -24,6 +24,8 @@ import (
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/types"
+
+	"k8s.io/kube-gen/cmd/client-gen/generators/util"
 )
 
 // expansionGenerator produces a file for a expansion interfaces.
@@ -41,10 +43,10 @@ func (g *expansionGenerator) Filter(c *generator.Context, t *types.Type) bool {
 func (g *expansionGenerator) GenerateType(c *generator.Context, t *types.Type, w io.Writer) error {
 	sw := generator.NewSnippetWriter(w, c, "$", "$")
 	for _, t := range g.types {
+		tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
 		if _, err := os.Stat(filepath.Join(g.packagePath, strings.ToLower(t.Name.Name+"_expansion.go"))); os.IsNotExist(err) {
 			sw.Do(expansionInterfaceTemplate, t)
-			namespaced := !extractBoolTagOrDie("nonNamespaced", t.SecondClosestCommentLines)
-			if namespaced {
+			if !tags.NonNamespaced {
 				sw.Do(namespacedExpansionInterfaceTemplate, t)
 			}
 		}

--- a/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
@@ -167,7 +167,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 func objectMetaForPackage(p *types.Package) (*types.Type, bool, error) {
 	generatingForPackage := false
 	for _, t := range p.Types {
-		// filter out types which dont have genclient=true.
+		// filter out types which dont have genclient.
 		if !util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient {
 			continue
 		}

--- a/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
+
+	"k8s.io/kube-gen/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/kube-gen/cmd/client-gen/types"
 
 	"github.com/golang/glog"
@@ -115,8 +117,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
-			// filter out types which dont have genclient=true.
-			if extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == false {
+			if !util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient {
 				continue
 			}
 			typesToGenerate = append(typesToGenerate, t)
@@ -154,8 +155,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				return generators
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
-				// piggy-back on types that are tagged for client-gen
-				return extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == true
+				return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
 			},
 		})
 	}
@@ -168,7 +168,7 @@ func objectMetaForPackage(p *types.Package) (*types.Type, bool, error) {
 	generatingForPackage := false
 	for _, t := range p.Types {
 		// filter out types which dont have genclient=true.
-		if extractBoolTagOrDie("genclient", t.SecondClosestCommentLines) == false {
+		if !util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient {
 			continue
 		}
 		generatingForPackage = true
@@ -232,26 +232,31 @@ func (g *listerGenerator) GenerateType(c *generator.Context, t *types.Type, w io
 		"objectMeta": g.objectMeta,
 	}
 
-	namespaced := !extractBoolTagOrDie("nonNamespaced", t.SecondClosestCommentLines)
-	if namespaced {
-		sw.Do(typeListerInterface, m)
-	} else {
+	tags, err := util.ParseClientGenTags(t.SecondClosestCommentLines)
+	if err != nil {
+		return err
+	}
+
+	if tags.NonNamespaced {
 		sw.Do(typeListerInterface_NonNamespaced, m)
+	} else {
+		sw.Do(typeListerInterface, m)
 	}
 
 	sw.Do(typeListerStruct, m)
 	sw.Do(typeListerConstructor, m)
 	sw.Do(typeLister_List, m)
 
-	if namespaced {
-		sw.Do(typeLister_NamespaceLister, m)
-		sw.Do(namespaceListerInterface, m)
-		sw.Do(namespaceListerStruct, m)
-		sw.Do(namespaceLister_List, m)
-		sw.Do(namespaceLister_Get, m)
-	} else {
+	if tags.NonNamespaced {
 		sw.Do(typeLister_NonNamespacedGet, m)
+		return sw.Error()
 	}
+
+	sw.Do(typeLister_NamespaceLister, m)
+	sw.Do(namespaceListerInterface, m)
+	sw.Do(namespaceListerStruct, m)
+	sw.Do(namespaceLister_List, m)
+	sw.Do(namespaceLister_Get, m)
 
 	return sw.Error()
 }

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/types.go
@@ -21,10 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
+// +genclient
 // +resourceName=nodes
-// +readonly=true
-// +nonNamespaced=true
+// +genclient:readonly
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // resource usage metrics of a node.
@@ -54,9 +54,9 @@ type NodeMetricsList struct {
 	Items []NodeMetrics
 }
 
-// +genclient=true
+// +genclient
 // +resourceName=pods
-// +readonly=true
+// +genclient:readonly
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // resource usage metrics of a pod.

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/types.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/types.go
@@ -21,10 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +genclient=true
+// +genclient
 // +resourceName=nodes
-// +readonly=true
-// +nonNamespaced=true
+// +genclient:readonly
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // resource usage metrics of a node.
@@ -54,9 +54,9 @@ type NodeMetricsList struct {
 	Items []NodeMetrics `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// +genclient=true
+// +genclient
 // +resourceName=pods
-// +readonly=true
+// +genclient:readonly
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // resource usage metrics of a pod.

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
@@ -34,6 +34,7 @@ var nodemetricsesResource = schema.GroupVersionResource{Group: "metrics", Versio
 
 var nodemetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "NodeMetrics"}
 
+// Get takes name of the nodeMetrics, and returns the corresponding nodeMetrics object, and an error if there is any.
 func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.NodeMetrics, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(nodemetricsesResource, name), &v1alpha1.NodeMetrics{})
@@ -43,6 +44,7 @@ func (c *FakeNodeMetricses) Get(name string, options v1.GetOptions) (result *v1a
 	return obj.(*v1alpha1.NodeMetrics), err
 }
 
+// List takes label and field selectors, and returns the list of NodeMetricses that match those selectors.
 func (c *FakeNodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(nodemetricsesResource, nodemetricsesKind, opts), &v1alpha1.NodeMetricsList{})

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/typed/metrics/v1alpha1/fake/fake_podmetrics.go
@@ -35,6 +35,7 @@ var podmetricsesResource = schema.GroupVersionResource{Group: "metrics", Version
 
 var podmetricsesKind = schema.GroupVersionKind{Group: "metrics", Version: "v1alpha1", Kind: "PodMetrics"}
 
+// Get takes name of the podMetrics, and returns the corresponding podMetrics object, and an error if there is any.
 func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1.PodMetrics, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(podmetricsesResource, c.ns, name), &v1alpha1.PodMetrics{})
@@ -45,6 +46,7 @@ func (c *FakePodMetricses) Get(name string, options v1.GetOptions) (result *v1al
 	return obj.(*v1alpha1.PodMetrics), err
 }
 
+// List takes label and field selectors, and returns the list of PodMetricses that match those selectors.
 func (c *FakePodMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(podmetricsesResource, podmetricsesKind, c.ns, opts), &v1alpha1.PodMetricsList{})

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/types.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/types.go
@@ -34,7 +34,7 @@ type FlunderSpec struct {
 type FlunderStatus struct {
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Flunder struct {
@@ -45,8 +45,8 @@ type Flunder struct {
 	Status FlunderStatus
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Fischer struct {
@@ -57,7 +57,7 @@ type Fischer struct {
 	DisallowedFlunders []string
 }
 
-// +nonNamespaced=true
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // FischerList is a list of Fischer objects.

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/types.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/types.go
@@ -34,7 +34,7 @@ type FlunderSpec struct {
 type FlunderStatus struct {
 }
 
-// +genclient=true
+// +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Flunder struct {
@@ -45,8 +45,8 @@ type Flunder struct {
 	Status FlunderStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// +genclient=true
-// +nonNamespaced=true
+// +genclient
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Fischer struct {
@@ -57,7 +57,7 @@ type Fischer struct {
 	DisallowedFlunders []string `json:"disallowedFlunders,omitempty" protobuf:"bytes,2,rep,name=disallowedFlunders"`
 }
 
-// +nonNamespaced=true
+// +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // FischerList is a list of Fischer objects.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fake/fake_fischer.go
@@ -35,37 +35,7 @@ var fischersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Versi
 
 var fischersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "v1alpha1", Kind: "Fischer"}
 
-func (c *FakeFischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(fischersResource, fischer), &v1alpha1.Fischer{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Fischer), err
-}
-
-func (c *FakeFischers) Update(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(fischersResource, fischer), &v1alpha1.Fischer{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Fischer), err
-}
-
-func (c *FakeFischers) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(fischersResource, name), &v1alpha1.Fischer{})
-	return err
-}
-
-func (c *FakeFischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(fischersResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.FischerList{})
-	return err
-}
-
+// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
 func (c *FakeFischers) Get(name string, options v1.GetOptions) (result *v1alpha1.Fischer, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(fischersResource, name), &v1alpha1.Fischer{})
@@ -75,6 +45,7 @@ func (c *FakeFischers) Get(name string, options v1.GetOptions) (result *v1alpha1
 	return obj.(*v1alpha1.Fischer), err
 }
 
+// List takes label and field selectors, and returns the list of Fischers that match those selectors.
 func (c *FakeFischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(fischersResource, fischersKind, opts), &v1alpha1.FischerList{})
@@ -99,6 +70,41 @@ func (c *FakeFischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, 
 func (c *FakeFischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(fischersResource, opts))
+}
+
+// Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
+func (c *FakeFischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(fischersResource, fischer), &v1alpha1.Fischer{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Fischer), err
+}
+
+// Update takes the representation of a fischer and updates it. Returns the server's representation of the fischer, and an error, if there is any.
+func (c *FakeFischers) Update(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(fischersResource, fischer), &v1alpha1.Fischer{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Fischer), err
+}
+
+// Delete takes name of the fischer and deletes it. Returns an error if one occurs.
+func (c *FakeFischers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(fischersResource, name), &v1alpha1.Fischer{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeFischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(fischersResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.FischerList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched fischer.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fake/fake_flunder.go
@@ -36,50 +36,7 @@ var flundersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Versi
 
 var flundersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "v1alpha1", Kind: "Flunder"}
 
-func (c *FakeFlunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(flundersResource, c.ns, flunder), &v1alpha1.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Flunder), err
-}
-
-func (c *FakeFlunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(flundersResource, c.ns, flunder), &v1alpha1.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Flunder), err
-}
-
-func (c *FakeFlunders) UpdateStatus(flunder *v1alpha1.Flunder) (*v1alpha1.Flunder, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(flundersResource, "status", c.ns, flunder), &v1alpha1.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*v1alpha1.Flunder), err
-}
-
-func (c *FakeFlunders) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(flundersResource, c.ns, name), &v1alpha1.Flunder{})
-
-	return err
-}
-
-func (c *FakeFlunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(flundersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &v1alpha1.FlunderList{})
-	return err
-}
-
+// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
 func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *v1alpha1.Flunder, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(flundersResource, c.ns, name), &v1alpha1.Flunder{})
@@ -90,6 +47,7 @@ func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *v1alpha1
 	return obj.(*v1alpha1.Flunder), err
 }
 
+// List takes label and field selectors, and returns the list of Flunders that match those selectors.
 func (c *FakeFlunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(flundersResource, flundersKind, c.ns, opts), &v1alpha1.FlunderList{})
@@ -116,6 +74,56 @@ func (c *FakeFlunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(flundersResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
+func (c *FakeFlunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(flundersResource, c.ns, flunder), &v1alpha1.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Flunder), err
+}
+
+// Update takes the representation of a flunder and updates it. Returns the server's representation of the flunder, and an error, if there is any.
+func (c *FakeFlunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(flundersResource, c.ns, flunder), &v1alpha1.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Flunder), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeFlunders) UpdateStatus(flunder *v1alpha1.Flunder) (*v1alpha1.Flunder, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(flundersResource, "status", c.ns, flunder), &v1alpha1.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1alpha1.Flunder), err
+}
+
+// Delete takes name of the flunder and deletes it. Returns an error if one occurs.
+func (c *FakeFlunders) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(flundersResource, c.ns, name), &v1alpha1.Flunder{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeFlunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(flundersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &v1alpha1.FlunderList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched flunder.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/fischer.go
@@ -56,6 +56,38 @@ func newFischers(c *WardleV1alpha1Client) *fischers {
 	}
 }
 
+// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
+func (c *fischers) Get(name string, options v1.GetOptions) (result *v1alpha1.Fischer, err error) {
+	result = &v1alpha1.Fischer{}
+	err = c.client.Get().
+		Resource("fischers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Fischers that match those selectors.
+func (c *fischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err error) {
+	result = &v1alpha1.FischerList{}
+	err = c.client.Get().
+		Resource("fischers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested fischers.
+func (c *fischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("fischers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
 func (c *fischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, err error) {
 	result = &v1alpha1.Fischer{}
@@ -97,38 +129,6 @@ func (c *fischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
-func (c *fischers) Get(name string, options v1.GetOptions) (result *v1alpha1.Fischer, err error) {
-	result = &v1alpha1.Fischer{}
-	err = c.client.Get().
-		Resource("fischers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Fischers that match those selectors.
-func (c *fischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err error) {
-	result = &v1alpha1.FischerList{}
-	err = c.client.Get().
-		Resource("fischers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested fischers.
-func (c *fischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("fischers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched fischer.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/flunder.go
@@ -85,7 +85,7 @@ func (c *flunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, 
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *flunders) UpdateStatus(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
 	result = &v1alpha1.Flunder{}

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset/typed/wardle/v1alpha1/flunder.go
@@ -59,6 +59,41 @@ func newFlunders(c *WardleV1alpha1Client, namespace string) *flunders {
 	}
 }
 
+// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
+func (c *flunders) Get(name string, options v1.GetOptions) (result *v1alpha1.Flunder, err error) {
+	result = &v1alpha1.Flunder{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Flunders that match those selectors.
+func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err error) {
+	result = &v1alpha1.FlunderList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested flunders.
+func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, err error) {
 	result = &v1alpha1.Flunder{}
@@ -120,41 +155,6 @@ func (c *flunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
-func (c *flunders) Get(name string, options v1.GetOptions) (result *v1alpha1.Flunder, err error) {
-	result = &v1alpha1.Flunder{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Flunders that match those selectors.
-func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err error) {
-	result = &v1alpha1.FlunderList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested flunders.
-func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched flunder.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fake/fake_fischer.go
@@ -35,37 +35,7 @@ var fischersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Versi
 
 var fischersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "", Kind: "Fischer"}
 
-func (c *FakeFischers) Create(fischer *wardle.Fischer) (result *wardle.Fischer, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootCreateAction(fischersResource, fischer), &wardle.Fischer{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*wardle.Fischer), err
-}
-
-func (c *FakeFischers) Update(fischer *wardle.Fischer) (result *wardle.Fischer, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateAction(fischersResource, fischer), &wardle.Fischer{})
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*wardle.Fischer), err
-}
-
-func (c *FakeFischers) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewRootDeleteAction(fischersResource, name), &wardle.Fischer{})
-	return err
-}
-
-func (c *FakeFischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewRootDeleteCollectionAction(fischersResource, listOptions)
-
-	_, err := c.Fake.Invokes(action, &wardle.FischerList{})
-	return err
-}
-
+// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
 func (c *FakeFischers) Get(name string, options v1.GetOptions) (result *wardle.Fischer, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootGetAction(fischersResource, name), &wardle.Fischer{})
@@ -75,6 +45,7 @@ func (c *FakeFischers) Get(name string, options v1.GetOptions) (result *wardle.F
 	return obj.(*wardle.Fischer), err
 }
 
+// List takes label and field selectors, and returns the list of Fischers that match those selectors.
 func (c *FakeFischers) List(opts v1.ListOptions) (result *wardle.FischerList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewRootListAction(fischersResource, fischersKind, opts), &wardle.FischerList{})
@@ -99,6 +70,41 @@ func (c *FakeFischers) List(opts v1.ListOptions) (result *wardle.FischerList, er
 func (c *FakeFischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewRootWatchAction(fischersResource, opts))
+}
+
+// Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
+func (c *FakeFischers) Create(fischer *wardle.Fischer) (result *wardle.Fischer, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootCreateAction(fischersResource, fischer), &wardle.Fischer{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*wardle.Fischer), err
+}
+
+// Update takes the representation of a fischer and updates it. Returns the server's representation of the fischer, and an error, if there is any.
+func (c *FakeFischers) Update(fischer *wardle.Fischer) (result *wardle.Fischer, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewRootUpdateAction(fischersResource, fischer), &wardle.Fischer{})
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*wardle.Fischer), err
+}
+
+// Delete takes name of the fischer and deletes it. Returns an error if one occurs.
+func (c *FakeFischers) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewRootDeleteAction(fischersResource, name), &wardle.Fischer{})
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeFischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewRootDeleteCollectionAction(fischersResource, listOptions)
+
+	_, err := c.Fake.Invokes(action, &wardle.FischerList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched fischer.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fake/fake_flunder.go
@@ -36,50 +36,7 @@ var flundersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Versi
 
 var flundersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "", Kind: "Flunder"}
 
-func (c *FakeFlunders) Create(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewCreateAction(flundersResource, c.ns, flunder), &wardle.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*wardle.Flunder), err
-}
-
-func (c *FakeFlunders) Update(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateAction(flundersResource, c.ns, flunder), &wardle.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*wardle.Flunder), err
-}
-
-func (c *FakeFlunders) UpdateStatus(flunder *wardle.Flunder) (*wardle.Flunder, error) {
-	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(flundersResource, "status", c.ns, flunder), &wardle.Flunder{})
-
-	if obj == nil {
-		return nil, err
-	}
-	return obj.(*wardle.Flunder), err
-}
-
-func (c *FakeFlunders) Delete(name string, options *v1.DeleteOptions) error {
-	_, err := c.Fake.
-		Invokes(testing.NewDeleteAction(flundersResource, c.ns, name), &wardle.Flunder{})
-
-	return err
-}
-
-func (c *FakeFlunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
-	action := testing.NewDeleteCollectionAction(flundersResource, c.ns, listOptions)
-
-	_, err := c.Fake.Invokes(action, &wardle.FlunderList{})
-	return err
-}
-
+// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
 func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *wardle.Flunder, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewGetAction(flundersResource, c.ns, name), &wardle.Flunder{})
@@ -90,6 +47,7 @@ func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *wardle.F
 	return obj.(*wardle.Flunder), err
 }
 
+// List takes label and field selectors, and returns the list of Flunders that match those selectors.
 func (c *FakeFlunders) List(opts v1.ListOptions) (result *wardle.FlunderList, err error) {
 	obj, err := c.Fake.
 		Invokes(testing.NewListAction(flundersResource, flundersKind, c.ns, opts), &wardle.FlunderList{})
@@ -116,6 +74,56 @@ func (c *FakeFlunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
 	return c.Fake.
 		InvokesWatch(testing.NewWatchAction(flundersResource, c.ns, opts))
 
+}
+
+// Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
+func (c *FakeFlunders) Create(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewCreateAction(flundersResource, c.ns, flunder), &wardle.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*wardle.Flunder), err
+}
+
+// Update takes the representation of a flunder and updates it. Returns the server's representation of the flunder, and an error, if there is any.
+func (c *FakeFlunders) Update(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateAction(flundersResource, c.ns, flunder), &wardle.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*wardle.Flunder), err
+}
+
+// UpdateStatus was generated because the type contains a Status member.
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
+func (c *FakeFlunders) UpdateStatus(flunder *wardle.Flunder) (*wardle.Flunder, error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(flundersResource, "status", c.ns, flunder), &wardle.Flunder{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*wardle.Flunder), err
+}
+
+// Delete takes name of the flunder and deletes it. Returns an error if one occurs.
+func (c *FakeFlunders) Delete(name string, options *v1.DeleteOptions) error {
+	_, err := c.Fake.
+		Invokes(testing.NewDeleteAction(flundersResource, c.ns, name), &wardle.Flunder{})
+
+	return err
+}
+
+// DeleteCollection deletes a collection of objects.
+func (c *FakeFlunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOptions) error {
+	action := testing.NewDeleteCollectionAction(flundersResource, c.ns, listOptions)
+
+	_, err := c.Fake.Invokes(action, &wardle.FlunderList{})
+	return err
 }
 
 // Patch applies the patch and returns the patched flunder.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/fischer.go
@@ -56,6 +56,38 @@ func newFischers(c *WardleClient) *fischers {
 	}
 }
 
+// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
+func (c *fischers) Get(name string, options v1.GetOptions) (result *wardle.Fischer, err error) {
+	result = &wardle.Fischer{}
+	err = c.client.Get().
+		Resource("fischers").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Fischers that match those selectors.
+func (c *fischers) List(opts v1.ListOptions) (result *wardle.FischerList, err error) {
+	result = &wardle.FischerList{}
+	err = c.client.Get().
+		Resource("fischers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested fischers.
+func (c *fischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Resource("fischers").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
 func (c *fischers) Create(fischer *wardle.Fischer) (result *wardle.Fischer, err error) {
 	result = &wardle.Fischer{}
@@ -97,38 +129,6 @@ func (c *fischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
-func (c *fischers) Get(name string, options v1.GetOptions) (result *wardle.Fischer, err error) {
-	result = &wardle.Fischer{}
-	err = c.client.Get().
-		Resource("fischers").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Fischers that match those selectors.
-func (c *fischers) List(opts v1.ListOptions) (result *wardle.FischerList, err error) {
-	result = &wardle.FischerList{}
-	err = c.client.Get().
-		Resource("fischers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested fischers.
-func (c *fischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Resource("fischers").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched fischer.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/flunder.go
@@ -59,6 +59,41 @@ func newFlunders(c *WardleClient, namespace string) *flunders {
 	}
 }
 
+// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
+func (c *flunders) Get(name string, options v1.GetOptions) (result *wardle.Flunder, err error) {
+	result = &wardle.Flunder{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		Name(name).
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// List takes label and field selectors, and returns the list of Flunders that match those selectors.
+func (c *flunders) List(opts v1.ListOptions) (result *wardle.FlunderList, err error) {
+	result = &wardle.FlunderList{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// Watch returns a watch.Interface that watches the requested flunders.
+func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
+	opts.Watch = true
+	return c.client.Get().
+		Namespace(c.ns).
+		Resource("flunders").
+		VersionedParams(&opts, scheme.ParameterCodec).
+		Watch()
+}
+
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
 func (c *flunders) Create(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
 	result = &wardle.Flunder{}
@@ -120,41 +155,6 @@ func (c *flunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		Body(options).
 		Do().
 		Error()
-}
-
-// Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
-func (c *flunders) Get(name string, options v1.GetOptions) (result *wardle.Flunder, err error) {
-	result = &wardle.Flunder{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		Name(name).
-		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// List takes label and field selectors, and returns the list of Flunders that match those selectors.
-func (c *flunders) List(opts v1.ListOptions) (result *wardle.FlunderList, err error) {
-	result = &wardle.FlunderList{}
-	err = c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Do().
-		Into(result)
-	return
-}
-
-// Watch returns a watch.Interface that watches the requested flunders.
-func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
-	opts.Watch = true
-	return c.client.Get().
-		Namespace(c.ns).
-		Resource("flunders").
-		VersionedParams(&opts, scheme.ParameterCodec).
-		Watch()
 }
 
 // Patch applies the patch and returns the patched flunder.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset/typed/wardle/internalversion/flunder.go
@@ -85,7 +85,7 @@ func (c *flunders) Update(flunder *wardle.Flunder) (result *wardle.Flunder, err 
 }
 
 // UpdateStatus was generated because the type contains a Status member.
-// Add a +genclientstatus=false comment above the type to avoid generating UpdateStatus().
+// Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
 
 func (c *flunders) UpdateStatus(flunder *wardle.Flunder) (result *wardle.Flunder, err error) {
 	result = &wardle.Flunder{}


### PR DESCRIPTION
This will change the syntax of the existing `genclient` tags be like this:

```
// +genclient
// +genclient:noStatus
// +genclient:noVerbs
// +genclient:nonNamespaced
// +genclient:readonly
```

The first one indicates the client will be generated from the struct below and the other tags are basically options to the genclient (which justify why they should be prefixed with `genclient:`)

This also changes the `// +genclientstatus=false` to `// +genclient:noStatus` to follow the pattern and also changes the `// +noMethods=true` to `// +genclient:noVerbs` as we call the REST operations verbs so it will make it consistent with terminology.

In addition to existing options this patch also add two more to allow more fine-grained control on which verbs are going to be generated. This is extra useful for third-party projects (like OpenShift) where some resources does not implement full CRUD, but for example just "create" verb or "create" and "delete"...
To support that, you can use this syntax:

```
// +genclient:onlyVerbs=create,delete
// +genclient:skipVerbs=patch
```

The first one will generate only create and delete functions and second one will generate full CRUD without "patch" actions. This somehow overlaps with the existing "readonly" tag, but I want to keep that tag in place as it reads better in some cases ;-)