### PR TITLE
Allow update to GC fields for RBAC resources

### DIFF
--- a/pkg/registry/rbac/BUILD
+++ b/pkg/registry/rbac/BUILD
@@ -5,14 +5,22 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["escalation_check.go"],
+    srcs = [
+        "escalation_check.go",
+        "helpers.go",
+    ],
     tags = ["automanaged"],
     deps = [
+        "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
@@ -40,4 +48,17 @@ filegroup(
         "//pkg/registry/rbac/validation:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    library = ":go_default_library",
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/api/helper:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
 )

--- a/pkg/registry/rbac/clusterrole/policybased/BUILD
+++ b/pkg/registry/rbac/clusterrole/policybased/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["storage.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/api/helper:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
@@ -59,6 +60,11 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx genericapirequest.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
 		clusterRole := obj.(*rbac.ClusterRole)
+
+		// if we're only mutating fields needed for the GC to eventually delete this obj, return
+		if rbacregistry.IsOnlyMutatingGCFields(obj, oldObj, kapihelper.Semantic) {
+			return obj, nil
+		}
 
 		rules := clusterRole.Rules
 		if err := rbacregistryvalidation.ConfirmNoEscalation(ctx, s.ruleResolver, rules); err != nil {

--- a/pkg/registry/rbac/clusterrolebinding/policybased/BUILD
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["storage.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/api/helper:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
+	kapihelper "k8s.io/kubernetes/pkg/api/helper"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	rbacregistry "k8s.io/kubernetes/pkg/registry/rbac"
 	rbacregistryvalidation "k8s.io/kubernetes/pkg/registry/rbac/validation"
@@ -70,6 +71,11 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 
 	nonEscalatingInfo := rest.WrapUpdatedObjectInfo(obj, func(ctx genericapirequest.Context, obj runtime.Object, oldObj runtime.Object) (runtime.Object, error) {
 		clusterRoleBinding := obj.(*rbac.ClusterRoleBinding)
+
+		// if we're only mutating fields needed for the GC to eventually delete this obj, return
+		if rbacregistry.IsOnlyMutatingGCFields(obj, oldObj, kapihelper.Semantic) {
+			return obj, nil
+		}
 
 		// if we're explicitly authorized to bind this clusterrole, return
 		if rbacregistry.BindingAuthorized(ctx, clusterRoleBinding.RoleRef, metav1.NamespaceNone, s.authorizer) {

--- a/pkg/registry/rbac/helpers.go
+++ b/pkg/registry/rbac/helpers.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+// IsOnlyMutatingGCFields checks finalizers and ownerrefs which GC manipulates
+// and indicates that only those fields are changing
+func IsOnlyMutatingGCFields(obj, old runtime.Object, equalities conversion.Equalities) bool {
+	// make a copy of the newObj so that we can stomp for comparison
+	copied, err := kapi.Scheme.Copy(obj)
+	if err != nil {
+		// if we couldn't copy, don't fail, just make it do the check
+		return false
+	}
+	copiedMeta, err := meta.Accessor(copied)
+	if err != nil {
+		return false
+	}
+	oldMeta, err := meta.Accessor(old)
+	if err != nil {
+		return false
+	}
+	copiedMeta.SetOwnerReferences(oldMeta.GetOwnerReferences())
+	copiedMeta.SetFinalizers(oldMeta.GetFinalizers())
+	copiedMeta.SetSelfLink(oldMeta.GetSelfLink())
+
+	return equalities.DeepEqual(copied, old)
+}

--- a/pkg/registry/rbac/helpers_test.go
+++ b/pkg/registry/rbac/helpers_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rbac
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kapihelper "k8s.io/kubernetes/pkg/api/helper"
+)
+
+func newPod() *kapi.Pod {
+	return &kapi.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations:     map[string]string{},
+			Name:            "foo",
+			OwnerReferences: []metav1.OwnerReference{},
+		},
+	}
+
+}
+
+func TestIsOnlyMutatingGCFields(t *testing.T) {
+	tests := []struct {
+		name     string
+		obj      func() runtime.Object
+		old      func() runtime.Object
+		expected bool
+	}{
+		{
+			name: "same",
+			obj: func() runtime.Object {
+				return newPod()
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: true,
+		},
+		{
+			name: "only annotations",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.Annotations["foo"] = "bar"
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: false,
+		},
+		{
+			name: "only other",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.Spec.RestartPolicy = kapi.RestartPolicyAlways
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: false,
+		},
+		{
+			name: "only ownerRef",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.OwnerReferences = append(obj.OwnerReferences, metav1.OwnerReference{Name: "foo"})
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: true,
+		},
+		{
+			name: "ownerRef and finalizer",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.OwnerReferences = append(obj.OwnerReferences, metav1.OwnerReference{Name: "foo"})
+				obj.Finalizers = []string{"final"}
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: true,
+		},
+		{
+			name: "and annotations",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.OwnerReferences = append(obj.OwnerReferences, metav1.OwnerReference{Name: "foo"})
+				obj.Annotations["foo"] = "bar"
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: false,
+		},
+		{
+			name: "and other",
+			obj: func() runtime.Object {
+				obj := newPod()
+				obj.OwnerReferences = append(obj.OwnerReferences, metav1.OwnerReference{Name: "foo"})
+				obj.Spec.RestartPolicy = kapi.RestartPolicyAlways
+				return obj
+			},
+			old: func() runtime.Object {
+				return newPod()
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		actual := IsOnlyMutatingGCFields(tc.obj(), tc.old(), kapihelper.Semantic)
+		if tc.expected != actual {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expected, actual)
+		}
+	}
+}

--- a/pkg/registry/rbac/role/policybased/BUILD
+++ b/pkg/registry/rbac/role/policybased/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["storage.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/api/helper:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",

--- a/pkg/registry/rbac/rolebinding/policybased/BUILD
+++ b/pkg/registry/rbac/rolebinding/policybased/BUILD
@@ -12,6 +12,7 @@ go_library(
     srcs = ["storage.go"],
     tags = ["automanaged"],
     deps = [
+        "//pkg/api/helper:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/registry/rbac:go_default_library",
         "//pkg/registry/rbac/validation:go_default_library",


### PR DESCRIPTION
This change makes it so that no escalation check is performed when updating only the garbage collector fields (owner references and finalizers) of RBAC resources.  This allows the garbage collector to delete roles that grant permissions such as "create", which it will never have.

Signed-off-by: Monis Khan <mkhan@redhat.com>

@kubernetes/sig-auth-api-reviews 

```release-note
NONE
```