### PR TITLE
Deprecate `restuserkey` SC parameter from GlusterFS plugin.

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -411,7 +411,6 @@ func (plugin *glusterfsPlugin) newProvisionerInternal(options volume.VolumeOptio
 type provisionerConfig struct {
 	url             string
 	user            string
-	userKey         string
 	secretNamespace string
 	secretName      string
 	secretValue     string
@@ -936,7 +935,7 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 		case "restuser":
 			cfg.user = v
 		case "restuserkey":
-			cfg.userKey = v
+			return nil, fmt.Errorf("glusterfs: option %q for volume plugin %s is deprecated, use `secretname` and `secretnamespace` for user password", k, glusterfsPluginName)
 		case "secretname":
 			cfg.secretName = v
 		case "secretnamespace":
@@ -1028,12 +1027,10 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 		cfg.user = ""
 		cfg.secretName = ""
 		cfg.secretNamespace = ""
-		cfg.userKey = ""
 		cfg.secretValue = ""
 	}
 
 	if len(cfg.secretName) != 0 || len(cfg.secretNamespace) != 0 {
-		// secretName + Namespace has precedence over userKey
 		if len(cfg.secretName) != 0 && len(cfg.secretNamespace) != 0 {
 			cfg.secretValue, err = parseSecret(cfg.secretNamespace, cfg.secretName, kubeClient)
 			if err != nil {
@@ -1042,8 +1039,6 @@ func parseClassParameters(params map[string]string, kubeClient clientset.Interfa
 		} else {
 			return nil, fmt.Errorf("StorageClass for provisioner %q must have secretNamespace and secretName either both set or both empty", glusterfsPluginName)
 		}
-	} else {
-		cfg.secretValue = cfg.userKey
 	}
 
 	if cfg.gidMin > cfg.gidMax {


### PR DESCRIPTION
Until now there are two options provided for an admin to specify
heketi/rest service password via StorageClass. It can be provided
either via `secret` or a plain text password using `restuserkey`
SC parameter. It is no longer a best practise to provide an option
to supply plain text passwords via storageclass parameter. This patch
deprecate the option

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
