### PR TITLE
Add more logging to PD node delete test

### DIFF
--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -450,16 +450,16 @@ var _ = SIGDescribe("Pod Disks", func() {
 		framework.ExpectNoError(waitForPDInVolumesInUse(nodeClient, diskName, host0Name, nodeStatusTimeout, true /* should exist*/))
 
 		output, err := exec.Command("gcloud", "compute", "instances", "list").CombinedOutput()
-		framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances err=%v output=%s", err, output))
 		Expect(true, strings.Contains(string(output), string(host0Name)))
 
 		By("deleting host0")
 
 		output, err = exec.Command("gcloud", "compute", "instances", "delete", string(host0Name), "--project="+framework.TestContext.CloudConfig.ProjectID, "--zone="+framework.TestContext.CloudConfig.Zone).CombinedOutput()
-		framework.ExpectNoError(err, fmt.Sprintf("Failed to delete host0pod: %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("Failed to delete host0pod: err=%v output=%s", err, output))
 
 		output, err = exec.Command("gcloud", "compute", "instances", "list").CombinedOutput()
-		framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances %v", err))
+		framework.ExpectNoError(err, fmt.Sprintf("Unable to get list of node instances err=%v output=%s", err, output))
 		Expect(false, strings.Contains(string(output), string(host0Name)))
 
 		// The disk should be detached from host0 on it's deletion


### PR DESCRIPTION
**What this PR does / why we need it**: Adds more logging to `Pod Disks should be able to detach from a node which was deleted` test which started failing because `gcloud compute instances list` is failing with `exit status 1`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: https://github.com/kubernetes/kubernetes/issues/49185

**Special notes for your reviewer**:

**Release note**: none