### PR TITLE
fix apps DeploymentSpec conversion issue

### DIFF
--- a/pkg/apis/apps/v1beta1/conversion.go
+++ b/pkg/apis/apps/v1beta1/conversion.go
@@ -99,7 +99,7 @@ func Convert_v1beta1_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta1.Sta
 	} else {
 		out.Selector = nil
 	}
-	if err := s.Convert(&in.Template, &out.Template, 0); err != nil {
+	if err := k8s_api_v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if in.VolumeClaimTemplates != nil {
@@ -139,7 +139,7 @@ func Convert_apps_StatefulSetSpec_To_v1beta1_StatefulSetSpec(in *apps.StatefulSe
 	} else {
 		out.Selector = nil
 	}
-	if err := s.Convert(&in.Template, &out.Template, 0); err != nil {
+	if err := k8s_api_v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if in.VolumeClaimTemplates != nil {

--- a/pkg/apis/apps/v1beta2/conversion.go
+++ b/pkg/apis/apps/v1beta2/conversion.go
@@ -118,7 +118,7 @@ func Convert_v1beta2_StatefulSetSpec_To_apps_StatefulSetSpec(in *appsv1beta2.Sta
 	} else {
 		out.Selector = nil
 	}
-	if err := s.Convert(&in.Template, &out.Template, 0); err != nil {
+	if err := k8s_api_v1.Convert_v1_PodTemplateSpec_To_api_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if in.VolumeClaimTemplates != nil {
@@ -158,7 +158,7 @@ func Convert_apps_StatefulSetSpec_To_v1beta2_StatefulSetSpec(in *apps.StatefulSe
 	} else {
 		out.Selector = nil
 	}
-	if err := s.Convert(&in.Template, &out.Template, 0); err != nil {
+	if err := k8s_api_v1.Convert_api_PodTemplateSpec_To_v1_PodTemplateSpec(&in.Template, &out.Template, s); err != nil {
 		return err
 	}
 	if in.VolumeClaimTemplates != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

When working on #49645, I found current conversion for `v1.PodTemplateSpec` to `api.PodTemplateSpec` did not work properly. It should function as [L244-L246](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/apps/v1beta1/conversion.go#L244-L246).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/cc @janetkuo 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix apps DeploymentSpec conversion issue
```
