### PR TITLE
Remove default binding of system:node role to system:nodes group

### DIFF
--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -115,9 +115,6 @@ func (config AuthorizationConfig) New() (authorizer.Authorizer, error) {
 			nodeAuthorizer := node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
 			authorizers = append(authorizers, nodeAuthorizer)
 
-			// Don't bind system:nodes to the system:node role
-			bootstrappolicy.AddClusterRoleBindingFilter(bootstrappolicy.OmitNodesGroupBinding)
-
 		case modes.ModeAlwaysAllow:
 			authorizers = append(authorizers, authorizerfactory.NewAlwaysAllowAuthorizer())
 		case modes.ModeAlwaysDeny:

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-role-bindings.yaml
@@ -121,10 +121,7 @@ items:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole
     name: system:node
-  subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:nodes
+  subjects: []
 - apiVersion: rbac.authorization.k8s.io/v1beta1
   kind: ClusterRoleBinding
   metadata:

--- a/test/integration/auth/BUILD
+++ b/test/integration/auth/BUILD
@@ -49,7 +49,6 @@ go_test(
         "//plugin/pkg/admission/noderestriction:go_default_library",
         "//plugin/pkg/auth/authenticator/token/bootstrap:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac:go_default_library",
-        "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
         "//test/e2e/lifecycle/bootstrap:go_default_library",
         "//test/integration:go_default_library",
         "//test/integration/framework:go_default_library",

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -38,7 +38,6 @@ import (
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/kubeapiserver/authorizer"
 	"k8s.io/kubernetes/plugin/pkg/admission/noderestriction"
-	"k8s.io/kubernetes/plugin/pkg/auth/authorizer/rbac/bootstrappolicy"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -79,7 +78,6 @@ func TestNodeAuthorizer(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer bootstrappolicy.ClearClusterRoleBindingFilters()
 
 	// Set up NodeRestriction admission
 	nodeRestrictionAdmission := noderestriction.NewPlugin(nodeidentifier.NewDefaultNodeIdentifier())


### PR DESCRIPTION
part of https://github.com/kubernetes/features/issues/279

deprecation of this automatic binding announced in 1.7 in https://github.com/kubernetes/kubernetes/pull/46076

```release-note
RBAC: the `system:node` role is no longer automatically granted to the `system:nodes` group in new clusters. It is recommended that nodes be authorized using the `Node` authorization mode instead. Installations that wish to continue giving all members of the `system:nodes` group the `system:node` role (which grants broad read access, including all secrets and configmaps) must create an installation-specific `ClusterRoleBinding`.
```