### PR TITLE
getHashEquivalencePod should return if equivalence pod is found

### DIFF
--- a/plugin/pkg/scheduler/core/equivalence_cache.go
+++ b/plugin/pkg/scheduler/core/equivalence_cache.go
@@ -51,7 +51,7 @@ func newAlgorithmCache() AlgorithmCache {
 	}
 }
 
-// Store a map of predicate cache with maxsize
+// EquivalenceCache stores a map of predicate cache with maxsize
 type EquivalenceCache struct {
 	sync.RWMutex
 	getEquivalencePod algorithm.GetEquivalencePodFunc
@@ -179,13 +179,14 @@ func (ec *EquivalenceCache) InvalidateCachedPredicateItemForPodAdd(pod *v1.Pod, 
 }
 
 // getHashEquivalencePod returns the hash of equivalence pod.
-// if no equivalence pod found, return 0
-func (ec *EquivalenceCache) getHashEquivalencePod(pod *v1.Pod) uint64 {
+// 1. equivalenceHash
+// 2. if equivalence pod is found
+func (ec *EquivalenceCache) getHashEquivalencePod(pod *v1.Pod) (uint64, bool) {
 	equivalencePod := ec.getEquivalencePod(pod)
 	if equivalencePod != nil {
 		hash := fnv.New32a()
 		hashutil.DeepHashObject(hash, equivalencePod)
-		return uint64(hash.Sum32())
+		return uint64(hash.Sum32()), true
 	}
-	return 0
+	return 0, false
 }

--- a/plugin/pkg/scheduler/core/equivalence_cache_test.go
+++ b/plugin/pkg/scheduler/core/equivalence_cache_test.go
@@ -287,9 +287,9 @@ func TestGetHashEquivalencePod(t *testing.T) {
 		},
 	}
 
-	hash1 := ecache.getHashEquivalencePod(pod1)
-	hash2 := ecache.getHashEquivalencePod(pod2)
-	hash3 := ecache.getHashEquivalencePod(pod3)
+	hash1, _ := ecache.getHashEquivalencePod(pod1)
+	hash2, _ := ecache.getHashEquivalencePod(pod2)
+	hash3, _ := ecache.getHashEquivalencePod(pod3)
 
 	if hash1 != hash2 {
 		t.Errorf("Failed: pod %v and %v is expected to be equivalent", pod1.Name, pod2.Name)
@@ -305,11 +305,10 @@ func TestGetHashEquivalencePod(t *testing.T) {
 			Name: "pod4",
 		},
 	}
-	hash4 := ecache.getHashEquivalencePod(pod4)
-
-	if hash4 != 0 {
-		t.Errorf("Failed: equivalence hash of pod %v is expected to be: 0, but got: %v",
-			pod4.Name, hash4)
+	_, found := ecache.getHashEquivalencePod(pod4)
+	if found {
+		t.Errorf("Failed: equivalence hash of pod %v is not expected to be found, but got: %v",
+			pod4.Name, found)
 	}
 }
 

--- a/plugin/pkg/scheduler/core/generic_scheduler.go
+++ b/plugin/pkg/scheduler/core/generic_scheduler.go
@@ -244,8 +244,7 @@ func podFitsOnNode(pod *v1.Pod, meta interface{}, info *schedulercache.NodeInfo,
 	)
 	if ecache != nil {
 		// getHashEquivalencePod will return immediately if no equivalence pod found
-		equivalenceHash = ecache.getHashEquivalencePod(pod)
-		eCacheAvailable = (equivalenceHash != 0)
+		equivalenceHash, eCacheAvailable = ecache.getHashEquivalencePod(pod)
 	}
 	for predicateKey, predicate := range predicateFuncs {
 		// If equivalenceCache is available


### PR DESCRIPTION
Signed-off-by: sakeven <jc5930@sina.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

getHashEquivalencePod should return if equivalence pod is found, rather than simply check equivalenceHash equals to 0 later.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
