### PR TITLE
Do not spin forever if kubectl drain races with other removal

### DIFF
--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -495,9 +495,12 @@ func (o *DrainOptions) evictPods(pods []api.Pod, policyGroupVersion string, getP
 				err = o.evictPod(pod, policyGroupVersion)
 				if err == nil {
 					break
+				} else if apierrors.IsNotFound(err) {
+					doneCh <- true
+					return
 				} else if apierrors.IsTooManyRequests(err) {
 					time.Sleep(5 * time.Second)
-				} else if !apierrors.IsNotFound(err) {
+				} else {
 					errCh <- fmt.Errorf("error when evicting pod %q: %v", pod.Name, err)
 					return
 				}


### PR DESCRIPTION
In https://github.com/kubernetes/kubernetes/pull/47450 we stopped
returning an error if a pod disappeared before we could remove it.
Instead we just continue to spin forever. Return "success" if a pod
disappeared before we actually removed it.

https://bugzilla.redhat.com/1473777
bug 1473777

```release-note
`kubectl drain` no longer spins trying to delete pods that do not exist
```
