### PR TITLE
Fix the matching rule of instance ProviderID

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -19,7 +19,7 @@ package openstack
 import (
 	"errors"
 	"fmt"
-	"net/url"
+	"regexp"
 
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud"
@@ -208,14 +208,16 @@ func srvInstanceType(srv *servers.Server) (string, error) {
 	return "", fmt.Errorf("flavor name/id not found")
 }
 
+// instanceIDFromProviderID splits a provider's id and return instanceID.
+// A providerID is build out of '${ProviderName}:///${instance-id}'which contains ':///'.
+// See cloudprovider.GetInstanceProviderID and Instances.InstanceID.
 func instanceIDFromProviderID(providerID string) (instanceID string, err error) {
-	parsedID, err := url.Parse(providerID)
-	if err != nil {
-		return "", err
-	}
-	if parsedID.Scheme != ProviderName {
-		return "", fmt.Errorf("unrecognized provider %q", parsedID.Scheme)
-	}
+	// If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
+	var providerIdRegexp = regexp.MustCompile(`^` + ProviderName + `:///([^/]+)$`)
 
-	return parsedID.Host, nil
+	matches := providerIdRegexp.FindStringSubmatch(providerID)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"openstack:///InstanceID\"", providerID)
+	}
+	return matches[1], nil
 }

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -557,9 +557,14 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 		fail       bool
 	}{
 		{
-			providerID: "openstack://7b9cf879-7146-417c-abfd-cb4272f0c935",
+			providerID: ProviderName + "://" + "/" + "7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
 			fail:       false,
+		},
+		{
+			providerID: "openstack://7b9cf879-7146-417c-abfd-cb4272f0c935",
+			instanceID: "",
+			fail:       true,
 		},
 		{
 			providerID: "7b9cf879-7146-417c-abfd-cb4272f0c935",
@@ -567,7 +572,7 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 			fail:       true,
 		},
 		{
-			providerID: "other-provider://7b9cf879-7146-417c-abfd-cb4272f0c935",
+			providerID: "other-provider:///7b9cf879-7146-417c-abfd-cb4272f0c935",
 			instanceID: "",
 			fail:       true,
 		},


### PR DESCRIPTION
Url.Parse() can't parse ProviderID which contains ':///'.
This PR use regexp to match ProviderID.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fix #49769

**Release note**:
```release-note
NONE
```
