### PR TITLE
make cAdvisor configs in kubelet configurable

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -524,7 +524,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies) (err error) {
 	}
 
 	if kubeDeps.CAdvisorInterface == nil {
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(s.Address, uint(s.CAdvisorPort), s.ContainerRuntime, s.RootDirectory)
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(s.Address, uint(s.CAdvisorPort), s.CAdvisorStatsCacheDuration, s.CAdvisorMaxHousekeepingInterval, s.CAdvisorAllowDynamicHousekeeping, s.ContainerRuntime, s.RootDirectory)
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -271,6 +271,14 @@ type KubeletConfiguration struct {
 	MaxContainerCount int32
 	// cAdvisorPort is the port of the localhost cAdvisor endpoint
 	CAdvisorPort int32
+	// cAdvisorStatsCacheDuration is the amount of time for cAdvisor to keep stats in memory.
+	// Must be greater than or equal to 0.
+	CAdvisorStatsCacheDuration metav1.Duration
+	// cAdvisorMaxHousekeepingInterval is the largest interval for cAdvisor to allow between container housekeepings.
+	// Must be greater than or equal to 0.
+	CAdvisorMaxHousekeepingInterval metav1.Duration
+	// cAdvisorAllowDynamicHousekeeping indicates whether to allow cAdvisor's housekeeping interval to be dynamic.
+	CAdvisorAllowDynamicHousekeeping bool
 	// healthzPort is the port of the localhost healthz endpoint
 	HealthzPort int32
 	// healthzBindAddress is the IP address for the healthz server to serve

--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/github.com/google/cadvisor/utils/sysfs:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
     ],
 )

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/metrics"
 	"github.com/google/cadvisor/utils/sysfs"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -49,12 +50,7 @@ type cadvisorClient struct {
 
 var _ Interface = new(cadvisorClient)
 
-// TODO(vmarmol): Make configurable.
-// The amount of time for which to keep stats in memory.
-const statsCacheDuration = 2 * time.Minute
-const maxHousekeepingInterval = 15 * time.Second
 const defaultHousekeepingInterval = 10 * time.Second
-const allowDynamicHousekeeping = true
 
 func init() {
 	// Override cAdvisor flag defaults.
@@ -96,7 +92,7 @@ func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
 }
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(address string, port uint, runtime string, rootPath string) (Interface, error) {
+func New(address string, port uint, statscacheDuration, maxHousekeepingInterval metav1.Duration, allowDynamicHousekeeping bool, runtime string, rootPath string) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
 	// Create and start the cAdvisor container manager.


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR makes three cadvisor configs `CAdvisorStatsCacheDuration`, `CAdvisorMaxHousekeepingInterval`, `CAdvisorAllowDynamicHousekeeping` configurable in kubelet.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Special notes for your reviewer**:
make cAdvisor configs in kubelet configurable

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
make cAdvisor configs in kubelet configurable
```
