### PR TITLE
Add short form to get or delete [roles | rolebingings  | clusterroles | clusterrolebindings] 

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -203,8 +203,8 @@ __custom_func() {
 
     * all
     * certificatesigningrequests (aka 'csr')
-    * clusterrolebindings
-    * clusterroles
+    * clusterrolebindings (aka 'crb')
+    * clusterroles (aka 'cr')
     * clusters (valid only for federation apiservers)
     * componentstatuses (aka 'cs')
     * configmaps (aka 'cm')
@@ -232,7 +232,7 @@ __custom_func() {
     * replicasets (aka 'rs')
     * replicationcontrollers (aka 'rc')
     * resourcequotas (aka 'quota')
-    * rolebindings
+    * rolebindings (aka 'rb')
     * roles
     * secrets
     * serviceaccounts (aka 'sa')

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -142,6 +142,22 @@ var ResourcesShortcutStatic = []ResourceShortcuts{
 		ShortForm: schema.GroupResource{Group: "extensions", Resource: "psp"},
 		LongForm:  schema.GroupResource{Group: "extensions", Resource: "podSecurityPolicies"},
 	},
+  {
+    ShortForm: schema.GroupResource{Resource: "crb"},
+    LongForm: schema.GroupResource{Resource: "clusterrolebindings"},
+  },
+  {
+    ShortForm: schema.GroupResource{Resource: "cr"},
+    LongForm: schema.GroupResource{Resource: "clusterroles"},
+  },
+  {
+    ShortForm: schema.GroupResource{Resource: "rb"},
+    LongForm: schema.GroupResource{Resource: "rolebindings"},
+  },
+  {
+    ShortForm: schema.GroupResource{Resource: "ro"},
+    LongForm: schema.GroupResource{Resource: "roles"},
+  },
 }
 
 // ResourceShortFormFor looks up for a short form of resource names.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds some short forms to `kubectl get` for roles, rolebingings, clusterroles, clusterrolebindings resources which are `ro`, `rb`, `cr` and `crb` respectively. I realized that the shortcuts could be helpful when I was cleaning up this resources when the `kubefed join` was failing and I needed remove some some federation role then it shortcuts can help us to type less.
 
**Which issue this PR fixes** Not Apply

**Special notes for your reviewer**:
/sig cli
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds short commands to get roles(aka 'ro'), rolebingings(aka 'rb'), clusterroles(aka 'cr') and clusterrolebindings(aka 'crb') resources
```
