### PR TITLE
Add new node to nodesToUpdateStatusFor when nodeAdd event is received

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -450,7 +450,7 @@ func (adc *attachDetachController) nodeAdd(obj interface{}) {
 	// This is to workaround the case when a node add causes to wipe out
 	// the attached volumes field. This function ensures that we sync with
 	// the actual status.
-	adc.actualStateOfWorld.SetNodeStatusUpdateNeeded(nodeName)
+	adc.actualStateOfWorld.AddNodeIntoUpdateStatusFor(nodeName)
 }
 
 func (adc *attachDetachController) nodeUpdate(oldObj, newObj interface{}) {

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -125,6 +125,10 @@ type ActualStateOfWorld interface {
 
 	// GetNodesToUpdateStatusFor returns the map of nodeNames to nodeToUpdateStatusFor
 	GetNodesToUpdateStatusFor() map[types.NodeName]nodeToUpdateStatusFor
+
+	// AddNodeIntoUpdateStatusFor add node to nodesToUpdateStatusFor when
+	// the specified node does not exists in the nodesToUpdateStatusFor list.
+	AddNodeIntoUpdateStatusFor(nodeName types.NodeName)
 }
 
 // AttachedVolume represents a volume that is attached to a node.
@@ -496,6 +500,30 @@ func (asw *actualStateOfWorld) SetNodeStatusUpdateNeeded(nodeName types.NodeName
 	if err := asw.updateNodeStatusUpdateNeeded(nodeName, true); err != nil {
 		glog.Errorf("Failed to update statusUpdateNeeded field in actual state of world: %v", err)
 	}
+}
+
+// AddNodeIntoUpdateStatusFor add node to nodesToUpdateStatusFor when
+// the specified node does not exists in the nodesToUpdateStatusFor list.
+func (asw *actualStateOfWorld) AddNodeIntoUpdateStatusFor(nodeName types.NodeName) {
+	asw.Lock()
+	defer asw.Unlock()
+	nodeToUpdate, nodeToUpdateExists := asw.nodesToUpdateStatusFor[nodeName]
+	if nodeToUpdateExists {
+		glog.V(4).Infof("The node %q already exists in nodesToUpdateStatusFor", nodeName)
+		// Update the actual status
+		nodeToUpdate.statusUpdateNeeded = true
+		asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+		return
+	}
+
+	// Add new node, no need to update the actual status
+	nodeToUpdate = nodeToUpdateStatusFor{
+		nodeName:                  nodeName,
+		statusUpdateNeeded:        false,
+		volumesToReportAsAttached: make(map[v1.UniqueVolumeName]v1.UniqueVolumeName),
+	}
+	asw.nodesToUpdateStatusFor[nodeName] = nodeToUpdate
+	glog.V(4).Infof("Add new node %q to nodesToUpdateStatusFor", nodeName)
 }
 
 func (asw *actualStateOfWorld) DeleteVolumeNode(

--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world_test.go
@@ -152,6 +152,34 @@ func Test_AddVolumeNode_Positive_ExistingVolumeExistingNode(t *testing.T) {
 	verifyAttachedVolume(t, attachedVolumes, generatedVolumeName1, string(volumeName), nodeName, devicePath, true /* expectedMountedByNode */, false /* expectNonZeroDetachRequestedTime */)
 }
 
+// Test_AddNodeIntoUpdateStatusFor expects the map nodesToUpdateStatusFor
+// adds a new node if the AddNodeFromAttachUpdates is called on a node that
+// does not exist in the actual state of the world.
+func Test_AddNodeIntoUpdateStatusFor(t *testing.T) {
+	// Arrange
+	volumePluginMgr, _ := volumetesting.GetTestVolumePluginMgr(t)
+	asw := NewActualStateOfWorld(volumePluginMgr)
+	nodeName := types.NodeName("new-node")
+
+	// Act
+	asw.AddNodeIntoUpdateStatusFor(nodeName)
+
+	// Assert
+	nodesToUpdateStatusFor := asw.GetNodesToUpdateStatusFor()
+	if len(nodesToUpdateStatusFor) != 1 {
+		t.Fatalf("the new node should be added into nodesToUpdateStatusFor.")
+	}
+
+	// Act again
+	asw.AddNodeIntoUpdateStatusFor(nodeName)
+
+	// Assert
+	nodesToUpdateStatusFor = asw.GetNodesToUpdateStatusFor()
+	if len(nodesToUpdateStatusFor) != 1 {
+		t.Fatalf("the new node should be added into nodesToUpdateStatusFor.")
+	}
+}
+
 // Populates data struct with one volume/node entry.
 // Calls DeleteVolumeNode() to delete volume/node.
 // Verifies no volume/node entries exists.


### PR DESCRIPTION
Fix #49549
Using SetNodeStatusUpdateNeeded when node already be added, and
using AddNodeFromAttachUpdates when nodeAdd event is received.

**Release note**:
```release-note
NONE
```
