### PR TITLE
Update build requirements

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -5,10 +5,10 @@ Building Kubernetes is easy if you take advantage of the containerized build env
 ## Requirements
 
 1. Docker, using one of the following configurations:
-  1. **Mac OS X** You can either use Docker for Mac or docker-machine. See installation instructions [here](https://docs.docker.com/docker-for-mac/).
+  * **Mac OS X** You can either use Docker for Mac or docker-machine. See installation instructions [here](https://docs.docker.com/docker-for-mac/).
      **Note**: You will want to set the Docker VM to have at least 3GB of initial memory or building will likely fail. (See: [#11852]( http://issue.k8s.io/11852)).
-  2. **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.
-  3. **Remote Docker engine** Use a big machine in the cloud to build faster. This is a little trickier so look at the section later on.
+  * **Linux with local Docker**  Install Docker according to the [instructions](https://docs.docker.com/installation/#installation) for your OS.
+  * **Remote Docker engine** Use a big machine in the cloud to build faster. This is a little trickier so look at the section later on.
 2. **Optional** [Google Cloud SDK](https://developers.google.com/cloud/sdk/)
 
 You must install and configure Google Cloud SDK if you want to upload your release to Google Cloud Storage and may safely omit this otherwise.


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the build requirements for docker so that the three configurations are shown as sub-lists instead of a parallel list. 

Currently, the requirements are shown in this way.
1. xxx
2. xxx
3. xxx
4. xxx
5. xxx

But it should be shown as something like this:
1. xxx
  * xxx
  * xxx
  * xxx
2. xxx

The problem is because markdown doesn't support well for ordered sub-list under ordered list. So, change it to unordered sub-list can avoid this problem.

