### PR TITLE
Automated cherry pick of #49043

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -71,8 +71,6 @@ fi
 
 if [[ -n "${NODE_INSTANCE_PREFIX:-}" ]]; then
   NODE_INSTANCE_GROUP="${NODE_INSTANCE_PREFIX}-group"
-else
-  NODE_INSTANCE_GROUP=""
 fi
 
 if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
@@ -88,7 +86,10 @@ if [[ "${KUBERNETES_PROVIDER}" == "gce" ]]; then
   done
 fi
 
-if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+# TODO(kubernetes/test-infra#3330): Allow NODE_INSTANCE_GROUP to be
+# set before we get here, which eliminates any cluster/gke use if
+# KUBERNETES_CONFORMANCE_PROVIDER is set to "gke".
+if [[ -z "${NODE_INSTANCE_GROUP:-}" ]] && [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
   detect-node-instance-groups
   NODE_INSTANCE_GROUP=$(kube::util::join , "${NODE_INSTANCE_GROUPS[@]}")
 fi


### PR DESCRIPTION
Cherry pick of #49043 on release-1.6.

#49043: cluster/gke: If NODE_INSTANCE_GROUP is set, don't execute any