### PR TITLE
Update repo-infra and rules_go Bazel workspace dependencies

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,15 +1,15 @@
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "a1596c14c799d5a1b5f49ca28fa948414c2242110d69ef324d6ed160ec890dbf",
-    strip_prefix = "rules_go-03c634753160632c00f506afeafc819fbea4c422",
-    urls = ["https://github.com/bazelbuild/rules_go/archive/03c634753160632c00f506afeafc819fbea4c422.tar.gz"],
+    sha256 = "abdea3986d9e850eda27b12163b0b558accdb5bca69ef945b022356f920d430d",
+    strip_prefix = "rules_go-473417ec48310325e1fcb1c154621a83197a17fe",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/473417ec48310325e1fcb1c154621a83197a17fe.tar.gz"],
 )
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "2555f94944df8547066471377e7b30215abd9831c46647062f83abbc4a0e80d2",
-    strip_prefix = "repo-infra-4291717be0a0f9e789c800c295f2a4067de15bef",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/4291717be0a0f9e789c800c295f2a4067de15bef.tar.gz"],
+    sha256 = "232fec0ffcb53df5e87fc036ae3e966ea32122fc89ead4c32581b3255c1ab7d0",
+    strip_prefix = "repo-infra-f521b5d472e00e05da5394994942064510a6e8bf",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/f521b5d472e00e05da5394994942064510a6e8bf.tar.gz"],
 )
 
 ETCD_VERSION = "3.0.17"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: bumping the `repo-infra` dependency gets us https://github.com/kubernetes/repo-infra/pull/25, which hopefully fixes the `gsutil -m rsync` flakiness in the `pull-kubernetes-e2e-gce-bazel` job, and https://github.com/kubernetes/repo-infra/pull/26, which lets us bump the `rules_go` dependency.

Bumping the `rules_go` dependency fixes the build on bazel 0.5.3+, gives us race detector support, and probably a bunch of other features, too. It's also a prerequisite for switching to gazelle (#47558).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @spxtr @mikedanese 