### PR TITLE
Fix Operation names for subresources

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -3813,7 +3813,7 @@
    },
    "/api/v1/namespaces/{namespace}/pods/{name}/binding": {
     "post": {
-     "description": "create binding of a Binding",
+     "description": "create binding of a Pod",
      "consumes": [
       "*/*"
      ],
@@ -3828,7 +3828,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedBindingBinding",
+     "operationId": "createCoreV1NamespacedPodBinding",
      "parameters": [
       {
        "name": "body",
@@ -3885,7 +3885,7 @@
    },
    "/api/v1/namespaces/{namespace}/pods/{name}/eviction": {
     "post": {
-     "description": "create eviction of an Eviction",
+     "description": "create eviction of a Pod",
      "consumes": [
       "*/*"
      ],
@@ -3900,7 +3900,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "createCoreV1NamespacedEvictionEviction",
+     "operationId": "createCoreV1NamespacedPodEviction",
      "parameters": [
       {
        "name": "body",
@@ -5888,7 +5888,7 @@
    },
    "/api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified ReplicationController",
      "consumes": [
       "*/*"
      ],
@@ -5903,7 +5903,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "readCoreV1NamespacedScaleScale",
+     "operationId": "readCoreV1NamespacedReplicationControllerScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -5923,7 +5923,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified ReplicationController",
      "consumes": [
       "*/*"
      ],
@@ -5938,7 +5938,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "replaceCoreV1NamespacedScaleScale",
+     "operationId": "replaceCoreV1NamespacedReplicationControllerScale",
      "parameters": [
       {
        "name": "body",
@@ -5968,7 +5968,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified ReplicationController",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -5985,7 +5985,7 @@
      "tags": [
       "core_v1"
      ],
-     "operationId": "patchCoreV1NamespacedScaleScale",
+     "operationId": "patchCoreV1NamespacedReplicationControllerScale",
      "parameters": [
       {
        "name": "body",
@@ -20501,7 +20501,7 @@
    },
    "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/rollback": {
     "post": {
-     "description": "create rollback of a DeploymentRollback",
+     "description": "create rollback of a Deployment",
      "consumes": [
       "*/*"
      ],
@@ -20516,7 +20516,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "createAppsV1beta1NamespacedDeploymentRollbackRollback",
+     "operationId": "createAppsV1beta1NamespacedDeploymentRollback",
      "parameters": [
       {
        "name": "body",
@@ -20573,7 +20573,7 @@
    },
    "/apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -20588,7 +20588,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "readAppsV1beta1NamespacedScaleScale",
+     "operationId": "readAppsV1beta1NamespacedDeploymentScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -20608,7 +20608,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -20623,7 +20623,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "replaceAppsV1beta1NamespacedScaleScale",
+     "operationId": "replaceAppsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -20653,7 +20653,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified Deployment",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -20670,7 +20670,7 @@
      "tags": [
       "apps_v1beta1"
      ],
-     "operationId": "patchAppsV1beta1NamespacedScaleScale",
+     "operationId": "patchAppsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -23050,7 +23050,7 @@
    },
    "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/rollback": {
     "post": {
-     "description": "create rollback of a DeploymentRollback",
+     "description": "create rollback of a Deployment",
      "consumes": [
       "*/*"
      ],
@@ -23065,7 +23065,7 @@
      "tags": [
       "apps_v1beta2"
      ],
-     "operationId": "createAppsV1beta2NamespacedDeploymentRollbackRollback",
+     "operationId": "createAppsV1beta2NamespacedDeploymentRollback",
      "parameters": [
       {
        "name": "body",
@@ -23122,7 +23122,7 @@
    },
    "/apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -23137,7 +23137,7 @@
      "tags": [
       "apps_v1beta2"
      ],
-     "operationId": "readAppsV1beta2NamespacedScaleScale",
+     "operationId": "readAppsV1beta2NamespacedDeploymentScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -23157,7 +23157,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -23172,7 +23172,7 @@
      "tags": [
       "apps_v1beta2"
      ],
-     "operationId": "replaceAppsV1beta2NamespacedScaleScale",
+     "operationId": "replaceAppsV1beta2NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -23202,7 +23202,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified Deployment",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -23219,7 +23219,7 @@
      "tags": [
       "apps_v1beta2"
      ],
-     "operationId": "patchAppsV1beta2NamespacedScaleScale",
+     "operationId": "patchAppsV1beta2NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -32808,7 +32808,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback": {
     "post": {
-     "description": "create rollback of a DeploymentRollback",
+     "description": "create rollback of a Deployment",
      "consumes": [
       "*/*"
      ],
@@ -32823,7 +32823,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "createExtensionsV1beta1NamespacedDeploymentRollbackRollback",
+     "operationId": "createExtensionsV1beta1NamespacedDeploymentRollback",
      "parameters": [
       {
        "name": "body",
@@ -32880,7 +32880,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -32895,7 +32895,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "readExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "readExtensionsV1beta1NamespacedDeploymentScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -32915,7 +32915,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -32930,7 +32930,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "replaceExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "replaceExtensionsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -32960,7 +32960,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified Deployment",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -32977,7 +32977,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "patchExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "patchExtensionsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -34722,7 +34722,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified ReplicaSet",
      "consumes": [
       "*/*"
      ],
@@ -34737,7 +34737,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "readExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "readExtensionsV1beta1NamespacedReplicaSetScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -34757,7 +34757,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified ReplicaSet",
      "consumes": [
       "*/*"
      ],
@@ -34772,7 +34772,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "replaceExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "replaceExtensionsV1beta1NamespacedReplicaSetScale",
      "parameters": [
       {
        "name": "body",
@@ -34802,7 +34802,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified ReplicaSet",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -34819,7 +34819,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "patchExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "patchExtensionsV1beta1NamespacedReplicaSetScale",
      "parameters": [
       {
        "name": "body",
@@ -35030,7 +35030,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified ReplicationControllerDummy",
      "consumes": [
       "*/*"
      ],
@@ -35045,7 +35045,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "readExtensionsV1beta1NamespacedReplicationcontrollersScale",
+     "operationId": "readExtensionsV1beta1NamespacedReplicationControllerDummyScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -35065,7 +35065,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified ReplicationControllerDummy",
      "consumes": [
       "*/*"
      ],
@@ -35080,7 +35080,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "replaceExtensionsV1beta1NamespacedReplicationcontrollersScale",
+     "operationId": "replaceExtensionsV1beta1NamespacedReplicationControllerDummyScale",
      "parameters": [
       {
        "name": "body",
@@ -35110,7 +35110,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified ReplicationControllerDummy",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -35127,7 +35127,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "patchExtensionsV1beta1NamespacedReplicationcontrollersScale",
+     "operationId": "patchExtensionsV1beta1NamespacedReplicationControllerDummyScale",
      "parameters": [
       {
        "name": "body",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -1737,8 +1737,8 @@
      {
       "type": "v1beta1.DeploymentRollback",
       "method": "POST",
-      "summary": "create rollback of a DeploymentRollback",
-      "nickname": "createNamespacedDeploymentRollbackRollback",
+      "summary": "create rollback of a Deployment",
+      "nickname": "createNamespacedDeploymentRollback",
       "parameters": [
        {
         "type": "string",
@@ -1798,8 +1798,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified Deployment",
+      "nickname": "readNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -1845,8 +1845,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified Deployment",
+      "nickname": "replaceNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -1900,8 +1900,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified Deployment",
+      "nickname": "patchNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -876,8 +876,8 @@
      {
       "type": "v1beta2.DeploymentRollback",
       "method": "POST",
-      "summary": "create rollback of a DeploymentRollback",
-      "nickname": "createNamespacedDeploymentRollbackRollback",
+      "summary": "create rollback of a Deployment",
+      "nickname": "createNamespacedDeploymentRollback",
       "parameters": [
        {
         "type": "string",
@@ -937,8 +937,8 @@
      {
       "type": "v1beta2.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified Deployment",
+      "nickname": "readNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -984,8 +984,8 @@
      {
       "type": "v1beta2.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified Deployment",
+      "nickname": "replaceNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -1039,8 +1039,8 @@
      {
       "type": "v1beta2.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified Deployment",
+      "nickname": "patchNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -1902,8 +1902,8 @@
      {
       "type": "v1beta1.DeploymentRollback",
       "method": "POST",
-      "summary": "create rollback of a DeploymentRollback",
-      "nickname": "createNamespacedDeploymentRollbackRollback",
+      "summary": "create rollback of a Deployment",
+      "nickname": "createNamespacedDeploymentRollback",
       "parameters": [
        {
         "type": "string",
@@ -1963,8 +1963,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified Deployment",
+      "nickname": "readNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -2010,8 +2010,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified Deployment",
+      "nickname": "replaceNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -2065,8 +2065,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified Deployment",
+      "nickname": "patchNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -5656,8 +5656,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified ReplicaSet",
+      "nickname": "readNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",
@@ -5703,8 +5703,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified ReplicaSet",
+      "nickname": "replaceNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",
@@ -5758,8 +5758,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified ReplicaSet",
+      "nickname": "patchNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",
@@ -5986,8 +5986,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified ReplicationControllerDummy",
+      "nickname": "readNamespacedReplicationControllerDummyScale",
       "parameters": [
        {
         "type": "string",
@@ -6033,8 +6033,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified ReplicationControllerDummy",
+      "nickname": "replaceNamespacedReplicationControllerDummyScale",
       "parameters": [
        {
         "type": "string",
@@ -6088,8 +6088,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified ReplicationControllerDummy",
+      "nickname": "patchNamespacedReplicationControllerDummyScale",
       "parameters": [
        {
         "type": "string",

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -9271,8 +9271,8 @@
      {
       "type": "v1.Binding",
       "method": "POST",
-      "summary": "create binding of a Binding",
-      "nickname": "createNamespacedBindingBinding",
+      "summary": "create binding of a Pod",
+      "nickname": "createNamespacedPodBinding",
       "parameters": [
        {
         "type": "string",
@@ -9332,8 +9332,8 @@
      {
       "type": "v1beta1.Eviction",
       "method": "POST",
-      "summary": "create eviction of an Eviction",
-      "nickname": "createNamespacedEvictionEviction",
+      "summary": "create eviction of a Pod",
+      "nickname": "createNamespacedPodEviction",
       "parameters": [
        {
         "type": "string",
@@ -12234,8 +12234,8 @@
      {
       "type": "v1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified ReplicationController",
+      "nickname": "readNamespacedReplicationControllerScale",
       "parameters": [
        {
         "type": "string",
@@ -12281,8 +12281,8 @@
      {
       "type": "v1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified ReplicationController",
+      "nickname": "replaceNamespacedReplicationControllerScale",
       "parameters": [
        {
         "type": "string",
@@ -12336,8 +12336,8 @@
      {
       "type": "v1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified ReplicationController",
+      "nickname": "patchNamespacedReplicationControllerScale",
       "parameters": [
        {
         "type": "string",

--- a/docs/api-reference/apps/v1beta1/operations.html
+++ b/docs/api-reference/apps/v1beta1/operations.html
@@ -2735,7 +2735,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_rollback_of_a_deploymentrollback">create rollback of a DeploymentRollback</h3>
+<h3 id="_create_rollback_of_a_deployment">create rollback of a Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/rollback</pre>
@@ -2862,7 +2862,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_deployment">read scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -2981,7 +2981,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_deployment">replace scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -3108,7 +3108,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_deployment">partially update scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/apps/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -6693,7 +6693,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-19 00:29:43 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/apps/v1beta2/operations.html
+++ b/docs/api-reference/apps/v1beta2/operations.html
@@ -1589,7 +1589,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_rollback_of_a_deploymentrollback">create rollback of a DeploymentRollback</h3>
+<h3 id="_create_rollback_of_a_deployment">create rollback of a Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/rollback</pre>
@@ -1716,7 +1716,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_deployment">read scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -1835,7 +1835,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_deployment">replace scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -1962,7 +1962,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_deployment">partially update scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/apps/v1beta2/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -4993,7 +4993,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-19 00:29:43 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/extensions/v1beta1/operations.html
+++ b/docs/api-reference/extensions/v1beta1/operations.html
@@ -3271,7 +3271,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_rollback_of_a_deploymentrollback">create rollback of a DeploymentRollback</h3>
+<h3 id="_create_rollback_of_a_deployment">create rollback of a Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback</pre>
@@ -3398,7 +3398,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_deployment">read scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -3517,7 +3517,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_deployment">replace scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -3644,7 +3644,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_deployment">partially update scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -7502,7 +7502,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale_2">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_replicaset">read scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>
@@ -7621,7 +7621,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale_2">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_replicaset">replace scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>
@@ -7748,7 +7748,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale_2">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_replicaset">partially update scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>
@@ -8260,7 +8260,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale_3">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_replicationcontrollerdummy">read scale of the specified ReplicationControllerDummy</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>
@@ -8379,7 +8379,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale_3">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_replicationcontrollerdummy">replace scale of the specified ReplicationControllerDummy</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>
@@ -8506,7 +8506,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale_3">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_replicationcontrollerdummy">partially update scale of the specified ReplicationControllerDummy</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>

--- a/docs/api-reference/scheduling.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/scheduling.k8s.io/v1alpha1/definitions.html
@@ -1347,7 +1347,7 @@ Examples:<br>
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-18 22:23:24 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
+++ b/docs/api-reference/scheduling.k8s.io/v1alpha1/operations.html
@@ -1702,7 +1702,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2017-07-18 22:23:24 UTC
+
 </div>
 </div>
 </body>

--- a/docs/api-reference/v1/operations.html
+++ b/docs/api-reference/v1/operations.html
@@ -8329,7 +8329,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_binding_of_a_binding">create binding of a Binding</h3>
+<h3 id="_create_binding_of_a_pod">create binding of a Pod</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /api/v1/namespaces/{namespace}/pods/{name}/binding</pre>
@@ -8456,7 +8456,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_eviction_of_an_eviction">create eviction of an Eviction</h3>
+<h3 id="_create_eviction_of_a_pod">create eviction of a Pod</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /api/v1/namespaces/{namespace}/pods/{name}/eviction</pre>
@@ -12820,7 +12820,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_replicationcontroller">read scale of the specified ReplicationController</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>
@@ -12939,7 +12939,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_replicationcontroller">replace scale of the specified ReplicationController</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>
@@ -13066,7 +13066,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_replicationcontroller">partially update scale of the specified ReplicationController</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale</pre>

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -5809,7 +5809,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback": {
     "post": {
-     "description": "create rollback of a DeploymentRollback",
+     "description": "create rollback of a Deployment",
      "consumes": [
       "*/*"
      ],
@@ -5824,7 +5824,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "createExtensionsV1beta1NamespacedDeploymentRollbackRollback",
+     "operationId": "createExtensionsV1beta1NamespacedDeploymentRollback",
      "parameters": [
       {
        "name": "body",
@@ -5881,7 +5881,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -5896,7 +5896,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "readExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "readExtensionsV1beta1NamespacedDeploymentScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -5916,7 +5916,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified Deployment",
      "consumes": [
       "*/*"
      ],
@@ -5931,7 +5931,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "replaceExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "replaceExtensionsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -5961,7 +5961,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified Deployment",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -5978,7 +5978,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "patchExtensionsV1beta1NamespacedDeploymentsScale",
+     "operationId": "patchExtensionsV1beta1NamespacedDeploymentScale",
      "parameters": [
       {
        "name": "body",
@@ -7263,7 +7263,7 @@
    },
    "/apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale": {
     "get": {
-     "description": "read scale of the specified Scale",
+     "description": "read scale of the specified ReplicaSet",
      "consumes": [
       "*/*"
      ],
@@ -7278,7 +7278,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "readExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "readExtensionsV1beta1NamespacedReplicaSetScale",
      "responses": {
       "200": {
        "description": "OK",
@@ -7298,7 +7298,7 @@
      }
     },
     "put": {
-     "description": "replace scale of the specified Scale",
+     "description": "replace scale of the specified ReplicaSet",
      "consumes": [
       "*/*"
      ],
@@ -7313,7 +7313,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "replaceExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "replaceExtensionsV1beta1NamespacedReplicaSetScale",
      "parameters": [
       {
        "name": "body",
@@ -7343,7 +7343,7 @@
      }
     },
     "patch": {
-     "description": "partially update scale of the specified Scale",
+     "description": "partially update scale of the specified ReplicaSet",
      "consumes": [
       "application/json-patch+json",
       "application/merge-patch+json",
@@ -7360,7 +7360,7 @@
      "tags": [
       "extensions_v1beta1"
      ],
-     "operationId": "patchExtensionsV1beta1NamespacedReplicasetsScale",
+     "operationId": "patchExtensionsV1beta1NamespacedReplicaSetScale",
      "parameters": [
       {
        "name": "body",

--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -1902,8 +1902,8 @@
      {
       "type": "v1beta1.DeploymentRollback",
       "method": "POST",
-      "summary": "create rollback of a DeploymentRollback",
-      "nickname": "createNamespacedDeploymentRollbackRollback",
+      "summary": "create rollback of a Deployment",
+      "nickname": "createNamespacedDeploymentRollback",
       "parameters": [
        {
         "type": "string",
@@ -1963,8 +1963,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified Deployment",
+      "nickname": "readNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -2010,8 +2010,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified Deployment",
+      "nickname": "replaceNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -2065,8 +2065,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified Deployment",
+      "nickname": "patchNamespacedDeploymentScale",
       "parameters": [
        {
         "type": "string",
@@ -4180,8 +4180,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "GET",
-      "summary": "read scale of the specified Scale",
-      "nickname": "readNamespacedScaleScale",
+      "summary": "read scale of the specified ReplicaSet",
+      "nickname": "readNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",
@@ -4227,8 +4227,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PUT",
-      "summary": "replace scale of the specified Scale",
-      "nickname": "replaceNamespacedScaleScale",
+      "summary": "replace scale of the specified ReplicaSet",
+      "nickname": "replaceNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",
@@ -4282,8 +4282,8 @@
      {
       "type": "v1beta1.Scale",
       "method": "PATCH",
-      "summary": "partially update scale of the specified Scale",
-      "nickname": "patchNamespacedScaleScale",
+      "summary": "partially update scale of the specified ReplicaSet",
+      "nickname": "patchNamespacedReplicaSetScale",
       "parameters": [
        {
         "type": "string",

--- a/federation/docs/api-reference/extensions/v1beta1/operations.html
+++ b/federation/docs/api-reference/extensions/v1beta1/operations.html
@@ -3271,7 +3271,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_create_rollback_of_a_deploymentrollback">create rollback of a DeploymentRollback</h3>
+<h3 id="_create_rollback_of_a_deployment">create rollback of a Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>POST /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback</pre>
@@ -3398,7 +3398,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_deployment">read scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -3517,7 +3517,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_deployment">replace scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -3644,7 +3644,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_deployment">partially update scale of the specified Deployment</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale</pre>
@@ -6513,7 +6513,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_read_scale_of_the_specified_scale_2">read scale of the specified Scale</h3>
+<h3 id="_read_scale_of_the_specified_replicaset">read scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>GET /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>
@@ -6632,7 +6632,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_replace_scale_of_the_specified_scale_2">replace scale of the specified Scale</h3>
+<h3 id="_replace_scale_of_the_specified_replicaset">replace scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PUT /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>
@@ -6759,7 +6759,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 </div>
 </div>
 <div class="sect2">
-<h3 id="_partially_update_scale_of_the_specified_scale_2">partially update scale of the specified Scale</h3>
+<h3 id="_partially_update_scale_of_the_specified_replicaset">partially update scale of the specified ReplicaSet</h3>
 <div class="listingblock">
 <div class="content">
 <pre>PATCH /apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale</pre>

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -577,6 +577,14 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 
 		routes := []*restful.RouteBuilder{}
 
+		// If there is a subresource, kind should be the parent's kind.
+		if hasSubresource {
+			fqParentKind, err := a.getResourceKind(resource, a.group.Storage[resource])
+			if err != nil {
+				return nil, err
+			}
+			kind = fqParentKind.Kind
+		}
 		switch action.Verb {
 		case "GET": // Get a resource.
 			var handler restful.RouteFunction

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/openapi/openapi.go
@@ -63,10 +63,6 @@ func GetOperationIDAndTags(r *restful.Route) (string, []string, error) {
 	op := r.Operation
 	path := r.Path
 	var tags []string
-	// TODO: This is hacky, figure out where this name conflict is created and fix it at the root.
-	if strings.HasPrefix(path, "/apis/extensions/v1beta1/namespaces/{namespace}/") && strings.HasSuffix(op, "ScaleScale") {
-		op = op[:len(op)-10] + strings.Title(strings.Split(path[48:], "/")[0]) + "Scale"
-	}
 	prefix, exists := verbs.GetPrefix(op)
 	if !exists {
 		return op, tags, fmt.Errorf("operation names should start with a verb. Cannot determine operation verb from %v", op)


### PR DESCRIPTION
Subresources may have their kind but in operationID and description we should use their parent kind not their own kind. The subresource name represents subresources and no need to repeat in with their kind. e.g. `Scale` has kind of `Scale` and subresource name of `Scale`. This creates names like `read scale of the specified Scale` or `readCoreV1NamespacedScaleScale` for scale on replication controller. This PR fixes description and operation ID for them to `read scale of the specified ReplicationController` and `readCoreV1NamespacedReplicationControllerScale`.

@caesarxuchao I would like this to be patched in 1.7 too as it is useful for all clients and there is no need to wait for 1.8 for this documentation fix.

```release-note
Fixed OpenAPI Description and Nickname of API objects with subresources
```

fixes #49250