### PR TITLE
Scheduler perf metrics server

### DIFF
--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//plugin/pkg/scheduler/factory:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/integration/scheduler_perf/scheduler_bench_test.go
+++ b/test/integration/scheduler_perf/scheduler_bench_test.go
@@ -55,7 +55,7 @@ func BenchmarkScheduling1000Nodes1000Pods(b *testing.B) {
 // and specific number of pods already scheduled. Since an operation takes relatively
 // long time, b.N should be small: 10 - 100.
 func benchmarkScheduling(numNodes, numScheduledPods int, b *testing.B) {
-	schedulerConfigFactory, finalFunc := mustSetupScheduler()
+	schedulerConfigFactory, finalFunc := mustSetupScheduler(metricServer)
 	defer finalFunc()
 	c := schedulerConfigFactory.GetClient()
 

--- a/test/integration/scheduler_perf/scheduler_test.go
+++ b/test/integration/scheduler_perf/scheduler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package benchmark
 
 import (
+	"flag"
 	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -68,6 +69,10 @@ var (
 	}
 )
 
+// To hold metric server flag being given as input.
+// TODO: Remove this variable once, we are reading this as input from yaml file.
+var metricServer bool
+
 // TestSchedule100Node3KPods schedules 3k pods on 100 nodes.
 func TestSchedule100Node3KPods(t *testing.T) {
 	if testing.Short() {
@@ -115,7 +120,7 @@ type testConfig struct {
 
 // getBaseConfig returns baseConfig after initializing number of nodes and pods.
 func getBaseConfig(nodes int, pods int) *testConfig {
-	schedulerConfigFactory, destroyFunc := mustSetupScheduler()
+	schedulerConfigFactory, destroyFunc := mustSetupScheduler(metricServer)
 	return &testConfig{
 		schedulerSupportFunctions: schedulerConfigFactory,
 		destroyFunc:               destroyFunc,
@@ -274,4 +279,9 @@ func writePodAndNodeTopologyToConfig(config *testConfig) error {
 		return err
 	}
 	return nil
+}
+
+func init() {
+	flag.BoolVar(&metricServer, "start-metrics-server", false, "Metrics server")
+	flag.Parse()
 }

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -17,10 +17,12 @@ limitations under the License.
 package benchmark
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
@@ -44,7 +46,7 @@ const enableEquivalenceCache = true
 // remove resources after finished.
 // Notes on rate limiter:
 //   - client rate limit is set to 5000.
-func mustSetupScheduler() (schedulerConfigurator scheduler.Configurator, destroyFunc func()) {
+func mustSetupScheduler(metricServerEnabled bool) (schedulerConfigurator scheduler.Configurator, destroyFunc func()) {
 
 	h := &framework.MasterHolder{Initialized: make(chan struct{})}
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -52,6 +54,9 @@ func mustSetupScheduler() (schedulerConfigurator scheduler.Configurator, destroy
 		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
+	if metricServerEnabled {
+		go setupMetricsServer()
+	}
 	framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
 
 	clientSet := clientset.NewForConfigOrDie(&restclient.Config{
@@ -99,6 +104,22 @@ func mustSetupScheduler() (schedulerConfigurator scheduler.Configurator, destroy
 		close(stop)
 		s.Close()
 		glog.Infof("destroyed")
+	}
+	return
+}
+
+// setupMetricsServer starts the metrics server on port 9091.
+func setupMetricsServer() {
+	glog.Infof("starting metrics server")
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", prometheus.Handler())
+	server := &http.Server{
+		// TODO: make the port configurable once we have yaml file.
+		Addr:    net.JoinHostPort("127.0.0.1", "9091"),
+		Handler: mux,
+	}
+	if err := server.ListenAndServe(); err != nil {
+		glog.Errorf("Error creating metrics server. Either port: %v", err)
 	}
 	return
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Prometheus metrics server for scheduler perf.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
@jayunit100 This for enabling prometheus metrics server in kubernetes. I have taken most of functions from your PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
