### PR TITLE
Panic on assertion failure instead of Fatalf

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
@@ -27,7 +27,6 @@ go_library(
     ],
     tags = ["automanaged"],
     deps = [
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/converter.go
@@ -32,8 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	"github.com/golang/glog"
 )
 
 // Converter is an interface for converting between interface{}
@@ -117,10 +115,10 @@ func (c *converterImpl) FromUnstructured(u map[string]interface{}, obj interface
 		newObj := reflect.New(t.Elem()).Interface()
 		newErr := fromUnstructuredViaJSON(u, newObj)
 		if (err != nil) != (newErr != nil) {
-			glog.Fatalf("FromUnstructured unexpected error for %v: error: %v", u, err)
+			panic(fmt.Errorf("FromUnstructured unexpected error for %v: error: %v / %v", u, err, newErr))
 		}
 		if err == nil && !apiequality.Semantic.DeepEqual(obj, newObj) {
-			glog.Fatalf("FromUnstructured mismatch for %#v, diff: %v", obj, diff.ObjectReflectDiff(obj, newObj))
+			panic(fmt.Errorf("FromUnstructured mismatch for %#v, diff: %v", obj, diff.ObjectReflectDiff(obj, newObj)))
 		}
 	}
 	return err
@@ -400,10 +398,10 @@ func (c *converterImpl) ToUnstructured(obj interface{}) (map[string]interface{},
 		newUnstr := &map[string]interface{}{}
 		newErr := toUnstructuredViaJSON(obj, newUnstr)
 		if (err != nil) != (newErr != nil) {
-			glog.Fatalf("ToUnstructured unexpected error for %v: error: %v", obj, err)
+			panic(fmt.Errorf("ToUnstructured unexpected error for %v: error: %v / %v", obj, err, newErr))
 		}
 		if err == nil && !apiequality.Semantic.DeepEqual(u, newUnstr) {
-			glog.Fatalf("ToUnstructured mismatch for %#v, diff: %v", u, diff.ObjectReflectDiff(u, newUnstr))
+			panic(fmt.Errorf("ToUnstructured mismatch for %#v, diff: %v", u, diff.ObjectReflectDiff(u, newUnstr)))
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Library code should not decide whether the program should terminate. This is especially annoying in unit tests.

Also, when `err` != `newErr` both should be added to the message. It was hard to debug an issue because `newErr` was missing and `err` was nil.

Perhaps library code should be audited and some Fatalf replaced with panics. IMHO it is fine to do Fatalf in cmd but in library code it is better to use panic.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
/sig api-machinery
