### PR TITLE
StatefulSet: Remove `pod.alpha.kubernetes.io/initialized` annotation.

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -31,8 +31,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
-
-	"github.com/golang/glog"
 )
 
 // maxUpdateRetries is the maximum number of retries used for update conflict resolution prior to failure
@@ -191,26 +189,9 @@ func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Spec.Subdomain = set.Spec.ServiceName
 }
 
-// isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady, and if the init
-// annotation has not explicitly disabled the Pod from being ready.
+// isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
 func isRunningAndReady(pod *v1.Pod) bool {
-	if pod.Status.Phase != v1.PodRunning {
-		return false
-	}
-	podReady := podutil.IsPodReady(pod)
-	// User may have specified a pod readiness override through a debug annotation.
-	initialized, ok := pod.Annotations[apps.StatefulSetInitAnnotation]
-	if ok {
-		if initAnnotation, err := strconv.ParseBool(initialized); err != nil {
-			glog.V(4).Infof("Failed to parse %v annotation on pod %v: %v",
-				apps.StatefulSetInitAnnotation, pod.Name, err)
-		} else if !initAnnotation {
-			glog.V(4).Infof("StatefulSet pod %v waiting on annotation %v", pod.Name,
-				apps.StatefulSetInitAnnotation)
-			podReady = initAnnotation
-		}
-	}
-	return podReady
+	return pod.Status.Phase == v1.PodRunning && podutil.IsPodReady(pod)
 }
 
 // isCreated returns true if pod has been created and is maintained by the API server

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -213,18 +213,6 @@ func TestIsRunningAndReady(t *testing.T) {
 	if !isRunningAndReady(pod) {
 		t.Error("Pod should be running and ready")
 	}
-	pod.Annotations[apps.StatefulSetInitAnnotation] = "true"
-	if !isRunningAndReady(pod) {
-		t.Error("isRunningAndReady does not respected init annotation set to true")
-	}
-	pod.Annotations[apps.StatefulSetInitAnnotation] = "false"
-	if isRunningAndReady(pod) {
-		t.Error("isRunningAndReady does not respected init annotation set to false")
-	}
-	pod.Annotations[apps.StatefulSetInitAnnotation] = "blah"
-	if !isRunningAndReady(pod) {
-		t.Error("isRunningAndReady does not erroneous init annotation")
-	}
 }
 
 func TestAscendingOrdinal(t *testing.T) {

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -24,8 +24,6 @@ import (
 )
 
 const (
-	// StatefulSetInitAnnotation if present, and set to false, indicates that a Pod's readiness should be ignored.
-	StatefulSetInitAnnotation      = "pod.alpha.kubernetes.io/initialized"
 	ControllerRevisionHashLabelKey = "controller-revision-hash"
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 )

--- a/test/e2e/upgrades/apps/statefulset.go
+++ b/test/e2e/upgrades/apps/statefulset.go
@@ -62,12 +62,12 @@ func (t *StatefulSetUpgradeTest) Setup(f *framework.Framework) {
 	t.set = framework.NewStatefulSet(ssName, ns, headlessSvcName, 2, statefulPodMounts, podMounts, labels)
 	t.service = framework.CreateStatefulSetService(ssName, labels)
 	*(t.set.Spec.Replicas) = 3
-	framework.SetStatefulSetInitializedAnnotation(t.set, "false")
+	t.tester = framework.NewStatefulSetTester(f.ClientSet)
+	t.tester.PauseNewPods(t.set)
 
 	By("Creating service " + headlessSvcName + " in namespace " + ns)
 	_, err := f.ClientSet.Core().Services(ns).Create(t.service)
 	Expect(err).NotTo(HaveOccurred())
-	t.tester = framework.NewStatefulSetTester(f.ClientSet)
 
 	By("Creating statefulset " + ssName + " in namespace " + ns)
 	*(t.set.Spec.Replicas) = 3


### PR DESCRIPTION
The `pod.alpha.kubernetes.io/initialized` annotation was originally a tool for validating StatefulSet's ordered Pod creation guarantees during the feature's alpha phase.

If set to "false" on a given Pod, it would interrupt StatefulSet's normal behavior. In v1.5.0, the annotation was deprecated and the default became "true" as part of StatefulSet's graduation to beta.

The annotation is now ignored, meaning it cannot be used to interrupt StatefulSet Pod management.

```release-note
StatefulSet: The deprecated `pod.alpha.kubernetes.io/initialized` annotation for interrupting StatefulSet Pod management is now ignored. If you were setting it to `true` or leaving it unset, no action is required. However, if you were setting it to `false`, be aware that previously-dormant StatefulSets may become active after upgrading.
```

ref #41605