### PR TITLE
Add UT for pkg/kubectl/autoscale_test.go

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -9,6 +9,7 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "autoscale_test.go",
         "cluster_test.go",
         "configmap_test.go",
         "delete_test.go",
@@ -50,6 +51,7 @@ go_test(
         "//pkg/printers:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -116,7 +118,6 @@ go_library(
         "//pkg/api/v1:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
-        "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/policy:go_default_library",
@@ -140,6 +141,7 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/kubectl/autoscale.go
+++ b/pkg/kubectl/autoscale.go
@@ -20,10 +20,9 @@ import (
 	"fmt"
 	"strconv"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 type HorizontalPodAutoscalerV1 struct{}
@@ -91,12 +90,12 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 		}
 	}
 
-	scaler := autoscaling.HorizontalPodAutoscaler{
+	scaler := autoscalingv1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: autoscaling.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscaling.CrossVersionObjectReference{
+		Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
 				Kind:       params["scaleRef-kind"],
 				Name:       params["scaleRef-name"],
 				APIVersion: params["scaleRef-apiVersion"],
@@ -110,15 +109,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 	if cpu >= 0 {
 		c := int32(cpu)
-		scaler.Spec.Metrics = []autoscaling.MetricSpec{
-			{
-				Type: autoscaling.ResourceMetricSourceType,
-				Resource: &autoscaling.ResourceMetricSource{
-					Name: api.ResourceCPU,
-					TargetAverageUtilization: &c,
-				},
-			},
-		}
+		scaler.Spec.TargetCPUUtilizationPercentage = &c
 	}
 	return &scaler, nil
 }

--- a/pkg/kubectl/autoscale_test.go
+++ b/pkg/kubectl/autoscale_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"reflect"
+	"testing"
+
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestHPAGenerate(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    map[string]interface{}
+		expected  *autoscalingv1.HorizontalPodAutoscaler
+		expectErr bool
+	}{
+		{
+			name: "valid case",
+			params: map[string]interface{}{
+				"name":                "foo",
+				"min":                 "1",
+				"max":                 "10",
+				"cpu-percent":         "80",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expected: &autoscalingv1.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: autoscalingv1.HorizontalPodAutoscalerSpec{
+					TargetCPUUtilizationPercentage: newInt32(80),
+					ScaleTargetRef: autoscalingv1.CrossVersionObjectReference{
+						Kind:       "kind",
+						Name:       "name",
+						APIVersion: "apiVersion",
+					},
+					MaxReplicas: int32(10),
+					MinReplicas: newInt32(1),
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "'name' is a required parameter",
+			params: map[string]interface{}{
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+		{
+			name: "'max' is a required parameter",
+			params: map[string]interface{}{
+				"default-name":        "foo",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+		{
+			name: "'max' must be greater than or equal to 'min'",
+			params: map[string]interface{}{
+				"name":                "foo",
+				"min":                 "10",
+				"max":                 "1",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+		{
+			name: "cpu-percent must be an integer if specified",
+			params: map[string]interface{}{
+				"name":                "foo",
+				"min":                 "1",
+				"max":                 "10",
+				"cpu-percent":         "",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+		{
+			name: "'min' must be an integer if specified",
+			params: map[string]interface{}{
+				"name":                "foo",
+				"min":                 "foo",
+				"max":                 "10",
+				"cpu-percent":         "60",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+		{
+			name: "'max' must be an integer if specified",
+			params: map[string]interface{}{
+				"name":                "foo",
+				"min":                 "1",
+				"max":                 "bar",
+				"cpu-percent":         "90",
+				"scaleRef-kind":       "kind",
+				"scaleRef-name":       "name",
+				"scaleRef-apiVersion": "apiVersion",
+			},
+			expectErr: true,
+		},
+	}
+	generator := HorizontalPodAutoscalerV1{}
+	for _, test := range tests {
+		obj, err := generator.Generate(test.params)
+		if test.expectErr && err != nil {
+			continue
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("[%s] unexpected error: %v", test.name, err)
+		}
+		if test.expectErr && err == nil {
+			t.Errorf("[%s] expect error, got nil", test.name)
+		}
+		if !reflect.DeepEqual(obj.(*autoscalingv1.HorizontalPodAutoscaler), test.expected) {
+			t.Errorf("[%s] want:\n%#v\ngot:\n%#v", test.name, test.expected, obj.(*autoscalingv1.HorizontalPodAutoscaler))
+		}
+	}
+}
+
+func newInt32(value int) *int32 {
+	v := int32(value)
+	return &v
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

I find there is no UT for testing pkg/kubectl `HorizontalPodAutoscalerV1.generate(params)`. This PR add some UTs in pkg/kubectl/autoscale_test.go

**Which issue this PR fixes** : fixes #50810

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/sig cli