### PR TITLE
Extend controller manager with optional secrets

### DIFF
--- a/federation/pkg/dnsprovider/providers/coredns/BUILD
+++ b/federation/pkg/dnsprovider/providers/coredns/BUILD
@@ -25,10 +25,12 @@ go_library(
         "//federation/pkg/dnsprovider/providers/coredns/stubs:go_default_library",
         "//federation/pkg/dnsprovider/rrstype:go_default_library",
         "//vendor/github.com/coreos/etcd/client:go_default_library",
+        "//vendor/github.com/coreos/etcd/pkg/transport:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/miekg/coredns/middleware/etcd/msg:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
     ],
 )
 

--- a/federation/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns.go
@@ -105,15 +105,15 @@ func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 		etcdEndpoints = cfg.Global.EtcdEndpoints
 		dnsZones = cfg.Global.DNSZones
 		certFile = cfg.Global.CertFile
-		keyFile = cfg.Global.KeyFile
 		caFile = cfg.Global.CAFile
+		keyFile = cfg.Global.KeyFile
 	}
 	glog.Infof("Using CoreDNS DNS provider")
 
 	if dnsZones == "" {
 		return nil, fmt.Errorf("Need to provide at least one DNS Zone")
 	}
-
+	glog.Infof("Creating etcd transport with %s, %s, %s", certFile, keyFile, caFile)
 	etcdTransport, err := newTransportForETCD2(certFile, keyFile, caFile)
 	if err != nil {
 		return nil, fmt.Errorf("error creating transport for etcd: %v", err)

--- a/federation/pkg/dnsprovider/providers/coredns/coredns.go
+++ b/federation/pkg/dnsprovider/providers/coredns/coredns.go
@@ -18,14 +18,21 @@ limitations under the License.
 package coredns
 
 import (
+	"crypto/tls"
 	"fmt"
-	etcdc "github.com/coreos/etcd/client"
-	"github.com/golang/glog"
-	"gopkg.in/gcfg.v1"
 	"io"
-	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"net"
+	"net/http"
 	"strconv"
 	"strings"
+	"time"
+
+	etcdc "github.com/coreos/etcd/client"
+	"github.com/coreos/etcd/pkg/transport"
+	"github.com/golang/glog"
+	"gopkg.in/gcfg.v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
 )
 
 // "coredns" should be used to use this DNS provider
@@ -37,6 +44,9 @@ const (
 type Config struct {
 	Global struct {
 		EtcdEndpoints    string `gcfg:"etcd-endpoints"`
+		CertFile         string `gcfg:"etcd-cert-file"`
+		KeyFile          string `gcfg:"etcd-key-file"`
+		CAFile           string `gcfg:"etcd-ca-file"`
 		DNSZones         string `gcfg:"zones"`
 		CoreDNSEndpoints string `gcfg:"coredns-endpoints"`
 	}
@@ -48,11 +58,42 @@ func init() {
 	})
 }
 
+func newTransportForETCD2(certFile, keyFile, caFile string) (*http.Transport, error) {
+	var cfg *tls.Config
+	if len(certFile) == 0 && len(keyFile) == 0 && len(caFile) == 0 {
+		cfg = nil
+	} else {
+		info := transport.TLSInfo{
+			CertFile: certFile,
+			KeyFile:  keyFile,
+			CAFile:   caFile,
+		}
+		var err error
+		cfg, err = info.ClientConfig()
+		if err != nil {
+			return nil, fmt.Errorf("error creating tls config: %v", err)
+		}
+	}
+	// Copied from etcd.DefaultTransport declaration.
+	// TODO: Determine if transport needs optimization
+	tr := utilnet.SetTransportDefaults(&http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		Dial: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 10 * time.Second,
+		TLSClientConfig:     cfg,
+	})
+	return tr, nil
+}
+
 // newCoreDnsProviderInterface creates a new instance of an CoreDNS DNS Interface.
 func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 	etcdEndpoints := "http://federation-dns-server-etcd:2379"
 	etcdPathPrefix := "skydns"
 	dnsZones := ""
+	var certFile, keyFile, caFile string
 
 	// Possibly override defaults with config below
 	if config != nil {
@@ -63,6 +104,9 @@ func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 		}
 		etcdEndpoints = cfg.Global.EtcdEndpoints
 		dnsZones = cfg.Global.DNSZones
+		certFile = cfg.Global.CertFile
+		keyFile = cfg.Global.KeyFile
+		caFile = cfg.Global.CAFile
 	}
 	glog.Infof("Using CoreDNS DNS provider")
 
