### PR TITLE
Update calico to v2.4 and enable health checks

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: calico/node:v1.3.0
+          image: calico/node:v2.4.1
           env:
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
@@ -46,6 +46,8 @@ spec:
               value: "none"
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"
+            - name: FELIX_HEALTHENABLED
+              value: "true"
             - name: IP
               value: ""
             - name: NO_DEFAULT_POOLS
@@ -61,6 +63,18 @@ spec:
           resources:
             requests:
               cpu: __CALICO_NODE_CPU__
+          livenessProbe:
+            httpGet:
+              path: /liveness
+              port: 9099
+            periodSeconds: 10
+            initialDelaySeconds: 10
+            failureThreshold: 6
+          readinessProbe:
+            httpGet:
+              path: /readiness
+              port: 9099
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /lib/modules
               name: lib-modules
@@ -71,7 +85,7 @@ spec:
         # This container installs the Calico CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: calico/cni:v1.9.1
+          image: calico/cni:v1.10.0
           command: ["/install-cni.sh"]
           env:
             - name: CNI_CONF_NAME

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         operator: Exists
       hostNetwork: true
       containers:
-      - image: calico/typha:v0.2.3
+      - image: calico/typha:v0.3.1
         name: calico-typha
         ports:
         - containerPort: 5473
@@ -45,6 +45,8 @@ spec:
             value: "kubernetes"
           - name: TYPHA_MAXCONNECTIONSLOWERLIMIT
             value: "1"
+          - name: TYPHA_HEALTHENABLED
+            value: "true"
         volumeMounts:
         - mountPath: /etc/calico
           name: etc-calico
@@ -52,6 +54,17 @@ spec:
         resources:
           requests:
             cpu: __CALICO_TYPHA_CPU__
+        livenessProbe:
+          httpGet:
+            path: /liveness
+            port: 9098
+          periodSeconds: 30
+          initialDelaySeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readiness
+            port: 9098
+          periodSeconds: 10
       volumes:
       - name: etc-calico
         hostPath:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
- Updates Calico to `v2.4`
  - Calico/node to `v2.4`
  - Calico CNI to `v1.10.0`
  - Typha to `v0.3.1`
- Enable health check endpoints
  - Add Readiness probe for calico-node and Typha
  - Add Liveness probe for calico-node and Typha
 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NA

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
