### PR TITLE
WIP: Barebone prototype of Flexvolume plugin prober, with dependency injection through VolumeHost.

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -178,6 +178,7 @@ func startAttachDetachController(ctx ControllerContext) (bool, error) {
 			ctx.Options.DisableAttachDetachReconcilerSync,
 			ctx.Options.ReconcilerSyncLoopPeriod.Duration,
 			attachdetach.DefaultTimerConfig,
+			ctx.Options.VolumeConfiguration,
 		)
 	if attachDetachControllerErr != nil {
 		return true, fmt.Errorf("failed to start attach/detach controller: %v", attachDetachControllerErr)

--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -42,7 +42,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/azure_file"
 	"k8s.io/kubernetes/pkg/volume/cinder"
 	"k8s.io/kubernetes/pkg/volume/fc"
-	"k8s.io/kubernetes/pkg/volume/flexvolume"
+	//"k8s.io/kubernetes/pkg/volume/flexvolume"
 	"k8s.io/kubernetes/pkg/volume/flocker"
 	"k8s.io/kubernetes/pkg/volume/gce_pd"
 	"k8s.io/kubernetes/pkg/volume/glusterfs"
@@ -71,7 +71,7 @@ func ProbeAttachableVolumePlugins(config componentconfig.VolumeConfiguration) []
 	allPlugins = append(allPlugins, aws_ebs.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, gce_pd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, cinder.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(config.FlexVolumePluginDir)...)
+	//allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(config.FlexVolumePluginDir)...)
 	allPlugins = append(allPlugins, portworx.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, vsphere_volume.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, azure_dd.ProbeVolumePlugins()...)

--- a/cmd/kubelet/app/plugins.go
+++ b/cmd/kubelet/app/plugins.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/volume/downwardapi"
 	"k8s.io/kubernetes/pkg/volume/empty_dir"
 	"k8s.io/kubernetes/pkg/volume/fc"
-	"k8s.io/kubernetes/pkg/volume/flexvolume"
+	//"k8s.io/kubernetes/pkg/volume/flexvolume"
 	"k8s.io/kubernetes/pkg/volume/flocker"
 	"k8s.io/kubernetes/pkg/volume/gce_pd"
 	"k8s.io/kubernetes/pkg/volume/git_repo"
@@ -88,7 +88,7 @@ func ProbeVolumePlugins(pluginDir string) []volume.VolumePlugin {
 	allPlugins = append(allPlugins, downwardapi.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, fc.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, flocker.ProbeVolumePlugins()...)
-	allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(pluginDir)...)
+	//allPlugins = append(allPlugins, flexvolume.ProbeVolumePlugins(pluginDir)...)
 	allPlugins = append(allPlugins, azure_file.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, configmap.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, vsphere_volume.ProbeVolumePlugins()...)

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -96,3 +96,7 @@ func (adc *PersistentVolumeController) GetConfigMapFunc() func(namespace, name s
 func (ctrl *PersistentVolumeController) GetNodeLabels() (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in PersistentVolumeController")
 }
+
+func (ctrl *PersistentVolumeController) ProbeFlexVolumePlugins() []vol.VolumePlugin {
+	return nil
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -717,7 +717,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dep
 		kubeDeps.Recorder)
 
 	klet.volumePluginMgr, err =
-		NewInitializedVolumePluginMgr(klet, secretManager, configMapManager, kubeDeps.VolumePlugins)
+		NewInitializedVolumePluginMgr(klet, secretManager, configMapManager, kubeDeps.VolumePlugins, kubeCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -22,11 +22,22 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 )
 
-// This is the primary entrypoint for volume plugins.
-func ProbeVolumePlugins(pluginDir string) []volume.VolumePlugin {
+type FlexVolumeProber interface {
+	Probe() []volume.VolumePlugin
+}
+
+type flexVolumeProber struct {
+	pluginDir string
+}
+
+func NewFlexVolumeProber(pluginDir string) FlexVolumeProber {
+	return &flexVolumeProber{pluginDir: pluginDir}
+}
+
+func (prober *flexVolumeProber) Probe() []volume.VolumePlugin {
 	plugins := []volume.VolumePlugin{}
 
-	files, _ := ioutil.ReadDir(pluginDir)
+	files, _ := ioutil.ReadDir(prober.pluginDir)
 	for _, f := range files {
 		// only directories are counted as plugins
 		// and pluginDir/dirname/dirname should be an executable
@@ -34,7 +45,7 @@ func ProbeVolumePlugins(pluginDir string) []volume.VolumePlugin {
 		// e.g. dirname = vendor~cifs
 		// then, executable will be pluginDir/dirname/cifs
 		if f.IsDir() {
-			plugin, err := NewFlexVolumePlugin(pluginDir, f.Name())
+			plugin, err := NewFlexVolumePlugin(prober.pluginDir, f.Name())
 			if err != nil {
 				continue
 			}

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -246,6 +246,8 @@ type VolumeHost interface {
 
 	// Returns the labels on the node
 	GetNodeLabels() (map[string]string, error)
+
+	ProbeFlexVolumePlugins() []VolumePlugin
 }
 
 // VolumePluginMgr tracks registered plugins.

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	. "k8s.io/kubernetes/pkg/volume"
+	"k8s.io/kubernetes/pkg/volume/flexvolume"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 )
 
@@ -150,6 +151,11 @@ func (f *fakeVolumeHost) GetConfigMapFunc() func(namespace, name string) (*v1.Co
 
 func (f *fakeVolumeHost) GetNodeLabels() (map[string]string, error) {
 	return map[string]string{"test-label": "test-value"}, nil
+}
+
+func (f *fakeVolumeHost) ProbeFlexVolumePlugins() []VolumePlugin {
+	// TODO implement
+	return nil
 }
 
 func ProbeVolumePlugins(config VolumeConfig) []VolumePlugin {


### PR DESCRIPTION
See the design proposal here: https://github.com/kubernetes/community/pull/833

To make the Flexvolume Prober available for VolumePluginMgr to use, in the design doc I proposed using PluginStub as the plugin type in plugins list and have Prober implement it. There are flaws to this approach, as discussed in the Alternative Designs section.

Instead, I would like to propose a different solution: adding a method GetFlexvolumePlugins() to VolumeHost. VolumePluginMgr already contains an instance of VolumeHost, making it easy to access probed plugins. There is a lot less code change comparing to alternatives, and to me it makes sense because plugin probing is a host operation.

Is this a valid approach?

do-not-merge

/release-note-none

/sig-storage

/cc @chakri-nelluri @saad-ali @gnufied 