### PR TITLE
Add and update doc.go files throughout kubelet

### DIFF
--- a/pkg/kubelet/apis/BUILD
+++ b/pkg/kubelet/apis/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "well_known_annotations.go",
         "well_known_labels.go",
     ],

--- a/pkg/kubelet/apis/cri/BUILD
+++ b/pkg/kubelet/apis/cri/BUILD
@@ -7,7 +7,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["services.go"],
+    srcs = [
+        "doc.go",
+        "services.go",
+    ],
     deps = ["//pkg/kubelet/apis/cri/v1alpha1/runtime:go_default_library"],
 )
 

--- a/pkg/kubelet/apis/cri/doc.go
+++ b/pkg/kubelet/apis/cri/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package cri (Container Runtime Interface) allows pluggable container runtimes.
+package cri

--- a/pkg/kubelet/apis/doc.go
+++ b/pkg/kubelet/apis/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package apis provides the API server, including the Container Runtime
+// Interface (CRI) and stats.
+package apis

--- a/pkg/kubelet/cadvisor/doc.go
+++ b/pkg/kubelet/cadvisor/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Kubelet interactions with cAdvisor.
+// Package cadvisor provides kubelet interaction with cAdvisor.
 package cadvisor // import "k8s.io/kubernetes/pkg/kubelet/cadvisor"

--- a/pkg/kubelet/certificate/BUILD
+++ b/pkg/kubelet/certificate/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "certificate_manager.go",
         "certificate_store.go",
+        "doc.go",
         "kubelet.go",
         "transport.go",
     ],

