### PR TITLE
Status objects for 404 API errors will have the correct APIVersion

### DIFF
--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -48,12 +48,12 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewREST returns a RESTStorage object that will work against clusters.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &federation.Cluster{} },
-		NewListFunc:       func() runtime.Object { return &federation.ClusterList{} },
-		PredicateFunc:     cluster.MatchCluster,
-		QualifiedResource: federation.Resource("clusters"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusters"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &federation.Cluster{} },
+		NewListFunc:              func() runtime.Object { return &federation.ClusterList{} },
+		PredicateFunc:            cluster.MatchCluster,
+		DefaultQualifiedResource: federation.Resource("clusters"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusters"),
 
 		CreateStrategy:      cluster.Strategy,
 		UpdateStrategy:      cluster.Strategy,

--- a/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
@@ -40,9 +40,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*admissionregistration.ExternalAdmissionHookConfiguration).Name, nil
 		},
-		PredicateFunc:     externaladmissionhookconfiguration.MatchExternalAdmissionHookConfiguration,
-		QualifiedResource: admissionregistration.Resource("externaladmissionhookconfigurations"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("externaladmissionhookconfigurations"),
+		PredicateFunc:            externaladmissionhookconfiguration.MatchExternalAdmissionHookConfiguration,
+		DefaultQualifiedResource: admissionregistration.Resource("externaladmissionhookconfigurations"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("externaladmissionhookconfigurations"),
 
 		CreateStrategy: externaladmissionhookconfiguration.Strategy,
 		UpdateStrategy: externaladmissionhookconfiguration.Strategy,

--- a/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
@@ -40,9 +40,9 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		ObjectNameFunc: func(obj runtime.Object) (string, error) {
 			return obj.(*admissionregistration.InitializerConfiguration).Name, nil
 		},
-		PredicateFunc:     initializerconfiguration.MatchInitializerConfiguration,
-		QualifiedResource: admissionregistration.Resource("initializerconfigurations"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("initializerconfigurations"),
+		PredicateFunc:            initializerconfiguration.MatchInitializerConfiguration,
+		DefaultQualifiedResource: admissionregistration.Resource("initializerconfigurations"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("initializerconfigurations"),
 
 		CreateStrategy: initializerconfiguration.Strategy,
 		UpdateStrategy: initializerconfiguration.Strategy,

--- a/pkg/registry/apps/controllerrevision/storage/storage.go
+++ b/pkg/registry/apps/controllerrevision/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work with ControllerRevision objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &apps.ControllerRevision{} },
-		NewListFunc:       func() runtime.Object { return &apps.ControllerRevisionList{} },
-		PredicateFunc:     controllerrevision.MatchControllerRevision,
-		QualifiedResource: apps.Resource("controllerrevisions"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("controllerrevisions"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &apps.ControllerRevision{} },
+		NewListFunc:              func() runtime.Object { return &apps.ControllerRevisionList{} },
+		PredicateFunc:            controllerrevision.MatchControllerRevision,
+		DefaultQualifiedResource: apps.Resource("controllerrevisions"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("controllerrevisions"),
 
 		CreateStrategy: controllerrevision.Strategy,
 		UpdateStrategy: controllerrevision.Strategy,

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &appsapi.StatefulSet{} },
-		NewListFunc:       func() runtime.Object { return &appsapi.StatefulSetList{} },
-		PredicateFunc:     statefulset.MatchStatefulSet,
-		QualifiedResource: appsapi.Resource("statefulsets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("statefulsets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &appsapi.StatefulSet{} },
+		NewListFunc:              func() runtime.Object { return &appsapi.StatefulSetList{} },
+		PredicateFunc:            statefulset.MatchStatefulSet,
+		DefaultQualifiedResource: appsapi.Resource("statefulsets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("statefulsets"),
 
 		CreateStrategy: statefulset.Strategy,
 		UpdateStrategy: statefulset.Strategy,

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -36,12 +36,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
-		NewListFunc:       func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
-		PredicateFunc:     horizontalpodautoscaler.MatchAutoscaler,
-		QualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
+		NewListFunc:              func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
+		PredicateFunc:            horizontalpodautoscaler.MatchAutoscaler,
+		DefaultQualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),
 
 		CreateStrategy: horizontalpodautoscaler.Strategy,
 		UpdateStrategy: horizontalpodautoscaler.Strategy,

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -37,15 +37,14 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against CronJobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &batch.CronJob{} },
-		NewListFunc:       func() runtime.Object { return &batch.CronJobList{} },
-		QualifiedResource: batch.Resource("cronjobs"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("cronjobs"),
-
-		CreateStrategy: cronjob.Strategy,
-		UpdateStrategy: cronjob.Strategy,
-		DeleteStrategy: cronjob.Strategy,
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &batch.CronJob{} },
+		NewListFunc:              func() runtime.Object { return &batch.CronJobList{} },
+		DefaultQualifiedResource: batch.Resource("cronjobs"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("cronjobs"),
+		CreateStrategy:           cronjob.Strategy,
+		UpdateStrategy:           cronjob.Strategy,
+		DeleteStrategy:           cronjob.Strategy,
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -52,12 +52,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Jobs.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &batch.Job{} },
-		NewListFunc:       func() runtime.Object { return &batch.JobList{} },
-		PredicateFunc:     job.MatchJob,
-		QualifiedResource: batch.Resource("jobs"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("jobs"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &batch.Job{} },
+		NewListFunc:              func() runtime.Object { return &batch.JobList{} },
+		PredicateFunc:            job.MatchJob,
+		DefaultQualifiedResource: batch.Resource("jobs"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("jobs"),
 
 		CreateStrategy: job.Strategy,
 		UpdateStrategy: job.Strategy,

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -36,12 +36,12 @@ type REST struct {
 // NewREST returns a registry which will store CertificateSigningRequest in the given helper
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *ApprovalREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &certificates.CertificateSigningRequest{} },
-		NewListFunc:       func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
-		PredicateFunc:     csrregistry.Matcher,
-		QualifiedResource: certificates.Resource("certificatesigningrequests"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &certificates.CertificateSigningRequest{} },
+		NewListFunc:              func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
+		PredicateFunc:            csrregistry.Matcher,
+		DefaultQualifiedResource: certificates.Resource("certificatesigningrequests"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),
 
 		CreateStrategy: csrregistry.Strategy,
 		UpdateStrategy: csrregistry.Strategy,

--- a/pkg/registry/core/configmap/storage/storage.go
+++ b/pkg/registry/core/configmap/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work with ConfigMap objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ConfigMap{} },
-		NewListFunc:       func() runtime.Object { return &api.ConfigMapList{} },
-		PredicateFunc:     configmap.MatchConfigMap,
-		QualifiedResource: api.Resource("configmaps"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("configmaps"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ConfigMap{} },
+		NewListFunc:              func() runtime.Object { return &api.ConfigMapList{} },
+		PredicateFunc:            configmap.MatchConfigMap,
+		DefaultQualifiedResource: api.Resource("configmaps"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("configmaps"),
 
 		CreateStrategy: configmap.Strategy,
 		UpdateStrategy: configmap.Strategy,

--- a/pkg/registry/core/endpoint/storage/storage.go
+++ b/pkg/registry/core/endpoint/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against endpoints.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Endpoints{} },
-		NewListFunc:       func() runtime.Object { return &api.EndpointsList{} },
-		PredicateFunc:     endpoint.MatchEndpoints,
-		QualifiedResource: api.Resource("endpoints"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("endpoints"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Endpoints{} },
+		NewListFunc:              func() runtime.Object { return &api.EndpointsList{} },
+		PredicateFunc:            endpoint.MatchEndpoints,
+		DefaultQualifiedResource: api.Resource("endpoints"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("endpoints"),
 
 		CreateStrategy: endpoint.Strategy,
 		UpdateStrategy: endpoint.Strategy,

--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -50,8 +50,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 		TTLFunc: func(runtime.Object, uint64, bool) (uint64, error) {
 			return ttl, nil
 		},
-		QualifiedResource: resource,
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource(resource.Resource),
+		DefaultQualifiedResource: resource,
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource(resource.Resource),
 
 		CreateStrategy: event.Strategy,
 		UpdateStrategy: event.Strategy,

--- a/pkg/registry/core/limitrange/storage/storage.go
+++ b/pkg/registry/core/limitrange/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.LimitRange{} },
-		NewListFunc:       func() runtime.Object { return &api.LimitRangeList{} },
-		PredicateFunc:     limitrange.MatchLimitRange,
-		QualifiedResource: api.Resource("limitranges"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("limitranges"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.LimitRange{} },
+		NewListFunc:              func() runtime.Object { return &api.LimitRangeList{} },
+		PredicateFunc:            limitrange.MatchLimitRange,
+		DefaultQualifiedResource: api.Resource("limitranges"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("limitranges"),
 
 		CreateStrategy: limitrange.Strategy,
 		UpdateStrategy: limitrange.Strategy,

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -54,12 +54,12 @@ type FinalizeREST struct {
 // NewREST returns a RESTStorage object that will work against namespaces.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *FinalizeREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Namespace{} },
-		NewListFunc:       func() runtime.Object { return &api.NamespaceList{} },
-		PredicateFunc:     namespace.MatchNamespace,
-		QualifiedResource: api.Resource("namespaces"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("namespaces"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Namespace{} },
+		NewListFunc:              func() runtime.Object { return &api.NamespaceList{} },
+		PredicateFunc:            namespace.MatchNamespace,
+		DefaultQualifiedResource: api.Resource("namespaces"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("namespaces"),
 
 		CreateStrategy:      namespace.Strategy,
 		UpdateStrategy:      namespace.Strategy,

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -73,12 +73,12 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 // NewStorage returns a NodeStorage object that will work against nodes.
 func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client.KubeletClientConfig, proxyTransport http.RoundTripper) (*NodeStorage, error) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Node{} },
-		NewListFunc:       func() runtime.Object { return &api.NodeList{} },
-		PredicateFunc:     node.MatchNode,
-		QualifiedResource: api.Resource("nodes"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("nodes"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Node{} },
+		NewListFunc:              func() runtime.Object { return &api.NodeList{} },
+		PredicateFunc:            node.MatchNode,
+		DefaultQualifiedResource: api.Resource("nodes"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("nodes"),
 
 		CreateStrategy: node.Strategy,
 		UpdateStrategy: node.Strategy,

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PersistentVolume{} },
-		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeList{} },
-		PredicateFunc:     persistentvolume.MatchPersistentVolumes,
-		QualifiedResource: api.Resource("persistentvolumes"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumes"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PersistentVolume{} },
+		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeList{} },
+		PredicateFunc:            persistentvolume.MatchPersistentVolumes,
+		DefaultQualifiedResource: api.Resource("persistentvolumes"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumes"),
 
 		CreateStrategy:      persistentvolume.Strategy,
 		UpdateStrategy:      persistentvolume.Strategy,

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volume claims.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PersistentVolumeClaim{} },
-		NewListFunc:       func() runtime.Object { return &api.PersistentVolumeClaimList{} },
-		PredicateFunc:     persistentvolumeclaim.MatchPersistentVolumeClaim,
-		QualifiedResource: api.Resource("persistentvolumeclaims"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PersistentVolumeClaim{} },
+		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeClaimList{} },
+		PredicateFunc:            persistentvolumeclaim.MatchPersistentVolumeClaim,
+		DefaultQualifiedResource: api.Resource("persistentvolumeclaims"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),
 
 		CreateStrategy:      persistentvolumeclaim.Strategy,
 		UpdateStrategy:      persistentvolumeclaim.Strategy,

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -66,12 +66,12 @@ type REST struct {
 func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGetter, proxyTransport http.RoundTripper, podDisruptionBudgetClient policyclient.PodDisruptionBudgetsGetter) PodStorage {
 
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Pod{} },
-		NewListFunc:       func() runtime.Object { return &api.PodList{} },
-		PredicateFunc:     pod.MatchPod,
-		QualifiedResource: api.Resource("pods"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("pods"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Pod{} },
+		NewListFunc:              func() runtime.Object { return &api.PodList{} },
+		PredicateFunc:            pod.MatchPod,
+		DefaultQualifiedResource: api.Resource("pods"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("pods"),
 
 		CreateStrategy:      pod.Strategy,
 		UpdateStrategy:      pod.Strategy,

--- a/pkg/registry/core/podtemplate/storage/storage.go
+++ b/pkg/registry/core/podtemplate/storage/storage.go
@@ -32,12 +32,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod templates.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.PodTemplate{} },
-		NewListFunc:       func() runtime.Object { return &api.PodTemplateList{} },
-		PredicateFunc:     podtemplate.MatchPodTemplate,
-		QualifiedResource: api.Resource("podtemplates"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podtemplates"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.PodTemplate{} },
+		NewListFunc:              func() runtime.Object { return &api.PodTemplateList{} },
+		PredicateFunc:            podtemplate.MatchPodTemplate,
+		DefaultQualifiedResource: api.Resource("podtemplates"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podtemplates"),
 
 		CreateStrategy: podtemplate.Strategy,
 		UpdateStrategy: podtemplate.Strategy,

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -61,12 +61,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ReplicationController{} },
-		NewListFunc:       func() runtime.Object { return &api.ReplicationControllerList{} },
-		PredicateFunc:     replicationcontroller.MatchController,
-		QualifiedResource: api.Resource("replicationcontrollers"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ReplicationController{} },
+		NewListFunc:              func() runtime.Object { return &api.ReplicationControllerList{} },
+		PredicateFunc:            replicationcontroller.MatchController,
+		DefaultQualifiedResource: api.Resource("replicationcontrollers"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),
 
 		CreateStrategy: replicationcontroller.Strategy,
 		UpdateStrategy: replicationcontroller.Strategy,

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against resource quotas.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ResourceQuota{} },
-		NewListFunc:       func() runtime.Object { return &api.ResourceQuotaList{} },
-		PredicateFunc:     resourcequota.MatchResourceQuota,
-		QualifiedResource: api.Resource("resourcequotas"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("resourcequotas"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ResourceQuota{} },
+		NewListFunc:              func() runtime.Object { return &api.ResourceQuotaList{} },
+		PredicateFunc:            resourcequota.MatchResourceQuota,
+		DefaultQualifiedResource: api.Resource("resourcequotas"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("resourcequotas"),
 
 		CreateStrategy:      resourcequota.Strategy,
 		UpdateStrategy:      resourcequota.Strategy,

--- a/pkg/registry/core/secret/storage/storage.go
+++ b/pkg/registry/core/secret/storage/storage.go
@@ -32,12 +32,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against secrets.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Secret{} },
-		NewListFunc:       func() runtime.Object { return &api.SecretList{} },
-		PredicateFunc:     secret.Matcher,
-		QualifiedResource: api.Resource("secrets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("secrets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Secret{} },
+		NewListFunc:              func() runtime.Object { return &api.SecretList{} },
+		PredicateFunc:            secret.Matcher,
+		DefaultQualifiedResource: api.Resource("secrets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("secrets"),
 
 		CreateStrategy: secret.Strategy,
 		UpdateStrategy: secret.Strategy,

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against services.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.Service{} },
-		NewListFunc:       func() runtime.Object { return &api.ServiceList{} },
-		PredicateFunc:     service.MatchServices,
-		QualifiedResource: api.Resource("services"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("services"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.Service{} },
+		NewListFunc:              func() runtime.Object { return &api.ServiceList{} },
+		PredicateFunc:            service.MatchServices,
+		DefaultQualifiedResource: api.Resource("services"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("services"),
 
 		CreateStrategy: service.Strategy,
 		UpdateStrategy: service.Strategy,

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -33,12 +33,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against service accounts.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &api.ServiceAccount{} },
-		NewListFunc:       func() runtime.Object { return &api.ServiceAccountList{} },
-		PredicateFunc:     serviceaccount.Matcher,
-		QualifiedResource: api.Resource("serviceaccounts"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("serviceaccounts"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &api.ServiceAccount{} },
+		NewListFunc:              func() runtime.Object { return &api.ServiceAccountList{} },
+		PredicateFunc:            serviceaccount.Matcher,
+		DefaultQualifiedResource: api.Resource("serviceaccounts"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("serviceaccounts"),
 
 		CreateStrategy:      serviceaccount.Strategy,
 		UpdateStrategy:      serviceaccount.Strategy,

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against DaemonSets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.DaemonSet{} },
-		NewListFunc:       func() runtime.Object { return &extensions.DaemonSetList{} },
-		PredicateFunc:     daemonset.MatchDaemonSet,
-		QualifiedResource: extensions.Resource("daemonsets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("daemonsets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.DaemonSet{} },
+		NewListFunc:              func() runtime.Object { return &extensions.DaemonSetList{} },
+		PredicateFunc:            daemonset.MatchDaemonSet,
+		DefaultQualifiedResource: extensions.Resource("daemonsets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("daemonsets"),
 
 		CreateStrategy: daemonset.Strategy,
 		UpdateStrategy: daemonset.Strategy,

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -63,12 +63,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against deployments.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *RollbackREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.Deployment{} },
-		NewListFunc:       func() runtime.Object { return &extensions.DeploymentList{} },
-		PredicateFunc:     deployment.MatchDeployment,
-		QualifiedResource: extensions.Resource("deployments"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("deployments"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.Deployment{} },
+		NewListFunc:              func() runtime.Object { return &extensions.DeploymentList{} },
+		PredicateFunc:            deployment.MatchDeployment,
+		DefaultQualifiedResource: extensions.Resource("deployments"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("deployments"),
 
 		CreateStrategy: deployment.Strategy,
 		UpdateStrategy: deployment.Strategy,

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.Ingress{} },
-		NewListFunc:       func() runtime.Object { return &extensions.IngressList{} },
-		PredicateFunc:     ingress.MatchIngress,
-		QualifiedResource: extensions.Resource("ingresses"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("ingresses"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.Ingress{} },
+		NewListFunc:              func() runtime.Object { return &extensions.IngressList{} },
+		PredicateFunc:            ingress.MatchIngress,
+		DefaultQualifiedResource: extensions.Resource("ingresses"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("ingresses"),
 
 		CreateStrategy: ingress.Strategy,
 		UpdateStrategy: ingress.Strategy,

--- a/pkg/registry/extensions/networkpolicy/storage/storage.go
+++ b/pkg/registry/extensions/networkpolicy/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against network policies.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
-		PredicateFunc:     networkpolicy.MatchNetworkPolicy,
-		QualifiedResource: extensionsapi.Resource("networkpolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("networkpolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensionsapi.NetworkPolicy{} },
+		NewListFunc:              func() runtime.Object { return &extensionsapi.NetworkPolicyList{} },
+		PredicateFunc:            networkpolicy.MatchNetworkPolicy,
+		DefaultQualifiedResource: extensionsapi.Resource("networkpolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("networkpolicies"),
 
 		CreateStrategy: networkpolicy.Strategy,
 		UpdateStrategy: networkpolicy.Strategy,

--- a/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against PodSecurityPolicy objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.PodSecurityPolicy{} },
-		NewListFunc:       func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
-		PredicateFunc:     podsecuritypolicy.MatchPodSecurityPolicy,
-		QualifiedResource: extensions.Resource("podsecuritypolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.PodSecurityPolicy{} },
+		NewListFunc:              func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
+		PredicateFunc:            podsecuritypolicy.MatchPodSecurityPolicy,
+		DefaultQualifiedResource: extensions.Resource("podsecuritypolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),
 
 		CreateStrategy:      podsecuritypolicy.Strategy,
 		UpdateStrategy:      podsecuritypolicy.Strategy,

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -60,12 +60,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ReplicaSet.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &extensions.ReplicaSet{} },
-		NewListFunc:       func() runtime.Object { return &extensions.ReplicaSetList{} },
-		PredicateFunc:     replicaset.MatchReplicaSet,
-		QualifiedResource: extensions.Resource("replicasets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("replicasets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &extensions.ReplicaSet{} },
+		NewListFunc:              func() runtime.Object { return &extensions.ReplicaSetList{} },
+		PredicateFunc:            replicaset.MatchReplicaSet,
+		DefaultQualifiedResource: extensions.Resource("replicasets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicasets"),
 
 		CreateStrategy: replicaset.Strategy,
 		UpdateStrategy: replicaset.Strategy,

--- a/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against NetworkPolicies
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &networkingapi.NetworkPolicy{} },
-		NewListFunc:       func() runtime.Object { return &networkingapi.NetworkPolicyList{} },
-		PredicateFunc:     networkpolicy.Matcher,
-		QualifiedResource: networkingapi.Resource("networkpolicies"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("networkpolicies"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &networkingapi.NetworkPolicy{} },
+		NewListFunc:              func() runtime.Object { return &networkingapi.NetworkPolicyList{} },
+		PredicateFunc:            networkpolicy.Matcher,
+		DefaultQualifiedResource: networkingapi.Resource("networkpolicies"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("networkpolicies"),
 
 		CreateStrategy: networkpolicy.Strategy,
 		UpdateStrategy: networkpolicy.Strategy,

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -37,12 +37,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against pod disruption budgets.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
-		NewListFunc:       func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
-		PredicateFunc:     poddisruptionbudget.MatchPodDisruptionBudget,
-		QualifiedResource: policyapi.Resource("poddisruptionbudgets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
+		NewListFunc:              func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
+		PredicateFunc:            poddisruptionbudget.MatchPodDisruptionBudget,
+		DefaultQualifiedResource: policyapi.Resource("poddisruptionbudgets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),
 
 		CreateStrategy: poddisruptionbudget.Strategy,
 		UpdateStrategy: poddisruptionbudget.Strategy,

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRole objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.ClusterRole{} },
-		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleList{} },
-		PredicateFunc:     clusterrole.Matcher,
-		QualifiedResource: rbac.Resource("clusterroles"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterroles"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.ClusterRole{} },
+		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleList{} },
+		PredicateFunc:            clusterrole.Matcher,
+		DefaultQualifiedResource: rbac.Resource("clusterroles"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterroles"),
 
 		CreateStrategy: clusterrole.Strategy,
 		UpdateStrategy: clusterrole.Strategy,

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against ClusterRoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.ClusterRoleBinding{} },
-		NewListFunc:       func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
-		PredicateFunc:     clusterrolebinding.Matcher,
-		QualifiedResource: rbac.Resource("clusterrolebindings"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.ClusterRoleBinding{} },
+		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
+		PredicateFunc:            clusterrolebinding.Matcher,
+		DefaultQualifiedResource: rbac.Resource("clusterrolebindings"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),
 
 		CreateStrategy: clusterrolebinding.Strategy,
 		UpdateStrategy: clusterrolebinding.Strategy,

--- a/pkg/registry/rbac/role/storage/storage.go
+++ b/pkg/registry/rbac/role/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against Role objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.Role{} },
-		NewListFunc:       func() runtime.Object { return &rbac.RoleList{} },
-		PredicateFunc:     role.Matcher,
-		QualifiedResource: rbac.Resource("roles"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("roles"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.Role{} },
+		NewListFunc:              func() runtime.Object { return &rbac.RoleList{} },
+		PredicateFunc:            role.Matcher,
+		DefaultQualifiedResource: rbac.Resource("roles"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("roles"),
 
 		CreateStrategy: role.Strategy,
 		UpdateStrategy: role.Strategy,

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against RoleBinding objects.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &rbac.RoleBinding{} },
-		NewListFunc:       func() runtime.Object { return &rbac.RoleBindingList{} },
-		PredicateFunc:     rolebinding.Matcher,
-		QualifiedResource: rbac.Resource("rolebindings"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("rolebindings"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &rbac.RoleBinding{} },
+		NewListFunc:              func() runtime.Object { return &rbac.RoleBindingList{} },
+		PredicateFunc:            rolebinding.Matcher,
+		DefaultQualifiedResource: rbac.Resource("rolebindings"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("rolebindings"),
 
 		CreateStrategy: rolebinding.Strategy,
 		UpdateStrategy: rolebinding.Strategy,

--- a/pkg/registry/scheduling/priorityclass/storage/storage.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage.go
@@ -35,12 +35,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against priority classes.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &schedulingapi.PriorityClass{} },
-		NewListFunc:       func() runtime.Object { return &schedulingapi.PriorityClassList{} },
-		PredicateFunc:     priorityclass.Matcher,
-		QualifiedResource: schedulingapi.Resource("priorityclasses"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("priorityclasses"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &schedulingapi.PriorityClass{} },
+		NewListFunc:              func() runtime.Object { return &schedulingapi.PriorityClassList{} },
+		PredicateFunc:            priorityclass.Matcher,
+		DefaultQualifiedResource: schedulingapi.Resource("priorityclasses"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("priorityclasses"),
 
 		CreateStrategy: priorityclass.Strategy,
 		UpdateStrategy: priorityclass.Strategy,

--- a/pkg/registry/settings/podpreset/storage/storage.go
+++ b/pkg/registry/settings/podpreset/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against replication controllers.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &settingsapi.PodPreset{} },
-		NewListFunc:       func() runtime.Object { return &settingsapi.PodPresetList{} },
-		PredicateFunc:     podpreset.Matcher,
-		QualifiedResource: settingsapi.Resource("podpresets"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("podpresets"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &settingsapi.PodPreset{} },
+		NewListFunc:              func() runtime.Object { return &settingsapi.PodPresetList{} },
+		PredicateFunc:            podpreset.Matcher,
+		DefaultQualifiedResource: settingsapi.Resource("podpresets"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podpresets"),
 
 		CreateStrategy: podpreset.Strategy,
 		UpdateStrategy: podpreset.Strategy,

--- a/pkg/registry/storage/storageclass/storage/storage.go
+++ b/pkg/registry/storage/storageclass/storage/storage.go
@@ -34,12 +34,12 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against persistent volumes.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
-		Copier:            api.Scheme,
-		NewFunc:           func() runtime.Object { return &storageapi.StorageClass{} },
-		NewListFunc:       func() runtime.Object { return &storageapi.StorageClassList{} },
-		PredicateFunc:     storageclass.MatchStorageClasses,
-		QualifiedResource: storageapi.Resource("storageclasses"),
-		WatchCacheSize:    cachesize.GetWatchCacheSizeByResource("storageclass"),
+		Copier:                   api.Scheme,
+		NewFunc:                  func() runtime.Object { return &storageapi.StorageClass{} },
+		NewListFunc:              func() runtime.Object { return &storageapi.StorageClassList{} },
+		PredicateFunc:            storageclass.MatchStorageClasses,
+		DefaultQualifiedResource: storageapi.Resource("storageclasses"),
+		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("storageclass"),
 
 		CreateStrategy:      storageclass.Strategy,
 		UpdateStrategy:      storageclass.Strategy,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -40,8 +40,8 @@ func NewREST(resource schema.GroupResource, listKind schema.GroupVersionKind, co
 			ret.SetGroupVersionKind(listKind)
 			return ret
 		},
-		PredicateFunc:     strategy.MatchCustomResourceDefinitionStorage,
-		QualifiedResource: resource,
+		PredicateFunc:            strategy.MatchCustomResourceDefinitionStorage,
+		DefaultQualifiedResource: resource,
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -41,11 +41,11 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
-		NewListFunc:       func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
-		PredicateFunc:     MatchCustomResourceDefinition,
-		QualifiedResource: apiextensions.Resource("customresourcedefinitions"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &apiextensions.CustomResourceDefinition{} },
+		NewListFunc:              func() runtime.Object { return &apiextensions.CustomResourceDefinitionList{} },
+		PredicateFunc:            MatchCustomResourceDefinition,
+		DefaultQualifiedResource: apiextensions.Resource("customresourcedefinitions"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -35,11 +35,11 @@ type REST struct {
 func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) *REST {
 	strategy := apiservice.NewStrategy(scheme)
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &apiregistration.APIService{} },
-		NewListFunc:       func() runtime.Object { return &apiregistration.APIServiceList{} },
-		PredicateFunc:     apiservice.MatchAPIService,
-		QualifiedResource: apiregistration.Resource("apiservices"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &apiregistration.APIService{} },
+		NewListFunc:              func() runtime.Object { return &apiregistration.APIServiceList{} },
+		PredicateFunc:            apiservice.MatchAPIService,
+		DefaultQualifiedResource: apiregistration.Resource("apiservices"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/etcd.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer/etcd.go
@@ -29,11 +29,11 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &wardle.Fischer{} },
-		NewListFunc:       func() runtime.Object { return &wardle.FischerList{} },
-		PredicateFunc:     MatchFischer,
-		QualifiedResource: wardle.Resource("fischers"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &wardle.Fischer{} },
+		NewListFunc:              func() runtime.Object { return &wardle.FischerList{} },
+		PredicateFunc:            MatchFischer,
+		DefaultQualifiedResource: wardle.Resource("fischers"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/etcd.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/etcd.go
@@ -29,11 +29,11 @@ func NewREST(scheme *runtime.Scheme, optsGetter generic.RESTOptionsGetter) (*reg
 	strategy := NewStrategy(scheme)
 
 	store := &genericregistry.Store{
-		Copier:            scheme,
-		NewFunc:           func() runtime.Object { return &wardle.Flunder{} },
-		NewListFunc:       func() runtime.Object { return &wardle.FlunderList{} },
-		PredicateFunc:     MatchFlunder,
-		QualifiedResource: wardle.Resource("flunders"),
+		Copier:                   scheme,
+		NewFunc:                  func() runtime.Object { return &wardle.Flunder{} },
+		NewListFunc:              func() runtime.Object { return &wardle.FlunderList{} },
+		PredicateFunc:            MatchFlunder,
+		DefaultQualifiedResource: wardle.Resource("flunders"),
 
 		CreateStrategy: strategy,
 		UpdateStrategy: strategy,


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/48959
superseded https://github.com/kubernetes/kubernetes/pull/49183


```release-note 
Status objects for 404 API errors will have the correct APIVersion
```