### PR TITLE
Reverting deprecation of vCenter port in vSphere Cloud Provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -332,8 +332,8 @@ func newVSphere(cfg VSphereConfig) (*VSphere, error) {
 	if cfg.Global.RoundTripperCount == 0 {
 		cfg.Global.RoundTripperCount = RoundTripperDefaultCount
 	}
-	if cfg.Global.VCenterPort != "" {
-		glog.Warningf("port is a deprecated field in vsphere.conf and will be removed in future release.")
+	if cfg.Global.VCenterPort == "" {
+		cfg.Global.VCenterPort = "443"
 	}
 
 	var c *govmomi.Client
@@ -382,7 +382,7 @@ func logout(vs *VSphere) {
 
 func newClient(ctx context.Context, cfg *VSphereConfig) (*govmomi.Client, error) {
 	// Parse URL from string
-	u, err := url.Parse(fmt.Sprintf("https://%s/sdk", cfg.Global.VCenterIP))
+	u, err := url.Parse(fmt.Sprintf("https://%s:%s/sdk", cfg.Global.VCenterIP, cfg.Global.VCenterPort))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_test.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_test.go
@@ -33,6 +33,7 @@ func configFromEnv() (cfg VSphereConfig, ok bool) {
 	var InsecureFlag bool
 	var err error
 	cfg.Global.VCenterIP = os.Getenv("VSPHERE_VCENTER")
+	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -61,6 +61,7 @@ func GetVSphere() (*VSphere, error) {
 func getVSphereConfig() *VSphereConfig {
 	var cfg VSphereConfig
 	cfg.Global.VCenterIP = os.Getenv("VSPHERE_VCENTER")
+	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR reverts back the deprecation of vCenter port made with PR: kubernetes#42024
We observed an issue when kubernetes cluster is deployed on the vCenter with non-default Port.
When VC is configured with non default port govmomi requests were going to default port 443. This is not valid, as confirmed in https://github.com/vmware/govmomi/issues/802


**Which issue this PR fixes**  
fixes # https://github.com/vmware/kubernetes/issues/220

**Special notes for your reviewer**:
Verified with deploying Kubernetes Cluster on the vCenter with port (7443).
Used following vsphere.conf file on master and worker nodes

```
# cat vsphere.conf
[Global]
        user = "Administrator@vsphere.local"
        password = "Admin!23"
        server = "10.192.87.209"
        port = "7443"
        insecure-flag = "1"
        datacenter = "Datacenter"
        datastore = "storage1"
        working-dir = "kubernetes"
[Disk]
	scsicontrollertype = pvscsi
```
Created Storage Class, PV, PVC and Pod. Verified Attach, Detach, Create and Delete Volume Operations are working as expected.


Also verified with completely removing port from vsphere.conf file. default 443 is used in this case.

```
# cat vsphere.conf
[Global]
        user = "Administrator@vsphere.local"
        password = "Admin!23"
        server = "10.192.66.216"
        insecure-flag = "1"
        datacenter = "Datacenter"
        datastore = "storage1"
        working-dir = "kubernetes"
[Disk]
	scsicontrollertype = pvscsi
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Revert deprecation of vCenter port in vSphere Cloud Provider.
```

@luomiao @BaluDontu @tusharnt @rohitjogvmw