### PR TITLE
kubeadm: Add back labels for the Static Pod control plane

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/BUILD
+++ b/cmd/kubeadm/app/phases/controlplane/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -166,6 +166,9 @@ func componentPod(container v1.Container, volumes []v1.Volume) v1.Pod {
 			Name:        container.Name,
 			Namespace:   metav1.NamespaceSystem,
 			Annotations: map[string]string{kubetypes.CriticalPodAnnotationKey: ""},
+			// The component and tier labels are useful for quickly identifying the control plane Pods when doing a .List()
+			// against Pods in the kube-system namespace. Can for example be used together with the WaitForPodsWithLabel function
+			Labels: map[string]string{"component": container.Name, "tier": "control-plane"},
 		},
 		Spec: v1.PodSpec{
 			Containers:  []v1.Container{container},

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -179,22 +180,43 @@ func TestComponentProbe(t *testing.T) {
 
 func TestComponentPod(t *testing.T) {
 	var tests = []struct {
-		n string
+		name     string
+		expected v1.Pod
 	}{
 		{
-			n: "foo",
+			name: "foo",
+			expected: v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "foo",
+					Namespace:   "kube-system",
+					Annotations: map[string]string{"scheduler.alpha.kubernetes.io/critical-pod": ""},
+					Labels:      map[string]string{"component": "foo", "tier": "control-plane"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foo",
+						},
+					},
+					HostNetwork: true,
+					Volumes:     []v1.Volume{},
+				},
+			},
 		},
 	}
 
 	for _, rt := range tests {
-		c := v1.Container{Name: rt.n}
-		v := []v1.Volume{}
-		actual := componentPod(c, v)
-		if actual.ObjectMeta.Name != rt.n {
+		c := v1.Container{Name: rt.name}
+		actual := componentPod(c, []v1.Volume{})
+		if !reflect.DeepEqual(rt.expected, actual) {
 			t.Errorf(
-				"failed componentPod:\n\texpected: %s\n\t  actual: %s",
-				rt.n,
-				actual.ObjectMeta.Name,
+				"failed componentPod:\n\texpected: %v\n\t  actual: %v",
+				rt.expected,
+				actual,
 			)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This Labels section has been removed now for a short period during the v1.8 dev cycle, but I found a good use-case for it; namely filtering Mirror Pods by the `component=kube-*` label when waiting for the self-hosted control plane to come up after an upgrade. It's not _really_ neccessary, but nice to have.

Also noticed the lack of coverage for this func, so added a small unit test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Dependency for: https://github.com/kubernetes/kubernetes/pull/48899

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @dmmcquay @timothysc @mattmoyer 