### PR TITLE
Simplify a command for unmounting mounted directories

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -97,7 +97,7 @@ func (r *Reset) Run(out io.Writer) error {
 
 	// Try to unmount mounted directories under /var/lib/kubelet in order to be able to remove the /var/lib/kubelet directory later
 	fmt.Printf("[reset] Unmounting mounted directories in %q\n", "/var/lib/kubelet")
-	umountDirsCmd := "cat /proc/mounts | awk '{print $2}' | grep '/var/lib/kubelet' | xargs -r umount"
+	umountDirsCmd := "awk '$2 ~ path {print $2}' path=/var/lib/kubelet /proc/mounts | xargs -r umount"
 	umountOutputBytes, err := exec.Command("sh", "-c", umountDirsCmd).Output()
 	if err != nil {
 		fmt.Printf("[reset] Failed to unmount mounted directories in /var/lib/kubelet: %s\n", string(umountOutputBytes))


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simplifies a command for unmounting mounted directories. It replaces `cat | awk | grep` by a single `awk` expression.

**Special notes for your reviewer**:
Link about useless cat/grep usage: http://porkmail.org/era/unix/award.html#grep

**Credit**:
I saw this code fragment in the Julia Evans (@jvns) [write up](https://jvns.ca/blog/2017/07/30/a-couple-useful-ideas-from-google/).

**Release note**:
```release-note
NONE
```

CC @simo5