### PR TITLE
Add UT for pkg/kubectl/clusterrolebinding_test.go

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -12,6 +12,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "cluster_test.go",
+        "clusterrolebinding_test.go",
         "configmap_test.go",
         "delete_test.go",
         "deployment_test.go",
@@ -59,6 +60,7 @@ go_test(
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -153,6 +155,7 @@ go_library(
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/kubectl/clusterrolebinding.go
+++ b/pkg/kubectl/clusterrolebinding.go
@@ -21,9 +21,9 @@ import (
 
 	"strings"
 
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/apis/rbac"
 )
 
 // ClusterRoleBindingGeneratorV1 supports stable generation of a clusterRoleBinding.
@@ -109,24 +109,24 @@ func (s ClusterRoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, err
 	if err := s.validate(); err != nil {
 		return nil, err
 	}
-	clusterRoleBinding := &rbac.ClusterRoleBinding{}
+	clusterRoleBinding := &rbacv1beta1.ClusterRoleBinding{}
 	clusterRoleBinding.Name = s.Name
-	clusterRoleBinding.RoleRef = rbac.RoleRef{
-		APIGroup: rbac.GroupName,
+	clusterRoleBinding.RoleRef = rbacv1beta1.RoleRef{
+		APIGroup: rbacv1beta1.GroupName,
 		Kind:     "ClusterRole",
 		Name:     s.ClusterRole,
 	}
 	for _, user := range sets.NewString(s.Users...).List() {
-		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbac.Subject{
-			Kind:     rbac.UserKind,
-			APIGroup: rbac.GroupName,
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1beta1.Subject{
+			Kind:     rbacv1beta1.UserKind,
+			APIGroup: rbacv1beta1.GroupName,
 			Name:     user,
 		})
 	}
 	for _, group := range sets.NewString(s.Groups...).List() {
-		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbac.Subject{
-			Kind:     rbac.GroupKind,
-			APIGroup: rbac.GroupName,
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1beta1.Subject{
+			Kind:     rbacv1beta1.GroupKind,
+			APIGroup: rbacv1beta1.GroupName,
 			Name:     group,
 		})
 	}
@@ -135,8 +135,8 @@ func (s ClusterRoleBindingGeneratorV1) StructuredGenerate() (runtime.Object, err
 		if len(tokens) != 2 || tokens[0] == "" || tokens[1] == "" {
 			return nil, fmt.Errorf("serviceaccount must be <namespace>:<name>")
 		}
-		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbac.Subject{
-			Kind:      rbac.ServiceAccountKind,
+		clusterRoleBinding.Subjects = append(clusterRoleBinding.Subjects, rbacv1beta1.Subject{
+			Kind:      rbacv1beta1.ServiceAccountKind,
 			APIGroup:  "",
 			Namespace: tokens[0],
 			Name:      tokens[1],

--- a/pkg/kubectl/clusterrolebinding_test.go
+++ b/pkg/kubectl/clusterrolebinding_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubectl
+
+import (
+	"reflect"
+	"testing"
+
+	rbacv1beta1 "k8s.io/api/rbac/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestClusterRoleBindingGenerate(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    map[string]interface{}
+		expected  *rbacv1beta1.ClusterRoleBinding
+		expectErr bool
+	}{
+		{
+			name: "valid case 1",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"clusterrole":    "admin",
+				"user":           []string{"user"},
+				"group":          []string{"group"},
+				"serviceaccount": []string{"ns1:name1"},
+			},
+			expected: &rbacv1beta1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				RoleRef: rbacv1beta1.RoleRef{
+					APIGroup: rbacv1beta1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "admin",
+				},
+				Subjects: []rbacv1beta1.Subject{
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.UserKind,
+						Name:     "user",
+					},
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.GroupKind,
+						Name:     "group",
+					},
+					{
+						Kind:      rbacv1beta1.ServiceAccountKind,
+						APIGroup:  "",
+						Namespace: "ns1",
+						Name:      "name1",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid case 2",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"clusterrole":    "admin",
+				"user":           []string{"user1", "user2"},
+				"group":          []string{"group1", "group2"},
+				"serviceaccount": []string{"ns1:name1", "ns2:name2"},
+			},
+			expected: &rbacv1beta1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				RoleRef: rbacv1beta1.RoleRef{
+					APIGroup: rbacv1beta1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "admin",
+				},
+				Subjects: []rbacv1beta1.Subject{
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.UserKind,
+						Name:     "user1",
+					},
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.UserKind,
+						Name:     "user2",
+					},
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.GroupKind,
+						Name:     "group1",
+					},
+					{
+						APIGroup: rbacv1beta1.GroupName,
+						Kind:     rbacv1beta1.GroupKind,
+						Name:     "group2",
+					},
+					{
+						Kind:      rbacv1beta1.ServiceAccountKind,
+						APIGroup:  "",
+						Namespace: "ns1",
+						Name:      "name1",
+					},
+					{
+						Kind:      rbacv1beta1.ServiceAccountKind,
+						APIGroup:  "",
+						Namespace: "ns2",
+						Name:      "name2",
+					},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "valid case 3",
+			params: map[string]interface{}{
+				"name":        "foo",
+				"clusterrole": "admin",
+			},
+			expected: &rbacv1beta1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				RoleRef: rbacv1beta1.RoleRef{
+					APIGroup: rbacv1beta1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     "admin",
+				},
+			},
+			expectErr: false,
+		},
+		{
+			name: "invalid serviceaccount, expected format: <namespace:name>",
+			params: map[string]interface{}{
+				"name":           "role",
+				"clusterrole":    "admin",
+				"user":           []string{"user"},
+				"group":          []string{"group"},
+				"serviceaccount": []string{"ns1-name1"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "name must be specified",
+			params: map[string]interface{}{
+				"name":           "",
+				"clusterrole":    "admin",
+				"user":           []string{"user"},
+				"group":          []string{"group"},
+				"serviceaccount": []string{"ns1:name1"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "clusterrole must be specified",
+			params: map[string]interface{}{
+				"name":           "foo",
+				"clusterrole":    "",
+				"user":           []string{"user"},
+				"group":          []string{"group"},
+				"serviceaccount": []string{"ns1:name1"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "expected user []string",
+			params: map[string]interface{}{
+				"name":           "role",
+				"clusterrole":    "admin",
+				"user":           "user",
+				"group":          []string{"group"},
+				"serviceaccount": []string{"ns1:name1"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "expected group []string",
+			params: map[string]interface{}{
+				"name":           "role",
+				"clusterrole":    "admin",
+				"user":           []string{"user"},
+				"group":          "group",
+				"serviceaccount": []string{"ns1:name1"},
+			},
+			expectErr: true,
+		},
+		{
+			name: "expected serviceaccount []string",
+			params: map[string]interface{}{
+				"name":           "role",
+				"clusterrole":    "admin",
+				"user":           []string{"user"},
+				"group":          []string{"group"},
+				"serviceaccount": "ns1",
+			},
+			expectErr: true,
+		},
+	}
+	generator := ClusterRoleBindingGeneratorV1{}
+	for i := range tests {
+		obj, err := generator.Generate(tests[i].params)
+		if !tests[i].expectErr && err != nil {
+			t.Errorf("[%d] unexpected error: %v", i, err)
+		}
+		if tests[i].expectErr && err != nil {
+			continue
+		}
+		if tests[i].expectErr && err == nil {
+			t.Errorf("[%s] expect error, got nil", tests[i].name)
+		}
+		if !reflect.DeepEqual(obj.(*rbacv1beta1.ClusterRoleBinding), tests[i].expected) {
+			t.Errorf("\n[%s] want:\n%#v\ngot:\n%#v", tests[i].name, tests[i].expected, obj.(*rbacv1beta1.ClusterRoleBinding))
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

I find there is no UT case for pkg/kubectl/clusterrolebinding.go. This PR Adds some UTs for pkg/kubectl/clusterrolebinding_test.go

**Which issue this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/sig cli
