### PR TITLE
StatefulSet: Remove `initialized` annotation from apps/v1beta2.

### DIFF
--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	// StatefulSetInitAnnotation if present, and set to false, indicates that a Pod's readiness should be ignored.
-	StatefulSetInitAnnotation      = "pod.alpha.kubernetes.io/initialized"
 	ControllerRevisionHashLabelKey = "controller-revision-hash"
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 )


### PR DESCRIPTION
The annotation was already removed from apps/v1beta1 in #49251, but this copy survived due to another concurrent PR.

ref #41605