### PR TITLE
Add additional example usage

### DIFF
--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -48,7 +48,10 @@ type VersionOptions struct {
 var (
 	versionExample = templates.Examples(i18n.T(`
 		# Print the client and server versions for the current context
-		kubectl version`))
+		kubectl version
+
+		# Print the client version in yaml format
+		kubectl version --client --output=yaml`))
 )
 
 func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl version --help` has only a single example. There are three options to the `version` command, an extra example aids command comprehension.

/sig cli
/kind documentation

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Add additional command example to `kubectl version --help`
```