### PR TITLE
Automated cherry pick of #49212 upstream release 1.7

### DIFF
--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: rescheduler-v0.3.0
+  name: rescheduler-v0.3.1
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: rescheduler
-    version: v0.3.0
+    version: v0.3.1
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google-containers/rescheduler:v0.3.0
+  - image: gcr.io/google-containers/rescheduler:v0.3.1
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log


### PR DESCRIPTION
Cherry pick of #49212 on release-1.7.

#49212: Bump rescheduler version to v0.3.1