### PR TITLE
Change default update strategy to rolling update

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -51838,7 +51838,7 @@
       "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet"
      },
      "type": {
-      "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is OnDelete.",
+      "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
       "type": "string"
      }
     }
@@ -52287,7 +52287,7 @@
     "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
     "properties": {
      "partition": {
-      "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
+      "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
       "type": "integer",
       "format": "int32"
      }
@@ -52517,7 +52517,7 @@
       "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy"
      },
      "type": {
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy.",
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
       "type": "string"
      }
     }

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -7046,7 +7046,7 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is OnDelete."
+      "description": "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate."
      },
      "rollingUpdate": {
       "$ref": "v1beta2.RollingUpdateDaemonSet",
@@ -7836,7 +7836,7 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy."
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate."
      },
      "rollingUpdate": {
       "$ref": "v1beta2.RollingUpdateStatefulSetStrategy",
@@ -7851,7 +7851,7 @@
      "partition": {
       "type": "integer",
       "format": "int32",
-      "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned."
+      "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0."
      }
     }
    },

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -2191,7 +2191,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">partition</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Partition indicates the ordinal at which the StatefulSet should be partitioned.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7105,7 +7105,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is OnDelete.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7335,7 +7335,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -43,7 +43,7 @@ func SetDefaults_DaemonSet(obj *appsv1beta2.DaemonSet) {
 	}
 	updateStrategy := &obj.Spec.UpdateStrategy
 	if updateStrategy.Type == "" {
-		updateStrategy.Type = appsv1beta2.OnDeleteDaemonSetStrategyType
+		updateStrategy.Type = appsv1beta2.RollingUpdateDaemonSetStrategyType
 	}
 	if updateStrategy.Type == appsv1beta2.RollingUpdateDaemonSetStrategyType {
 		if updateStrategy.RollingUpdate == nil {
@@ -68,8 +68,19 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 	}
 
 	if obj.Spec.UpdateStrategy.Type == "" {
-		obj.Spec.UpdateStrategy.Type = appsv1beta2.OnDeleteStatefulSetStrategyType
+		obj.Spec.UpdateStrategy.Type = appsv1beta2.RollingUpdateStatefulSetStrategyType
+
+		// UpdateStrategy.RollingUpdate will take default values below.
+		obj.Spec.UpdateStrategy.RollingUpdate = &appsv1beta2.RollingUpdateStatefulSetStrategy{}
 	}
+
+	if obj.Spec.UpdateStrategy.Type == appsv1beta2.RollingUpdateStatefulSetStrategyType &&
+		obj.Spec.UpdateStrategy.RollingUpdate != nil &&
+		obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
+		obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
+		*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
+	}
+
 	labels := obj.Spec.Template.Labels
 	if labels != nil {
 		if obj.Spec.Selector == nil {
@@ -89,13 +100,6 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		obj.Spec.RevisionHistoryLimit = new(int32)
 		*obj.Spec.RevisionHistoryLimit = 10
 	}
-	if obj.Spec.UpdateStrategy.Type == appsv1beta2.RollingUpdateStatefulSetStrategyType &&
-		obj.Spec.UpdateStrategy.RollingUpdate != nil &&
-		obj.Spec.UpdateStrategy.RollingUpdate.Partition == nil {
-		obj.Spec.UpdateStrategy.RollingUpdate.Partition = new(int32)
-		*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
-	}
-
 }
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -157,8 +157,7 @@ message DaemonSetStatus {
 
 // WIP: This is not ready to be used and we plan to make breaking changes to it.
 message DaemonSetUpdateStrategy {
-  // Type of daemon set update. Can be "RollingUpdate" or "OnDelete".
-  // Default is OnDelete.
+  // Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
   // +optional
   optional string type = 1;
 
@@ -521,6 +520,8 @@ message RollingUpdateDeployment {
 message RollingUpdateStatefulSetStrategy {
   // Partition indicates the ordinal at which the StatefulSet should be
   // partitioned.
+  // Default value is 0.
+  // +optional
   optional int32 partition = 1;
 }
 
@@ -698,9 +699,12 @@ message StatefulSetStatus {
 // necessary to perform the update for the indicated strategy.
 message StatefulSetUpdateStrategy {
   // Type indicates the type of the StatefulSetUpdateStrategy.
+  // Default is RollingUpdate.
+  // +optional
   optional string type = 1;
 
   // RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+  // +optional
   optional RollingUpdateStatefulSetStrategy rollingUpdate = 2;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -122,8 +122,11 @@ const (
 // necessary to perform the update for the indicated strategy.
 type StatefulSetUpdateStrategy struct {
 	// Type indicates the type of the StatefulSetUpdateStrategy.
+	// Default is RollingUpdate.
+	// +optional
 	Type StatefulSetUpdateStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=StatefulSetStrategyType"`
 	// RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+	// +optional
 	RollingUpdate *RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty" protobuf:"bytes,2,opt,name=rollingUpdate"`
 }
 
@@ -151,6 +154,8 @@ const (
 type RollingUpdateStatefulSetStrategy struct {
 	// Partition indicates the ordinal at which the StatefulSet should be
 	// partitioned.
+	// Default value is 0.
+	// +optional
 	Partition *int32 `json:"partition,omitempty" protobuf:"varint,1,opt,name=partition"`
 }
 
@@ -504,8 +509,7 @@ type DeploymentList struct {
 
 // WIP: This is not ready to be used and we plan to make breaking changes to it.
 type DaemonSetUpdateStrategy struct {
-	// Type of daemon set update. Can be "RollingUpdate" or "OnDelete".
-	// Default is OnDelete.
+	// Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
 	// +optional
 	Type DaemonSetUpdateStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 

--- a/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
@@ -81,7 +81,7 @@ func (DaemonSetStatus) SwaggerDoc() map[string]string {
 
 var map_DaemonSetUpdateStrategy = map[string]string{
 	"":              "WIP: This is not ready to be used and we plan to make breaking changes to it.",
-	"type":          "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is OnDelete.",
+	"type":          "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if type = \"RollingUpdate\".",
 }
 
@@ -268,7 +268,7 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 
 var map_RollingUpdateStatefulSetStrategy = map[string]string{
 	"":          "WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
-	"partition": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
+	"partition": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
 }
 
 func (RollingUpdateStatefulSetStrategy) SwaggerDoc() map[string]string {
@@ -357,7 +357,7 @@ func (StatefulSetStatus) SwaggerDoc() map[string]string {
 
 var map_StatefulSetUpdateStrategy = map[string]string{
 	"":              "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
-	"type":          "Type indicates the type of the StatefulSetUpdateStrategy.",
+	"type":          "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
 	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/49604
Change default update strategy to rolling update for daemonset and statefulset in v1beta2

cc @kubernetes/sig-apps-pr-reviews @lukaszo @kargakis 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make rolling update the default update strategy for v1beta2.DaemonSet and v1beta2.StatefulSet
```
