### PR TITLE
Lowercases hostname for kubeadm cert slice

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/certs_test.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/renstrom/dedent"
@@ -144,7 +145,7 @@ func TestSubCmdApiServerFlags(t *testing.T) {
 	if err != nil {
 		t.Errorf("couldn't get the hostname: %v", err)
 	}
-	for i, name := range []string{hostname, "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.mycluster.local"} {
+	for i, name := range []string{strings.ToLower(hostname), "kubernetes", "kubernetes.default", "kubernetes.default.svc", "kubernetes.default.svc.mycluster.local"} {
 		if APIserverCert.DNSNames[i] != name {
 			t.Errorf("APIserverCert.DNSNames[%d] is %s instead of %s", i, APIserverCert.DNSNames[i], name)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, unit tests on master were failing due to this error:
```
--- FAIL: TestSubCmdApiServerFlags (0.99s)
	certs_test.go:149: APIserverCert.DNSNames[0] is danehans-m-c1kp instead of DANEHANS-M-C1KP
```
The PR fixes the TestSubCmdApiServerFlags test, which uses the OS hostname to compare the apiserver serving cert and fails if the OS hostname is in caps.

**Which issue this PR fixes**: fixes # https://github.com/kubernetes/kubeadm/issues/361

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:-->
```NONE
```
