### PR TITLE
Add a SUPPORT.md file for github

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,39 @@
+## Support for deploying and using Kubernetes 
+
+Welcome to Kubernetes! We use GitHub for tracking bugs and feature requests. 
+This isn't the right place to get support for using Kubernetes, but the following 
+resources are available below, thanks for understanding.
+
+### Stack Overflow
+
+The Kubernetes Community is active on Stack Overflow, you can post your questions there: 
+
+* [Kubernetes on Stack Overflow](http://stackoverflow.com/questions/tagged/kubernetes)
+
+  * Here are some tips for [about how to ask good questions](http://stackoverflow.com/help/how-to-ask).
+  * Don't forget to check to see [what's on topic](http://stackoverflow.com/help/on-topic).
+
+### Documentation 
+
+* [User Documentation](https://kubernetes.io/docs/) 
+* [Troubleshooting Guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/)
+
+
+### Real-time Chat
+
+* [Slack](https://kubernetes.slack.com) ([registration](http://slack.k8s.io)):
+The `#kubernetes-users` and `#kubernetes-novice` channels are usual places where 
+people offer support.
+
+* Also check out the 
+[Slack Archive](http://kubernetes.slackarchive.io/) of past conversations.
+
+### Mailing Lists/Groups
+
+* [Kubernetes-users group](https://groups.google.com/forum/#!forum/kubernetes-users)
+
+
+
+<!---
+Derived from https://github.com/kubernetes/community/blob/master/contributors/devel/on-call-user-support.md
+--> 


### PR DESCRIPTION
**What this PR does / why we need it**:

Github has recently added the ability to support a SUPPORT.md file that allows a project to point to support resources, similar to CONTRIBUTING.md

They support having SUPPORT.md in docs/ and .github but I figured it should be in root alongside CONTRIBUTING.md, but we can put it in one of those places if we want to keep the root clean. 

See also: 

https://help.github.com/articles/adding-support-resources-to-your-project/
https://github.com/blog/2400-support-file-support

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes https://github.com/kubernetes/community/issues/830