### PR TITLE
Move the audit e2e test out of the node SIG

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -49,6 +49,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "audit.go",
         "certificates.go",
         "dashboard.go",
         "e2e.go",

--- a/test/e2e/audit.go
+++ b/test/e2e/audit.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package node
+package e2e
 
 import (
 	"bufio"
@@ -29,7 +29,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Advanced Audit [Feature:Audit]", func() {
+var _ = framework.KubeDescribe("Advanced Audit [Feature:Audit]", func() {
 	f := framework.NewDefaultFramework("audit")
 
 	It("should audit API calls", func() {

--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -11,7 +11,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "apparmor.go",
-        "audit.go",
         "kubelet.go",
         "kubelet_perf.go",
         "nodeoutofdisk.go",


### PR DESCRIPTION
It was mistakenly moved to sig-node in https://github.com/kubernetes/kubernetes/pull/48910, but this is an apiserver feature, not a node feature.

/cc @crassirostris 