### PR TITLE
Emit event and retry when fail to start healthz server on kube-proxy

### DIFF
--- a/pkg/proxy/healthcheck/BUILD
+++ b/pkg/proxy/healthcheck/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )

--- a/pkg/proxy/healthcheck/healthcheck.go
+++ b/pkg/proxy/healthcheck/healthcheck.go
@@ -31,9 +31,12 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api"
 )
+
+var nodeHealthzRetryInterval = 60 * time.Second
 
 // Server serves HTTP endpoints for each service name, with results
 // based on the endpoints.  If there are 0 endpoints for a service, it returns a
@@ -161,7 +164,7 @@ func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) err
 						Namespace: nsn.Namespace,
 						Name:      nsn.Name,
 						UID:       types.UID(nsn.String()),
-					}, api.EventTypeWarning, "FailedToStartHealthcheck", msg)
+					}, api.EventTypeWarning, "FailedToStartServiceHealthcheck", msg)
 			}
 			glog.Error(msg)
 			continue
@@ -259,16 +262,18 @@ type HealthzServer struct {
 	addr          string
 	port          int32
 	healthTimeout time.Duration
+	recorder      record.EventRecorder
+	nodeRef       *v1.ObjectReference
 
 	lastUpdated atomic.Value
 }
 
 // NewDefaultHealthzServer returns a default healthz http server.
-func NewDefaultHealthzServer(addr string, healthTimeout time.Duration) *HealthzServer {
-	return newHealthzServer(nil, nil, nil, addr, healthTimeout)
+func NewDefaultHealthzServer(addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *HealthzServer {
+	return newHealthzServer(nil, nil, nil, addr, healthTimeout, recorder, nodeRef)
 }
 
-func newHealthzServer(listener Listener, httpServerFactory HTTPServerFactory, c clock.Clock, addr string, healthTimeout time.Duration) *HealthzServer {
+func newHealthzServer(listener Listener, httpServerFactory HTTPServerFactory, c clock.Clock, addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *HealthzServer {
 	if listener == nil {
 		listener = stdNetListener{}
 	}
@@ -284,6 +289,8 @@ func newHealthzServer(listener Listener, httpServerFactory HTTPServerFactory, c 
 		clock:         c,
 		addr:          addr,
 		healthTimeout: healthTimeout,
+		recorder:      recorder,
+		nodeRef:       nodeRef,
 	}
 }
 
@@ -297,19 +304,26 @@ func (hs *HealthzServer) Run() {
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/healthz", healthzHandler{hs: hs})
 	server := hs.httpFactory.New(hs.addr, serveMux)
-	listener, err := hs.listener.Listen(hs.addr)
-	if err != nil {
-		glog.Errorf("Failed to start healthz on %s: %v", hs.addr, err)
-		return
-	}
-	go func() {
+
+	go wait.Until(func() {
 		glog.V(3).Infof("Starting goroutine for healthz on %s", hs.addr)
-		if err := server.Serve(listener); err != nil {
-			glog.Errorf("Healhz closed: %v", err)
+
+		listener, err := hs.listener.Listen(hs.addr)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to start node healthz on %s: %v", hs.addr, err)
+			if hs.recorder != nil {
+				hs.recorder.Eventf(hs.nodeRef, api.EventTypeWarning, "FailedToStartNodeHealthcheck", msg)
+			}
+			glog.Error(msg)
 			return
 		}
-		glog.Errorf("Unexpected healhz closed.")
-	}()
+
+		if err := server.Serve(listener); err != nil {
+			glog.Errorf("Healthz closed with error: %v", err)
+			return
+		}
+		glog.Errorf("Unexpected healthz closed.")
+	}, nodeHealthzRetryInterval, wait.NeverStop)
 }
 
 type healthzHandler struct {

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -368,7 +368,7 @@ func TestHealthzServer(t *testing.T) {
 	httpFactory := newFakeHTTPServerFactory()
 	fakeClock := clock.NewFakeClock(time.Now())
 
-	hs := newHealthzServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second)
+	hs := newHealthzServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second, nil, nil)
 	server := hs.httpFactory.New(hs.addr, healthzHandler{hs: hs})
 
 	// Should return 200 "OK" by default.


### PR DESCRIPTION
**What this PR does / why we need it**: Enhance kube-proxy's logic when fail to start healthz server.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: From #49263.

**Special notes for your reviewer**:
/assign @thockin @nicksardo @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kube-proxy will emit "FailedToStartNodeHealthcheck" event when fails to start healthz server.
```
