### PR TITLE
Add UTs for pkg/kubectl/generate_test.go

### DIFF
--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -159,6 +159,12 @@ func ParseProtocols(protocols interface{}) (map[string]string, error) {
 		if len(portProtocol) != 2 {
 			return nil, fmt.Errorf("unexpected port protocol mapping: %s", protocolsSlice[ix])
 		}
+		if len(portProtocol[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty port")
+		}
+		if len(portProtocol[1]) == 0 {
+			return nil, fmt.Errorf("unexpected empty protocol")
+		}
 		portProtocolMap[portProtocol[0]] = portProtocol[1]
 	}
 	return portProtocolMap, nil
@@ -187,6 +193,9 @@ func ParseLabels(labelSpec interface{}) (map[string]string, error) {
 		labelSpec := strings.Split(labelSpecs[ix], "=")
 		if len(labelSpec) != 2 {
 			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
+		}
+		if len(labelSpec[0]) == 0 {
+			return nil, fmt.Errorf("unexpected empty label key")
 		}
 		labels[labelSpec[0]] = labelSpec[1]
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Fix  pkg/kubectl [ParseLabels](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/generate.go#L176) & [ParseProtocols](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/generate.go#L147) bugs and add some UTs

**Which issue this PR fixes**: fixes #50060 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
