### PR TITLE
kubeadm: Replace *clientset.Clientset with clientset.Interface

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -193,7 +193,7 @@ func NewCmdTokenGenerate(out io.Writer) *cobra.Command {
 }
 
 // RunCreateToken generates a new bootstrap token and stores it as a secret on the server.
-func RunCreateToken(out io.Writer, client *clientset.Clientset, token string, tokenDuration time.Duration, usages []string, description string) error {
+func RunCreateToken(out io.Writer, client clientset.Interface, token string, tokenDuration time.Duration, usages []string, description string) error {
 
 	if len(token) == 0 {
 		var err error
@@ -230,7 +230,7 @@ func RunGenerateToken(out io.Writer) error {
 }
 
 // RunListTokens lists details on all existing bootstrap tokens on the server.
-func RunListTokens(out io.Writer, errW io.Writer, client *clientset.Clientset) error {
+func RunListTokens(out io.Writer, errW io.Writer, client clientset.Interface) error {
 	// First, build our selector for bootstrap tokens only
 	tokenSelector := fields.SelectorFromSet(
 		map[string]string{
@@ -312,7 +312,7 @@ func RunListTokens(out io.Writer, errW io.Writer, client *clientset.Clientset) e
 }
 
 // RunDeleteToken removes a bootstrap token from the server.
-func RunDeleteToken(out io.Writer, client *clientset.Clientset, tokenIdOrToken string) error {
+func RunDeleteToken(out io.Writer, client clientset.Interface, tokenIdOrToken string) error {
 	// Assume the given first argument is a token id and try to parse it
 	tokenId := tokenIdOrToken
 	if err := tokenutil.ParseTokenID(tokenIdOrToken); err != nil {

--- a/cmd/kubeadm/app/node/validate.go
+++ b/cmd/kubeadm/app/node/validate.go
@@ -24,15 +24,15 @@ import (
 )
 
 // ValidateAPIServer makes sure the server we're connecting to supports the Beta Certificates API
-func ValidateAPIServer(client *clientset.Clientset) error {
-	version, err := client.DiscoveryClient.ServerVersion()
+func ValidateAPIServer(client clientset.Interface) error {
+	version, err := client.Discovery().ServerVersion()
 	if err != nil {
 		return fmt.Errorf("failed to check server version: %v", err)
 	}
 	fmt.Printf("[bootstrap] Detected server version: %s\n", version.String())
 
 	// Check certificates API. If the server supports the version of the Certificates API we're using, we're good to go
-	serverGroups, err := client.DiscoveryClient.ServerGroups()
+	serverGroups, err := client.Discovery().ServerGroups()
 	if err != nil {
 		return fmt.Errorf("certificate API check failed: failed to retrieve a list of supported API objects [%v]", err)
 	}

--- a/cmd/kubeadm/app/phases/addons/addons.go
+++ b/cmd/kubeadm/app/phases/addons/addons.go
@@ -35,7 +35,7 @@ import (
 )
 
 // CreateEssentialAddons creates the kube-proxy and kube-dns addons
-func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 	proxyConfigMapBytes, err := kubeadmutil.ParseTemplate(KubeProxyConfigMap, struct{ MasterEndpoint string }{
 		// Fetch this value from the kubeconfig file
 		MasterEndpoint: fmt.Sprintf("https://%s:%d", cfg.API.AdvertiseAddress, cfg.API.BindPort),
@@ -94,7 +94,7 @@ func CreateEssentialAddons(cfg *kubeadmapi.MasterConfiguration, client *clientse
 	return nil
 }
 
-func CreateKubeProxyAddon(configMapBytes, daemonSetbytes []byte, client *clientset.Clientset) error {
+func CreateKubeProxyAddon(configMapBytes, daemonSetbytes []byte, client clientset.Interface) error {
 	kubeproxyConfigMap := &v1.ConfigMap{}
 	if err := kuberuntime.DecodeInto(api.Codecs.UniversalDecoder(), configMapBytes, kubeproxyConfigMap); err != nil {
 		return fmt.Errorf("unable to decode kube-proxy configmap %v", err)
@@ -127,7 +127,7 @@ func CreateKubeProxyAddon(configMapBytes, daemonSetbytes []byte, client *clients
 	return nil
 }
 
-func CreateKubeDNSAddon(deploymentBytes, serviceBytes []byte, client *clientset.Clientset) error {
+func CreateKubeDNSAddon(deploymentBytes, serviceBytes []byte, client clientset.Interface) error {
 	kubednsDeployment := &extensions.Deployment{}
 	if err := kuberuntime.DecodeInto(api.Codecs.UniversalDecoder(), deploymentBytes, kubednsDeployment); err != nil {
 		return fmt.Errorf("unable to decode kube-dns deployment %v", err)
@@ -164,7 +164,7 @@ func CreateKubeDNSAddon(deploymentBytes, serviceBytes []byte, client *clientset.
 }
 
 // getDNSIP fetches the kubernetes service's ClusterIP and appends a "0" to it in order to get the DNS IP
-func getDNSIP(client *clientset.Clientset) (net.IP, error) {
+func getDNSIP(client clientset.Interface) (net.IP, error) {
 	k8ssvc, err := client.CoreV1().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't fetch information about the kubernetes service: %v", err)

--- a/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
+++ b/cmd/kubeadm/app/phases/apiconfig/clusterroles.go
@@ -74,7 +74,7 @@ func CreateServiceAccounts(clientset clientset.Interface) error {
 }
 
 // CreateRBACRules creates the essential RBAC rules for a minimally set-up cluster
-func CreateRBACRules(clientset *clientset.Clientset, k8sVersion *version.Version) error {
+func CreateRBACRules(clientset clientset.Interface, k8sVersion *version.Version) error {
 	if err := createRoles(clientset); err != nil {
 		return err
 	}
@@ -95,7 +95,7 @@ func CreateRBACRules(clientset *clientset.Clientset, k8sVersion *version.Version
 	return nil
 }
 
-func createRoles(clientset *clientset.Clientset) error {
+func createRoles(clientset clientset.Interface) error {
 	roles := []rbac.Role{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -121,7 +121,7 @@ func createRoles(clientset *clientset.Clientset) error {
 	return nil
 }
 
-func createRoleBindings(clientset *clientset.Clientset) error {
+func createRoleBindings(clientset clientset.Interface) error {
 	roleBindings := []rbac.RoleBinding{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -156,7 +156,7 @@ func createRoleBindings(clientset *clientset.Clientset) error {
 	return nil
 }
 
-func createClusterRoles(clientset *clientset.Clientset) error {
+func createClusterRoles(clientset clientset.Interface) error {
 	clusterRoles := []rbac.ClusterRole{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -182,7 +182,7 @@ func createClusterRoles(clientset *clientset.Clientset) error {
 	return nil
 }
 
-func createClusterRoleBindings(clientset *clientset.Clientset) error {
+func createClusterRoleBindings(clientset clientset.Interface) error {
 	clusterRoleBindings := []rbac.ClusterRoleBinding{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -249,7 +249,7 @@ func createClusterRoleBindings(clientset *clientset.Clientset) error {
 	return nil
 }
 
-func deletePermissiveNodesBindingWhenUsingNodeAuthorization(clientset *clientset.Clientset, k8sVersion *version.Version) error {
+func deletePermissiveNodesBindingWhenUsingNodeAuthorization(clientset clientset.Interface, k8sVersion *version.Version) error {
 
 	nodesRoleBinding, err := clientset.RbacV1beta1().ClusterRoleBindings().Get(kubeadmconstants.NodesClusterRoleBinding, metav1.GetOptions{})
 	if err != nil {

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -54,7 +54,7 @@ const (
 // 7. The self-hosted containers should now step up and take over.
 // 8. In order to avoid race conditions, we're still making sure the API /healthz endpoint is healthy
 // 9. Do that for the kube-apiserver, kube-controller-manager and kube-scheduler in a loop
-func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 
 	if err := createTLSSecrets(cfg, client); err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -220,7 +220,7 @@ func controllerManagerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Vo
 	}
 }
 
-func createTLSSecrets(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+func createTLSSecrets(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 	for _, tlsKeyPair := range getTLSKeyPairs() {
 		secret, err := createTLSSecretFromFiles(
 			tlsKeyPair.name,
@@ -240,7 +240,7 @@ func createTLSSecrets(cfg *kubeadmapi.MasterConfiguration, client *clientset.Cli
 	return nil
 }
 
-func createOpaqueSecrets(cfg *kubeadmapi.MasterConfiguration, client *clientset.Clientset) error {
+func createOpaqueSecrets(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 	files := []string{
 		kubeadmconstants.SchedulerKubeConfigFileName,
 		kubeadmconstants.ControllerManagerKubeConfigFileName,

--- a/cmd/kubeadm/app/util/apiclient.go
+++ b/cmd/kubeadm/app/util/apiclient.go
@@ -43,7 +43,7 @@ func CreateClientAndWaitForAPI(file string) (*clientset.Clientset, error) {
 }
 
 // WaitForAPI waits for the API Server's /healthz endpoint to report "ok"
-func WaitForAPI(client *clientset.Clientset) {
+func WaitForAPI(client clientset.Interface) {
 	start := time.Now()
 	wait.PollInfinite(kubeadmconstants.APICallRetryInterval, func() (bool, error) {
 		healthStatus := 0
@@ -59,7 +59,7 @@ func WaitForAPI(client *clientset.Clientset) {
 
 // WaitForPodsWithLabel will lookup pods with the given label and wait until they are all
 // reporting status as running.
-func WaitForPodsWithLabel(client *clientset.Clientset, labelKeyValPair string) {
+func WaitForPodsWithLabel(client clientset.Interface, labelKeyValPair string) {
 	// TODO: Implement a timeout
 	// TODO: Implement a verbosity switch
 	wait.PollInfinite(kubeadmconstants.APICallRetryInterval, func() (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Needed for https://github.com/kubernetes/kubernetes/pull/48899
We should always use `clientset.Interface` instead of `*clientset.Clientset`, for better testability and all the other benefits of using an interface.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Should be straightforward to merge

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@timothysc @dmmcquay @pipejakob 