### PR TITLE
FC volume plugin: remove block device at DetachDisk

### DIFF
--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -142,7 +142,24 @@ func (detacher *fcDetacher) Detach(deviceMountPath string, nodeName types.NodeNa
 }
 
 func (detacher *fcDetacher) UnmountDevice(deviceMountPath string) error {
-	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
+	// Specify device name for DetachDisk later
+	devName, _, err := mount.GetDeviceNameFromMount(detacher.mounter, deviceMountPath)
+	if err != nil {
+		glog.Errorf("fc: failed to get device from mnt: %s\nError: %v", deviceMountPath, err)
+		return err
+	}
+	// Unmount for deviceMountPath(=globalPDPath)
+	err = volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
+	if err != nil {
+		return fmt.Errorf("fc: failed to unmount: %s\nError: %v", deviceMountPath, err)
+	}
+	unMounter := volumeSpecToUnmounter(detacher.mounter)
+	err = detacher.manager.DetachDisk(*unMounter, devName)
+	if err != nil {
+		return fmt.Errorf("fc: failed to detach disk: %s\nError: %v", devName, err)
+	}
+	glog.V(4).Infof("fc: successfully detached disk: %s", devName)
+	return nil
 }
 
 func volumeSpecToMounter(spec *volume.Spec, host volume.VolumeHost) (*fcDiskMounter, error) {
@@ -167,4 +184,13 @@ func volumeSpecToMounter(spec *volume.Spec, host volume.VolumeHost) (*fcDiskMoun
 		readOnly: readOnly,
 		mounter:  &mount.SafeFormatAndMount{Interface: host.GetMounter(), Runner: exec.New()},
 	}, nil
+}
+
+func volumeSpecToUnmounter(mounter mount.Interface) *fcDiskUnmounter {
+	return &fcDiskUnmounter{
+		fcDisk: &fcDisk{
+			io: &osIOHandler{},
+		},
+		mounter: mounter,
+	}
 }

--- a/pkg/volume/fc/disk_manager.go
+++ b/pkg/volume/fc/disk_manager.go
@@ -30,7 +30,7 @@ type diskManager interface {
 	// Attaches the disk to the kubelet's host machine.
 	AttachDisk(b fcDiskMounter) (string, error)
 	// Detaches the disk from the kubelet's host machine.
-	DetachDisk(disk fcDiskUnmounter, mntPath string) error
+	DetachDisk(disk fcDiskUnmounter, devName string) error
 }
 
 // utility to mount a disk based filesystem


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

After a volume is unmounted from pod and worker node, and then PV and PVC are deleted, cluster admin or external-provisioner might delete the disk from storage, therefore block device on the node should be cleaned up beforehand.

The photon volume plugin already has same functionality.

**Which issue this PR fixes**: fixes #49392

**Special notes for your reviewer**:

/assign @rootfs  
/cc @jsafrane @saad-ali 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
