### PR TITLE
Reset feature gate to false after each UT.

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1249,6 +1249,9 @@ func TestOutOfDiskNodeDaemonLaunchesCriticalPod(t *testing.T) {
 		utilfeature.DefaultFeatureGate.Set("ExperimentalCriticalPodAnnotation=True")
 		syncAndValidateDaemonSets(t, manager, ds, podControl, 1, 0, 0)
 	}
+
+	// Rollback feature gate to default value.
+	utilfeature.DefaultFeatureGate.Set("ExperimentalCriticalPodAnnotation=False")
 }
 
 // DaemonSet should launch a critical pod even when the node has insufficient free resource.
@@ -1291,6 +1294,9 @@ func TestInsufficientCapacityNodeDaemonLaunchesCriticalPod(t *testing.T) {
 			t.Fatalf("unexpected UpdateStrategy %+v", strategy)
 		}
 	}
+
+	// Rollback feature gate to default value.
+	utilfeature.DefaultFeatureGate.Set("ExperimentalCriticalPodAnnotation=False")
 }
 
 // DaemonSets should NOT launch a critical pod when there are port conflicts.
@@ -1319,6 +1325,9 @@ func TestPortConflictNodeDaemonDoesNotLaunchCriticalPod(t *testing.T) {
 		manager.dsStore.Add(ds)
 		syncAndValidateDaemonSets(t, manager, ds, podControl, 0, 0, 0)
 	}
+
+	// Rollback feature gate to default value.
+	utilfeature.DefaultFeatureGate.Set("ExperimentalCriticalPodAnnotation=False")
 }
 
 func setDaemonSetCritical(ds *extensions.DaemonSet) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Reset feature gate to false after each UT. No broken unit test for now, but it's a better practice, and it may avoid unexpected test result.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #N/A

**Release note**:

```release-note
None
```
