### PR TITLE
Delete redundant print 'got:'

### DIFF
--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -322,7 +322,7 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(times) != 0 {
-			t.Errorf("expected 0 start times, got: , got: %v", times)
+			t.Errorf("expected 0 start times, got: %v", times)
 		}
 	}
 	{
@@ -338,7 +338,7 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(times) != 1 {
-			t.Errorf("expected 2 start times, got: , got: %v", times)
+			t.Errorf("expected 1 start times, got: %v", times)
 		} else if !times[0].Equal(T2) {
 			t.Errorf("expected: %v, got: %v", T1, times[0])
 		}
@@ -354,7 +354,7 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if len(times) != 2 {
-			t.Errorf("expected 2 start times, got: , got: %v", times)
+			t.Errorf("expected 2 start times, got: %v", times)
 		} else {
 			if !times[0].Equal(T1) {
 				t.Errorf("expected: %v, got: %v", T1, times[0])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Delete redundant print 'got:'

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/50592

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
