### PR TITLE
Automated cherry pick of #49316 #49330

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -987,6 +987,8 @@ function start-node-problem-detector {
   flags+=" --logtostderr"
   flags+=" --system-log-monitors=${km_config},${dm_config}"
   flags+=" --apiserver-override=https://${KUBERNETES_MASTER_NAME}?inClusterConfig=false&auth=/var/lib/node-problem-detector/kubeconfig"
+  local -r npd_port=${NODE_PROBLEM_DETECTOR_PORT:-20256}
+  flags+=" --port=${npd_port}"
 
   # Write the systemd service file for node problem detector.
   cat <<EOF >/etc/systemd/system/node-problem-detector.service

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -37,8 +37,8 @@ var (
 )
 
 func init() {
-	if v, err := utilversion.ParseGeneric("1.7.0"); err != nil {
-		panic(err)
+	if v, err := utilversion.ParseGeneric("1.7.2"); err != nil {
+		glog.Fatalf("Failed to parse version for minNodesHealthCheckVersion: %v", err)
 	} else {
 		minNodesHealthCheckVersion = v
 	}

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks_test.go
@@ -27,8 +27,9 @@ func TestIsAtLeastMinNodesHealthCheckVersion(t *testing.T) {
 		version string
 		expect  bool
 	}{
-		{"v1.7.1", true},
-		{"v1.7.0-alpha.2.597+276d289b90d322", true},
+		{"v1.7.3", true},
+		{"v1.7.2", true},
+		{"v1.7.2-alpha.2.597+276d289b90d322", true},
 		{"v1.6.0-beta.3.472+831q821c907t31a", false},
 		{"v1.5.2", false},
 	}
@@ -52,14 +53,14 @@ func TestSupportsNodesHealthCheck(t *testing.T) {
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.1",
+							KubeProxyVersion: "v1.7.2",
 						},
 					},
 				},
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.0-alpha.2.597+276d289b90d322",
+							KubeProxyVersion: "v1.7.2-alpha.2.597+276d289b90d322",
 						},
 					},
 				},
@@ -92,14 +93,14 @@ func TestSupportsNodesHealthCheck(t *testing.T) {
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.1",
+							KubeProxyVersion: "v1.7.3",
 						},
 					},
 				},
 				{
 					Status: v1.NodeStatus{
 						NodeInfo: v1.NodeSystemInfo{
-							KubeProxyVersion: "v1.7.0-alpha.2.597+276d289b90d322",
+							KubeProxyVersion: "v1.7.2-alpha.2.597+276d289b90d322",
 						},
 					},
 				},


### PR DESCRIPTION
Cherry pick of #49316 #49330 on release-1.7.

#49316: Use custom port for node-problem-detector
#49330: Bump up minNodesHealthCheckVersion in gce_healthcheck due to known issues

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- Use port 20256 for node-problem-detector in standalone mode.
- GCE Cloud Provider: New created LoadBalancer type Service will have health checks for nodes by default if all nodes have version >= v1.7.2.
```