### PR TITLE
[tiny] fix wrong eventType for hpa condition

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -222,7 +222,7 @@ func (a *HorizontalController) computeReplicasForMetrics(hpa *autoscalingv2.Hori
 		if len(scale.Status.Selector) == 0 && len(scale.Status.TargetSelector) == 0 {
 			errMsg := "selector is required"
 			a.eventRecorder.Event(hpa, v1.EventTypeWarning, "SelectorRequired", errMsg)
-			setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "InvalidSelector", "the HPA target's scale is missing a selector")
+			setCondition(hpa, autoscalingv2.ScalingActive, v1.ConditionFalse, "SelectorRequired", "the HPA target's scale is missing a selector")
 			return 0, "", nil, time.Time{}, fmt.Errorf(errMsg)
 		}
 

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -1239,7 +1239,7 @@ func TestConditionInvalidSelectorMissing(t *testing.T) {
 			{
 				Type:   autoscalingv1.ScalingActive,
 				Status: v1.ConditionFalse,
-				Reason: "InvalidSelector",
+				Reason: "SelectorRequired",
 			},
 		},
 	}


### PR DESCRIPTION
Commit 1334b81d201c9 introduced setCondition() calls into horizontal.go but apparently included a copy'n'paste error in the "SelectorRequired" case.

Also see the design proposal for the original feature:
https://github.com/kubernetes/community/blob/master/contributors/design-proposals/hpa-status-conditions.md

@DirectXMan12 could you review this, please?