### PR TITLE
Fix typo in test/images/port-forward-tester/Makefile

### DIFF
--- a/test/images/port-forward-tester/Makefile
+++ b/test/images/port-forward-tester/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SRSC=portforwardtester
+SRCS=portforwardtester
 ARCH ?= amd64
 TARGET ?= $(CURDIR)
 GOLANG_VERSION ?= latest


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: the image build fails due to this typo:
```console
$ make WHAT=port-forward-tester
./image-util.sh build port-forward-tester
Building image for port-forward-tester ARCH: ppc64le...
make[1]: Entering directory '[home]/src/k8s.io/kubernetes/test/images/port-forward-tester'
../image-util.sh bin
../image-util.sh: line 22: $2: unbound variable
```

Images already pushed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/approve no-issue
/assign @mkumatag 