### PR TITLE
Correctly handle empty watch event cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/watch_cache.go
@@ -412,7 +412,9 @@ func (w *watchCache) SetOnEvent(onEvent func(*watchCacheEvent)) {
 
 func (w *watchCache) GetAllEventsSinceThreadUnsafe(resourceVersion uint64) ([]*watchCacheEvent, error) {
 	size := w.endIndex - w.startIndex
-	oldest := w.resourceVersion
+	// if we have no watch events in our cache, the oldest one we can successfully deliver to a watcher
+	// is the *next* event we'll receive, which will be at least one greater than our current resourceVersion
+	oldest := w.resourceVersion + 1
 	if size > 0 {
 		oldest = w.cache[w.startIndex%w.capacity].resourceVersion
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/49956

Introduced by https://github.com/kubernetes/kubernetes/commit/ada60236f70c31dfa8fd8b5799cae12ab44d3e36 which did not adjust the oldest available resourceVersion for an empty watch event cache.

Exposed by https://github.com/kubernetes/kubernetes/commit/74b9ba3b4d7c6f0a116464ac01a5f98b915d4586, which allowed controllers to get list results from etcd before the watch cache is ready (normally they list with resourceVersion=0 which serves the list request from the watch cache, blocking until it is ready)

When the watch cache had an empty cache of watch events, it currently allows establishing a watch as if it can deliver a watch event for its currently synced resourceVersion. This results in an off-by-one error which can result in a missed watch event.

Scenario:

bob:
1. creates object at resourceVersion=11

sally:
1. does a list API request, gets a list resourceVersion of 10 (just before bob creates the object)
2. starts watch handled by watch cache at resourceVersion=10

Watch cache:
1. initial list gets resourceVersion=11, including the item created by bob
2. when determining the initial watch events to send to sally's watch, there are no watch events in the cache, so no initial watch events are sent.
3. the cache listerwatcher watches etcd starting at resourceVersion=11, so future events are fed into the event cache and to sally's watch

The watch cache should have dropped sally's watch from resourceVersion=10 with a "gone" error, since it can't deliver the watch event for resourceVersion=11. This would force sally to relist (where she would get a list at resourceVersion=11) and rewatch (from resourceVersion=11)

This particularly affects tests that create CRD/TPRs and establish watches on the new types as the storage layer's watch cache is also populating for that type.

```release-note
Fixed a bug in the API server watch cache, which could cause a missing watch event immediately after cache initialization.
```