### PR TITLE
Add individual kubeclient for leader-election in scheduler

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -69,6 +69,14 @@ func Run(s *options.SchedulerServer) error {
 	if err != nil {
 		return fmt.Errorf("unable to create kube client: %v", err)
 	}
+	// TODO: Deprecate this when upstream has a better solution.
+	// Use individual client for leader-election, to separate controlling requests e.g. leader election
+	// and data requests e.g. get pods. To avoid the case that when there are lot of data requests,
+	// leader-election get blocked and make scheduler panic.
+	leaderElectionCli, err := createClient(s)
+	if err != nil {
+		return fmt.Errorf("unable to create kube client for leader-election: %v", err)
+	}
 
 	recorder := createRecorder(kubecli, s)
 
@@ -121,7 +129,7 @@ func Run(s *options.SchedulerServer) error {
 	rl, err := resourcelock.New(s.LeaderElection.ResourceLock,
 		s.LockObjectNamespace,
 		s.LockObjectName,
-		kubecli.CoreV1(),
+		leaderElectionCli.CoreV1(),
 		resourcelock.ResourceLockConfig{
 			Identity:      id,
 			EventRecorder: recorder,


### PR DESCRIPTION

**What this PR does / why we need it**:
Add individual kubeclient for leader-election in scheduler, to fix the case scheduler panic at leader election fail when there a lot of failed-scheduling pods

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49947

**Special notes for your reviewer**:
It is a quick fix for the issue,  and we should deprecate this when upstream has a better solution

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
