### PR TITLE
Update status to show failing services.

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -30,7 +30,6 @@ from shlex import split
 from subprocess import check_call
 from subprocess import check_output
 from subprocess import CalledProcessError
-from time import sleep
 
 from charms import layer
 from charms.layer import snap
@@ -335,19 +334,11 @@ def idle_status(kube_api, kube_control):
 
 def master_services_down():
     """Ensure master services are up and running.
-    Try to restart any failing services once.
 
     Return: list of failing services"""
     services = ['kube-apiserver',
                 'kube-controller-manager',
                 'kube-scheduler']
-    for service in services:
-        daemon = 'snap.{}.daemon'.format(service)
-        if not host.service_running(daemon):
-            hookenv.log("Service {} was down. Starting it.".format(daemon))
-            host.service_start(daemon)
-            sleep(10)
-
     failing_services = []
     for service in services:
         daemon = 'snap.{}.daemon'.format(service)

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -22,7 +22,6 @@ from shlex import split
 from subprocess import check_call, check_output
 from subprocess import CalledProcessError
 from socket import gethostname
-from time import sleep
 
 from charms import layer
 from charms.layer import snap
@@ -262,12 +261,6 @@ def update_kubelet_status():
         'kubelet',
         'kube-proxy'
     ]
-    for service in services:
-        daemon = 'snap.{}.daemon'.format(service)
-        if not _systemctl_is_active(daemon):
-            hookenv.log("Service {} id down. Starting it.".format(daemon))
-            sleep(10)
-
     failing_services = []
     for service in services:
         daemon = 'snap.{}.daemon'.format(service)

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -22,6 +22,7 @@ from shlex import split
 from subprocess import check_call, check_output
 from subprocess import CalledProcessError
 from socket import gethostname
+from time import sleep
 
 from charms import layer
 from charms.layer import snap
@@ -257,11 +258,27 @@ def update_kubelet_status():
     ''' There are different states that the kubelet can be in, where we are
     waiting for dns, waiting for cluster turnup, or ready to serve
     applications.'''
-    if (_systemctl_is_active('snap.kubelet.daemon')):
+    services = [
+        'kubelet',
+        'kube-proxy'
+    ]
+    for service in services:
+        daemon = 'snap.{}.daemon'.format(service)
+        if not _systemctl_is_active(daemon):
+            hookenv.log("Service {} id down. Starting it.".format(daemon))
+            sleep(10)
+
+    failing_services = []
+    for service in services:
+        daemon = 'snap.{}.daemon'.format(service)
+        if not _systemctl_is_active(daemon):
+            failing_services.append(service)
+
+    if len(failing_services) == 0:
         hookenv.status_set('active', 'Kubernetes worker running.')
-    # if kubelet is not running, we're waiting on something else to converge
-    elif (not _systemctl_is_active('snap.kubelet.daemon')):
-        hookenv.status_set('waiting', 'Waiting for kubelet to start.')
+    else:
+        msg = 'Waiting for {} to start.'.format(','.join(failing_services))
+        hookenv.status_set('waiting', msg)
 
 
 @when('certificates.available')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Report on charm status any services that are not running.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/341

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Report failing services in Juju deployed clusters.
```
