### PR TITLE
Pass clientset's Interface to CreateScheduler.

### DIFF
--- a/plugin/cmd/kube-scheduler/app/configurator.go
+++ b/plugin/cmd/kube-scheduler/app/configurator.go
@@ -83,7 +83,7 @@ func createClient(s *options.SchedulerServer) (*clientset.Clientset, *kubernetes
 // CreateScheduler encapsulates the entire creation of a runnable scheduler.
 func CreateScheduler(
 	s *options.SchedulerServer,
-	kubecli *clientset.Clientset,
+	kubecli clientset.Interface,
 	nodeInformer coreinformers.NodeInformer,
 	podInformer coreinformers.PodInformer,
 	pvInformer coreinformers.PersistentVolumeInformer,


### PR DESCRIPTION
**What this PR does / why we need it**:
CreateSchedueler takes clientset.Clientset param and passes it to NewConfigFactory which takes clientset.Interface. It'd be better for CreateSchedueler to take clientset.Interface to be in sync with NewConfigFactory and it would be easier to reuse CreateSchedueler in implementations which relies on interface rather than actual client implementation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
No issue.
@kubernetes/sig-scheduling-pr-reviews @bsalamat 