### PR TITLE
glbc: change the label of the l7-lb-controller pod

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -6,9 +6,8 @@ metadata:
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
-    k8s-app: glbc
+    k8s-app: gcp-lb-controller
     version: v0.9.5
-    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600


### PR DESCRIPTION
This ensures that the default http backend service doesn't include this
pod as its endpoint. This fixes #49159
