### PR TITLE
set juju master charm state to blocked if the services appear to be failing

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -329,7 +329,7 @@ def idle_status(kube_api, kube_control):
             hookenv.status_set('active', 'Kubernetes master running.')
         else:
             msg = 'Stopped services: {}'.format(','.join(failing_services))
-            hookenv.status_set('waiting', msg)
+            hookenv.status_set('blocked', msg)
 
 
 def master_services_down():


### PR DESCRIPTION
**What this PR does / why we need it**: set the juju master charm state to blocked if the services appear to be failing

**Release note**:
```release-note
set the juju master charm state to blocked if the services appear to be failing
```