--- a/pkg/kubelet/certificate/doc.go
+++ b/pkg/kubelet/certificate/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+/*
+Package certificate provides certificate management. It provides a certificate store
+that stores key/cert pairs. It also provides a certificate manager which rotates and
+updates certificates. The certificate manager also starts the API server stats sync loop.
+*/
+package certificate

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -9,6 +9,7 @@ go_library(
         "container_manager_unsupported.go",
         "device_plugin_handler.go",
         "device_plugin_handler_stub.go",
+        "doc.go",
         "fake_internal_container_lifecycle.go",
         "helpers_unsupported.go",
         "internal_container_lifecycle.go",

--- a/pkg/kubelet/cm/doc.go
+++ b/pkg/kubelet/cm/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+/*
+Package cm (Container Manager) provides container creation and management. It
+interfaces, on the [Linux] host, with cgroups via OCI's libcontainer. cm also
+provides stubs for unsupported hosts.
+
+Includes QOS containers and provides pod level container management if QOS
+cgroup is enabled.
+*/
+package cm

--- a/pkg/kubelet/configmap/BUILD
+++ b/pkg/kubelet/configmap/BUILD
@@ -10,6 +10,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "configmap_manager.go",
+        "doc.go",
         "fake_manager.go",
     ],
     deps = [

--- a/pkg/kubelet/configmap/doc.go
+++ b/pkg/kubelet/configmap/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+/*
+Package configmap provides storage and management of pod ConfigMaps. Implements
+a cache of ConfigMaps for registered pods. Interfaces with the API server to fetch
+ConfigMaps not valid in cache.
+*/
+package configmap

--- a/pkg/kubelet/container/BUILD
+++ b/pkg/kubelet/container/BUILD
@@ -6,6 +6,7 @@ go_library(
         "cache.go",
         "container_gc.go",
         "container_reference_manager.go",
+        "doc.go",
         "helpers.go",
         "os.go",
         "pty_unsupported.go",

--- a/pkg/kubelet/container/doc.go
+++ b/pkg/kubelet/container/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+/*
+Package container provides various container related functionality. Provides
+garbage collection of containers. Provides a cache of pods as well as a cache
+of pod status'. Also provides generation and management of container references.
+*/
+package container

--- a/pkg/kubelet/doc.go
+++ b/pkg/kubelet/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package kubelet is the package that contains the libraries that drive the Kubelet binary.
-// The kubelet is responsible for node level pod management.  It runs on each worker in the cluster.
+// Package kubelet provides the libraries that drive the Kubelet binary. The kubelet
+// is responsible for node level pod management.  It runs on each worker in the cluster.
 package kubelet // import "k8s.io/kubernetes/pkg/kubelet"

--- a/pkg/kubelet/envvars/doc.go
+++ b/pkg/kubelet/envvars/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package envvars is the package that build the environment variables that kubernetes provides
-// to the containers run by it.
+// Package envvars provides the construction of environment variables
+// provided to containers managed by Kubernetes.
 package envvars // import "k8s.io/kubernetes/pkg/kubelet/envvars"

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package events provides event constants.
 package events
 
 const (

--- a/pkg/kubelet/gpu/BUILD
+++ b/pkg/kubelet/gpu/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "gpu_manager_stub.go",
         "types.go",
     ],

--- a/pkg/kubelet/gpu/doc.go
+++ b/pkg/kubelet/gpu/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package gpu provides management of the GPU on a local node.
+package gpu

--- a/pkg/kubelet/lifecycle/doc.go
+++ b/pkg/kubelet/lifecycle/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Handlers for pod lifecycle events and interfaces to integrate
-// with kubelet admission, synchronization, and eviction of pods.
+// Package lifecycle provides handlers for pod lifecycle events and interfaces
+// to integrate with kubelet admission, synchronization, and eviction of pods.
 package lifecycle // import "k8s.io/kubernetes/pkg/kubelet/lifecycle"

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package metrics provides pod and container metrics.
 package metrics
 
 import (

--- a/pkg/kubelet/network/BUILD
+++ b/pkg/kubelet/network/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "network.go",
         "plugins.go",
     ],

--- a/pkg/kubelet/network/doc.go
+++ b/pkg/kubelet/network/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package network provides kubelet with support for network plugins
+// following the Container Network Interface (CNI).
+package network

--- a/pkg/kubelet/pod/BUILD
+++ b/pkg/kubelet/pod/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "mirror_client.go",
         "pod_manager.go",
     ],

--- a/pkg/kubelet/pod/doc.go
+++ b/pkg/kubelet/pod/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package pod provides the pod manager. Manager stores and manages access
+// to pods, maintaining the mappings between static pods and mirror pods.
+package pod

--- a/pkg/kubelet/preemption/preemption.go
+++ b/pkg/kubelet/preemption/preemption.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package preemtion provides eviction of pods in order to enable admission
+// of critical pods. Pods are evicted in a best effort attempt to cause minimal impact.
 package preemption
 
 import (

--- a/pkg/kubelet/prober/BUILD
+++ b/pkg/kubelet/prober/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "prober.go",
         "prober_manager.go",
         "worker.go",

--- a/pkg/kubelet/prober/doc.go
+++ b/pkg/kubelet/prober/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+/*
+Package prober provides probing of containers to ascertain liveness/readiness.
+Pods are managed by the probe manager, probe manager creates a worker for
+every container to periodically probe the container and caches the results.
+*/
+package prober

--- a/pkg/kubelet/qos/doc.go
+++ b/pkg/kubelet/qos/doc.go
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// package qos contains helper functions for quality of service.
-// For each resource (memory, CPU) Kubelet supports three classes of containers.
-// Memory guaranteed containers will receive the highest priority and will get all the resources
-// they need.
-// Burstable containers will be guaranteed their request and can “burst” and use more resources
-// when available.
-// Best-Effort containers, which don’t specify a request, can use resources only if not being used
-// by other pods.
+/*
+Package qos contains helper functions for quality of service. For each resource (memory, CPU)
+Kubelet supports three classes of containers. Memory guaranteed containers will receive the highest
+priority and will get all the resources they need. Burstable containers will be guaranteed their
+request and can “burst” and use more resources when available. Best-Effort containers, which don’t
+specify a request, can use resources only if not being used by other pods.
+*/
 package qos // import "k8s.io/kubernetes/pkg/kubelet/qos"

--- a/pkg/kubelet/rktshim/doc.go
+++ b/pkg/kubelet/rktshim/doc.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package rktshim is the package that contains the shim code for rkt to be used
-// as the kubelet container runtime implementation that is integrated using the
-// Container Runtime Interface.
+// Package rktshim provides the shim code for rkt to be used as the kubelet container
+// runtime implementation that is integrated using the Container Runtime Interface.
 package rktshim

--- a/pkg/kubelet/secret/BUILD
+++ b/pkg/kubelet/secret/BUILD
@@ -25,6 +25,7 @@ go_test(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "fake_manager.go",
         "secret_manager.go",
     ],

--- a/pkg/kubelet/secret/doc.go
+++ b/pkg/kubelet/secret/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package secret provides a secret manager to cache locally secrets from the API
+// server. Caches all secrets for registered pods.
+package secret

--- a/pkg/kubelet/status/BUILD
+++ b/pkg/kubelet/status/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "generate.go",
         "status_manager.go",
     ],

--- a/pkg/kubelet/status/doc.go
+++ b/pkg/kubelet/status/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package status provides the status manager. Status manager is the source of truth for kubelet
+// pod status. Manager provides status to other components and updates status in the API server.
+package status

--- a/pkg/kubelet/sysctl/BUILD
+++ b/pkg/kubelet/sysctl/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "namespace.go",
         "runtime.go",
         "whitelist.go",

--- a/pkg/kubelet/sysctl/doc.go
+++ b/pkg/kubelet/sysctl/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package sysctl provides verification of Linux kernel sysctl support by a container runtime.
+package sysctl

--- a/pkg/kubelet/types/doc.go
+++ b/pkg/kubelet/types/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Common types in the Kubelet.
+// Package types provides common types in the Kubelet.
 package types // import "k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/util/doc.go
+++ b/pkg/kubelet/util/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Utility functions.
+// Package util provides kubelet utility functions.
 package util // import "k8s.io/kubernetes/pkg/kubelet/util"

--- a/pkg/kubelet/volumemanager/BUILD
+++ b/pkg/kubelet/volumemanager/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["volume_manager.go"],
+    srcs = [
+        "doc.go",
+        "volume_manager.go",
+    ],
     deps = [
         "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",

--- a/pkg/kubelet/volumemanager/doc.go
+++ b/pkg/kubelet/volumemanager/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package dockershim provides Docker integration using
-//  pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
-package dockershim
+// Package volumemanager provides VolumeManager. Volume manager ensures volumes
+// are attached/mounted/unmounted/detached based on the pods scheduled on a node.
+package volumemanager


### PR DESCRIPTION
**What this PR does / why we need it**:

As noted in issue #11663 kubelet currently does not contain package doc comments for all packages.

This PR adds doc comments to all top level packages within kubelet; either as a `doc.go` file or, for packages with a single source file within that source file. Also, cleans up current doc strings to be consistent across the kubelet package, including some grammatical fixes.

**Special notes for your reviewer**:

I am new to the k8s project, please review wording to ensure it is correct. Comments are at times brief since I am not totally across the code base. 
