### PR TITLE
remove redundant param in e2e_node/remote

### DIFF
--- a/test/e2e_node/remote/remote.go
+++ b/test/e2e_node/remote/remote.go
@@ -114,7 +114,7 @@ func RunRemote(suite TestSuite, archive string, host string, cleanup bool, image
 	// Do not log the output here, let the caller deal with the test output.
 	if err != nil {
 		aggErrs = append(aggErrs, err)
-		collectSystemLog(host, workspace)
+		collectSystemLog(host)
 	}
 
 	glog.V(2).Infof("Copying test artifacts from %q", host)
@@ -160,7 +160,7 @@ func getTestArtifacts(host, testDir string) error {
 
 // collectSystemLog is a temporary hack to collect system log when encountered on
 // unexpected error.
-func collectSystemLog(host, workspace string) {
+func collectSystemLog(host string) {
 	// Encountered an unexpected error. The remote test harness may not
 	// have finished retrieved and stored all the logs in this case. Try
 	// to get some logs for debugging purposes.
@@ -171,7 +171,7 @@ func collectSystemLog(host, workspace string) {
 		logPath  = fmt.Sprintf("/tmp/%s-%s", getTimestamp(), logName)
 		destPath = fmt.Sprintf("%s/%s-%s", *resultsDir, host, logName)
 	)
-	glog.V(2).Infof("Test failed unexpectedly. Attempting to retreiving system logs (only works for nodes with journald)")
+	glog.V(2).Infof("Test failed unexpectedly. Attempting to retrieving system logs (only works for nodes with journald)")
 	// Try getting the system logs from journald and store it to a file.
 	// Don't reuse the original test directory on the remote host because
 	// it could've be been removed if the node was rebooted.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

* remove redundant param in e2e_node/remote/remote.go
* fix a small typo

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