@@ -70,9 +114,14 @@ func newCoreDNSProviderInterface(config io.Reader) (*Interface, error) {
 		return nil, fmt.Errorf("Need to provide at least one DNS Zone")
 	}
 
+	etcdTransport, err := newTransportForETCD2(certFile, keyFile, caFile)
+	if err != nil {
+		return nil, fmt.Errorf("error creating transport for etcd: %v", err)
+	}
+
 	etcdCfg := etcdc.Config{
 		Endpoints: strings.Split(etcdEndpoints, ","),
-		Transport: etcdc.DefaultTransport,
+		Transport: etcdTransport,
 	}
 
 	c, err := etcdc.New(etcdCfg)

--- a/federation/pkg/kubefed/init/BUILD
+++ b/federation/pkg/kubefed/init/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",

--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -41,5 +42,12 @@ filegroup(
 filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    library = ":go_default_library",
     tags = ["automanaged"],
 )

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -35,6 +35,8 @@ import (
 	kubectlcmd "k8s.io/kubernetes/pkg/kubectl/cmd"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 
+	"strings"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -128,6 +130,25 @@ func (a *adminConfig) getClientConfig(context, kubeconfigPath string) clientcmd.
 	}
 
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&loadingRules, overrides)
+}
+
+type MapValue map[string]string
+
+func (m *MapValue) String() string {
+	return fmt.Sprintf("%+v", *m)
+}
+
+func (m *MapValue) Set(val string) error {
+	parts := strings.Split(val, "=")
+	if len(parts) != 2 {
+		return fmt.Errorf("Value %s doesn't match pattern <key>=<value>", val)
+	}
+	(*m)[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	return nil
+}
+
+func (m *MapValue) Type() string {
+	return "string"
 }
 
 // SubcommandOptions holds the configuration required by the subcommands of

--- a/federation/pkg/kubefed/util/util_test.go
+++ b/federation/pkg/kubefed/util/util_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestMapValueFlag(t *testing.T) {
+	for i, tc := range []struct {
+		description string
+		passed      []string
+		expected    map[string]string
+		expectedErr bool
+	}{
+		{
+			description: "wont allow duplicates",
+			passed:      []string{"key1=val1", "key1=val1"},
+			expected:    map[string]string{"key1": "val1"},
+		},
+		{
+			description: "set multiple key values pairs",
+			passed:      []string{"key1=val1", "key2=val2"},
+			expected:    map[string]string{"key1": "val1", "key2": "val2"},
+		},
+		{
+			description: "trim empty spaces",
+			passed:      []string{" key1 = val1 "},
+			expected:    map[string]string{"key1": "val1"},
+		},
+		{
+			description: "error on absense of separator (=)",
+			passed:      []string{"key1"},
+			expectedErr: true,
+		},
+		{
+			description: "error on multiple separators (=)",
+			passed:      []string{"key1=val1,key2=val2"},
+			expectedErr: true,
+		},
+		{
+			description: "leave empty if nothing is passed",
+			expected:    map[string]string{},
+		},
+	} {
+		t.Run(string(i), func(t *testing.T) {
+			t.Log("Running test ", tc.description)
+			mv := &MapValue{}
+			for _, i := range tc.passed {
+				if err := mv.Set(i); err == nil && tc.expectedErr {
+					t.Errorf("Unexpected success for value %s", i)
+				} else if err != nil && !tc.expectedErr {
+					t.Errorf("Unexpected error for value %s: %v", i, err)
+				}
+			}
+			if !tc.expectedErr && !reflect.DeepEqual(map[string]string(*mv), tc.expected) {
+				t.Errorf("%+v != %+v", *mv, tc.expected)
+			}
+		})
+	}
+}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -143,6 +143,7 @@ contain-pod-resources
 contention-profiling
 controllermanager-arg-overrides
 controller-start-interval
+controller-secrets
 core-kubeconfig
 cors-allowed-origins
 cpu-cfs-quota


### PR DESCRIPTION
In order to support etcd tls configuration with coredns provider
we need to mount additional files into controller manager pod.
Thus this patch extends definition of controller managed deployment
and mounts any secrets provided by user, all of them  will be created
as optional.

Added TestMapValueFlag test to verify new sys args parser behaviour.
Extended TestInitFedration to take into account additiona volumes.

Also I had to change behavior of federation system namespace creation,
now kubefed init will not fail if namespace already exists.

Includes: https://github.com/kubernetes/kubernetes/pull/47049/
For reference the way we are using this feature in our dev env: https://github.com/lukaszo/kubernetes-dind-federation/pull/1