### PR TITLE
Bump up gce minNodesHealthCheckVersion due to known issues

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -37,8 +37,8 @@ var (
 )
 
 func init() {
-	if v, err := utilversion.ParseGeneric("1.7.0"); err != nil {
-		panic(err)
+	if v, err := utilversion.ParseGeneric("1.7.2"); err != nil {
+		glog.Fatalf("Failed to parse version for minNodesHealthCheckVersion: %v", err)
 	} else {
 		minNodesHealthCheckVersion = v
 	}

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks_test.go
@@ -27,8 +27,9 @@ func TestIsAtLeastMinNodesHealthCheckVersion(t *testing.T) {
 		version string
 		expect  bool
 	}{
-		{"v1.7.1", true},
-		{"v1.7.0-alpha.2.597+276d289b90d322", true},
+		{"v1.7.3", true},
+		{"v1.7.2", true},
+		{"v1.7.2-alpha.2.597+276d289b90d322", true},
 		{"v1.6.0-beta.3.472+831q821c907t31a", false},
 		{"v1.5.2", false},
 	}
@@ -52,14 +53,14 @@ func TestSupportsNodesHealthCheck(t *testing.T) {
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.1",
+							KubeProxyVersion: "v1.7.2",
 						},
 					},
 				},
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.0-alpha.2.597+276d289b90d322",
+							KubeProxyVersion: "v1.7.2-alpha.2.597+276d289b90d322",
 						},
 					},
 				},
@@ -92,14 +93,14 @@ func TestSupportsNodesHealthCheck(t *testing.T) {
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.1",
+							KubeProxyVersion: "v1.7.3",
 						},
 					},
 				},
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.0-alpha.2.597+276d289b90d322",
+							KubeProxyVersion: "v1.7.2-alpha.2.597+276d289b90d322",
 						},
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: There are some known issues in previous 1.7 versions causing kube-proxy not correctly responding healthz traffic.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: From #49263.

**Special notes for your reviewer**:
/assign @nicksardo @freehan 
cc @bowei @thockin 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
GCE Cloud Provider: New created LoadBalancer type Service will have health checks for nodes by default if all nodes have version >= v1.7.2.
```
