### PR TITLE
apimachinery: fail early with deepcopy problems during roundtrip tests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
@@ -276,6 +276,12 @@ func roundTrip(t *testing.T, scheme *runtime.Scheme, codec runtime.Codec, object
 	object = copied.(runtime.Object)
 	name := reflect.TypeOf(object).Elem().Name()
 
+	// catch deepcopy errors early
+	if !apiequality.Semantic.DeepEqual(original, object) {
+		t.Errorf("%v: DeepCopy did not lead to equal object, diff: %v", name, diff.ObjectReflectDiff(original, object))
+		return
+	}
+
 	// encode (serialize) the deep copy using the provided codec
 	data, err := runtime.Encode(codec, object)
 	if err != nil {


### PR DESCRIPTION
If deepcopy is broken for some type, it's easy to diagnose. This PR let's the roundtrip test to fail early in this case.