### PR TITLE
Use case-insensitive header keys for `--requestheader-group-headers`.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -145,7 +145,8 @@ func headerValue(h http.Header, headerNames []string) string {
 func allHeaderValues(h http.Header, headerNames []string) []string {
 	ret := []string{}
 	for _, headerName := range headerNames {
-		values, ok := h[headerName]
+		headerKey := http.CanonicalHeaderKey(headerName)
+		values, ok := h[headerKey]
 		if !ok {
 			continue
 		}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -111,6 +111,20 @@ func TestRequestHeader(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		"groups case-insensitive": {
+			nameHeaders:  []string{"X-REMOTE-User"},
+			groupHeaders: []string{"X-REMOTE-Group"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Bob"},
+				"X-Remote-Group": {"Users"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name:   "Bob",
+				Groups: []string{"Users"},
+				Extra:  map[string][]string{},
+			},
+			expectedOk: true,
+		},
 
 		"extra prefix matches case-insensitive": {
 			nameHeaders:        []string{"X-Remote-User"},


### PR DESCRIPTION
This flag is documented as being case-insensitive, but the code was
doing a case-sensitive map lookup.

**Release note**:
```release-note
Bug fix: Parsing of `--requestheader-group-headers` in requests should be case-insensitive.
```
