### PR TITLE
make get pod log with follow option as CONNECT verb

### DIFF
--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -87,3 +87,14 @@ func (r *LogREST) Get(ctx genericapirequest.Context, name string, opts runtime.O
 func (r *LogREST) NewGetOptions() (runtime.Object, bool, string) {
 	return &api.PodLogOptions{}, false, ""
 }
+
+// OverrideMetricsVerb override the GET verb to CONNECT for pod log resource
+func (r *LogREST) OverrideMetricsVerb(oldVerb string) (newVerb string) {
+	newVerb = oldVerb
+
+	if oldVerb == "GET" {
+		newVerb = "CONNECT"
+	}
+
+	return
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -64,6 +64,12 @@ type action struct {
 	AllNamespaces bool // true iff the action is namespaced but works on aggregate result for all namespaces
 }
 
+// An interface to see if one storage supports override its default verb for monitoring
+type StorageMetricsOverride interface {
+	// OverrideMetricsVerb gives a storage object an opportunity to override the verb reported to the metrics endpoint
+	OverrideMetricsVerb(oldVerb string) (newVerb string)
+}
+
 // An interface to see if an object supports swagger documentation as a method
 type documentable interface {
 	SwaggerDoc() map[string]string
@@ -593,6 +599,9 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			}
 			kind = fqParentKind.Kind
 		}
+
+		verbOverrider, needOverride := storage.(StorageMetricsOverride)
+
 		switch action.Verb {
 		case "GET": // Get a resource.
 			var handler restful.RouteFunction
@@ -601,7 +610,14 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 			} else {
 				handler = restfulGetResource(getter, exporter, reqScope)
 			}
-			handler = metrics.InstrumentRouteFunc(action.Verb, resource, subresource, namespaceScope, handler)
+
+			if needOverride {
+				// need change the reported verb
+				handler = metrics.InstrumentRouteFunc(verbOverrider.OverrideMetricsVerb(action.Verb), resource, subresource, namespaceScope, handler)
+			} else {
+				handler = metrics.InstrumentRouteFunc(action.Verb, resource, subresource, namespaceScope, handler)
+			}
+
 			if a.enableAPIResponseCompression {
 				handler = genericfilters.RestfulWithCompression(handler, a.group.Context)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't make the get log with follow option request mix with GET pods request. Make it reported as a WATCH pod log request.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #49998 

```release-note
Pod log attempts are now reported in apiserver prometheus metrics with verb `CONNECT` since they can run for very long periods of time.
```
