### PR TITLE
make volumesInUse sorted in node status updates

### DIFF
--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -18,6 +18,7 @@ package volumemanager
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"time"
 
@@ -286,15 +287,8 @@ func (vm *volumeManager) GetVolumesInUse() []v1.UniqueVolumeName {
 	// volume *should* be attached to this node until it is safely unmounted.
 	desiredVolumes := vm.desiredStateOfWorld.GetVolumesToMount()
 	mountedVolumes := vm.actualStateOfWorld.GetGloballyMountedVolumes()
-	volumesToReportInUse :=
-		make(
-			[]v1.UniqueVolumeName,
-			0, /* len */
-			len(desiredVolumes)+len(mountedVolumes) /* cap */)
-	desiredVolumesMap :=
-		make(
-			map[v1.UniqueVolumeName]bool,
-			len(desiredVolumes)+len(mountedVolumes) /* cap */)
+	volumesToReportInUse := make([]v1.UniqueVolumeName, 0, len(desiredVolumes)+len(mountedVolumes))
+	desiredVolumesMap := make(map[v1.UniqueVolumeName]bool, len(desiredVolumes)+len(mountedVolumes))
 
 	for _, volume := range desiredVolumes {
 		if volume.PluginIsAttachable {
@@ -313,6 +307,9 @@ func (vm *volumeManager) GetVolumesInUse() []v1.UniqueVolumeName {
 		}
 	}
 
+	sort.Slice(volumesToReportInUse, func(i, j int) bool {
+		return string(volumesToReportInUse[i]) < string(volumesToReportInUse[j])
+	})
 	return volumesToReportInUse
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

`volumesInUse` is not sent in a stable sort order. This will make node status patch requests larger than needed, and makes debugging nodes harder than necessary.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49731

**Special notes for your reviewer**:

/cc @derekwaynecarr @jboyd01

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
make volumesInUse sorted in node status updates
```
