### PR TITLE
remove apps/v1beta2 defaulting codes for obj.Spec.Selector and obj.Labels

### DIFF
--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -18,7 +18,6 @@ package v1beta2
 
 import (
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -28,19 +27,6 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 }
 
 func SetDefaults_DaemonSet(obj *appsv1beta2.DaemonSet) {
-	labels := obj.Spec.Template.Labels
-
-	// TODO: support templates defined elsewhere when we support them in the API
-	if labels != nil {
-		if obj.Spec.Selector == nil {
-			obj.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: labels,
-			}
-		}
-		if len(obj.Labels) == 0 {
-			obj.Labels = labels
-		}
-	}
 	updateStrategy := &obj.Spec.UpdateStrategy
 	if updateStrategy.Type == "" {
 		updateStrategy.Type = appsv1beta2.RollingUpdateDaemonSetStrategyType
@@ -81,17 +67,6 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
 	}
 
-	labels := obj.Spec.Template.Labels
-	if labels != nil {
-		if obj.Spec.Selector == nil {
-			obj.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: labels,
-			}
-		}
-		if len(obj.Labels) == 0 {
-			obj.Labels = labels
-		}
-	}
 	if obj.Spec.Replicas == nil {
 		obj.Spec.Replicas = new(int32)
 		*obj.Spec.Replicas = 1
@@ -109,17 +84,6 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 // - RevisionHistoryLimit set to 10 (not set in extensions)
 // - ProgressDeadlineSeconds set to 600s (not set in extensions)
 func SetDefaults_Deployment(obj *appsv1beta2.Deployment) {
-	// Default labels and selector to labels from pod template spec.
-	labels := obj.Spec.Template.Labels
-
-	if labels != nil {
-		if obj.Spec.Selector == nil {
-			obj.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
-		}
-		if len(obj.Labels) == 0 {
-			obj.Labels = labels
-		}
-	}
 	// Set appsv1beta2.DeploymentSpec.Replicas to 1 if it is not set.
 	if obj.Spec.Replicas == nil {
 		obj.Spec.Replicas = new(int32)
@@ -157,19 +121,6 @@ func SetDefaults_Deployment(obj *appsv1beta2.Deployment) {
 }
 
 func SetDefaults_ReplicaSet(obj *appsv1beta2.ReplicaSet) {
-	labels := obj.Spec.Template.Labels
-
-	// TODO: support templates defined elsewhere when we support them in the API
-	if labels != nil {
-		if obj.Spec.Selector == nil {
-			obj.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: labels,
-			}
-		}
-		if len(obj.Labels) == 0 {
-			obj.Labels = labels
-		}
-	}
 	if obj.Spec.Replicas == nil {
 		obj.Spec.Replicas = new(int32)
 		*obj.Spec.Replicas = 1

--- a/pkg/apis/apps/v1beta2/defaults_test.go
+++ b/pkg/apis/apps/v1beta2/defaults_test.go
@@ -73,9 +73,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					Labels: defaultLabels,
 				},
 				Spec: appsv1beta2.DaemonSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: defaultLabels,
-					},
 					Template: defaultTemplate,
 					UpdateStrategy: appsv1beta2.DaemonSetUpdateStrategy{
 						Type: appsv1beta2.RollingUpdateStatefulSetStrategyType,
@@ -106,9 +103,6 @@ func TestSetDefaultDaemonSetSpec(t *testing.T) {
 					},
 				},
 				Spec: appsv1beta2.DaemonSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: defaultLabels,
-					},
 					Template: defaultTemplate,
 					UpdateStrategy: appsv1beta2.DaemonSetUpdateStrategy{
 						Type: appsv1beta2.RollingUpdateStatefulSetStrategyType,
@@ -196,7 +190,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 		original *appsv1beta2.StatefulSet
 		expected *appsv1beta2.StatefulSet
 	}{
-		{ // Selector, labels and default update strategy
+		{ // labels and default update strategy
 			original: &appsv1beta2.StatefulSet{
 				Spec: appsv1beta2.StatefulSetSpec{
 					Template: defaultTemplate,
@@ -207,9 +201,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					Labels: defaultLabels,
 				},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: defaultLabels,
-					},
 					Replicas:            &defaultReplicas,
 					Template:            defaultTemplate,
 					PodManagementPolicy: appsv1beta2.OrderedReadyPodManagement,
@@ -237,9 +228,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					Labels: defaultLabels,
 				},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: defaultLabels,
-					},
 					Replicas:            &defaultReplicas,
 					Template:            defaultTemplate,
 					PodManagementPolicy: appsv1beta2.OrderedReadyPodManagement,
@@ -262,9 +250,6 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 					Labels: defaultLabels,
 				},
 				Spec: appsv1beta2.StatefulSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: defaultLabels,
-					},
 					Replicas:            &defaultReplicas,
 					Template:            defaultTemplate,
 					PodManagementPolicy: appsv1beta2.ParallelPodManagement,
