### PR TITLE
Ignore UDP metrics in kubelet

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -100,7 +100,7 @@ func New(address string, port uint, runtime string, rootPath string) (Interface,
 	sysFs := sysfs.NewRealSysFs()
 
 	// Create and start the cAdvisor container manager.
-	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}}, http.DefaultClient)
+	m, err := manager.New(memory.New(statsCacheDuration, nil), sysFs, maxHousekeepingInterval, allowDynamicHousekeeping, cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}, cadvisormetrics.NetworkUdpUsageMetrics: struct{}{}}, http.DefaultClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updating cadvisor godeps to 0.26.0 for the 1.7 release (#46658) added udp metrics.  However, they were not disabled in the kubelet.
This PR disables collection of UDP metrics in the kubelet.
This should be cherrypicked to the 1.7 branch.

cc @dchen1107 