### PR TITLE
Fix pods stuck in Pending state forever

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -195,12 +195,14 @@ func (sched *Scheduler) assume(pod *v1.Pod, host string) (*v1.Pod, error) {
 	if err := sched.config.SchedulerCache.AssumePod(&assumed); err != nil {
 		glog.Errorf("scheduler cache AssumePod failed: %v", err)
 
+		// This is most probably result of a BUG in retrying logic.
+		// We report an error here so that pod scheduling can be retried.
 		sched.config.Error(pod, err)
 		sched.config.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", "AssumePod failed: %v", err)
 		sched.config.PodConditionUpdater.Update(pod, &v1.PodCondition{
 			Type:    v1.PodScheduled,
 			Status:  v1.ConditionFalse,
-			Reason:  "AssumePodFailed",
+			Reason:  "SchedulerError",
 			Message: err.Error(),
 		})
 		return nil, err

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -17,7 +17,6 @@ limitations under the License.
 package scheduler
 
 import (
-	"fmt"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -223,6 +222,9 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 	// If binding succeeded then PodScheduled condition will be updated in apiserver so that
 	// it's atomic with setting host.
 	err := sched.config.Binder.Bind(b)
+	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
+		glog.Errorf("scheduler cache FinishBinding failed: %v", err)
+	}
 	if err != nil {
 		glog.V(1).Infof("Failed to bind pod: %v/%v", assumed.Namespace, assumed.Name)
 		if err := sched.config.SchedulerCache.ForgetPod(assumed); err != nil {
@@ -236,10 +238,6 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 			Reason: "BindingRejected",
 		})
 		return err
-	}
-
-	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
-		return fmt.Errorf("scheduler cache FinishBinding failed: %v", err)
 	}
 
 	metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -152,7 +152,7 @@ func TestScheduler(t *testing.T) {
 			sendPod:        podWithID("foo", ""),
 			assumePodError: errA,
 			algo:           mockScheduler{testNode.Name, nil},
-			expectErrorPod: podWithID("foo", ""),
+			expectErrorPod: podWithID("foo", testNode.Name),
 			eventReason:    "FailedScheduling",
 			expectError:    errA,
 		},

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -24,17 +24,19 @@ import (
 
 // FakeCache is used for testing
 type FakeCache struct {
-	AssumeFunc func(*v1.Pod)
+	AssumeFunc func(*v1.Pod) error
+	ForgetFunc func(*v1.Pod) error
 }
 
 func (f *FakeCache) AssumePod(pod *v1.Pod) error {
-	f.AssumeFunc(pod)
-	return nil
+	return f.AssumeFunc(pod)
 }
 
 func (f *FakeCache) FinishBinding(pod *v1.Pod) error { return nil }
 
-func (f *FakeCache) ForgetPod(pod *v1.Pod) error { return nil }
+func (f *FakeCache) ForgetPod(pod *v1.Pod) error { 
+	return f.ForgetFunc(pod)
+}
 
 func (f *FakeCache) AddPod(pod *v1.Pod) error { return nil }
 

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -34,7 +34,7 @@ func (f *FakeCache) AssumePod(pod *v1.Pod) error {
 
 func (f *FakeCache) FinishBinding(pod *v1.Pod) error { return nil }
 
-func (f *FakeCache) ForgetPod(pod *v1.Pod) error { 
+func (f *FakeCache) ForgetPod(pod *v1.Pod) error {
 	return f.ForgetFunc(pod)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes 2 bugs introduced into the scheduler in https://github.com/kubernetes/kubernetes/commit/ecb962e6585#diff-67f2b61521299ca8d8687b0933bbfb19R223.

Together, they meant that when a pod fails to bind to a node, it can end up stuck in the Pending state indefinitely. The way this happened was:

1. The pod fails to bind to the node
2. `ForgetPod` fails, because the wrong `*v1.Pod` struct was passed into `bind` and therefore `ForgetPod`  (`pod` instead of `assumed`) -- `ForgetPod` requires that the pod ask it to forget matches the pod in the cache
3. `bind` returns immediately after ForgetPod fails instead of correctly reporting an error, because of this line: https://github.com/kubernetes/kubernetes/commit/ecb962e6585#diff-67f2b61521299ca8d8687b0933bbfb19R223 -- this should be a `glog.Errorf`, not a return. The return on that line causes the function to skip the error handling, which means that the pod isn't put back onto the queue to attempt scheduling again.
4. Because the pod isn't put back on to the queue, the pod stays stuck in `Pending` forever until the scheduler is restarted.

This also adds better error handling when `AssumePod` fails -- it seems to me that any time pod scheduling fails, we should handle the error with `sched.config.Error` and put the pod back in the queue to be rescheduled instead of silently failing and leaving the pod potentially stuck in `Pending` forever.

It also adds 2 new unit tests, which test:

- when both `ForgetPod` and `Bind` fail, the correct error is reported
- when `AssumePod` fails, the correct error is reported
- when `Bind` fails, the correct pod is passed into ForgetPod

**Which issue this PR fixes** 
fixes #49314 

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix bug where pods stuck in Pending state forever after binding fails
```