@@ -455,119 +440,6 @@ func TestDefaultDeploymentAvailability(t *testing.T) {
 
 	if *(d.Spec.Replicas)-int32(maxUnavailable) <= 0 {
 		t.Fatalf("the default value of maxUnavailable can lead to no active replicas during rolling update")
-	}
-}
-
-func TestSetDefaultReplicaSet(t *testing.T) {
-	tests := []struct {
-		rs             *appsv1beta2.ReplicaSet
-		expectLabels   bool
-		expectSelector bool
-	}{
-		{
-			rs: &appsv1beta2.ReplicaSet{
-				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			expectLabels:   true,
-			expectSelector: true,
-		},
-		{
-			rs: &appsv1beta2.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"bar": "foo",
-					},
-				},
-				Spec: appsv1beta2.ReplicaSetSpec{
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			expectLabels:   false,
-			expectSelector: true,
-		},
-		{
-			rs: &appsv1beta2.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						"bar": "foo",
-					},
-				},
-				Spec: appsv1beta2.ReplicaSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"some": "other",
-						},
-					},
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			expectLabels:   false,
-			expectSelector: false,
-		},
-		{
-			rs: &appsv1beta2.ReplicaSet{
-				Spec: appsv1beta2.ReplicaSetSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							"some": "other",
-						},
-					},
-					Template: v1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{
-								"foo": "bar",
-							},
-						},
-					},
-				},
-			},
-			expectLabels:   true,
-			expectSelector: false,
-		},
-	}
-
-	for _, test := range tests {
-		rs := test.rs
-		obj2 := roundTrip(t, runtime.Object(rs))
-		rs2, ok := obj2.(*appsv1beta2.ReplicaSet)
-		if !ok {
-			t.Errorf("unexpected object: %v", rs2)
-			t.FailNow()
-		}
-		if test.expectSelector != reflect.DeepEqual(rs2.Spec.Selector.MatchLabels, rs2.Spec.Template.Labels) {
-			if test.expectSelector {
-				t.Errorf("expected: %v, got: %v", rs2.Spec.Template.Labels, rs2.Spec.Selector)
-			} else {
-				t.Errorf("unexpected equality: %v", rs.Spec.Selector)
-			}
-		}
-		if test.expectLabels != reflect.DeepEqual(rs2.Labels, rs2.Spec.Template.Labels) {
-			if test.expectLabels {
-				t.Errorf("expected: %v, got: %v", rs2.Spec.Template.Labels, rs2.Labels)
-			} else {
-				t.Errorf("unexpected equality: %v", rs.Labels)
-			}
-		}
 	}
 }
 

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -133,7 +133,7 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// k8s.io/kubernetes/pkg/apis/apps/v1beta1
 	gvr("apps", "v1beta1", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss1"}, "spec": {"template": {"metadata": {"labels": {"a": "b"}}}}}`,
+		stub:             `{"metadata": {"name": "ss1"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
 		expectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss1",
 	},
 	gvr("apps", "v1beta1", "deployments"): {
@@ -149,7 +149,7 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 
 	// k8s.io/kubernetes/pkg/apis/apps/v1beta2
 	gvr("apps", "v1beta2", "statefulsets"): {
-		stub:             `{"metadata": {"name": "ss2"}, "spec": {"template": {"metadata": {"labels": {"a": "b"}}}}}`,
+		stub:             `{"metadata": {"name": "ss2"}, "spec": {"selector": {"matchLabels": {"a": "b"}}, "template": {"metadata": {"labels": {"a": "b"}}}}}`,
 		expectedEtcdPath: "/registry/statefulsets/etcdstoragepathtestnamespace/ss2",
 		expectedGVK:      gvkP("apps", "v1beta1", "StatefulSet"),
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes defaulting codes for `obj.Spec.Selector`. Currently, `obj.Spec.Selector.MatchLabels` is set to `obj.Spec.Template.Labels` if `obj.Spec.Template.Labels != nil && obj.Spec.Selector == nil`. We should not perform this defaulting operation as controllers selectors are immutable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50339

**Special notes for your reviewer**:
This PR removes defaulting codes for `apps/v1beta2` only. The defaulting codes for validation will be removed in another PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
