### PR TITLE
Validate token length of TokenReview

### DIFF
--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -49,6 +49,10 @@ func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, include
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("namespace is not allowed on this type: %v", namespace))
 	}
 
+	if len(tokenReview.Spec.Token) == 0 {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("token is required for TokenReview in authentication"))
+	}
+
 	if r.tokenAuthenticator == nil {
 		return tokenReview, nil
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

I find API Resource TokenReview has no validation yet. Without validation, client may post unexpected data to API Server. I think we need to validate it before processing it.

This PR Validate TokenReview Resource.

Fixes #50588

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
