### PR TITLE
allow exceptions to be specified to handle conflicting group and resource names

### DIFF
--- a/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/kube-gen/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -213,7 +213,7 @@ var $.type|allLowercasePlural$Resource = $.GroupVersionResource|raw${Group: "$.g
 `
 
 var kind = `
-var $.type|allLowercasePlural$Kind = $.GroupVersionKind|raw${Group: "$.groupName$", Version: "$.version$", Kind: "$.type|public$"}
+var $.type|allLowercasePlural$Kind = $.GroupVersionKind|raw${Group: "$.groupName$", Version: "$.version$", Kind: "$.type|singularKind$"}
 `
 
 var listTemplate = `


### PR DESCRIPTION
When a group name and resource name conflict, the generated code doesn't have prefixes or suffixes to produce compiling code.  Instead, it simply produces code that won't compile.

This makes it possible for the code generator to have a special kind of namer that can codify the exceptions to get compiling code.  As we move the generators to become more general, this should be updated to be plumbed by flags.

@gmarek give this a try in your event pull.  Specify your type and see if the names are adjusted.
@sttts we hit this downstream