### PR TITLE
Add sig-testing OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -35,10 +35,17 @@ aliases:
     - smarterclayton
     - soltysh
     - sttts
-  test-infra-maintainers:
+  sig-testing-reviewers:
     - fejta
     - ixdy
     - rmmh
+    - spiffxp
+    - spxtr
+  sig-testing-approvers:
+    - fejta
+    - ixdy
+    - rmmh
+    - spiffxp
     - spxtr
   sig-node-reviewers:
     - Random-Liu

--- a/hack/jenkins/OWNERS
+++ b/hack/jenkins/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- test-infra-maintainers
+- sig-testing-approvers
 reviewers:
-- test-infra-maintainers
+- sig-testing-reviewers

--- a/test/OWNERS
+++ b/test/OWNERS
@@ -4,10 +4,8 @@ reviewers:
   - enisoc
   - erictune
   - fabianofranz # for test/e2e/kubectl.go
-  - fejta
   - foxish # for test/e2e/network-partition.go
   - gmarek
-  - ixdy
   - janetkuo
   - kow3ns # for test/e2e/statefulset.go
   - krousey
@@ -17,12 +15,10 @@ reviewers:
   - mikedanese
   - ncdc
   - pwittrock # for test/e2e/kubectl.go
-  - rmmh
   - saad-ali
   - smarterclayton
   - soltysh
-  - spiffxp
-  - spxtr
+  - sig-testing-reviewers
   - sttts
   - zmerlynn
 approvers:
@@ -32,10 +28,8 @@ approvers:
   - eparis
   - erictune
   - fabianofranz # for test/e2e/kubectl.go
-  - fejta
   - foxish # for test/e2e/network-partition.go
   - gmarek
-  - ixdy
   - janetkuo
   - kow3ns # for test/e2e/statefulset.go
   - krousey
@@ -46,9 +40,8 @@ approvers:
   - ncdc
   - pwittrock # for test/e2e/kubectl.go
   - saad-ali
+  - sig-testing-approvers
   - smarterclayton
   - soltysh
-  - spiffxp
-  - spxtr
   - sttts
   - zmerlynn


### PR DESCRIPTION
/sig testing

**What this PR does / why we need it**: 

follow the sig-foo-{reviewers,approvers} convention
- rename test-infra-maintainers to sig-testing-approvers
- copy sig-testing-approvers to sig-testing-reviewers
- remove inviduals in test/OWNERS in favor of new aliases

as a result
- rmmh gets test/ approver privileges
- spiffxp gets hack/jenkins/ approver privileges

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49580

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```