### PR TITLE
Fix: PV metric is not namespaced

### DIFF
--- a/cluster/juju/layers/kubernetes-master/metrics.yaml
+++ b/cluster/juju/layers/kubernetes-master/metrics.yaml
@@ -23,7 +23,7 @@ metrics:
   persistentvolume:
     type: gauge
     description: number of pv
-    command: /snap/bin/kubectl get pv --all-namespaces | tail -n+2 | wc -l
+    command: /snap/bin/kubectl get pv | tail -n+2 | wc -l
   persistentvolumeclaims:
     type: gauge
     description: number of claims


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The PV metric of juju deployments is not namespaced. This PR fixes this bug. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/348

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
