### PR TITLE
Add goroutine to update stale data items

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -1354,6 +1354,8 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		)
 	}
 
+	e.Storage.BeginStaleWatch(e.NewFunc, e.KeyRootFunc)
+
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -37,6 +37,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	utiltrace "k8s.io/apiserver/pkg/util/trace"
 	"k8s.io/client-go/tools/cache"
 )
@@ -533,6 +534,9 @@ func (c *Cacher) GuaranteedUpdate(
 	// If we couldn't get the object, fallback to no-suggestion.
 	return c.storage.GuaranteedUpdate(ctx, key, ptrToType, ignoreNotFound, preconditions, tryUpdate)
 }
+
+// Implements storage.Interface.
+func (*Cacher) BeginStaleWatch(func() runtime.Object, func(genericapirequest.Context) string) {}
 
 func (c *Cacher) triggerValues(event *watchCacheEvent) ([]string, bool) {
 	// TODO: Currently we assume that in a given Cacher object, its <c.triggerFunc>

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/cache:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd/util:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -33,6 +33,7 @@ import (
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd/metrics"
 	etcdutil "k8s.io/apiserver/pkg/storage/etcd/util"
@@ -587,6 +588,9 @@ func (h *etcdHelper) GuaranteedUpdate(
 		return toStorageErr(err, key, int64(index))
 	}
 }
+
+// Implements storage.Interface.
+func (*etcdHelper) BeginStaleWatch(func() runtime.Object, func(genericapirequest.Context) string) {}
 
 // etcdCache defines interface used for caching objects stored in etcd. Objects are keyed by
 // their Node.ModifiedIndex, which is unique across all types.

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/value:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -34,10 +34,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/etcd"
 	"k8s.io/apiserver/pkg/storage/value"
 	utiltrace "k8s.io/apiserver/pkg/util/trace"
+)
+
+const (
+	// delayBetweenStaleCheck is the time period of the goroutine which reads and updates
+	// stale data items.
+	delayBetweenStaleCheck = 60
 )
 
 // authenticatedDataString satisfies the value.Context interface. It uses the key to
@@ -60,12 +67,13 @@ type store struct {
 	client *clientv3.Client
 	// getOpts contains additional options that should be passed
 	// to all Get() calls.
-	getOps      []clientv3.OpOption
-	codec       runtime.Codec
-	versioner   storage.Versioner
-	transformer value.Transformer
-	pathPrefix  string
-	watcher     *watcher
+	getOps        []clientv3.OpOption
+	codec         runtime.Codec
+	versioner     storage.Versioner
+	transformer   value.Transformer
+	pathPrefix    string
+	watcher       *watcher
+	staleQuitChan chan struct{}
 }
 
 type elemForDecode struct {
@@ -110,12 +118,22 @@ func newStore(c *clientv3.Client, quorumRead bool, codec runtime.Codec, prefix s
 		// options for all Get operations.
 		result.getOps = append(result.getOps, clientv3.WithSerializable())
 	}
+
 	return result
 }
 
 // Versioner implements storage.Interface.Versioner.
 func (s *store) Versioner() storage.Versioner {
 	return s.versioner
+}
+
+func (s *store) BeginStaleWatch(newFunc func() runtime.Object, keyRootFunc func(genericapirequest.Context) string) {
+	// TODO(sakshams): Shut down this goroutine on exit, if possible.
+	// Start a periodic service to re-encrypt stale data
+	ticker := time.NewTicker(delayBetweenStaleCheck * time.Minute)
+	quit := make(chan struct{})
+	go s.staleWatch(newFunc, keyRootFunc, ticker, quit)
+	s.staleQuitChan = quit
 }
 
 // Get implements storage.Interface.Get.
@@ -425,6 +443,52 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 	}
 	// update version with cluster level revision
 	return s.versioner.UpdateList(listObj, uint64(getResp.Header.Revision))
+}
+
+// staleWatch is a periodic service that lists all data this storage is responsible for, and re-encrypts
+// stale data.
+func (s *store) staleWatch(newFunc func() runtime.Object, keyRootFunc func(genericapirequest.Context) string, ticker *time.Ticker, quit chan struct{}) {
+	ctx := context.Background()
+	for {
+		select {
+		case <-ticker.C:
+			key := s.pathPrefix + keyRootFunc(ctx)
+			// We need to make sure the key ended with "/" so that we only get children "directories".
+			// e.g. if we have key "/a", "/a/b", "/ab", getting keys with prefix "/a" will return all three,
+			// while with prefix "/a/" will return only "/a/b" which is the correct answer.
+			if !strings.HasSuffix(key, "/") {
+				key += "/"
+			}
+			getResp, err := s.client.KV.Get(ctx, key, clientv3.WithPrefix())
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("unable to list items %q: %v", key, err))
+				continue
+			}
+
+			// This updates the latest known key version in KMS transformer.
+			s.transformer.TransformToStorage([]byte("test"), authenticatedDataString(""))
+
+			for _, kv := range getResp.Kvs {
+				_, stale, err := s.transformer.TransformFromStorage(kv.Value, authenticatedDataString(kv.Key))
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("unable to transform key %q: %v", kv.Key, err))
+					continue
+				}
+				if stale {
+					err = s.GuaranteedUpdate(ctx, strings.TrimPrefix(string(kv.Key), s.pathPrefix), newFunc(), false, nil, storage.SimpleUpdate(func(obj runtime.Object) (runtime.Object, error) {
+						return obj, nil
+					}))
+					if err != nil {
+						utilruntime.HandleError(fmt.Errorf("unable to update key %q: %v", kv.Key, err))
+						continue
+					}
+				}
+			}
+		case <-quit:
+			ticker.Stop()
+			return
+		}
+	}
 }
 
 // Watch implements storage.Interface.Watch.

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 )
 
 // Versioner abstracts setting and retrieving metadata fields from database response
@@ -185,4 +186,8 @@ type Interface interface {
 	GuaranteedUpdate(
 		ctx context.Context, key string, ptrToType runtime.Object, ignoreNotFound bool,
 		precondtions *Preconditions, tryUpdate UpdateFunc, suggestion ...runtime.Object) error
+
+	// BeginStaleWatch starts a background goroutine to monitor data in this storage, and re-write
+	// it if it is stale. Responds to the stale information provided by the underlying transformer.
+	BeginStaleWatch(newFunc func() runtime.Object, keyRootFunc func(genericapirequest.Context) string)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Acts upon the `stale` information provided by the transformer layer. Will be useful to ensure automatic re-encryption of data when using KMS transformer (Reference: #48574 and sakshamsharma#4).
When the key stored in KMS is modified, we want to be able to re-encrypt stale data to automatically migrate it to the new key.

Contains a rough approach I made to work. The transformer layer is only available to the raw storage, and the `newFunc` and `keyRootFunc` are only available to the generic registry storage, and thus the hack to pass those functions to the raw storage.

Suggestions requested.

@smarterclayton @wojtek-t @mikedanese @jcbsmpsn @cjcullen 
