### PR TITLE
There is no need to split service key repeatedly

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -328,12 +328,6 @@ func (e *EndpointController) syncService(key string) error {
 		// service is deleted. However, if we're down at the time when
 		// the service is deleted, we will miss that deletion, so this
 		// doesn't completely solve the problem. See #6877.
-		namespace, name, err := cache.SplitMetaNamespaceKey(key)
-		if err != nil {
-			utilruntime.HandleError(fmt.Errorf("Need to delete endpoint with key %q, but couldn't understand the key: %v", key, err))
-			// Don't retry, as the key isn't going to magically become understandable.
-			return nil
-		}
 		err = e.client.Core().Endpoints(namespace).Delete(name, nil)
 		if err != nil && !errors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```
