### PR TITLE
Return warning instead of Error when no cloud provider provided

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -57,6 +57,13 @@ import (
 )
 
 func startServiceController(ctx ControllerContext) (bool, error) {
+	if ctx.Cloud == nil {
+		// don't return error when no cloud provider provided, just output a WARNING
+		glog.Warning("WARNING: no cloud provider provided, services of type LoadBalancer will fail." +
+			" Will not start service controller.")
+		return false, nil
+	}
+
 	serviceController, err := servicecontroller.New(
 		ctx.Cloud,
 		ctx.ClientBuilder.ClientOrDie("service-controller"),

--- a/pkg/controller/service/servicecontroller.go
+++ b/pkg/controller/service/servicecontroller.go
@@ -206,10 +206,6 @@ func (s *ServiceController) worker() {
 }
 
 func (s *ServiceController) init() error {
-	if s.cloud == nil {
-		return fmt.Errorf("WARNING: no cloud provider provided, services of type LoadBalancer will fail.")
-	}
-
 	balancer, ok := s.cloud.LoadBalancer()
 	if !ok {
 		return fmt.Errorf("the cloud provider does not support external load balancers.")


### PR DESCRIPTION
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#49612

**Release note**:
```release-note
NONE
```
