### PR TITLE
Bump rescheduler version to v0.3.1

### DIFF
--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: rescheduler-v0.3.0
+  name: rescheduler-v0.3.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: rescheduler
-    version: v0.3.0
+    version: v0.3.1
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google-containers/rescheduler:v0.3.0
+  - image: gcr.io/google-containers/rescheduler:v0.3.1
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Rescheduler version to v0.3.1 to log to STDERR.

**Which issue this PR fixes**
Fixes https://github.com/kubernetes/contrib/issues/2518

**Release note**:
```release-note
Fix a bug where rescheduler logs were going to /tmp/rescheduler.INFO - direct them to STDERR instead.
```
