### PR TITLE
Add Unit Test: opaque int resource name

### DIFF
--- a/pkg/api/v1/helper/helpers_test.go
+++ b/pkg/api/v1/helper/helpers_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helper
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -25,6 +26,64 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
+
+func TestIsOpaqueIntResourceName(t *testing.T) { // resourceName input with the correct OpaqueIntResourceName prefix ("pod.alpha.kubernetes.io/opaque-int-resource-") should pass
+	testCases := []struct {
+		resourceName v1.ResourceName
+		expectVal    bool
+	}{
+		{
+			resourceName: "pod.alpha.kubernetes.io/opaque-int-resource-foo",
+			expectVal:    true, // resourceName should pass because the resourceName has the correct prefix.
+		},
+		{
+			resourceName: "foo",
+			expectVal:    false, // resourceName should fail because the resourceName has the wrong prefix.
+		},
+		{
+			resourceName: "",
+			expectVal:    false, // resourceName should fail, empty resourceName.
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("resourceName input=%s, expected value=%v", tc.resourceName, tc.expectVal), func(t *testing.T) {
+			t.Parallel()
+			v := IsOpaqueIntResourceName(tc.resourceName)
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
+
+func TestOpaqueIntResourceName(t *testing.T) { // each output should have the correct appended prefix ("pod.alpha.kubernetes.io/opaque-int-resource-") for opaque counted resources.
+	testCases := []struct {
+		name      string
+		expectVal v1.ResourceName
+	}{
+		{
+			name:      "foo",
+			expectVal: "pod.alpha.kubernetes.io/opaque-int-resource-foo", // append prefix to input string foo
+		},
+		{
+			name:      "",
+			expectVal: "pod.alpha.kubernetes.io/opaque-int-resource-", // append prefix to input empty string
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(fmt.Sprintf("name input=%s, expected value=%s", tc.name, tc.expectVal), func(t *testing.T) {
+			t.Parallel()
+			v := OpaqueIntResourceName(tc.name)
+			if v != tc.expectVal {
+				t.Errorf("Got %v but expected %v", v, tc.expectVal)
+			}
+		})
+	}
+}
 
 func TestAddToNodeAddresses(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: https://github.com/kubernetes/kubernetes/issues/49384, adding unit tests for functions related to the prefix OpaqueIntResourceName in /pkg/api/v1helper

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
