### PR TITLE
Remove useless conversion-gen tags

### DIFF
--- a/pkg/apis/extensions/v1beta1/doc.go
+++ b/pkg/apis/extensions/v1beta1/doc.go
@@ -16,9 +16,6 @@ limitations under the License.
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
 // +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/extensions/v1beta1
-// +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
-// +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
-// +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/networking
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/extensions/v1beta1
 


### PR DESCRIPTION
To generate cross group conversions, `+k8s:conversion-gen` should be added in the way https://github.com/kubernetes/kubernetes/pull/49751 did. This PR removes the useless tags in pkg/apis/extensions/v1beta1/doc.go