### PR TITLE
Add waitForFailure for e2e test framework

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -202,6 +202,23 @@ func (c *PodClient) WaitForSuccess(name string, timeout time.Duration) {
 	)).To(Succeed(), "wait for pod %q to success", name)
 }
 
+// WaitForFailure waits for pod to fail.
+func (c *PodClient) WaitForFailure(name string, timeout time.Duration) {
+	f := c.f
+	Expect(WaitForPodCondition(f.ClientSet, f.Namespace.Name, name, "success or failure", timeout,
+		func(pod *v1.Pod) (bool, error) {
+			switch pod.Status.Phase {
+			case v1.PodFailed:
+				return true, nil
+			case v1.PodSucceeded:
+				return true, fmt.Errorf("pod %q successed with reason: %q, message: %q", name, pod.Status.Reason, pod.Status.Message)
+			default:
+				return false, nil
+			}
+		},
+	)).To(Succeed(), "wait for pod %q to fail", name)
+}
+
 // WaitForSuccess waits for pod to succeed or an error event for that pod.
 func (c *PodClient) WaitForErrorEventOrSuccess(pod *v1.Pod) (*v1.Event, error) {
 	var ev *v1.Event

--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -340,39 +340,25 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			podName := fmt.Sprintf("busybox-readonly-%v-%s", readOnlyRootFilesystem, uuid.NewUUID())
 			podClient.Create(makeUserPod(podName,
 				"gcr.io/google_containers/busybox:1.24",
-				[]string{"sh", "-c", "touch checkfile && [ -f checkfile ] && echo Found || true"},
+				[]string{"sh", "-c", "touch checkfile"},
 				readOnlyRootFilesystem,
 			))
 
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			if readOnlyRootFilesystem {
+				podClient.WaitForFailure(podName, framework.PodStartTimeout)
+			} else {
+				podClient.WaitForSuccess(podName, framework.PodStartTimeout)
+			}
 
 			return podName
 		}
 
 		It("should run the container with readonly rootfs when readOnlyRootFilesystem=true", func() {
-			podName := createAndWaitUserPod(true)
-			logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
-			if err != nil {
-				framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
-			}
-
-			framework.Logf("Got logs for pod %q: %q", podName, logs)
-			if strings.Contains(logs, "Found") {
-				framework.Failf("readonly-rootfs container shouldn't be able to write files")
-			}
+			createAndWaitUserPod(true)
 		})
 
 		It("should run the container with writable rootfs when readOnlyRootFilesystem=false", func() {
-			podName := createAndWaitUserPod(false)
-			logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, podName)
-			if err != nil {
-				framework.Failf("GetPodLogs for pod %q failed: %v", podName, err)
-			}
-
-			framework.Logf("Got logs for pod %q: %q", podName, logs)
-			if !strings.Contains(logs, "Found") {
-				framework.Failf("non-readonly-rootfs container should be able to write files")
-			}
+			createAndWaitUserPod(false)
 		})
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Add waitForFailure for e2e test framework, this could reduce the reliance on logs.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Part of #44118. Refer https://github.com/kubernetes/kubernetes/pull/48858#discussion_r128331726

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
