### PR TITLE
Supply Portworx StorageClass paramters in volume spec labels for server-side processing

### DIFF
--- a/pkg/volume/portworx/portworx_util.go
+++ b/pkg/volume/portworx/portworx_util.go
@@ -55,13 +55,17 @@ func (util *PortworxVolumeUtil) CreateVolume(p *portworxVolumeProvisioner) (stri
 	// Portworx Volumes are specified in GB
 	requestGB := int(volume.RoundUpSize(capacity.Value(), 1024*1024*1024))
 
+	// Perform a best-effort parsing of parameters. Portworx 1.2.9 and later parses volume parameters from
+	// spec.VolumeLabels. So even if below SpecFromOpts() fails to parse certain parameters or
+	// doesn't support new parameters, the server-side processing will parse it correctly.
+	// We still need to call SpecFromOpts() here to handle cases where someone is running Portworx 1.2.8 and lower.
 	specHandler := osdspec.NewSpecHandler()
 	spec, _ := specHandler.SpecFromOpts(p.options.Parameters)
 	if spec == nil {
 		spec = specHandler.DefaultSpec()
 	}
 
-	// Pass all parameters as volume labels for Portworx server-side processing
+	// Pass all parameters as volume labels for Portworx server-side processing.
 	spec.VolumeLabels = p.options.Parameters
 
 	spec.Size = uint64(requestGB * 1024 * 1024 * 1024)

--- a/pkg/volume/portworx/portworx_util.go
+++ b/pkg/volume/portworx/portworx_util.go
@@ -56,11 +56,14 @@ func (util *PortworxVolumeUtil) CreateVolume(p *portworxVolumeProvisioner) (stri
 	requestGB := int(volume.RoundUpSize(capacity.Value(), 1024*1024*1024))
 
 	specHandler := osdspec.NewSpecHandler()
-	spec, err := specHandler.SpecFromOpts(p.options.Parameters)
-	if err != nil {
-		glog.Errorf("Error parsing parameters for PVC: %v. Err: %v", p.options.PVC.Name, err)
-		return "", 0, nil, err
+	spec, _ := specHandler.SpecFromOpts(p.options.Parameters)
+	if spec == nil {
+		spec = specHandler.DefaultSpec()
 	}
+
+	// Pass all parameters as volume labels for Portworx server-side processing
+	spec.VolumeLabels = p.options.Parameters
+
 	spec.Size = uint64(requestGB * 1024 * 1024 * 1024)
 	source := osdapi.Source{}
 	locator := osdapi.VolumeLocator{


### PR DESCRIPTION
**What this PR does / why we need it**:
This change offloads the requirement of successfully parsing all existing and new portworx volume parameters to it's server-side components. As a result, for fixing bugs in existing volume parameters parsing and adding new support, we will not need to submit a k8s PR.

**Which issue this PR fixes**: fixes #49525 

**Release note**:
```release-note
Fix incorrect parsing of io_priority in Portworx volume StorageClass and add support for new paramters.
```
