### PR TITLE
add apiservices to "kubectl get" help info

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -202,6 +202,7 @@ __custom_func() {
 	validResources = `Valid resource types include:
 
     * all
+    * apiservices
     * certificatesigningrequests (aka 'csr')
     * clusterrolebindings
     * clusterroles


### PR DESCRIPTION
Now I am learning Aggregated API Servers feature.
I found that kubectl get -h didn't show "apiservices"
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
