### PR TITLE
add LocalZone into gce.conf and refactor gce cloud provider configura…

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -91,6 +91,7 @@ go_test(
     deps = [
         "//pkg/cloudprovider:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
+        "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -78,10 +78,19 @@ func setupProviderConfig() error {
 			managedZones = []string{zone}
 		}
 
-		gceCloud, err := gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ApiEndpoint,
-			framework.TestContext.CloudConfig.ProjectID,
-			region, zone, managedZones, "" /* networkUrl */, "" /* subnetworkUrl */, nil, /* nodeTags */
-			"" /* nodeInstancePerfix */, nil /* tokenSource */, false /* useMetadataServer */)
+		gceCloud, err := gcecloud.CreateGCECloud(&gcecloud.CloudConfig{
+			ApiEndpoint:        framework.TestContext.CloudConfig.ApiEndpoint,
+			ProjectID:          framework.TestContext.CloudConfig.ProjectID,
+			Region:             region,
+			Zone:               zone,
+			ManagedZones:       managedZones,
+			NetworkURL:         "",
+			SubnetworkURL:      "",
+			NodeTags:           nil,
+			NodeInstancePrefix: "",
+			TokenSource:        nil,
+			UseMetadataServer:  false})
+
 		if err != nil {
 			return fmt.Errorf("Error building GCE/GKE provider: %v", err)
 		}


### PR DESCRIPTION
The main goal of this PR is to make gce cloud provider able to run locally. 

1. added a LocalZone parameter into gce.conf. 
2. refactor `newGCECloud` to avoid contacting metadata server if configuration is already available. 

```release-note
None
```