### PR TITLE
fix node unschedulable when runtime hung

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -661,7 +661,7 @@ func NewMainKubelet(kubeCfg *componentconfig.KubeletConfiguration, kubeDeps *Dep
 
 	klet.pleg = pleg.NewGenericPLEG(klet.containerRuntime, plegChannelCapacity, plegRelistPeriod, klet.podCache, clock.RealClock{})
 	klet.runtimeState = newRuntimeState(maxWaitForContainerRuntime)
-	klet.runtimeState.addHealthCheck("PLEG", klet.pleg.Healthy)
+	klet.runtimeState.addHealthCheck(plegErrType, klet.pleg.Healthy)
 	klet.updatePodCIDR(kubeCfg.PodCIDR)
 
 	// setup containerGC

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -394,14 +394,23 @@ func (kl *Kubelet) tryUpdateNodeStatus(tryNumber int) error {
 	kl.updatePodCIDR(node.Spec.PodCIDR)
 
 	kl.setNodeStatus(node)
+
+	// Patch the current Spec on the API server
+	_, err = nodeutil.PatchNodeSpec(kl.kubeClient, types.NodeName(kl.nodeName), originalNode, node)
+	if err != nil {
+		return err
+	}
+
 	// Patch the current status on the API server
 	updatedNode, err := nodeutil.PatchNodeStatus(kl.kubeClient, types.NodeName(kl.nodeName), originalNode, node)
 	if err != nil {
 		return err
 	}
+
 	// If update finishes successfully, mark the volumeInUse as reportedInUse to indicate
 	// those volumes are already updated in the node's status
 	kl.volumeManager.MarkVolumesAsReportedInUse(updatedNode.Status.VolumesInUse)
+
 	return nil
 }
 
@@ -675,8 +684,21 @@ func (kl *Kubelet) setNodeReadyCondition(node *v1.Node) {
 	// ref: https://github.com/kubernetes/kubernetes/issues/16961
 	currentTime := metav1.NewTime(kl.clock.Now())
 	var newNodeReadyCondition v1.NodeCondition
-	rs := append(kl.runtimeState.runtimeErrors(), kl.runtimeState.networkErrors()...)
-	if len(rs) == 0 {
+
+	runtimeErrors := kl.runtimeState.runtimeErrors()
+	networkErrors := kl.runtimeState.networkErrors()
+
+	var rs []string
+	for _, val := range runtimeErrors {
+		rs = append(rs, val)
+	}
+	for _, val := range networkErrors {
+		rs = append(rs, val)
+	}
+
+	_, plegError := runtimeErrors[plegErrType]
+
+	if len(rs) == 0 || (len(runtimeErrors) == 1 && plegError) {
 		newNodeReadyCondition = v1.NodeCondition{
 			Type:              v1.NodeReady,
 			Status:            v1.ConditionTrue,
@@ -684,7 +706,7 @@ func (kl *Kubelet) setNodeReadyCondition(node *v1.Node) {
 			Message:           "kubelet is posting ready status",
 			LastHeartbeatTime: currentTime,
 		}
-	} else {
+	} else if !(len(runtimeErrors) == 1 && plegError) {
 		newNodeReadyCondition = v1.NodeCondition{
 			Type:              v1.NodeReady,
 			Status:            v1.ConditionFalse,
@@ -856,8 +878,15 @@ func (kl *Kubelet) setNodeDiskPressureCondition(node *v1.Node) {
 // TODO: why is this a package var?
 var oldNodeUnschedulable bool
 
-// record if node schedulable change.
-func (kl *Kubelet) recordNodeSchedulableEvent(node *v1.Node) {
+// setNodeSchedulable for the node.
+func (kl *Kubelet) setNodeSchedulable(node *v1.Node) {
+	runtimeErrors := kl.runtimeState.runtimeErrors()
+	_, plegError := runtimeErrors[plegErrType]
+
+	if len(runtimeErrors) == 1 && plegError {
+		node.Spec.Unschedulable = true
+	}
+
 	if oldNodeUnschedulable != node.Spec.Unschedulable {
 		if node.Spec.Unschedulable {
 			kl.recordNodeStatusEvent(v1.EventTypeNormal, events.NodeNotSchedulable)
@@ -906,7 +935,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 		withoutError(kl.setNodeDiskPressureCondition),
 		withoutError(kl.setNodeReadyCondition),
 		withoutError(kl.setNodeVolumesInUseStatus),
-		withoutError(kl.recordNodeSchedulableEvent),
+		withoutError(kl.setNodeSchedulable),
 	}
 }
 

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -226,9 +226,10 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 	kubelet.updateRuntimeUp()
 	assert.NoError(t, kubelet.updateNodeStatus())
 	actions := kubeClient.Actions()
-	require.Len(t, actions, 2)
+	require.Len(t, actions, 3)
 	require.True(t, actions[1].Matches("patch", "nodes"))
-	require.Equal(t, actions[1].GetSubresource(), "status")
+	require.Equal(t, actions[1].GetSubresource(), "")
+	require.Equal(t, actions[2].GetSubresource(), "status")
 
 	updatedNode, err := applyNodeStatusPatch(&existingNode, actions[1].(core.PatchActionImpl).GetPatch())
 	assert.NoError(t, err)
@@ -395,7 +396,7 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 	assert.NoError(t, kubelet.updateNodeStatus())
 
 	actions := kubeClient.Actions()
-	assert.Len(t, actions, 2)
+	assert.Len(t, actions, 3)
 
 	assert.IsType(t, core.PatchActionImpl{}, actions[1])
 	patchAction := actions[1].(core.PatchActionImpl)
@@ -521,9 +522,10 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 		kubeClient.ClearActions()
 		assert.NoError(t, kubelet.updateNodeStatus())
 		actions := kubeClient.Actions()
-		require.Len(t, actions, 2)
+		require.Len(t, actions, 3)
 		require.True(t, actions[1].Matches("patch", "nodes"))
-		require.Equal(t, actions[1].GetSubresource(), "status")
+		require.Equal(t, actions[1].GetSubresource(), "")
+		require.Equal(t, actions[2].GetSubresource(), "status")
 
 		updatedNode, err := applyNodeStatusPatch(&existingNode, actions[1].(core.PatchActionImpl).GetPatch())
 		require.NoError(t, err, "can't apply node status patch")
@@ -921,9 +923,10 @@ func TestUpdateNewNodeStatusTooLargeReservation(t *testing.T) {
 	kubelet.updateRuntimeUp()
 	assert.NoError(t, kubelet.updateNodeStatus())
 	actions := kubeClient.Actions()
-	require.Len(t, actions, 2)
+	require.Len(t, actions, 3)
 	require.True(t, actions[1].Matches("patch", "nodes"))
-	require.Equal(t, actions[1].GetSubresource(), "status")
+	require.Equal(t, actions[1].GetSubresource(), "")
+	require.Equal(t, actions[2].GetSubresource(), "status")
 
 	updatedNode, err := applyNodeStatusPatch(&existingNode, actions[1].(core.PatchActionImpl).GetPatch())
 	assert.NoError(t, err)

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -177,3 +177,27 @@ func PatchNodeStatus(c clientset.Interface, nodeName types.NodeName, oldNode *v1
 	}
 	return updatedNode, nil
 }
+
+// PatchNodeSpec patches node spec.
+func PatchNodeSpec(c clientset.Interface, nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) (*v1.Node, error) {
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
+	}
+
+	newData, err := json.Marshal(newNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNode, nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+	}
+
+	updatedNode, err := c.Core().Nodes().Patch(string(nodeName), types.StrategicMergePatchType, patchBytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to patch status %q for node %q: %v", patchBytes, nodeName, err)
+	}
+	return updatedNode, nil
+}


### PR DESCRIPTION
Currently when kubelet detect container runtime hung, it will update a knode ready condition to `notready` by checking the error generated by PLEG. 

If the container runtime is docker and container runtime hung, the already running containers will continue to run without any problem. So, if there is only an error and the error is generated by PLEG healthy check, maybe mark the knode as `unschedulable` is more reasonable which will stop scheduler from scheduling new pods to it.


```release-note
fix node unschedulable when runtime hung instead of notready
```
/cc @yujuhong @Random-Liu 