### PR TITLE
kubeadm: don't customize etcd selinux label

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -119,13 +119,6 @@ func WriteStaticPodManifests(cfg *kubeadmapi.MasterConfiguration) error {
 			LivenessProbe: componentProbe(2379, "/health", v1.URISchemeHTTP),
 		}, certsVolume(cfg), etcdVolume(cfg), k8sVolume())
 
-		etcdPod.Spec.SecurityContext = &v1.PodSecurityContext{
-			SELinuxOptions: &v1.SELinuxOptions{
-				// Unconfine the etcd container so it can write to the data dir with SELinux enforcing:
-				Type: "spc_t",
-			},
-		}
-
 		staticPodSpecs[etcd] = etcdPod
 	}
 


### PR DESCRIPTION
The original change that added the unconfined label included a comment
indicating it won't be needed in the future.
See: https://github.com/kubernetes/kubernetes/pull/33555#issuecomment-251126908

That time is now. https://github.com/kubernetes/kubernetes/pull/33663
has landed and means we no longer have to go out of our way to make that
work.

Removing the label also increases security since there wasn't really a
good reason for etcd to be run with such broad selinux privileges.

This also will allow kubeadm to avoid errors on distros without an spc_t
type, such as Gentoo and Container Linux (at the time of writing at
least).

Fixes https://github.com/kubernetes/kubeadm/issues/269

**Release note**:
```release-note
kubeadm: Don't set a specific `spc_t` SELinux label on the etcd Static Pod as that is more privs than etcd needs and due to that `spc_t` isn't compatible with some OSes.
```
