### PR TITLE
Make "kubeadm version" json format output more readable.

### DIFF
--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -67,7 +67,7 @@ func RunVersion(out io.Writer, cmd *cobra.Command) error {
 		}
 		fmt.Fprintln(out, string(y))
 	case "json":
-		y, err := json.Marshal(&v)
+		y, err := json.MarshalIndent(&v, "", "  ")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Add indent to json format output.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
ref: #43750 #46598

**Special notes for your reviewer**:
output example:
```
#kubeadm version -o json
{
  "clientVersion": {
    "major": "1",
    "minor": "8+",
    "gitVersion": "v1.8.0-alpha.2.1026+d8205661b700c6-dirty",
    "gitCommit": "d8205661b700c6f99c33ea0ac1e5ed3e49c202b2",
    "gitTreeState": "dirty",
    "buildDate": "2017-07-31T12:14:28Z",
    "goVersion": "go1.8.3",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
}
```


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
