### PR TITLE
[WIP] add a new dns provider for federation: dnspod

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -832,6 +832,10 @@
 			"Rev": "511bcaf42ccd42c38aba7427b6673277bf19e2a1"
 		},
 		{
+			"ImportPath": "github.com/decker502/dnspod-go",
+			"Rev": "f33a2c6040fc2550a631de7b3a53bddccdcd73fb"
+		},
+		{
 			"ImportPath": "github.com/dgrijalva/jwt-go",
 			"Comment": "v3.0.0-4-g01aeca5",
 			"Rev": "01aeca54ebda6e0fbfafd0a524d234159c05ec20"

--- a/federation/cmd/federation-controller-manager/app/BUILD
+++ b/federation/cmd/federation-controller-manager/app/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//federation/cmd/federation-controller-manager/app/options:go_default_library",
         "//federation/pkg/dnsprovider/providers/aws/route53:go_default_library",
         "//federation/pkg/dnsprovider/providers/coredns:go_default_library",
+        "//federation/pkg/dnsprovider/providers/dnspod:go_default_library",
         "//federation/pkg/dnsprovider/providers/google/clouddns:go_default_library",
         "//federation/pkg/federatedtypes:go_default_library",
         "//federation/pkg/federation-controller/cluster:go_default_library",

--- a/federation/cmd/federation-controller-manager/app/plugins.go
+++ b/federation/cmd/federation-controller-manager/app/plugins.go
@@ -23,5 +23,6 @@ import (
 	// DNS providers
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/aws/route53"
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/coredns"
+	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/dnspod"
 	_ "k8s.io/kubernetes/federation/pkg/dnsprovider/providers/google/clouddns"
 )

--- a/federation/pkg/dnsprovider/BUILD
+++ b/federation/pkg/dnsprovider/BUILD
@@ -39,6 +39,7 @@ filegroup(
         ":package-srcs",
         "//federation/pkg/dnsprovider/providers/aws/route53:all-srcs",
         "//federation/pkg/dnsprovider/providers/coredns:all-srcs",
+        "//federation/pkg/dnsprovider/providers/dnspod:all-srcs",
         "//federation/pkg/dnsprovider/providers/google/clouddns:all-srcs",
         "//federation/pkg/dnsprovider/rrstype:all-srcs",
         "//federation/pkg/dnsprovider/tests:all-srcs",

--- a/federation/pkg/dnsprovider/providers/dnspod/BUILD
+++ b/federation/pkg/dnsprovider/providers/dnspod/BUILD
@@ -1,0 +1,43 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "dnspod.go",
+        "int.go",
+        "interface.go",
+        "rrchangeset.go",
+        "rrset.go",
+        "rrsets.go",
+        "zone.go",
+        "zones.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//federation/pkg/dnsprovider:go_default_library",
+        "//federation/pkg/dnsprovider/rrstype:go_default_library",
+        "//vendor/github.com/decker502/dnspod-go:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/gopkg.in/gcfg.v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/federation/pkg/dnsprovider/providers/dnspod/dnspod.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/dnspod.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package dnspod is the implementation of pkg/dnsprovider interface for DNSPod
+package dnspod
+
+import (
+	"io"
+
+	"github.com/golang/glog"
+	"gopkg.in/gcfg.v1"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+const (
+	ProviderName = "dnspod"
+)
+
+type Config struct {
+	// Config to override defaults
+	Global struct {
+		LoginToken string `gcfg:"login-token"`
+	}
+}
+
+func init() {
+	dnsprovider.RegisterDnsProvider(ProviderName, func(config io.Reader) (dnsprovider.Interface, error) {
+		return newDnspodProviderInterface(config)
+	})
+}
+
+func newDnspodProviderInterface(config io.Reader) (*Interface, error) {
+	var loginToken string
+	if config != nil {
+		var cfg Config
+		if err := gcfg.ReadInto(&cfg, config); err != nil {
+			glog.Errorf("Couldn't read config: %v", err)
+			return nil, err
+		}
+		glog.Infof("Using DNSPod provider config %+v", cfg)
+		if cfg.Global.LoginToken != "" {
+			loginToken = cfg.Global.LoginToken
+		}
+	}
+	return CreateInterface(loginToken)
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/int.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/int.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	dns "github.com/decker502/dnspod-go"
+	"github.com/golang/glog"
+)
+
+func CreateInterface(loginToken string) (*Interface, error) {
+	params := dns.CommonParams{LoginToken: loginToken, Format: "json"}
+	client := dns.NewClient(params)
+	glog.Infof("Using DNSPod DNS provider")
+
+	//return newInterfaceWithStub(internal.NewService(client)), nil
+	return &Interface{client}, nil
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/interface.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/interface.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	dns "github.com/decker502/dnspod-go"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.Interface = Interface{}
+
+type Interface struct {
+	client *dns.Client
+}
+
+func (i Interface) Zones() (dnsprovider.Zones, bool) {
+	return Zones{i.client}, true
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/rrchangeset.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/rrchangeset.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.ResourceRecordChangeset = &ResourceRecordChangeset{}
+
+type ResourceRecordChangeset struct {
+	rrsets *ResourceRecordSets
+
+	additions []dnsprovider.ResourceRecordSet
+	removals  []dnsprovider.ResourceRecordSet
+}
+
+func (c *ResourceRecordChangeset) Add(rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordChangeset {
+	c.additions = append(c.additions, rrset)
+	return c
+}
+
+func (c *ResourceRecordChangeset) Remove(rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordChangeset {
+	c.removals = append(c.removals, rrset)
+	return c
+}
+
+func (c *ResourceRecordChangeset) Upsert(rrset dnsprovider.ResourceRecordSet) dnsprovider.ResourceRecordChangeset {
+	c.Remove(rrset)
+	c.Add(rrset)
+	return c
+}
+
+func (c *ResourceRecordChangeset) Apply() error {
+	rrsets := c.rrsets
+
+	for _, removal := range c.removals {
+		fmt.Println(removal)
+		rrset := removal.(ResourceRecordSet)
+		records := rrset.records
+		for _, record := range records {
+			_, err := rrsets.client.Domains.DeleteRecord(rrset.rrsets.zone.ID(), record.ID)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, addition := range c.additions {
+		fmt.Println(addition)
+		rrset := addition.(ResourceRecordSet)
+		records := rrset.records
+		for _, record := range records {
+			record.Line = "默认"
+			_, _, err := rrsets.client.Domains.CreateRecord(rrset.rrsets.zone.ID(), record)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *ResourceRecordChangeset) IsEmpty() bool {
+	return len(c.removals) == 0 && len(c.additions) == 0
+}
+
+// ResourceRecordSets returns the parent ResourceRecordSets
+func (c *ResourceRecordChangeset) ResourceRecordSets() dnsprovider.ResourceRecordSets {
+	return c.rrsets
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/rrset.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/rrset.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	"fmt"
+	"strconv"
+
+	dns "github.com/decker502/dnspod-go"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+// Compile time check for interface adeherence
+var _ dnsprovider.ResourceRecordSet = ResourceRecordSet{}
+
+type ResourceRecordSet struct {
+	domain  dns.Domain
+	records []dns.Record
+	rrsets  *ResourceRecordSets
+}
+
+func (rrset ResourceRecordSet) String() string {
+	return fmt.Sprintf("<(dnspod) %q type=%s rrdatas=%q ttl=%v>", rrset.Name(), rrset.Type(), rrset.Rrdatas(), rrset.Ttl())
+}
+
+func (rrset ResourceRecordSet) Name() string {
+	if rrset.records[0].Name == "@" {
+		return rrset.domain.Name
+	} else {
+		return fmt.Sprintf("%s.%s", rrset.records[0].Name, rrset.domain.Name)
+	}
+}
+
+func (rrset ResourceRecordSet) Rrdatas() []string {
+	rrdatas := make([]string, len(rrset.records))
+	for i, record := range rrset.records {
+		rrdatas[i] = record.Value
+	}
+	return rrdatas
+}
+
+func (rrset ResourceRecordSet) Ttl() int64 {
+	ttl, _ := strconv.ParseInt(rrset.domain.TTL, 10, 64)
+	return ttl
+}
+
+func (rrset ResourceRecordSet) Type() rrstype.RrsType {
+	return rrstype.RrsType(rrset.records[0].Type)
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/rrsets.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/rrsets.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	"strconv"
+	"strings"
+
+	dns "github.com/decker502/dnspod-go"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider/rrstype"
+)
+
+// Compile time check for interface adherence
+var _ dnsprovider.ResourceRecordSets = ResourceRecordSets{}
+
+type ResourceRecordSets struct {
+	zone   *Zone
+	client *dns.Client
+}
+
+type recordNameType struct {
+	recordName string
+	recordType string
+}
+
+func (rrsets ResourceRecordSets) List() ([]dnsprovider.ResourceRecordSet, error) {
+	records, _, err := rrsets.client.Domains.ListRecords(rrsets.zone.ID(), "")
+	if err != nil {
+		return nil, err
+	}
+
+	maps := map[recordNameType][]dns.Record{}
+	for _, record := range records {
+		maps[recordNameType{record.Name, record.Type}] = append(maps[recordNameType{record.Name, record.Type}], record)
+	}
+
+	list := make([]dnsprovider.ResourceRecordSet, len(maps))
+	i := 0
+	for p := range maps {
+		list[i] = ResourceRecordSet{rrsets.zone.domain, maps[p], &rrsets}
+		i = i + 1
+	}
+
+	return list, nil
+}
+
+func (rrsets ResourceRecordSets) Get(name string) ([]dnsprovider.ResourceRecordSet, error) {
+	rrsetList, err := rrsets.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var list []dnsprovider.ResourceRecordSet
+	for _, rrset := range rrsetList {
+		if rrset.Name() == name {
+			list = append(list, rrset)
+		}
+	}
+	return list, nil
+}
+
+func (r ResourceRecordSets) StartChangeset() dnsprovider.ResourceRecordChangeset {
+	return &ResourceRecordChangeset{
+		rrsets: &r,
+	}
+}
+
+func (r ResourceRecordSets) New(name string, rrdatas []string, ttl int64, rrstype rrstype.RrsType) dnsprovider.ResourceRecordSet {
+	domain := dns.Domain{Name: r.zone.Name(), TTL: strconv.FormatInt(ttl, 10)}
+	records := make([]dns.Record, len(rrdatas))
+	for i, rrdata := range rrdatas {
+		records[i] = dns.Record{Name: strings.TrimRight(name, domain.Name), Value: rrdata, Type: string(rrstype), TTL: domain.TTL}
+	}
+	return ResourceRecordSet{domain, records, &r}
+}
+
+// Zone returns the parent zone
+func (rrset ResourceRecordSets) Zone() dnsprovider.Zone {
+	return rrset.zone
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/zone.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/zone.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	"strconv"
+
+	dns "github.com/decker502/dnspod-go"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adeherence
+var _ dnsprovider.Zone = &Zone{}
+
+type Zone struct {
+	domain dns.Domain
+	zones  *Zones
+}
+
+func (zone *Zone) Name() string {
+	return zone.domain.Name
+}
+
+func (zone *Zone) ID() string {
+	return strconv.Itoa(zone.domain.ID)
+}
+
+func (zone *Zone) ResourceRecordSets() (dnsprovider.ResourceRecordSets, bool) {
+	return &ResourceRecordSets{zone, zone.zones.client}, true
+}

--- a/federation/pkg/dnsprovider/providers/dnspod/zones.go
+++ b/federation/pkg/dnsprovider/providers/dnspod/zones.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dnspod
+
+import (
+	"strconv"
+
+	dns "github.com/decker502/dnspod-go"
+	"k8s.io/kubernetes/federation/pkg/dnsprovider"
+)
+
+// Compile time check for interface adeherence
+var _ dnsprovider.Zones = Zones{}
+
+type Zones struct {
+	client *dns.Client
+}
+
+func (zones Zones) List() ([]dnsprovider.Zone, error) {
+	domains, _, err := zones.client.Domains.List()
+	if err != nil {
+		return nil, err
+	}
+	zoneList := make([]dnsprovider.Zone, len(domains))
+	for i, domain := range domains {
+		zoneList[i] = &Zone{domain, &zones}
+	}
+	return zoneList, nil
+}
+
+func (zones Zones) Add(zone dnsprovider.Zone) (dnsprovider.Zone, error) {
+	newDomain := dns.Domain{Name: zone.Name()}
+	domain, _, err := zones.client.Domains.Create(newDomain)
+	if err != nil {
+		return nil, err
+	}
+	return &Zone{domain, &zones}, nil
+}
+
+func (zones Zones) Remove(zone dnsprovider.Zone) error {
+	id, err := strconv.Atoi(zone.ID())
+	if err != nil {
+		return err
+	}
+	_, err = zones.client.Domains.Delete(id)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (zones Zones) New(name string) (dnsprovider.Zone, error) {
+	newDomain := dns.Domain{Name: name}
+	return &Zone{newDomain, &zones}, nil
+}

--- a/federation/pkg/kubefed/init/BUILD
+++ b/federation/pkg/kubefed/init/BUILD
@@ -13,6 +13,7 @@ go_library(
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//federation/apis/federation:go_default_library",
         "//federation/pkg/dnsprovider/providers/coredns:go_default_library",
+        "//federation/pkg/dnsprovider/providers/dnspod:go_default_library",
         "//federation/pkg/kubefed/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/apis/extensions:go_default_library",

--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -500,7 +500,7 @@ func populateStubDomainsIfRequired(configMap *api.ConfigMap, annotations map[str
 	dnsZoneName := annotations[util.FedDNSZoneName]
 	nameServer := annotations[util.FedNameServer]
 
-	if dnsProvider != util.FedDNSProviderCoreDNS || dnsZoneName == "" || nameServer == "" {
+	if (dnsProvider != util.FedDNSProviderCoreDNS && dnsProvider != util.FedDNSProviderDnspod) || dnsZoneName == "" || nameServer == "" {
 		return configMap
 	}
 	configMap.Data[util.KubeDnsStubDomains] = fmt.Sprintf(`{"%s":["%s"]}`, dnsZoneName, nameServer)

--- a/federation/pkg/kubefed/util/util.go
+++ b/federation/pkg/kubefed/util/util.go
@@ -55,6 +55,7 @@ const (
 	FedNameServer         = "nameserver"
 	FedDNSProvider        = "dns-provider"
 	FedDNSProviderCoreDNS = "coredns"
+	FedDNSProviderDnspod  = "dnspod"
 	KubeDnsStubDomains    = "stubDomains"
 
 	// DefaultFederationSystemNamespace is the namespace in which

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -45,6 +45,7 @@ federation/pkg/dnsprovider/providers/aws/route53
 federation/pkg/dnsprovider/providers/aws/route53/stubs
 federation/pkg/dnsprovider/providers/coredns
 federation/pkg/dnsprovider/providers/coredns/stubs
+federation/pkg/dnsprovider/providers/dnspod
 federation/pkg/dnsprovider/providers/google/clouddns
 federation/pkg/dnsprovider/providers/google/clouddns/internal
 federation/pkg/dnsprovider/providers/google/clouddns/internal/interfaces

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -120,6 +120,7 @@ filegroup(
         "//vendor/github.com/cpuguy83/go-md2man/md2man:all-srcs",
         "//vendor/github.com/davecgh/go-spew/spew:all-srcs",
         "//vendor/github.com/daviddengcn/go-colortext:all-srcs",
+        "//vendor/github.com/decker502/dnspod-go:all-srcs",
         "//vendor/github.com/dgrijalva/jwt-go:all-srcs",
         "//vendor/github.com/docker/distribution/digest:all-srcs",
         "//vendor/github.com/docker/distribution/reference:all-srcs",

--- a/vendor/github.com/decker502/dnspod-go/BUILD
+++ b/vendor/github.com/decker502/dnspod-go/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "dnspod.go",
+        "domain_records.go",
+        "domains.go",
+    ],
+    tags = ["automanaged"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/github.com/decker502/dnspod-go/LICENSE
+++ b/vendor/github.com/decker502/dnspod-go/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 decker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/decker502/dnspod-go/README.md
+++ b/vendor/github.com/decker502/dnspod-go/README.md
@@ -1,0 +1,56 @@
+# dnspod-go
+
+A Go client for the [DNSPod API](https://www.dnspod.cn/docs/index.html).
+
+Borrowed from : [dnsimple](https://github.com/weppos/dnsimple-go/dnsimple)
+
+## Installation
+
+```
+$ go get github.com/decker502/dnspod-go
+```
+
+
+## Getting Started
+
+This library is a Go client you can use to interact with the [DNSPod API](https://www.dnspod.cn/docs/index.html). Here are some examples.
+
+
+```go
+package main
+
+import (
+  "fmt"
+  "github.com/decker502/dnspod-go"
+)
+
+func main() {
+  apiToken := "xxxxxxx"
+
+  params := dnspod.CommonParams{LoginToken: "dnspod login token"}
+  client := dnspod.NewClient(apiToken)
+
+  // Get a list of your domains
+  domains, _, _ := client.Domains.List()
+  for _, domain := range domains {
+      fmt.Printf("Domain: %s (id: %d)\n", domain.Name, domain.Id)
+  }
+
+  // Get a list of your domains (with error management)
+  domains, _, error := client.Domains.List()
+  if error != nil {
+      log.Fatalln(error)
+  }
+  for _, domain := range domains {
+      fmt.Printf("Domain: %s (id: %d)\n", domain.Name, domain.Id)
+  }
+
+  // Create a new Domain
+  newDomain := Domain{Name: "example.com"}
+  domain, _, _ := client.Domains.Create(newDomain)
+  fmt.Printf("Domain: %s\n (id: %d)", domain.Name, domain.Id)
+}
+```
+## License
+
+This is Free Software distributed under the MIT license.

--- a/vendor/github.com/decker502/dnspod-go/dnspod.go
+++ b/vendor/github.com/decker502/dnspod-go/dnspod.go
@@ -1,0 +1,209 @@
+// Package dnspod implements a client for the dnspod API.
+//
+// In order to use this package you will need a dnspod account and your API Token.
+package dnspod
+
+import (
+	// "bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	libraryVersion = "0.1"
+	baseURL        = "https://dnsapi.cn/"
+	userAgent      = "dnspod-go/" + libraryVersion
+
+	apiVersion = "v1"
+)
+
+// dnspod API docs: https://www.dnspod.cn/docs/info.html
+
+type CommonParams struct {
+	LoginToken   string
+	Format       string
+	Lang         string
+	ErrorOnEmpty string
+	UserID       string
+}
+
+func newPayLoad(params CommonParams) url.Values {
+	p := url.Values{}
+
+	if params.LoginToken != "" {
+		p.Set("login_token", params.LoginToken)
+	}
+	if params.Format != "" {
+		p.Set("format", params.Format)
+	}
+	if params.Lang != "" {
+		p.Set("lang", params.Lang)
+	}
+	if params.ErrorOnEmpty != "" {
+		p.Set("error_on_empty", params.ErrorOnEmpty)
+	}
+	if params.UserID != "" {
+		p.Set("user_id", params.UserID)
+
+	}
+
+	return p
+}
+
+type Status struct {
+	Code      string `json:"code,omitempty"`
+	Message   string `json:"message,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+type Client struct {
+	// HTTP client used to communicate with the API.
+	HttpClient *http.Client
+
+	// CommonParams used communicating with the dnspod API.
+	CommonParams CommonParams
+
+	// Base URL for API requests.
+	// Defaults to the public dnspod API, but can be set to a different endpoint (e.g. the sandbox).
+	// BaseURL should always be specified with a trailing slash.
+	BaseURL string
+
+	// User agent used when communicating with the dnspod API.
+	UserAgent string
+
+	// Services used for talking to different parts of the dnspod API.
+	Domains *DomainsService
+}
+
+// NewClient returns a new dnspod API client.
+func NewClient(CommonParams CommonParams) *Client {
+	c := &Client{HttpClient: &http.Client{}, CommonParams: CommonParams, BaseURL: baseURL, UserAgent: userAgent}
+	c.Domains = &DomainsService{client: c}
+	return c
+
+}
+
+// NewRequest creates an API request.
+// The path is expected to be a relative path and will be resolved
+// according to the BaseURL of the Client. Paths should always be specified without a preceding slash.
+func (client *Client) NewRequest(method, path string, payload url.Values) (*http.Request, error) {
+	url := client.BaseURL + fmt.Sprintf("%s", path)
+
+	req, err := http.NewRequest(method, url, strings.NewReader(payload.Encode()))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("User-Agent", client.UserAgent)
+
+	return req, nil
+}
+
+func (c *Client) get(path string, v interface{}) (*Response, error) {
+	return c.Do("GET", path, nil, v)
+}
+
+func (c *Client) post(path string, payload url.Values, v interface{}) (*Response, error) {
+	return c.Do("POST", path, payload, v)
+}
+
+func (c *Client) put(path string, payload url.Values, v interface{}) (*Response, error) {
+	return c.Do("PUT", path, payload, v)
+}
+
+func (c *Client) delete(path string, payload url.Values) (*Response, error) {
+	return c.Do("DELETE", path, payload, nil)
+}
+
+// Do sends an API request and returns the API response.
+// The API response is JSON decoded and stored in the value pointed by v,
+// or returned as an error if an API error has occurred.
+// If v implements the io.Writer interface, the raw response body will be written to v,
+// without attempting to decode it.
+func (c *Client) Do(method, path string, payload url.Values, v interface{}) (*Response, error) {
+	req, err := c.NewRequest(method, path, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	response := &Response{Response: res}
+	err = CheckResponse(res)
+	if err != nil {
+		return response, err
+	}
+	if v != nil {
+		if w, ok := v.(io.Writer); ok {
+			io.Copy(w, res.Body)
+		} else {
+			err = json.NewDecoder(res.Body).Decode(v)
+		}
+	}
+
+	return response, err
+}
+
+// A Response represents an API response.
+type Response struct {
+	*http.Response
+}
+
+// An ErrorResponse represents an error caused by an API request.
+type ErrorResponse struct {
+	Response *http.Response // HTTP response that caused this error
+	Message  string         `json:"message"` // human-readable message
+}
+
+// Error implements the error interface.
+func (r *ErrorResponse) Error() string {
+	return fmt.Sprintf("%v %v: %d %v",
+		r.Response.Request.Method, r.Response.Request.URL,
+		r.Response.StatusCode, r.Message)
+}
+
+// CheckResponse checks the API response for errors, and returns them if present.
+// A response is considered an error if the status code is different than 2xx. Specific requests
+// may have additional requirements, but this is sufficient in most of the cases.
+func CheckResponse(r *http.Response) error {
+	if code := r.StatusCode; 200 <= code && code <= 299 {
+		return nil
+	}
+
+	errorResponse := &ErrorResponse{Response: r}
+	err := json.NewDecoder(r.Body).Decode(errorResponse)
+	if err != nil {
+		return err
+	}
+
+	return errorResponse
+}
+
+// Date custom type.
+type Date struct {
+	time.Time
+}
+
+// UnmarshalJSON handles the deserialization of the custom Date type.
+func (d *Date) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return fmt.Errorf("date should be a string, got %s", data)
+	}
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return fmt.Errorf("invalid date: %v", err)
+	}
+	d.Time = t
+	return nil
+}

--- a/vendor/github.com/decker502/dnspod-go/domain_records.go
+++ b/vendor/github.com/decker502/dnspod-go/domain_records.go
@@ -1,0 +1,237 @@
+package dnspod
+
+import (
+	"fmt"
+)
+
+type Record struct {
+	ID            string `json:"id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	Line          string `json:"line,omitempty"`
+	LineID        string `json:"line_id,omitempty"`
+	Type          string `json:"type,omitempty"`
+	TTL           string `json:"ttl,omitempty"`
+	Value         string `json:"value,omitempty"`
+	MX            string `json:"mx,omitempty"`
+	Enabled       string `json:"enabled,omitempty"`
+	Status        string `json:"status,omitempty"`
+	MonitorStatus string `json:"monitor_status,omitempty"`
+	Remark        string `json:"remark,omitempty"`
+	UpdateOn      string `json:"updated_on,omitempty"`
+	UseAQB        string `json:"use_aqb,omitempty"`
+}
+
+type recordsWrapper struct {
+	Status  Status     `json:"status"`
+	Info    DomainInfo `json:"info"`
+	Records []Record   `json:"records"`
+}
+
+type recordWrapper struct {
+	Status Status     `json:"status"`
+	Info   DomainInfo `json:"info"`
+	Record Record     `json:"record"`
+}
+
+// recordAction generates the resource path for given record that belongs to a domain.
+func recordAction(action string) string {
+	if len(action) > 0 {
+		return fmt.Sprintf("Record.%s", action)
+	}
+	return "Record.List"
+}
+
+// List the domain records.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/records.html#record-list
+func (s *DomainsService) ListRecords(domain string, recordName string) ([]Record, *Response, error) {
+	path := recordAction("List")
+
+	payload := newPayLoad(s.client.CommonParams)
+
+	payload.Add("domain_id", domain)
+
+	if recordName != "" {
+		payload.Add("sub_domain", recordName)
+	}
+
+	wrappedRecords := recordsWrapper{}
+
+	res, err := s.client.post(path, payload, &wrappedRecords)
+	if err != nil {
+		return []Record{}, res, err
+	}
+
+	if wrappedRecords.Status.Code != "1" {
+		return wrappedRecords.Records, nil, fmt.Errorf("Could not get domains: %s", wrappedRecords.Status.Message)
+	}
+
+	records := []Record{}
+	for _, record := range wrappedRecords.Records {
+		records = append(records, record)
+	}
+
+	return records, res, nil
+}
+
+// CreateRecord creates a domain record.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/records.html#record-create
+func (s *DomainsService) CreateRecord(domain string, recordAttributes Record) (Record, *Response, error) {
+	path := recordAction("Create")
+
+	payload := newPayLoad(s.client.CommonParams)
+
+	payload.Add("domain_id", domain)
+
+	if recordAttributes.Name != "" {
+		payload.Add("sub_domain", recordAttributes.Name)
+	}
+
+	if recordAttributes.Type != "" {
+		payload.Add("record_type", recordAttributes.Type)
+	}
+
+	if recordAttributes.Line != "" {
+		payload.Add("record_line", recordAttributes.Line)
+	}
+
+	if recordAttributes.LineID != "" {
+		payload.Add("record_line_id", recordAttributes.LineID)
+	}
+
+	if recordAttributes.Value != "" {
+		payload.Add("value", recordAttributes.Value)
+	}
+
+	if recordAttributes.MX != "" {
+		payload.Add("mx", recordAttributes.MX)
+	}
+
+	if recordAttributes.TTL != "" {
+		payload.Add("ttl", recordAttributes.TTL)
+	}
+
+	if recordAttributes.Status != "" {
+		payload.Add("status", recordAttributes.Status)
+	}
+
+	returnedRecord := recordWrapper{}
+
+	res, err := s.client.post(path, payload, &returnedRecord)
+	if err != nil {
+		return Record{}, res, err
+	}
+
+	if returnedRecord.Status.Code != "1" {
+		return returnedRecord.Record, nil, fmt.Errorf("Could not get domains: %s", returnedRecord.Status.Message)
+	}
+
+	return returnedRecord.Record, res, nil
+}
+
+// GetRecord fetches the domain record.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/records.html#record-info
+func (s *DomainsService) GetRecord(domain string, recordID string) (Record, *Response, error) {
+	path := recordAction("Info")
+
+	payload := newPayLoad(s.client.CommonParams)
+
+	payload.Add("domain_id", domain)
+	payload.Add("record_id", recordID)
+
+	returnedRecord := recordWrapper{}
+
+	res, err := s.client.post(path, payload, &returnedRecord)
+	if err != nil {
+		return Record{}, res, err
+	}
+
+	if returnedRecord.Status.Code != "1" {
+		return returnedRecord.Record, nil, fmt.Errorf("Could not get domains: %s", returnedRecord.Status.Message)
+	}
+
+	return returnedRecord.Record, res, nil
+}
+
+// UpdateRecord updates a domain record.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/records.html#record-modify
+func (s *DomainsService) UpdateRecord(domain string, recordID string, recordAttributes Record) (Record, *Response, error) {
+	path := recordAction("Modify")
+
+	payload := newPayLoad(s.client.CommonParams)
+
+	payload.Add("domain_id", domain)
+
+	if recordAttributes.Name != "" {
+		payload.Add("sub_domain", recordAttributes.Name)
+	}
+
+	if recordAttributes.Type != "" {
+		payload.Add("record_type", recordAttributes.Type)
+	}
+
+	if recordAttributes.Line != "" {
+		payload.Add("record_line", recordAttributes.Line)
+	}
+
+	if recordAttributes.LineID != "" {
+		payload.Add("record_line_id", recordAttributes.LineID)
+	}
+
+	if recordAttributes.Value != "" {
+		payload.Add("value", recordAttributes.Value)
+	}
+
+	if recordAttributes.MX != "" {
+		payload.Add("mx", recordAttributes.MX)
+	}
+
+	if recordAttributes.TTL != "" {
+		payload.Add("ttl", recordAttributes.TTL)
+	}
+
+	if recordAttributes.Status != "" {
+		payload.Add("status", recordAttributes.Status)
+	}
+
+	returnedRecord := recordWrapper{}
+
+	res, err := s.client.post(path, payload, &returnedRecord)
+	if err != nil {
+		return Record{}, res, err
+	}
+
+	if returnedRecord.Status.Code != "1" {
+		return returnedRecord.Record, nil, fmt.Errorf("Could not get domains: %s", returnedRecord.Status.Message)
+	}
+
+	return returnedRecord.Record, res, nil
+}
+
+// DeleteRecord deletes a domain record.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/records.html#record-remove
+func (s *DomainsService) DeleteRecord(domain string, recordID string) (*Response, error) {
+	path := recordAction("Remove")
+
+	payload := newPayLoad(s.client.CommonParams)
+
+	payload.Add("domain_id", domain)
+	payload.Add("record_id", recordID)
+
+	returnedRecord := recordWrapper{}
+
+	res, err := s.client.post(path, payload, &returnedRecord)
+	if err != nil {
+		return res, err
+	}
+
+	if returnedRecord.Status.Code != "1" {
+		return nil, fmt.Errorf("Could not get domains: %s", returnedRecord.Status.Message)
+	}
+
+	return res, nil
+}

--- a/vendor/github.com/decker502/dnspod-go/domains.go
+++ b/vendor/github.com/decker502/dnspod-go/domains.go
@@ -1,0 +1,161 @@
+package dnspod
+
+import (
+	"fmt"
+	"strconv"
+	// "time"
+)
+
+// DomainsService handles communication with the domain related
+// methods of the dnspod API.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/domains.html
+type DomainsService struct {
+	client *Client
+}
+
+type DomainInfo struct {
+	DomainTotal   int    `json:"domain_total,omitempty"`
+	AllTotal      int    `json:"all_total,omitempty"`
+	MineTotal     int    `json:"mine_total,omitempty"`
+	ShareTotal    string `json:"share_total,omitempty"`
+	VipTotal      int    `json:"vip_total,omitempty"`
+	IsMarkTotal   int    `json:"ismark_total,omitempty"`
+	PauseTotal    int    `json:"pause_total,omitempty"`
+	ErrorTotal    int    `json:"error_total,omitempty"`
+	LockTotal     int    `json:"lock_total,omitempty"`
+	SpamTotal     int    `json:"spam_total,omitempty"`
+	VipExpire     int    `json:"vip_expire,omitempty"`
+	ShareOutTotal int    `json:"share_out_total,omitempty"`
+}
+
+type Domain struct {
+	ID               int    `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	PunyCode         string `json:"punycode,omitempty"`
+	Grade            string `json:"grade,omitempty"`
+	GradeTitle       string `json:"grade_title,omitempty"`
+	Status           string `json:"status,omitempty"`
+	ExtStatus        string `json:"ext_status,omitempty"`
+	Records          string `json:"records,omitempty"`
+	GroupID          string `json:"group_id,omitempty"`
+	IsMark           string `json:"is_mark,omitempty"`
+	Remark           string `json:"remark,omitempty"`
+	IsVIP            string `json:"is_vip,omitempty"`
+	SearchenginePush string `json:"searchengine_push,omitempty"`
+	UserID           string `json:"user_id,omitempty"`
+	CreatedOn        string `json:"created_on,omitempty"`
+	UpdatedOn        string `json:"updated_on,omitempty"`
+	TTL              string `json:"ttl,omitempty"`
+	CNameSpeedUp     string `json:"cname_speedup,omitempty"`
+	Owner            string `json:"owner,omitempty"`
+	AuthToAnquanBao  bool   `json:"auth_to_anquanbao,omitempty"`
+}
+
+type domainListWrapper struct {
+	Status  Status     `json:"status"`
+	Info    DomainInfo `json:"info"`
+	Domains []Domain   `json:"domains"`
+}
+
+type domainWrapper struct {
+	Status Status     `json:"status"`
+	Info   DomainInfo `json:"info"`
+	Domain Domain     `json:"domain"`
+}
+
+// domainRequest represents a generic wrapper for a domain request,
+// when domainWrapper cannot be used because of type constraint on Domain.
+type domainRequest struct {
+	Domain interface{} `json:"domain"`
+}
+
+// domainAction generates the resource path for given domain.
+func domainAction(action string) string {
+	if len(action) > 0 {
+		return fmt.Sprintf("Domain.%s", action)
+	}
+	return "Domain.List"
+}
+
+// List the domains.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/domains.html#domain-list
+func (s *DomainsService) List() ([]Domain, *Response, error) {
+	path := domainAction("List")
+	returnedDomains := domainListWrapper{}
+
+	payload := newPayLoad(s.client.CommonParams)
+	res, err := s.client.post(path, payload, &returnedDomains)
+	if err != nil {
+		return []Domain{}, res, err
+	}
+
+	domains := []Domain{}
+
+	if returnedDomains.Status.Code != "1" {
+		return domains, nil, fmt.Errorf("Could not get domains: %s", returnedDomains.Status.Message)
+	}
+
+	for _, domain := range returnedDomains.Domains {
+		domains = append(domains, domain)
+	}
+
+	return domains, res, nil
+}
+
+// Create a new domain.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/domains.html#domain-create
+func (s *DomainsService) Create(domainAttributes Domain) (Domain, *Response, error) {
+	path := domainAction("Create")
+	returnedDomain := domainWrapper{}
+
+	payload := newPayLoad(s.client.CommonParams)
+	payload.Set("domain", domainAttributes.Name)
+	payload.Set("group_id", domainAttributes.GroupID)
+	payload.Set("is_mark", domainAttributes.IsMark)
+
+	res, err := s.client.post(path, payload, &returnedDomain)
+	if err != nil {
+		return Domain{}, res, err
+	}
+
+	return returnedDomain.Domain, res, nil
+}
+
+// Get fetches a domain.
+//
+// dnspod API docs: https://www.dnspod.cn/docs/domains.html#domain-info
+func (s *DomainsService) Get(ID int) (Domain, *Response, error) {
+	path := domainAction("Info")
+	returnedDomain := domainWrapper{}
+
+	payload := newPayLoad(s.client.CommonParams)
+	payload.Set("domain_id", strconv.FormatInt(int64(ID), 10))
+
+	res, err := s.client.post(path, payload, &returnedDomain)
+	if err != nil {
+		return Domain{}, res, err
+	}
+
+	return returnedDomain.Domain, res, nil
+}
+
+// Delete a domain.
+//
+// dnspod API docs: https://dnsapi.cn/Domain.Remove
+func (s *DomainsService) Delete(ID int) (*Response, error) {
+	path := domainAction("Remove")
+	returnedDomain := domainWrapper{}
+
+	payload := newPayLoad(s.client.CommonParams)
+	payload.Set("domain_id", strconv.FormatInt(int64(ID), 10))
+
+	res, err := s.client.post(path, payload, &returnedDomain)
+	if err != nil {
+		return res, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
I'm adding dnspod, which is a China dns provider, to make federation work in AWS China region.

I can build the codes without errors but I don't know the correct way to deploy the affected codes into a real cluster.

I'm going to test the modifications following these procedures, please correct me if I'm doing something wrong:

1. build the codes without any errors using `make` under kubernetes root folder, it will produce some binaries including `_output/bin/kubefed`
1. build a docker image `hyperkube-amd64` using `KUBE_REGISTRY=qqshfox KUBERNETES_PROVIDER=vagrant make build` under federation folder, it will produce a image named `qqshfox/hyperkube-amd64:v1.8.0-alpha.2.1022_eae2917402ab71`
1. push it to the registry
1. set up federation following https://kubernetes.io/docs/tasks/federation/set-up-cluster-federation-kubefed/, with extra options `--image  qqshfox/hyperkube-amd64:v1.8.0-alpha.2.1022_eae2917402ab71`