### PR TITLE
add back defaulting for parameter decoding

### DIFF
--- a/pkg/api/testing/defaulting_test.go
+++ b/pkg/api/testing/defaulting_test.go
@@ -58,8 +58,6 @@ func TestDefaulting(t *testing.T) {
 		{Group: "", Version: "v1", Kind: "PersistentVolumeList"}:                                  {},
 		{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"}:                                 {},
 		{Group: "", Version: "v1", Kind: "PersistentVolumeClaimList"}:                             {},
-		{Group: "", Version: "v1", Kind: "PodAttachOptions"}:                                      {},
-		{Group: "", Version: "v1", Kind: "PodExecOptions"}:                                        {},
 		{Group: "", Version: "v1", Kind: "Pod"}:                                                   {},
 		{Group: "", Version: "v1", Kind: "PodList"}:                                               {},
 		{Group: "", Version: "v1", Kind: "PodTemplate"}:                                           {},

--- a/pkg/apis/core/v1/defaults.go
+++ b/pkg/apis/core/v1/defaults.go
@@ -39,14 +39,6 @@ func SetDefaults_ResourceList(obj *v1.ResourceList) {
 	}
 }
 
-func SetDefaults_PodExecOptions(obj *v1.PodExecOptions) {
-	obj.Stdout = true
-	obj.Stderr = true
-}
-func SetDefaults_PodAttachOptions(obj *v1.PodAttachOptions) {
-	obj.Stdout = true
-	obj.Stderr = true
-}
 func SetDefaults_ReplicationController(obj *v1.ReplicationController) {
 	var labels map[string]string
 	if obj.Spec.Template != nil {

--- a/pkg/apis/core/v1/zz_generated.defaults.go
+++ b/pkg/apis/core/v1/zz_generated.defaults.go
@@ -46,8 +46,6 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 	})
 	scheme.AddTypeDefaultingFunc(&v1.PersistentVolumeList{}, func(obj interface{}) { SetObjectDefaults_PersistentVolumeList(obj.(*v1.PersistentVolumeList)) })
 	scheme.AddTypeDefaultingFunc(&v1.Pod{}, func(obj interface{}) { SetObjectDefaults_Pod(obj.(*v1.Pod)) })
-	scheme.AddTypeDefaultingFunc(&v1.PodAttachOptions{}, func(obj interface{}) { SetObjectDefaults_PodAttachOptions(obj.(*v1.PodAttachOptions)) })
-	scheme.AddTypeDefaultingFunc(&v1.PodExecOptions{}, func(obj interface{}) { SetObjectDefaults_PodExecOptions(obj.(*v1.PodExecOptions)) })
 	scheme.AddTypeDefaultingFunc(&v1.PodList{}, func(obj interface{}) { SetObjectDefaults_PodList(obj.(*v1.PodList)) })
 	scheme.AddTypeDefaultingFunc(&v1.PodTemplate{}, func(obj interface{}) { SetObjectDefaults_PodTemplate(obj.(*v1.PodTemplate)) })
 	scheme.AddTypeDefaultingFunc(&v1.PodTemplateList{}, func(obj interface{}) { SetObjectDefaults_PodTemplateList(obj.(*v1.PodTemplateList)) })
@@ -306,14 +304,6 @@ func SetObjectDefaults_Pod(in *v1.Pod) {
 			}
 		}
 	}
-}
-
-func SetObjectDefaults_PodAttachOptions(in *v1.PodAttachOptions) {
-	SetDefaults_PodAttachOptions(in)
-}
-
-func SetObjectDefaults_PodExecOptions(in *v1.PodExecOptions) {
-	SetDefaults_PodExecOptions(in)
 }
 
 func SetObjectDefaults_PodList(in *v1.PodList) {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec.go
@@ -139,6 +139,7 @@ func NewParameterCodec(scheme *Scheme) ParameterCodec {
 		typer:     scheme,
 		convertor: scheme,
 		creator:   scheme,
+		defaulter: scheme,
 	}
 }
 
@@ -147,6 +148,7 @@ type parameterCodec struct {
 	typer     ObjectTyper
 	convertor ObjectConvertor
 	creator   ObjectCreater
+	defaulter ObjectDefaulter
 }
 
 var _ ParameterCodec = &parameterCodec{}
@@ -163,15 +165,27 @@ func (c *parameterCodec) DecodeParameters(parameters url.Values, from schema.Gro
 	}
 	for i := range targetGVKs {
 		if targetGVKs[i].GroupVersion() == from {
-			return c.convertor.Convert(&parameters, into, nil)
+			if err := c.convertor.Convert(&parameters, into, nil); err != nil {
+				return err
+			}
+			// in the case where we going into the same object we're receiving, default on the outbound object
+			if c.defaulter != nil {
+				c.defaulter.Default(into)
+			}
+			return nil
 		}
 	}
+
 	input, err := c.creator.New(from.WithKind(targetGVKs[0].Kind))
 	if err != nil {
 		return err
 	}
 	if err := c.convertor.Convert(&parameters, input, nil); err != nil {
 		return err
+	}
+	// if we have defaulter, default the input before converting to output
+	if c.defaulter != nil {
+		c.defaulter.Default(input)
 	}
 	return c.convertor.Convert(input, into, nil)
 }


### PR DESCRIPTION
At the beginning of 1.7, we removed the last "conversion causes defaulting".  This broke the "default to true" behavior for exec and attach options, but we didn't notice.  This removes the broken defaulter (you can default a non-point bool to true on an object) and adds back defaulting to parameter codecs.

@k8s-mirror-api-machinery-misc @lavalamp @smarterclayton 