### PR TITLE
Restrict the visibility of two generated packages in pkg/client/

### DIFF
--- a/pkg/client/clientset_generated/clientset/BUILD
+++ b/pkg/client/clientset_generated/clientset/BUILD
@@ -16,6 +16,11 @@ go_library(
         "import_known_versions.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//cmd/kube-controller-manager/app:__pkg__",
+        "//pkg/client/clientset_generated/clientset:__subpackages__",
+        "//pkg/client/informers:__subpackages__",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/install:go_default_library",

--- a/pkg/client/informers/informers_generated/externalversions/BUILD
+++ b/pkg/client/informers/informers_generated/externalversions/BUILD
@@ -14,6 +14,9 @@ go_library(
         "generic.go",
     ],
     tags = ["automanaged"],
+    visibility = [
+        "//pkg/client/informers/informers_generated/externalversions:__subpackages__",
+    ],
     deps = [
         "//pkg/client/clientset_generated/clientset:go_default_library",
         "//pkg/client/informers/informers_generated/externalversions/admissionregistration:go_default_library",


### PR DESCRIPTION
These two packages are deprecated. Please use the client-go copy of these two packages.

Currently staging/copy.sh copied these two packages to client-go. I'll send follow-up PRs to let code-gen output to client-go directly and remove these two packages. The purpose of this PR is to prevent more imports of these packages while I refactor the codegen.