### PR TITLE
Temporarily remove SQ-blocking integration test

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/client-go_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/client-go_test.go
@@ -29,7 +29,7 @@ import (
 	examplecontroller "k8s.io/apiextensions-apiserver/examples/client-go/controller"
 )
 
-func TestClientGoCustomResourceExample(t *testing.T) {
+func SkipTestClientGoCustomResourceExample(t *testing.T) {
 	t.Logf("Creating apiextensions apiserver")
 	config, err := testserver.DefaultServerConfig()
 	if err != nil {


### PR DESCRIPTION
The SQ seems blocked due to `pull-kubernetes-unit` failing on this particular integration test (e.g - https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/pull/49382/pull-kubernetes-unit/)
Does this sound reasonable (or the other more drastic option is to revert https://github.com/kubernetes/kubernetes/pull/47665)? Otherwise feel free to close the PR.

/cc @k8s-oncall @wojtek-t @caesarxuchao @ironcladlou 