### PR TITLE
add cronjobs to all

### DIFF
--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -746,12 +746,12 @@ func TestDiscoveryReplaceAliases(t *testing.T) {
 		{
 			name:     "all-replacement",
 			arg:      "all",
-			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,deployments.extensions,replicasets.extensions",
+			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,deployments.extensions,replicasets.extensions",
 		},
 		{
 			name:     "alias-in-comma-separated-arg",
 			arg:      "all,secrets",
-			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,deployments.extensions,replicasets.extensions,secrets",
+			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,deployments.extensions,replicasets.extensions,secrets",
 		},
 	}
 

--- a/pkg/kubectl/resource/categories.go
+++ b/pkg/kubectl/resource/categories.go
@@ -117,6 +117,7 @@ var legacyUserResources = []schema.GroupResource{
 	{Group: "apps", Resource: "statefulsets"},
 	{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
 	{Group: "batch", Resource: "jobs"},
+	{Group: "batch", Resource: "cronjobs"},
 	{Group: "extensions", Resource: "deployments"},
 	{Group: "extensions", Resource: "replicasets"},
 }

--- a/pkg/kubectl/resource/categories_test.go
+++ b/pkg/kubectl/resource/categories_test.go
@@ -46,6 +46,7 @@ func TestCategoryExpansion(t *testing.T) {
 				{Resource: "statefulsets", Group: "apps"},
 				{Resource: "horizontalpodautoscalers", Group: "autoscaling"},
 				{Resource: "jobs", Group: "batch"},
+				{Resource: "cronjobs", Group: "batch"},
 				{Resource: "deployments", Group: "extensions"},
 				{Resource: "replicasets", Group: "extensions"},
 			},

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -59,6 +59,13 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	return &REST{store}, &StatusREST{store: &statusStore}
 }
 
+var _ rest.CategoriesProvider = &REST{}
+
+// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
+func (r *REST) Categories() []string {
+	return []string{"all"}
+}
+
 // StatusREST implements the REST endpoint for changing the status of a resourcequota.
 type StatusREST struct {
 	store *genericregistry.Store


### PR DESCRIPTION
Categories were added to the discovery API, but the `kubectl` plumbing didn't make it.  We *did* make `kubectl all` gate on discovery information, so it can least be a superset.  

`cronjobs` are user resources, so I've added them to the list.

@kubernetes/sig-cli-misc 

```release-note
added cronjobs.batch to all, so kubectl get all returns them.
```