### PR TITLE
Update OWNERS according to new rules.

### DIFF
--- a/plugin/cmd/kube-scheduler/OWNERS
+++ b/plugin/cmd/kube-scheduler/OWNERS
@@ -1,11 +1,4 @@
 approvers:
-- davidopp
-- timothysc
-- k82cn
+  - sig-scheduling-maintainers
 reviewers:
-- davidopp
-- bsalamat
-- timothysc
-- wojtek-t
-- k82cn
-- jayunit100
+  - sig-scheduling

--- a/plugin/pkg/scheduler/OWNERS
+++ b/plugin/pkg/scheduler/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sig-scheduling-maintainers
+  - sig-scheduling-maintainers
 reviewers:
-- sig-scheduling
+  - sig-scheduling

--- a/test/e2e/scheduling/OWNERS
+++ b/test/e2e/scheduling/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sig-scheduling-maintainers
+  - sig-scheduling-maintainers
 reviewers:
-- sig-scheduling
+  - sig-scheduling

--- a/test/integration/scheduler/OWNERS
+++ b/test/integration/scheduler/OWNERS
@@ -1,4 +1,4 @@
 approvers:
-- sig-scheduling-maintainers
+  - sig-scheduling-maintainers
 reviewers:
-- sig-scheduling
+  - sig-scheduling


### PR DESCRIPTION
**What this PR does / why we need it**:
Update OWNERS files of scheduling according to https://github.com/kubernetes/community/pull/878

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

**Release note**:

```release-note
None
```