### PR TITLE
Add daemonset to all categories

### DIFF
--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -746,12 +746,12 @@ func TestDiscoveryReplaceAliases(t *testing.T) {
 		{
 			name:     "all-replacement",
 			arg:      "all",
-			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,deployments.extensions,replicasets.extensions",
+			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,daemonsets.extensions,deployments.extensions,replicasets.extensions",
 		},
 		{
 			name:     "alias-in-comma-separated-arg",
 			arg:      "all,secrets",
-			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,deployments.extensions,replicasets.extensions,secrets",
+			expected: "pods,replicationcontrollers,services,statefulsets.apps,horizontalpodautoscalers.autoscaling,jobs.batch,cronjobs.batch,daemonsets.extensions,deployments.extensions,replicasets.extensions,secrets",
 		},
 	}
 

--- a/pkg/kubectl/resource/categories.go
+++ b/pkg/kubectl/resource/categories.go
@@ -118,6 +118,7 @@ var legacyUserResources = []schema.GroupResource{
 	{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
 	{Group: "batch", Resource: "jobs"},
 	{Group: "batch", Resource: "cronjobs"},
+	{Group: "extensions", Resource: "daemonsets"},
 	{Group: "extensions", Resource: "deployments"},
 	{Group: "extensions", Resource: "replicasets"},
 }

--- a/pkg/kubectl/resource/categories_test.go
+++ b/pkg/kubectl/resource/categories_test.go
@@ -47,6 +47,7 @@ func TestCategoryExpansion(t *testing.T) {
 				{Resource: "horizontalpodautoscalers", Group: "autoscaling"},
 				{Resource: "jobs", Group: "batch"},
 				{Resource: "cronjobs", Group: "batch"},
+				{Resource: "daemonsets", Group: "extensions"},
 				{Resource: "deployments", Group: "extensions"},
 				{Resource: "replicasets", Group: "extensions"},
 			},

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -67,6 +67,13 @@ func (r *REST) ShortNames() []string {
 	return []string{"ds"}
 }
 
+var _ rest.CategoriesProvider = &REST{}
+
+// Categories implements the CategoriesProvider interface. Returns a list of categories a resource is part of.
+func (r *REST) Categories() []string {
+	return []string{"all"}
+}
+
 // StatusREST implements the REST endpoint for changing the status of a daemonset
 type StatusREST struct {
 	store *genericregistry.Store


### PR DESCRIPTION

**What this PR does / why we need it**:
We could get daemonset resource by running command `kubectl get all`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fix https://github.com/kubernetes/kubernetes/issues/49620

