### PR TITLE
use return fast and ignore an else block to improve code in kubelet

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -253,29 +253,27 @@ func startKubeletConfigSyncLoop(s *options.KubeletServer, currentKC string) {
 // a background thread that checks for updates to configs.
 func initKubeletConfigSync(s *options.KubeletServer) (*componentconfig.KubeletConfiguration, error) {
 	jsonstr, err := getRemoteKubeletConfig(s, nil)
-	if err == nil {
-		// We will compare future API server config against the config we just got (jsonstr):
-		startKubeletConfigSyncLoop(s, jsonstr)
-
-		// Convert json from API server to external type struct, and convert that to internal type struct
-		extKC := componentconfigv1alpha1.KubeletConfiguration{}
-		err := runtime.DecodeInto(api.Codecs.UniversalDecoder(), []byte(jsonstr), &extKC)
-		if err != nil {
-			return nil, err
-		}
-		api.Scheme.Default(&extKC)
-		kc := componentconfig.KubeletConfiguration{}
-		err = api.Scheme.Convert(&extKC, &kc, nil)
-		if err != nil {
-			return nil, err
-		}
-		return &kc, nil
-	} else {
+	if err != nil {
 		// Couldn't get a configuration from the API server yet.
 		// Restart as soon as anything comes back from the API server.
 		startKubeletConfigSyncLoop(s, "")
 		return nil, err
 	}
+
+	// We will compare future API server config against the config we just got (jsonstr):
+	startKubeletConfigSyncLoop(s, jsonstr)
+
+	// Convert json from API server to external type struct, and convert that to internal type struct
+	extKC := componentconfigv1alpha1.KubeletConfiguration{}
+	if err := runtime.DecodeInto(api.Codecs.UniversalDecoder(), []byte(jsonstr), &extKC); err != nil {
+		return nil, err
+	}
+	api.Scheme.Default(&extKC)
+	kc := componentconfig.KubeletConfiguration{}
+	if err := api.Scheme.Convert(&extKC, &kc, nil); err != nil {
+		return nil, err
+	}
+	return &kc, nil
 }
 
 // Run runs the specified KubeletServer with the given Dependencies.  This should never exit.


### PR DESCRIPTION
Signed-off-by: allencloud <allen.sun@daocloud.io>

**What this PR does / why we need it**:
This PR uses return fast and ignore an else block for code. And I think this will make code more clean and more readable. This ignoring else block will make the main code stream keep in the same block.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Special notes for your reviewer**:
NONE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
