### PR TITLE
Fix premature return

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1138,7 +1138,7 @@ func mergePatchIntoOriginal(original, patch map[string]interface{}, t reflect.Ty
 				return err
 			}
 		case !foundOriginal && !foundPatch:
-			return nil
+			continue
 		}
 
 		// Split all items into patch items and server-only items and then enforce the order.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -5969,6 +5969,75 @@ retainKeysMergingList:
 `),
 		},
 	},
+	{
+		Description: "delete and reorder in one list, reorder in another",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+- name: a
+  value: a
+- name: b
+  value: b
+mergeItemPtr:
+- name: c
+  value: c
+- name: d
+  value: d
+`),
+			Current: []byte(`
+mergingList:
+- name: a
+  value: a
+- name: b
+  value: b
+mergeItemPtr:
+- name: c
+  value: c
+- name: d
+  value: d
+`),
+			Modified: []byte(`
+mergingList:
+- name: b
+  value: b
+mergeItemPtr:
+- name: d
+  value: d
+- name: c
+  value: c
+`),
+			TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: b
+$setElementOrder/mergeItemPtr:
+- name: d
+- name: c
+mergingList:
+- $patch: delete
+  name: a
+`),
+			ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: b
+$setElementOrder/mergeItemPtr:
+- name: d
+- name: c
+mergingList:
+- $patch: delete
+  name: a
+`),
+			Result: []byte(`
+mergingList:
+- name: b
+  value: b
+mergeItemPtr:
+- name: d
+  value: d
+- name: c
+  value: c
+`),
+		},
+	},
 }
 
 func TestStrategicMergePatch(t *testing.T) {
@@ -5993,9 +6062,12 @@ func TestStrategicMergePatch(t *testing.T) {
 		testThreeWayPatch(t, c)
 	}
 
-	for _, c := range strategicMergePatchRawTestCases {
-		testTwoWayPatchForRawTestCase(t, c)
-		testThreeWayPatchForRawTestCase(t, c)
+	// run multiple times to exercise different map traversal orders
+	for i := 0; i < 10; i++ {
+		for _, c := range strategicMergePatchRawTestCases {
+			testTwoWayPatchForRawTestCase(t, c)
+			testThreeWayPatchForRawTestCase(t, c)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Fixes a bug where the loop is prematurely terminated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50040 

**Special notes for your reviewer**:

**Release note**: 
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fixed a bug in strategic merge patch that caused kubectl apply to error under some conditions
```
