### PR TITLE
make admission tolerate object without objectmeta for errors

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/BUILD
@@ -13,10 +13,12 @@ go_test(
     srcs = [
         "chain_test.go",
         "config_test.go",
+        "errors_test.go",
     ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/apiserver:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/admission/errors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/errors.go
@@ -24,13 +24,19 @@ import (
 )
 
 func extractResourceName(a Attributes) (name string, resource schema.GroupResource, err error) {
-	name = "Unknown"
 	resource = a.GetResource().GroupResource()
+
+	if len(a.GetName()) > 0 {
+		return a.GetName(), resource, nil
+	}
+
+	name = "Unknown"
 	obj := a.GetObject()
 	if obj != nil {
 		accessor, err := meta.Accessor(obj)
 		if err != nil {
-			return "", schema.GroupResource{}, err
+			// not all object have ObjectMeta.  If we don't, return a name with a slash (always illegal)
+			return "Unknown/errorGettingName", resource, nil
 		}
 
 		// this is necessary because name object name generation has not occurred yet

--- a/staging/src/k8s.io/apiserver/pkg/admission/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/errors_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// makes sure that we never get:
+// Internal error occurred: [some error, object does not implement the Object interfaces]
+func TestNewForbidden(t *testing.T) {
+	attributes := NewAttributesRecord(
+		&fakeObj{},
+		nil,
+		schema.GroupVersionKind{Group: "foo", Version: "bar", Kind: "Baz"},
+		"",
+		"",
+		schema.GroupVersionResource{Group: "foo", Version: "bar", Resource: "baz"},
+		"",
+		Create,
+		nil)
+	err := errors.New("some error")
+	expectedErr := `baz.foo "Unknown/errorGettingName" is forbidden: some error`
+
+	actualErr := NewForbidden(attributes, err)
+	if actualErr.Error() != expectedErr {
+		t.Errorf("expected %v, got %v", expectedErr, actualErr)
+	}
+}
+
+type fakeObj struct{}
+type fakeObjKind struct{}
+
+func (f *fakeObj) GetObjectKind() schema.ObjectKind {
+	return &fakeObjKind{}
+}
+func (f *fakeObj) DeepCopyObject() runtime.Object {
+	return f
+}
+
+func (f *fakeObjKind) SetGroupVersionKind(kind schema.GroupVersionKind) {}
+func (f *fakeObjKind) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: "foo", Version: "bar", Kind: "Baz"}
+}


### PR DESCRIPTION
Not all object have ObjectMeta (see SARs for instance).  Admission should tolerate this condition without giving meaningless errors.

@derekwaynecarr ptal
@php-coder fyi