### PR TITLE
Automated cherry pick of #49125

### DIFF
--- a/test/e2e/framework/google_compute.go
+++ b/test/e2e/framework/google_compute.go
@@ -162,13 +162,16 @@ func lookupClusterImageSources() (string, string, error) {
 	frags := strings.Split(nodeImg, "/")
 	nodeImg = frags[len(frags)-1]
 
-	masterName := TestContext.CloudConfig.MasterName
-	masterImg, err := host2image(masterName)
-	if err != nil {
-		return "", "", err
+	// For GKE clusters, MasterName will not be defined; we just leave masterImg blank.
+	masterImg := ""
+	if masterName := TestContext.CloudConfig.MasterName; masterName != "" {
+		img, err := host2image(masterName)
+		if err != nil {
+			return "", "", err
+		}
+		frags = strings.Split(img, "/")
+		masterImg = frags[len(frags)-1]
 	}
-	frags = strings.Split(masterImg, "/")
-	masterImg = frags[len(frags)-1]
 
 	return masterImg, nodeImg, nil
 }


### PR DESCRIPTION
When testing, GKE created clusters don't provide a `MasterName`, so carry on anyway and log node OS images without it

Background: this is code that runs during gce/gke testing, and records which specific OS images were being run on the master and node. When we test new OS images for GKE, we need to test them on all supported branches (i.e. >=1.5), so this piece of work needs to be backported to all branches. This specific cherrypick adds a guard for GKE-created clusters, which omit the `MasterName`, letting it proceed and log the node OS.

Cherry pick of #49125 on release-1.7.

#49125: Tolerate a missing MasterName (for GKE)

```release-note:
NONE
```