### PR TITLE
csr: add resync to csr approver

### DIFF
--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -91,10 +91,15 @@ func (a *sarApprover) handle(csr *capi.CertificateSigningRequest) error {
 		return fmt.Errorf("unable to parse csr %q: %v", csr.Name, err)
 	}
 
+	tried := []string{}
+
 	for _, r := range a.recognizers {
 		if !r.recognize(csr, x509cr) {
 			continue
 		}
+
+		tried = append(tried, r.permission.Subresource)
+
 		approved, err := a.authorize(csr, r.permission)
 		if err != nil {
 			return err
@@ -108,6 +113,11 @@ func (a *sarApprover) handle(csr *capi.CertificateSigningRequest) error {
 			return nil
 		}
 	}
+
+	if len(tried) != 0 {
+		return fmt.Errorf("recognized csr %q as %v but subject access review was not approved", csr.Name, tried)
+	}
+
 	return nil
 }
 

--- a/pkg/controller/certificates/approver/sarapprove_test.go
+++ b/pkg/controller/certificates/approver/sarapprove_test.go
@@ -89,6 +89,7 @@ func TestHandle(t *testing.T) {
 		message    string
 		allowed    bool
 		recognized bool
+		err        bool
 		verify     func(*testing.T, []testclient.Action)
 	}{
 		{
@@ -119,6 +120,7 @@ func TestHandle(t *testing.T) {
 				}
 				_ = as[0].(testclient.CreateActionImpl)
 			},
+			err: true,
 		},
 		{
 			recognized: true,
@@ -155,7 +157,7 @@ func TestHandle(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		t.Run(fmt.Sprintf("recognized:%v,allowed: %v", c.recognized, c.allowed), func(t *testing.T) {
+		t.Run(fmt.Sprintf("recognized:%v,allowed: %v,err: %v", c.recognized, c.allowed, c.err), func(t *testing.T) {
 			client := &fake.Clientset{}
 			client.AddReactor("create", "subjectaccessreviews", func(action testclient.Action) (handled bool, ret runtime.Object, err error) {
 				return true, &authorization.SubjectAccessReview{
@@ -177,7 +179,7 @@ func TestHandle(t *testing.T) {
 				},
 			}
 			csr := makeTestCsr()
-			if err := approver.handle(csr); err != nil {
+			if err := approver.handle(csr); err != nil && !c.err {
 				t.Errorf("unexpected err: %v", err)
 			}
 			c.verify(t, client.Actions())


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/49787

```release-note
Fix an issue where if a CSR is not approved initially by the SAR approver is not retried.
```