### PR TITLE
deployment: SetNewReplicaSetAnnotations() should compare revisions as numbers than strings

### DIFF
--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -268,7 +268,6 @@ func SetNewReplicaSetAnnotations(deployment *extensions.Deployment, newRS *exten
 		glog.Warningf("Updating replica set revision NewRevision not int %s", err)
 		return false
 	}
-	glog.Warningf("OldRevision=%d Newrevsion=%d\n", oldRevisionInt, newRevisionInt)
 	if oldRevisionInt < newRevisionInt {
 		newRS.Annotations[RevisionAnnotation] = newRevision
 		annotationChanged = true

--- a/pkg/controller/deployment/util/deployment_util.go
+++ b/pkg/controller/deployment/util/deployment_util.go
@@ -253,7 +253,23 @@ func SetNewReplicaSetAnnotations(deployment *extensions.Deployment, newRS *exten
 	// The newRS's revision should be the greatest among all RSes. Usually, its revision number is newRevision (the max revision number
 	// of all old RSes + 1). However, it's possible that some of the old RSes are deleted after the newRS revision being updated, and
 	// newRevision becomes smaller than newRS's revision. We should only update newRS revision when it's smaller than newRevision.
-	if oldRevision < newRevision {
+
+	oldRevisionInt, err := strconv.ParseInt(oldRevision, 10, 64)
+	if err != nil {
+		if oldRevision != "" {
+			glog.Warningf("Updating replica set revision OldRevision not int %s", err)
+			return false
+		}
+		//If the RS annotation is empty then initialise it to 0
+		oldRevisionInt = 0
+	}
+	newRevisionInt, err := strconv.ParseInt(newRevision, 10, 64)
+	if err != nil {
+		glog.Warningf("Updating replica set revision NewRevision not int %s", err)
+		return false
+	}
+	glog.Warningf("OldRevision=%d Newrevsion=%d\n", oldRevisionInt, newRevisionInt)
+	if oldRevisionInt < newRevisionInt {
 		newRS.Annotations[RevisionAnnotation] = newRevision
 		annotationChanged = true
 		glog.V(4).Infof("Updating replica set %q revision to %s", newRS.Name, newRevision)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: 
1) SetNewReplicaSetAnnotations() when deployment revision annotation is copied over to RS, it performs a string comparison instead of int comparison, due to this any revision beyond 9 might not get copied.
2) Slightly improves the coverage by adding UT for Annotation related functions
3) Upgrade the test suite to use go-langs sub-test, which is very useful while investigating UT related failures.

```
--- FAIL: TestAnnotationUtils (0.00s)
    --- FAIL: TestAnnotationUtils/SetNewReplicaSetAnnotations (0.00s)
        deployment_util_test.go:1283: Revision Expected=10 Obtained=9
        deployment_util_test.go:1283: Revision Expected=11 Obtained=9
        deployment_util_test.go:1283: Revision Expected=12 Obtained=9
        deployment_util_test.go:1283: Revision Expected=13 Obtained=9
        deployment_util_test.go:1283: Revision Expected=14 Obtained=9
        deployment_util_test.go:1283: Revision Expected=15 Obtained=9
        deployment_util_test.go:1283: Revision Expected=16 Obtained=9
        deployment_util_test.go:1283: Revision Expected=17 Obtained=9
        deployment_util_test.go:1283: Revision Expected=18 Obtained=9
        deployment_util_test.go:1283: Revision Expected=19 Obtained=9
        deployment_util_test.go:1283: Revision Expected=20 Obtained=9
    --- PASS: TestAnnotationUtils/SetReplicasAnnotations (0.00s)
    --- PASS: TestAnnotationUtils/IsSaturated (0.00s)
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**: None
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
cc: @kargakis 