### PR TITLE
improve detectability of deleted pods

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1359,14 +1359,14 @@ func podNotPending(c clientset.Interface, podName, namespace string) wait.Condit
 // to terminate or if the pod terminated with an unexpected reason.
 func waitForPodTerminatedInNamespace(c clientset.Interface, podName, reason, namespace string) error {
 	return WaitForPodCondition(c, namespace, podName, "terminated due to deadline exceeded", PodStartTimeout, func(pod *v1.Pod) (bool, error) {
-		if pod.Status.Phase == v1.PodFailed {
-			if pod.Status.Reason == reason {
+		if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+			if reason == "" ||
+				strings.ToLower(strings.TrimSpace(pod.Status.Reason)) == strings.ToLower(strings.TrimSpace(reason)) {
 				return true, nil
 			} else {
-				return true, fmt.Errorf("Expected pod %v in namespace %v to be terminated with reason %v, got reason: %v", podName, namespace, reason, pod.Status.Reason)
+				return true, fmt.Errorf("Expected pod %q in namespace %q to be terminated with reason %q, got reason: %q", podName, namespace, reason, pod.Status.Reason)
 			}
 		}
-
 		return false, nil
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds comment to `waitForPodTerminatedInNamespace` to better explain how it's implemented.
~~It improves pod deletion detection in the e2e framework as follows:~~
~~1.  the `waitForPodTerminatedInNamespace` func looks for pod.Status.Phase ==  _PodFailed_ or _PodSucceeded_ since both values imply that all containers have terminated.~~
~~2.  the `waitForPodTerminatedInNamespace` func also ignores the pod's Reason if the passed-in `reason` parm is "". Reason is not really relevant to the pod being deleted or not, but if the caller passes a non-blank `reason` then it will be lower-cased, de-blanked and compared to the pod's Reason (also lower-cased and de-blanked). The idea is to make Reason checking more flexible and to prevent a pod from being considered running when all of its containers have terminated just because of a Reason mis-match.~~

Releated to pr [49597](https://github.com/kubernetes/kubernetes/pull/49597) and issue [49529](https://github.com/kubernetes/kubernetes/issues/49529).

**Release note**:
```release-note
NONE
```