### PR TITLE
Small change: Clear pvc Evaluator creation

### DIFF
--- a/pkg/quota/evaluator/core/persistent_volume_claims.go
+++ b/pkg/quota/evaluator/core/persistent_volume_claims.go
@@ -82,9 +82,11 @@ func listPersistentVolumeClaimsByNamespaceFuncUsingClient(kubeClient clientset.I
 // NewPersistentVolumeClaimEvaluator returns an evaluator that can evaluate persistent volume claims
 // if the specified shared informer factory is not nil, evaluator may use it to support listing functions.
 func NewPersistentVolumeClaimEvaluator(kubeClient clientset.Interface, f informers.SharedInformerFactory) quota.Evaluator {
-	listFuncByNamespace := listPersistentVolumeClaimsByNamespaceFuncUsingClient(kubeClient)
+	var listFuncByNamespace generic.ListFuncByNamespace
 	if f != nil {
 		listFuncByNamespace = generic.ListResourceUsingInformerFunc(f, v1.SchemeGroupVersion.WithResource("persistentvolumeclaims"))
+	} else {
+		listFuncByNamespace = listPersistentVolumeClaimsByNamespaceFuncUsingClient(kubeClient)
 	}
 	return &pvcEvaluator{
 		listFuncByNamespace: listFuncByNamespace,

--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -70,9 +70,11 @@ func listPodsByNamespaceFuncUsingClient(kubeClient clientset.Interface) generic.
 // NewPodEvaluator returns an evaluator that can evaluate pods
 // if the specified shared informer factory is not nil, evaluator may use it to support listing functions.
 func NewPodEvaluator(kubeClient clientset.Interface, f informers.SharedInformerFactory) quota.Evaluator {
-	listFuncByNamespace := listPodsByNamespaceFuncUsingClient(kubeClient)
+	var listFuncByNamespace generic.ListFuncByNamespace
 	if f != nil {
 		listFuncByNamespace = generic.ListResourceUsingInformerFunc(f, v1.SchemeGroupVersion.WithResource("pods"))
+	} else {
+		listFuncByNamespace = listPodsByNamespaceFuncUsingClient(kubeClient)
 	}
 	return &podEvaluator{
 		listFuncByNamespace: listFuncByNamespace,


### PR DESCRIPTION
Make it clear that if informer is not nil, do not need to list pvcs by namespace using kube client
Same to pods.

**Release note**:
```release-note
NONE
```
