### PR TITLE
Update cos-dev image in benchmark tests to cos-dev-61-9759-0-0

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -91,21 +91,21 @@ images:
     tests:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   cosdev-resource1:
-    image: cos-dev-61-9733-0-0
+    image: cos-dev-61-9759-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosdev-resource2:
-    image: cos-dev-61-9733-0-0
+    image: cos-dev-61-9759-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosdev-resource3:
-    image: cos-dev-61-9733-0-0
+    image: cos-dev-61-9759-0-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/42926

`cos-dev-61-9759-0-0` contains a fix in Linux utility `du` that would affect the measurement of docker performance in kubelet. I'd like to update the benchmark to use the new image.

**Release note**:
```
None
```

/assign @tallclair 
/cc @kewu1992 @abgworrall