### PR TITLE
AddOrUpdateTaint should ignore duplicate Taint.

### DIFF
--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -753,7 +753,7 @@ func TestAddOrUpdateTaintOnNode(t *testing.T) {
 				{Key: "key1", Value: "value1", Effect: "NoSchedule"},
 				{Key: "key2", Value: "value2", Effect: "NoExecute"},
 			},
-			requestCount: 3,
+			requestCount: 2,
 		},
 		{
 			name: "add taint to node without taints",

--- a/pkg/util/taints/BUILD
+++ b/pkg/util/taints/BUILD
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//pkg/api:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 

--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -271,7 +271,7 @@ func AddOrUpdateTaint(node *v1.Node, taint *v1.Taint) (*v1.Node, bool, error) {
 	updated := false
 	for i := range nodeTaints {
 		if taint.MatchTaint(&nodeTaints[i]) {
-			if helper.Semantic.DeepEqual(taint, nodeTaints[i]) {
+			if helper.Semantic.DeepEqual(*taint, nodeTaints[i]) {
 				return newNode, false, nil
 			}
 			newTaints = append(newTaints, *taint)


### PR DESCRIPTION
The parameter of AddOrUpdateTaint is Taint pointer, so should use
Taint object itself to compare with the node's taint list to ignore
duplicate taint.

While doing #49384, found this issue and fixed.

Fixed part of #49384, other test cases will be added in the following patch

**Release note**:
```
None
```