### PR TITLE
Update to version gate CRDs to 1.7 and greater

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/client/retry:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/printers:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/metrics:go_default_library",
         "//test/e2e/workload:go_default_library",

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -20,10 +20,13 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/test/integration/testserver"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
+
+var crdVersion = utilversion.MustParseSemantic("v1.7.0")
 
 var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 
@@ -31,6 +34,9 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 
 	Context("Simple CustomResourceDefinition", func() {
 		It("creating/deleting custom resource definition objects works [Conformance]", func() {
+
+			framework.SkipUnlessServerVersionGTE(crdVersion, f.ClientSet.Discovery())
+
 			config, err := framework.LoadConfig()
 			if err != nil {
 				framework.Failf("failed to load config: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows e2e's to be tested on earlier version do to version check.  

xref: #49313

**Release note**:
```
NONE
```

/cc @kubernetes/sig-api-machinery-bugs @kubernetes/sig-testing-bugs 
