### PR TITLE
Use --sandbox_fake_username with bazel build

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -7,3 +7,7 @@ build --workspace_status_command hack/print-workspace-status.sh
 
 # Make /tmp hermetic
 build --sandbox_tmpfs_path=/tmp
+
+# Ensure that Bazel never runs as root, which can cause unit tests to fail.
+# This flag requires Bazel 0.5.0+
+build --sandbox_fake_username


### PR DESCRIPTION
**What this PR does / why we need it**:
Per the Bazel 0.5.0 release notes:
> * The Linux sandbox no longer changes the user to 'nobody' by default, instead the current user is used as is. The old behavior can be restored via the --sandbox_fake_username flag.

On prow, Bazel runs inside a docker container as root. (We should maybe figure out how not to run as root, but that's a larger change.)
The `//third_party/forked/etcd221/pkg/fileutil:go_default_test` tests that after setting a directory read-only with chmod it cannot be written to, but root can always write to a read-only directory, so this test fails.
By enforcing that Bazel continues to drop to an unprivileged user, we can ensure the test still passes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49824

**Special notes for your reviewer**: this needs to be merged simultaneously with https://github.com/kubernetes/test-infra/issues/3809, since this flag only exists in Bazel 0.5.0+.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
