### PR TITLE
Add livenessProbe to kube-proxy templates

### DIFF
--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -75,6 +75,13 @@ spec:
     - -c
     - echo -998 > /proc/$$$/oom_score_adj && kube-proxy {{api_servers_with_port}} {{kubeconfig}} {{cluster_cidr}} --resource-container="" {{params}} 1>>/var/log/kube-proxy.log 2>&1
     {{container_env}}
+    livenessProbe:
+      # kube-proxy hosts healthz server on port 10256 by default.
+      httpGet:
+        path: /healthz
+        port: 10256
+        scheme: HTTP
+      initialDelaySeconds: 5
     securityContext:
       privileged: true
     volumeMounts:

--- a/cmd/kubeadm/app/phases/addons/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/manifests.go
@@ -74,6 +74,13 @@ spec:
         - /usr/local/bin/kube-proxy
         - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
         {{ .ClusterCIDR }}
+        livenessProbe:
+          # kube-proxy hosts healthz server on port 10256 by default.
+          httpGet:
+            path: /healthz
+            port: 10256
+            scheme: HTTP
+          initialDelaySeconds: 5
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This is a follow-up of #49267. Put `livenessProbe` here instead of `readinessProbe`, considering that if kube-proxy fails to host `/healthz` it means:
- It failed to start healthz server (probably due to port collision).
- It failed to update iptables in a reasonable timeframe (in iptables mode).

With livenessProbe failure, kube-proxy will be restarted and that may prevent it from halting forever in the second case. WDYT? 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: from #49263.

**Special notes for your reviewer**:
@bowei @yujuhong @thockin 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
