### PR TITLE
Removed un-used InodePressure condition.

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1514,7 +1514,6 @@ func TestUpdateNode(t *testing.T) {
 					{Type: v1.NodeMemoryPressure, Status: v1.ConditionFalse},
 					{Type: v1.NodeDiskPressure, Status: v1.ConditionFalse},
 					{Type: v1.NodeNetworkUnavailable, Status: v1.ConditionFalse},
-					{Type: v1.NodeInodePressure, Status: v1.ConditionFalse},
 				}
 				return node
 			}(),
@@ -1522,7 +1521,6 @@ func TestUpdateNode(t *testing.T) {
 				node := newNode("node1", nil)
 				node.Status.Conditions = []v1.NodeCondition{
 					{Type: v1.NodeOutOfDisk, Status: v1.ConditionTrue},
-					{Type: v1.NodeInodePressure, Status: v1.ConditionFalse},
 				}
 				return node
 			}(),

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3510,8 +3510,6 @@ const (
 	NodeDiskPressure NodeConditionType = "DiskPressure"
 	// NodeNetworkUnavailable means that network for the node is not correctly configured.
 	NodeNetworkUnavailable NodeConditionType = "NetworkUnavailable"
-	// NodeInodePressure means the kubelet is under pressure due to insufficient available inodes.
-	NodeInodePressure NodeConditionType = "InodePressure"
 )
 
 // NodeCondition contains condition information for a node.


### PR DESCRIPTION
**What this PR does / why we need it**:
Removed un-used InodePressure condition; kubelet did not report it anymore, so remove it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49103

**Release note**:

```release-note
The node condition 'NodeInodePressure' was removed, as kubelet did not report it.
```
