### PR TITLE
fix kubectl --as --as-group --request-timeout inside pods

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -485,6 +485,20 @@ func (config *inClusterClientConfig) ClientConfig() (*restclient.Config, error) 
 		if certificateAuthorityFile := config.overrides.ClusterInfo.CertificateAuthority; len(certificateAuthorityFile) > 0 {
 			icc.TLSClientConfig.CAFile = certificateAuthorityFile
 		}
+		if len(config.overrides.Timeout) > 0 {
+			timeout, err := ParseTimeout(config.overrides.Timeout)
+			if err != nil {
+				return nil, err
+			}
+			icc.Timeout = timeout
+		}
+		if len(config.overrides.AuthInfo.Impersonate) > 0 {
+			icc.Impersonate = restclient.ImpersonationConfig{
+				UserName: config.overrides.AuthInfo.Impersonate,
+				Groups:   config.overrides.AuthInfo.ImpersonateGroups,
+				Extra:    config.overrides.AuthInfo.ImpersonateUserExtra,
+			}
+		}
 	}
 
 	return icc, err

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/imdario/mergo"
 	restclient "k8s.io/client-go/rest"
@@ -438,6 +439,28 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 			},
 		},
 		{
+			overrides: &ConfigOverrides{
+				Timeout: "1s",
+			},
+		},
+		{
+			overrides: &ConfigOverrides{
+				AuthInfo: clientcmdapi.AuthInfo{
+					Impersonate:       "tom",
+					ImpersonateGroups: []string{"tenant-a", "system:master"},
+				},
+			},
+		},
+		{
+			overrides: &ConfigOverrides{
+				Timeout: "0",
+				AuthInfo: clientcmdapi.AuthInfo{
+					Impersonate:       "tom",
+					ImpersonateGroups: []string{"tenant-a", "system:master"},
+				},
+			},
+		},
+		{
 			overrides: &ConfigOverrides{},
 		},
 	}
@@ -446,6 +469,8 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 		expectedServer := "https://host-from-cluster.com"
 		expectedToken := "token-from-cluster"
 		expectedCAFile := "/path/to/ca-from-cluster.crt"
+		var expectedTimeout time.Duration
+		expectedImpersonate := restclient.ImpersonationConfig{}
 
 		icc := &inClusterClientConfig{
 			inClusterConfigProvider: func() (*restclient.Config, error) {
@@ -465,6 +490,16 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 			t.Fatalf("Unxpected error: %v", err)
 		}
 
+		if timeout := tc.overrides.Timeout; len(timeout) > 0 {
+			expectedTimeout, _ = ParseTimeout(timeout)
+		}
+		if impersonate := tc.overrides.AuthInfo.Impersonate; len(impersonate) > 0 {
+			expectedImpersonate = restclient.ImpersonationConfig{
+				UserName: tc.overrides.AuthInfo.Impersonate,
+				Groups:   tc.overrides.AuthInfo.ImpersonateGroups,
+				Extra:    tc.overrides.AuthInfo.ImpersonateUserExtra,
+			}
+		}
 		if overridenServer := tc.overrides.ClusterInfo.Server; len(overridenServer) > 0 {
 			expectedServer = overridenServer
 		}
@@ -475,6 +510,12 @@ func TestInClusterClientConfigPrecedence(t *testing.T) {
 			expectedCAFile = overridenCAFile
 		}
 
+		if clientConfig.Timeout != expectedTimeout {
+			t.Errorf("Expected server %v, got %v", expectedTimeout, clientConfig.Timeout)
+		}
+		if !reflect.DeepEqual(clientConfig.Impersonate, expectedImpersonate) {
+			t.Errorf("Expected server %v, got %v", expectedImpersonate, clientConfig.Impersonate)
+		}
 		if clientConfig.Host != expectedServer {
 			t.Errorf("Expected server %v, got %v", expectedServer, clientConfig.Host)
 		}

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -99,9 +99,8 @@ func TestInClusterConfig(t *testing.T) {
 	err1 := fmt.Errorf("unique error")
 
 	testCases := map[string]struct {
-		clientConfig  *testClientConfig
-		icc           *testICC
-		defaultConfig *DirectClientConfig
+		clientConfig *testClientConfig
+		icc          *testICC
 
 		checkedICC bool
 		result     *restclient.Config
@@ -126,31 +125,19 @@ func TestInClusterConfig(t *testing.T) {
 		},
 
 		"in-cluster checked when config is default": {
-			defaultConfig: default1,
-			clientConfig:  &testClientConfig{config: config1},
-			icc:           &testICC{},
+			clientConfig: &testClientConfig{config: config1},
+			icc:          &testICC{},
 
 			checkedICC: true,
 			result:     config1,
 			err:        nil,
 		},
 
-		"in-cluster not checked when default config is invalid": {
-			defaultConfig: defaultInvalid,
-			clientConfig:  &testClientConfig{config: config1},
-			icc:           &testICC{},
+		"in-cluster checked when config is not equal to default": {
+			clientConfig: &testClientConfig{config: config2},
+			icc:          &testICC{},
 
-			checkedICC: false,
-			result:     config1,
-			err:        nil,
-		},
-
-		"in-cluster not checked when config is not equal to default": {
-			defaultConfig: default1,
-			clientConfig:  &testClientConfig{config: config2},
-			icc:           &testICC{},
-
-			checkedICC: false,
+			checkedICC: true,
 			result:     config2,
 			err:        nil,
 		},
@@ -191,21 +178,11 @@ func TestInClusterConfig(t *testing.T) {
 			result:     config2,
 			err:        nil,
 		},
-
-		"in-cluster not checked when standard default is invalid": {
-			defaultConfig: &DefaultClientConfig,
-			clientConfig:  &testClientConfig{config: config2},
-			icc:           &testICC{},
-
-			checkedICC: false,
-			result:     config2,
-			err:        nil,
-		},
 	}
 
 	for name, test := range testCases {
 		c := &DeferredLoadingClientConfig{icc: test.icc}
-		c.loader = &ClientConfigLoadingRules{DefaultClientConfig: test.defaultConfig}
+		c.loader = &ClientConfigLoadingRules{}
 		c.clientConfig = test.clientConfig
 
 		cfg, err := c.ClientConfig()


### PR DESCRIPTION
Fixes:
https://github.com/kubernetes/kubernetes/issues/49622
https://github.com/kubernetes/kubernetes/issues/49343

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix --as, --as-group, --request-timeout for kubectl running inside a pod.
```
