### PR TITLE
Return Audit-Id http response header for trouble shooting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -27,6 +27,13 @@ const (
 	// Header to hold the audit ID as the request is propagated through the serving hierarchy. The
 	// Audit-ID header should be set by the first server to receive the request (e.g. the federation
 	// server or kube-aggregator).
+	//
+	// Audit ID is also returned to client by http response header.
+	// It's not guaranteed Audit-Id http header is sent for all requests. When kube-apiserver didn't
+	// audit the events according to the audit policy, no Audit-ID is returned. Also, for request to
+	// pods/exec, pods/attach, pods/proxy, kube-apiserver works like a proxy and redirect the request
+	// to kubelet node, users will only get http headers sent from kubelet node, so no Audit-ID is
+	// sent when users run command like "kubectl exec" or "kubectl attach".
 	HeaderAuditID = "Audit-ID"
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
@@ -28,6 +28,13 @@ const (
 	// Header to hold the audit ID as the request is propagated through the serving hierarchy. The
 	// Audit-ID header should be set by the first server to receive the request (e.g. the federation
 	// server or kube-aggregator).
+	//
+	// Audit ID is also returned to client by http response header.
+	// It's not guaranteed Audit-Id http header is sent for all requests. When kube-apiserver didn't
+	// audit the events according to the audit policy, no Audit-ID is returned. Also, for request to
+	// pods/exec, pods/attach, pods/proxy, kube-apiserver works like a proxy and redirect the request
+	// to kubelet node, users will only get http headers sent from kubelet node, so no Audit-ID is
+	// sent when users run command like "kubectl exec" or "kubectl attach".
 	HeaderAuditID = "Audit-ID"
 )
 


### PR DESCRIPTION
Users can use Audit-Id http response header to grep the audit events in log.
This provides a fast way to find the events in audit.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Audit-Id HTTP header is included in the apiserver responses for audited requests, except some cases when it's not possible, e.g. pods/exec.
```
@sttts @tallclair 