### PR TITLE
fix missing verb at end of format string

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go
@@ -110,7 +110,7 @@ func TestExpired(t *testing.T) {
 				return
 			}
 			if test.wantExpired == valid {
-				t.Errorf("wanted expired %t, got %", test.wantExpired, !valid)
+				t.Errorf("wanted expired %t, got %t", test.wantExpired, !valid)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
A missing verb at end of format string in Errorf call happens in `vendor/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc_test.go`, This PR fixes this problem.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`