### PR TITLE
use specified discovery information if possible

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -117,7 +117,10 @@ func NewDefaultRESTMapper(defaultGroupVersions []schema.GroupVersion, f VersionI
 
 func (m *DefaultRESTMapper) Add(kind schema.GroupVersionKind, scope RESTScope) {
 	plural, singular := UnsafeGuessKindToResource(kind)
+	m.AddSpecific(kind, plural, singular, scope)
+}
 
+func (m *DefaultRESTMapper) AddSpecific(kind schema.GroupVersionKind, plural, singular schema.GroupVersionResource, scope RESTScope) {
 	m.singularToPlural[singular] = plural
 	m.pluralToSingular[plural] = singular
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/49948

This uses the available discovery information if available, but it seems we never updated "normal" resources to show the singular name, so its often not available.  I've left this code compatible.

@enisoc @ash2k 
@kubernetes/sig-api-machinery-misc 

```release-note
custom resources that use unconventional pluralization now work properly with kubectl and garbage collection
```