### PR TITLE
Verify script for multiarch test images

### DIFF
--- a/hack/.multiarch_images_exceptions.txt
+++ b/hack/.multiarch_images_exceptions.txt
@@ -1,0 +1,7 @@
+test/images/pets/redis
+test/images/pets/zookeeper
+test/images/volumes-tester/ceph
+test/images/volumes-tester/gluster
+test/images/volumes-tester/iscsi
+test/images/volumes-tester/nfs
+test/images/volumes-tester/rbd

--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -38,6 +38,7 @@ QUICK_PATTERNS+=(
   "verify-boilerplate.sh"
   "verify-godep-licenses.sh"
   "verify-gofmt.sh"
+  "verify-multiarch-test-images.sh"
   "verify-pkg-names.sh"
   "verify-readonly-packages.sh"
   "verify-staging-client-go.sh"

--- a/hack/verify-multiarch-test-images.sh
+++ b/hack/verify-multiarch-test-images.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+cd "${KUBE_ROOT}"
+NON_MULTIARCH_IMAGES=()
+
+for IMAGE_DIR in $(find test/images -iname 'Dockerfile' -printf '%h\n'| LC_ALL=C sort -u)
+do
+    grep -q "^${IMAGE_DIR}$" hack/.multiarch_images_exceptions.txt && ret=$? || ret=$?
+    if [[ "${ret}" -ne 0 ]]; then
+        if [[ ! -f "${IMAGE_DIR}/VERSION" ]]; then
+            NON_MULTIARCH_IMAGES+=("${IMAGE_DIR}")
+        fi
+    fi
+done
+
+if [ ${#NON_MULTIARCH_IMAGES[@]} -ne 0 ]; then
+    echo "[${NON_MULTIARCH_IMAGES[@]}] these images are not written for multiarchitecture."
+    echo 'Please port these images to multiarchitectures to avoid this error.'
+    echo ''
+	echo 'If the above error does not make sense, you can exempt by adding the list to'
+	echo 'hack/.multiarch_images_exceptions.txt (if sig/testing is okay with it).'
+    exit 1
+fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR is to add verify script for checking images under `/test/images` are multiarch images
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
