### PR TITLE
add some checks for fedration-apiserver options

### DIFF
--- a/federation/cmd/federation-apiserver/app/options/validation.go
+++ b/federation/cmd/federation-apiserver/app/options/validation.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package options
 
+import "fmt"
+
 func (options *ServerRunOptions) Validate() []error {
 	var errors []error
 	if errs := options.Etcd.Validate(); len(errs) > 0 {
@@ -26,6 +28,27 @@ func (options *ServerRunOptions) Validate() []error {
 	}
 	if errs := options.InsecureServing.Validate("insecure-port"); len(errs) > 0 {
 		errors = append(errors, errs...)
+	}
+	if errs := options.Audit.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if errs := options.Features.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if errs := options.Admission.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if errs := options.Authentication.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if errs := options.Authorization.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if errs := options.CloudProvider.Validate(); len(errs) > 0 {
+		errors = append(errors, errs...)
+	}
+	if options.EventTTL <= 0 {
+		errors = append(errors, fmt.Errorf("--event-ttl must be greater than 0"))
 	}
 	// TODO: add more checks
 	return errors

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -89,3 +89,8 @@ func (a *AdmissionOptions) ApplyTo(serverCfg *server.Config, pluginInitializers 
 	serverCfg.AdmissionControl = admissionChain
 	return nil
 }
+
+func (a *AdmissionOptions) Validate() []error {
+	errs := []error{}
+	return errs
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/feature.go
@@ -55,3 +55,8 @@ func (o *FeatureOptions) ApplyTo(c *server.Config) error {
 
 	return nil
 }
+
+func (o *FeatureOptions) Validate() []error {
+	errs := []error{}
+	return errs
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

I find there is a TODO, see https://github.com/kubernetes/kubernetes/blob/master/federation/cmd/federation-apiserver/app/options/validation.go#L30

This PR add some checks for fedration-apiserver options

@sttts 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
