### PR TITLE
Add more debug info to openapi generator

### DIFF
--- a/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
+++ b/vendor/k8s.io/kube-openapi/pkg/generators/openapi.go
@@ -328,6 +328,7 @@ func (g openAPITypeWriter) generateMembers(t *types.Type, required []string) ([]
 			required = append(required, name)
 		}
 		if err = g.generateProperty(&m, t); err != nil {
+			fmt.Printf("Error when generating: %v, %v\n", name, m)
 			return required, err
 		}
 	}


### PR DESCRIPTION
This log makes it way easier to debug bugs in type references.