### PR TITLE
apiextensions: fix data race in storage

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -343,8 +343,17 @@ func (r *crdHandler) getServingInfoFor(crd *apiextensions.CustomResourceDefiniti
 		storage:      storage,
 		requestScope: requestScope,
 	}
-	storageMap[crd.UID] = ret
-	r.customStorage.Store(storageMap)
+
+	storageMap2 := make(crdStorageMap, len(storageMap))
+
+	// Copy because we cannot write to storageMap without a race
+	// as it is used without locking elsewhere
+	for k, v := range storageMap {
+		storageMap2[k] = v
+	}
+
+	storageMap2[crd.UID] = ret
+	r.customStorage.Store(storageMap2)
 	return ret
 }
 


### PR DESCRIPTION
Fixes data race in CRD storage.

Copy to a new map because we cannot write to storageMap without a race as it is used without locking elsewhere.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix data race during addition of new CRD
```

/cc @sttts 