### PR TITLE
Fix too extensive logging in Stackdriver Logging e2e tests

### DIFF
--- a/test/e2e/instrumentation/logging/utils.go
+++ b/test/e2e/instrumentation/logging/utils.go
@@ -227,7 +227,7 @@ func waitForFullLogsIngestion(f *framework.Framework, config *loggingTestConfig)
 			config.IngestionTimeout, totalMissing, lostFraction*100)
 		for podIdx, missing := range missingByPod {
 			if missing != 0 {
-				framework.Logf("Still missing %d lines for pod %v", missing, config.Pods[podIdx])
+				framework.Logf("Still missing %d lines for pod %s", missing, config.Pods[podIdx].Name)
 			}
 		}
 	}


### PR DESCRIPTION
Since logging pod now includes a cache, printing it out makes build-log unusable.