### PR TITLE
[Bug Fix] Fix updating LastHeartbeatTime for the OutOfDisk node condition.

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -865,14 +865,16 @@ func (kl *Kubelet) setNodeOODCondition(node *v1.Node) {
 	}
 
 	newOODCondition := nodeOODCondition == nil
-	if newOODCondition || nodeOODCondition.Status == v1.ConditionUnknown {
-		nodeOODCondition = &v1.NodeCondition{
-			Type:               v1.NodeOutOfDisk,
-			Status:             v1.ConditionFalse,
-			Reason:             "KubeletHasSufficientDisk",
-			Message:            "kubelet has sufficient disk space available",
-			LastTransitionTime: currentTime,
-		}
+	if newOODCondition {
+		nodeOODCondition = &v1.NodeCondition{}
+	}
+	if nodeOODCondition.Status != v1.ConditionFalse {
+		nodeOODCondition.Type = v1.NodeOutOfDisk
+		nodeOODCondition.Status = v1.ConditionFalse
+		nodeOODCondition.Reason = "KubeletHasSufficientDisk"
+		nodeOODCondition.Message = "kubelet has sufficient disk space available"
+		nodeOODCondition.LastTransitionTime = currentTime
+		kl.recordNodeStatusEvent(v1.EventTypeNormal, "NodeHasSufficientDisk")
 	}
 
 	// Update the heartbeat time irrespective of all the conditions.


### PR DESCRIPTION
Fixes #50058.  #49841 for some (currently unknown) reason did not correctly update LastHeartbeatTime, causing OutOfDisk to be marked unknown.
I have not found the reason for this yet.  This change makes the setNodeOODCondition method nearly identical to the other conditions (e.g. [setNodeMemoryPressureCondition](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/kubelet_node_status.go#L741)).

I have started a cluster with this change, and all nodes have been reporting `Ready` for 25 minutes.