### PR TITLE
Run mount in its own systemd scope.

### DIFF
--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -94,15 +94,6 @@ func (mounter *SafeFormatAndMount) FormatAndMount(source string, target string, 
 	return mounter.formatAndMount(source, target, fstype, options)
 }
 
-// New returns a mount.Interface for the current system.
-// It provides options to override the default mounter behavior.
-// mounterPath allows using an alternative to `/bin/mount` for mounting.
-func New(mounterPath string) Interface {
-	return &Mounter{
-		mounterPath: mounterPath,
-	}
-}
-
 // GetMountRefs finds all other references to the device referenced
 // by mountPath; returns a list of paths.
 func GetMountRefs(mounter Interface, mountPath string) ([]string, error) {

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -22,6 +22,15 @@ type Mounter struct {
 	mounterPath string
 }
 
+// New returns a mount.Interface for the current system.
+// It provides options to override the default mounter behavior.
+// mounterPath allows using an alternative to `/bin/mount` for mounting.
+func New(mounterPath string) Interface {
+	return &Mounter{
+		mounterPath: mounterPath,
+	}
+}
+
 func (mounter *Mounter) Mount(source string, target string, fstype string, options []string) error {
 	return nil
 }

--- a/pkg/util/mount/nsenter_mount.go
+++ b/pkg/util/mount/nsenter_mount.go
@@ -50,7 +50,7 @@ import (
 //     contents. TODO: remove this requirement.
 // 6.  The host image must have mount, findmnt, and umount binaries in /bin,
 //     /usr/sbin, or /usr/bin
-//
+// 7.  The host image should have systemd-run in /bin, /usr/sbin, or /usr/bin
 // For more information about mount propagation modes, see:
 //   https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
 type NsenterMounter struct {
@@ -61,9 +61,10 @@ type NsenterMounter struct {
 func NewNsenterMounter() *NsenterMounter {
 	m := &NsenterMounter{
 		paths: map[string]string{
-			"mount":   "",
-			"findmnt": "",
-			"umount":  "",
+			"mount":       "",
+			"findmnt":     "",
+			"umount":      "",
+			"systemd-run": "",
 		},
 	}
 	// search for the mount command in other locations besides /usr/bin
@@ -79,6 +80,7 @@ func NewNsenterMounter() *NsenterMounter {
 			break
 		}
 		// TODO: error, so that the kubelet can stop if the mounts don't exist
+		// (don't forget that systemd-run is optional)
 	}
 	return m
 }
@@ -127,15 +129,47 @@ func (n *NsenterMounter) doNsenterMount(source, target, fstype string, options [
 // makeNsenterArgs makes a list of argument to nsenter in order to do the
 // requested mount.
 func (n *NsenterMounter) makeNsenterArgs(source, target, fstype string, options []string) []string {
+	mountCmd := n.absHostPath("mount")
+	mountArgs := makeMountArgs(source, target, fstype, options)
+
+	if systemdRunPath, hasSystemd := n.paths["systemd-run"]; hasSystemd {
+		// Complete command line:
+		// nsenter --mount=/rootfs/proc/1/ns/mnt -- /bin/systemd-run --description=... --scope -- /bin/mount -t <type> <what> <where>
+		// Expected flow is:
+		// * nsenter breaks out of container's mount namespace and executes
+		//   host's systemd-run.
+		// * systemd-run creates a transient scope (=~ cgroup) and executes its
+		//   argument (/bin/mount) there.
+		// * mount does its job, forks a fuse daemon if necessary and finishes.
+		//   (systemd-run --scope finishes at this point, returning mount's exit
+		//   code and stdout/stderr - thats one of --scope benefits).
+		// * systemd keeps the fuse daemon running in the scope (i.e. in its own
+		//   cgroup) until the fuse daemon dies (another --scope benefit).
+		//   Kubelet container can be restarted and the fuse daemon survives.
+		// * When the daemon dies (e.g. during unmount) systemd removes the
+		//   scope automatically.
+		mountCmd, mountArgs = addSystemdScope(systemdRunPath, target, mountCmd, mountArgs)
+	} else {
+		// Fall back to simple mount when the host has no systemd.
+		// Complete command line:
+		// nsenter --mount=/rootfs/proc/1/ns/mnt -- /bin/mount -t <type> <what> <where>
+		// Expected flow is:
+		// * nsenter breaks out of container's mount namespace and executes host's /bin/mount.
+		// * mount does its job, forks a fuse daemon if necessary and finishes.
+		// * Any fuse daemon runs in cgroup of kubelet docker container,
+		//   restart of kubelet container will kill it!
+
+		// No code here, mountCmd and mountArgs use /bin/mount
+	}
+
 	nsenterArgs := []string{
 		"--mount=/rootfs/proc/1/ns/mnt",
 		"--",
-		n.absHostPath("mount"),
+		mountCmd,
 	}
+	nsenterArgs = append(nsenterArgs, mountArgs...)
 
-	args := makeMountArgs(source, target, fstype, options)
-
-	return append(nsenterArgs, args...)
+	return nsenterArgs
 }
 
 // Unmount runs umount(8) in the host's mount namespace.
@@ -146,7 +180,9 @@ func (n *NsenterMounter) Unmount(target string) error {
 		n.absHostPath("umount"),
 		target,
 	}
-
+	// No need to execute systemd-run here, it's enough that unmount is executed
+	// in the host's mount namespace. It will finish appropriate fuse daemon(s)
+	// running in any scope.
 	glog.V(5).Infof("Unmount command: %v %v", nsenterPath, args)
 	exec := exec.New()
 	outputBytes, err := exec.Command(nsenterPath, args...).CombinedOutput()


### PR DESCRIPTION
Kubelet needs to run /bin/mount in its own cgroup.

- When kubelet runs as a systemd service, "systemctl restart kubelet" may kill all processes in the same cgroup and thus terminate fuse daemons that are needed for gluster and cephfs mounts.

- When kubelet runs in a docker container, restart of the container kills all fuse daemons started in the container.

Killing fuse daemons is bad, it basically unmounts volumes from running pods.

This patch runs mount via "systemd-run --scope /bin/mount ...", which makes sure that any fuse daemons are forked in its own systemd scope (= cgroup) and they will survive restart of kubelet's systemd service or docker container.

This helps with #34965

As a downside, each new fuse daemon will run in its own transient systemd service and systemctl output may be cluttered.

@kubernetes/sig-storage-pr-reviews 
@kubernetes/sig-node-pr-reviews 

```release-note
fuse daemons for GlusterFS and CephFS are now run in their own systemd scope when Kubernetes runs on a system with systemd.
```
