### PR TITLE
codegen: skip generation of informers and listers on resources with missing verbs

### DIFF
--- a/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/kube-gen/cmd/informer-gen/generators/packages.go
@@ -172,7 +172,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
 			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
-			if !tags.GenerateClient || tags.NoVerbs {
+			if !tags.GenerateClient || tags.NoVerbs || !tags.HasVerb("list") || !tags.HasVerb("watch") {
 				continue
 			}
 
@@ -304,7 +304,8 @@ func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}
 }
@@ -344,7 +345,8 @@ func versionPackage(basePackage string, gv clientgentypes.GroupVersion, boilerpl
 			return generators
 		},
 		FilterFunc: func(c *generator.Context, t *types.Type) bool {
-			return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("watch")
 		},
 	}
 }

--- a/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/kube-gen/cmd/lister-gen/generators/lister.go
@@ -117,10 +117,14 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 		var typesToGenerate []*types.Type
 		for _, t := range p.Types {
-			if !util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient {
+			tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+			if !tags.GenerateClient || !tags.HasVerb("list") || !tags.HasVerb("get") {
 				continue
 			}
 			typesToGenerate = append(typesToGenerate, t)
+		}
+		if len(typesToGenerate) == 0 {
+			continue
 		}
 		orderer := namer.Orderer{Namer: namer.NewPrivateNamer(0)}
 		typesToGenerate = orderer.OrderTypes(typesToGenerate)
@@ -155,7 +159,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				return generators
 			},
 			FilterFunc: func(c *generator.Context, t *types.Type) bool {
-				return util.MustParseClientGenTags(t.SecondClosestCommentLines).GenerateClient
+				tags := util.MustParseClientGenTags(t.SecondClosestCommentLines)
+				return tags.GenerateClient && tags.HasVerb("list") && tags.HasVerb("get")
 			},
 		})
 	}


### PR DESCRIPTION
This patch will prevent generation of listers and informers for resources that does not implement the required verbs (list, get, watch). Currently informers and listers are generated for those resources which cause a compilation failure.