### PR TITLE
fix bug when azure cloud provider configuration file is not specified

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -327,6 +327,11 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 // ParseConfig returns a parsed configuration and azure.Environment for an Azure cloudprovider config file
 func ParseConfig(configReader io.Reader) (*Config, *azure.Environment, error) {
 	var config Config
+	var env azure.Environment
+
+	if configReader == nil {
+		return &config, &env, nil
+	}
 
 	configContents, err := ioutil.ReadAll(configReader)
 	if err != nil {
@@ -337,7 +342,6 @@ func ParseConfig(configReader io.Reader) (*Config, *azure.Environment, error) {
 		return nil, nil, err
 	}
 
-	var env azure.Environment
 	if config.Cloud == "" {
 		env = azure.PublicCloud
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Current [Azure cloud provider](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/azure/azure.go#L203) failed to [parse empty config file](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/plugins.go#L110-L124) when `--cloud-config` is not specified.

[GetServicePrincipalToken](https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/azure/azure.go#L157-L199) will raise an error if no valid secrets/tokens are found. So we just need to return empty config obj if `--cloud-config` is not set.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49228

**Special notes for your reviewer**:
@githubvick 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix bug when azure cloud provider configuration file is not specified
```
