### PR TITLE
Add [sig-autoscaling] prefix to autoscaling e2e tests

### DIFF
--- a/test/e2e/autoscaling/BUILD
+++ b/test/e2e/autoscaling/BUILD
@@ -13,6 +13,7 @@ go_library(
         "autoscaling_timer.go",
         "cluster_size_autoscaling.go",
         "dns_autoscaling.go",
+        "framework.go",
         "horizontal_pod_autoscaling.go",
     ],
     tags = ["automanaged"],

--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -29,10 +29,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling", func() {
+var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling", func() {
 	f := framework.NewDefaultFramework("autoscaling")
 
-	framework.KubeDescribe("Autoscaling a service", func() {
+	SIGDescribe("Autoscaling a service", func() {
 		BeforeEach(func() {
 			// Check if Cloud Autoscaler is enabled by trying to get its ConfigMap.
 			_, err := f.ClientSet.CoreV1().ConfigMaps("kube-system").Get("cluster-autoscaler-status", metav1.GetOptions{})

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -75,7 +75,7 @@ const (
 	caOngoingScaleUpStatus = "InProgress"
 )
 
-var _ = framework.KubeDescribe("Cluster size autoscaling [Slow]", func() {
+var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 	f := framework.NewDefaultFramework("autoscaling")
 	var c clientset.Interface
 	var nodeCount int

--- a/test/e2e/autoscaling/dns_autoscaling.go
+++ b/test/e2e/autoscaling/dns_autoscaling.go
@@ -41,7 +41,7 @@ const (
 	DNSAutoscalerLabelName = "kube-dns-autoscaler"
 )
 
-var _ = framework.KubeDescribe("DNS horizontal autoscaling", func() {
+var _ = SIGDescribe("DNS horizontal autoscaling", func() {
 	f := framework.NewDefaultFramework("dns-autoscaling")
 	var c clientset.Interface
 	var previousParams map[string]string

--- a/test/e2e/autoscaling/framework.go
+++ b/test/e2e/autoscaling/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package autoscaling
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-autoscaling] "+text, body)
+}

--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -27,14 +27,14 @@ import (
 
 // These tests don't seem to be running properly in parallel: issue: #20338.
 //
-var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
+var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
 	var rc *common.ResourceConsumer
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 
 	titleUp := "Should scale from 1 pod to 3 pods and from 3 to 5"
 	titleDown := "Should scale from 5 pods to 3 pods and from 3 to 1"
 
-	framework.KubeDescribe("[Serial] [Slow] Deployment", func() {
+	SIGDescribe("[Serial] [Slow] Deployment", func() {
 		// CPU tests via deployments
 		It(titleUp, func() {
 			scaleUp("test-deployment", common.KindDeployment, false, rc, f)
@@ -44,7 +44,7 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 		})
 	})
 
-	framework.KubeDescribe("[Serial] [Slow] ReplicaSet", func() {
+	SIGDescribe("[Serial] [Slow] ReplicaSet", func() {
 		// CPU tests via deployments
 		It(titleUp, func() {
 			scaleUp("rs", common.KindReplicaSet, false, rc, f)
@@ -55,7 +55,7 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 	})
 
 	// These tests take ~20 minutes each.
-	framework.KubeDescribe("[Serial] [Slow] ReplicationController", func() {
+	SIGDescribe("[Serial] [Slow] ReplicationController", func() {
 		// CPU tests via replication controllers
 		It(titleUp+" and verify decision stability", func() {
 			scaleUp("rc", common.KindRC, true, rc, f)
@@ -65,7 +65,7 @@ var _ = framework.KubeDescribe("[HPA] Horizontal pod autoscaling (scale resource
 		})
 	})
 
-	framework.KubeDescribe("ReplicationController light", func() {
+	SIGDescribe("ReplicationController light", func() {
 		It("Should scale from 1 pod to 2 pods", func() {
 			scaleTest := &HPAScaleTest{
 				initPods:                    1,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Add [sig-autoscaling] prefix to autoscaling e2e tests

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Umbrella issue #49161

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
