### PR TITLE
Avoid running panic

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -566,6 +566,10 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, _ v1.PodStatus, podStat
 			glog.V(4).Infof("Stopping PodSandbox for %q, will start new one", format.Pod(pod))
 		}
 
+		if podStatus == nil {
+			glog.Error("podStatus is nil")
+			return
+		}
 		killResult := m.killPodWithSyncResult(pod, kubecontainer.ConvertPodStatusToRunningPod(m.runtimeName, podStatus), nil)
 		result.AddPodSyncResult(killResult)
 		if killResult.Error() != nil {

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1804,6 +1804,10 @@ func (r *Runtime) SyncPod(pod *v1.Pod, _ v1.PodStatus, podStatus *kubecontainer.
 		}
 	}()
 	// TODO: (random-liu) Stop using running pod in SyncPod()
+	if podStatus == nil {
+		glog.Error("podStatus is nil")
+		return
+	}
 	runningPod := kubecontainer.ConvertPodStatusToRunningPod(r.Type(), podStatus)
 	// Add references to all containers.
 	unidentifiedContainers := make(map[kubecontainer.ContainerID]*kubecontainer.Container)


### PR DESCRIPTION
Kubelet_pods.go call ConvertPodStatusToRunningPod on the parameters were judged for the nil, but the other two did not judge, may cause run-time panic.
**Release note**:

```release-note
NONE
```
