### PR TITLE
Remove [k8s.io] tag and redundant [sig-storage] tags from volume tests

### DIFF
--- a/test/e2e/common/volumes.go
+++ b/test/e2e/common/volumes.go
@@ -53,7 +53,7 @@ import (
 
 // These tests need privileged containers, which are disabled by default.  Run
 // the test with "go run hack/e2e.go ... --ginkgo.focus=[Feature:Volumes]"
-var _ = framework.KubeDescribe("[sig-storage] GCP Volumes", func() {
+var _ = Describe("[sig-storage] GCP Volumes", func() {
 	f := framework.NewDefaultFramework("gcp-volume")
 
 	// If 'false', the test won't clear its volumes upon completion. Useful for debugging,
@@ -73,7 +73,7 @@ var _ = framework.KubeDescribe("[sig-storage] GCP Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// NFS
 	////////////////////////////////////////////////////////////////////////
-	framework.KubeDescribe("NFSv4", func() {
+	Describe("NFSv4", func() {
 		It("should be mountable for NFSv4", func() {
 			config, _, serverIP := framework.NewNFSServer(c, namespace.Name, []string{})
 			defer func() {
@@ -101,7 +101,7 @@ var _ = framework.KubeDescribe("[sig-storage] GCP Volumes", func() {
 		})
 	})
 
-	framework.KubeDescribe("NFSv3", func() {
+	Describe("NFSv3", func() {
 		It("should be mountable for NFSv3", func() {
 			config, _, serverIP := framework.NewNFSServer(c, namespace.Name, []string{})
 			defer func() {
@@ -131,7 +131,7 @@ var _ = framework.KubeDescribe("[sig-storage] GCP Volumes", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
-	framework.KubeDescribe("GlusterFS", func() {
+	Describe("GlusterFS", func() {
 		It("should be mountable", func() {
 			// create gluster server and endpoints
 			config, _, _ := framework.NewGlusterfsServer(c, namespace.Name)

--- a/test/e2e/storage/volume_io.go
+++ b/test/e2e/storage/volume_io.go
@@ -243,7 +243,7 @@ var _ = SIGDescribe("Volume plugin streaming [Slow]", func() {
 	////////////////////////////////////////////////////////////////////////
 	// NFS
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("NFS", func() {
+	Describe("NFS", func() {
 		testFile := "nfs_io_test"
 		// client pod uses selinux
 		podSec := v1.PodSecurityContext{
@@ -279,7 +279,7 @@ var _ = SIGDescribe("Volume plugin streaming [Slow]", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Gluster
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("GlusterFS", func() {
+	Describe("GlusterFS", func() {
 		var name string
 		testFile := "gluster_io_test"
 
@@ -325,7 +325,7 @@ var _ = SIGDescribe("Volume plugin streaming [Slow]", func() {
 	// iSCSI
 	// The iscsiadm utility and iscsi target kernel modules must be installed on all nodes.
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("iSCSI [Feature:Volumes]", func() {
+	Describe("iSCSI [Feature:Volumes]", func() {
 		testFile := "iscsi_io_test"
 
 		BeforeEach(func() {
@@ -362,7 +362,7 @@ var _ = SIGDescribe("Volume plugin streaming [Slow]", func() {
 	////////////////////////////////////////////////////////////////////////
 	// Ceph RBD
 	////////////////////////////////////////////////////////////////////////
-	SIGDescribe("Ceph-RBD [Feature:Volumes]", func() {
+	Describe("Ceph-RBD [Feature:Volumes]", func() {
 		var (
 			secret *v1.Secret
 			name   string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Removes redundant tags from storage e2e test names

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50178

**Release note**:
/release-note-none
