### PR TITLE
flexvolume: remove a mount directory in a error case

### DIFF
--- a/pkg/volume/flexvolume/mounter.go
+++ b/pkg/volume/flexvolume/mounter.go
@@ -17,6 +17,7 @@ limitations under the License.
 package flexvolume
 
 import (
+	"os"
 	"strconv"
 
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -74,6 +75,7 @@ func (f *flexVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 
 	// Extract secret and pass it as options.
 	if err := addSecretsToOptions(extraOptions, f.spec, f.podNamespace, f.driverName, f.plugin.host); err != nil {
+		os.Remove(dir)
 		return err
 	}
 
@@ -90,6 +92,7 @@ func (f *flexVolumeMounter) SetUpAt(dir string, fsGroup *int64) error {
 	}
 
 	if err != nil {
+		os.Remove(dir)
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

flexVolumeMounter.SetUpAt creates a directory, where a volume has to be
mounted, and we have to remove this directory in a error case. Otherwise
we see errors like this:

Orphaned pod 673b66d9-70f7-11e7-a5fa-525400307392 found, but volume paths are still present on disk

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/kubernetes/kubernetes/issues/49383

**Special notes for your reviewer**:

**Release note**:

Fix a rollback code for the flexvolume mount operation