### PR TITLE
Automated cherry pick of #44661 upstream release 1.5

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -251,6 +251,10 @@ func getVMName(client *govmomi.Client, cfg *VSphereConfig) (string, error) {
 		return "", err
 	}
 
+	if svm == nil {
+		return "", fmt.Errorf("unable to find machine reference by UUID")
+	}
+
 	var vm mo.VirtualMachine
 	err = s.Properties(ctx, svm.Reference(), []string{"name"}, &vm)
 	if err != nil {

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -260,3 +260,36 @@ func TestVolumes(t *testing.T) {
 	// 	t.Fatalf("Cannot delete VMDK volume %s: %v", volPath, err)
 	// }
 }
+
+func TestGetVMName(t *testing.T) {
+	cfg, ok := configFromEnv()
+	if !ok {
+		t.Skipf("No config found in environment")
+	}
+
+	// Create vSphere configuration object
+	vs, err := newVSphere(cfg)
+	if err != nil {
+		t.Fatalf("Failed to construct/authenticate vSphere: %s", err)
+	}
+
+	// Create context
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Create vSphere client
+	err = vSphereLogin(ctx, vs)
+	if err != nil {
+		t.Errorf("Failed to create vSpere client: %s", err)
+	}
+	defer vs.client.Logout(ctx)
+
+	// Get VM name
+	vmName, err := getVMName(vs.client, &cfg)
+	if err != nil {
+		t.Fatalf("Failed to get VM name: %s", err)
+	}
+	if vmName != "vmname" {
+		t.Errorf("Expect VM name 'vmname', got: %s", vmName)
+	}
+}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -278,7 +278,7 @@ func TestGetVMName(t *testing.T) {
 	defer cancel()
 
 	// Create vSphere client
-	err = vSphereLogin(ctx, vs)
+	err = vSphereLogin(vs, ctx)
 	if err != nil {
 		t.Errorf("Failed to create vSpere client: %s", err)
 	}


### PR DESCRIPTION
Cherry pick of #44661 on release-1.5

#44661: Fix panic when using `kubeadm init` with vsphere cloud-provider

@divyenpatel, @tusharnt, @BaluDontu 

