### PR TITLE
Remove extraneous white space

### DIFF
--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -47,7 +47,7 @@ var (
 		the --grace-period flag, or pass --now to set a grace-period of 1. Because these resources often
 		represent entities in the cluster, deletion may not be acknowledged immediately. If the node
 		hosting a pod is down or cannot reach the API server, termination may take significantly longer
-		than the grace period. To force delete a resource,	you must pass a grace	period of 0 and specify
+		than the grace period. To force delete a resource, you must pass a grace period of 0 and specify
 		the --force flag.
 
 		IMPORTANT: Force deleting pods does not wait for confirmation that the pod's processes have been
@@ -60,9 +60,9 @@ var (
 		Also, if you force delete pods the scheduler may place new pods on those nodes before the node
 		has released those resources and causing those pods to be evicted immediately.
 
-		Note that the delete command does NOT do resource version checks, so if someone
-		submits an update to a resource right when you submit a delete, their update
-		will be lost along with the rest of the resource.`))
+		Note that the delete command does NOT do resource version checks, so if someone submits an
+		update to a resource right when you submit a delete, their update will be lost along with the
+		rest of the resource.`))
 
 	delete_example = templates.Examples(i18n.T(`
 		# Delete a pod using the type and name specified in pod.json.


### PR DESCRIPTION
**What this PR does / why we need it**:

Output from command `kubectl delete --help` contains extraneous whitespace. While we are at it, paragraph in multi-paragraph section has shorter line lengths, text looks better if all paragraphs have similar line lengths.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

White space only. This PR is outward facing but so trivial I don't think it needs a release note. I'm new around here, if this assumption is incorrect please tell me. Thanks.

**Release note**:

```release-note
NONE
```
