### PR TITLE
Fix controller crash because of nil volume spec

### DIFF
--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -115,6 +115,10 @@ func (og *operationGenerator) GenerateVolumesAreAttachedFunc(
 	volumeSpecMap := make(map[*volume.Spec]v1.UniqueVolumeName)
 	// Iterate each volume spec and put them into a map index by the pluginName
 	for _, volumeAttached := range attachedVolumes {
+		if volumeAttached.VolumeSpec == nil {
+			glog.Errorf("VerifyVolumesAreAttached.GenerateVolumesAreAttachedFunc: nil spec for volume %s", volumeAttached.VolumeName)
+			continue
+		}
 		volumePlugin, err :=
 			og.volumePluginMgr.FindPluginBySpec(volumeAttached.VolumeSpec)
 		if err != nil || volumePlugin == nil {


### PR DESCRIPTION
For volumes that don't support bulk volume verification, a nil
volume spec can cause crash of controller.

Fixes #49418

**Release note**:
```release-note
Fixes #49418 where kube-controller-manager can panic on volume.CanSupport methods and enter a crash loop.
```
