### PR TITLE
not allowing "kubectl edit <resource>" when you got an empty list

### DIFF
--- a/pkg/kubectl/cmd/testdata/edit/testcase-edit-from-empty/0.response
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-edit-from-empty/0.response
@@ -1,0 +1,9 @@
+{
+    "kind": "ConfigMapList",
+    "apiVersion": "v1",
+    "metadata": {
+        "selfLink": "/api/v1/namespaces/edit-test/configmaps",
+        "resourceVersion": "252"
+    },
+    "items": []
+}

--- a/pkg/kubectl/cmd/testdata/edit/testcase-edit-from-empty/test.yaml
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-edit-from-empty/test.yaml
@@ -1,0 +1,15 @@
+description: add a testcase description
+mode: edit
+args:
+- configmap
+namespace: "edit-test"
+expectedStderr:
+- edit cancelled, no objects found.
+expectedExitCode: 1
+steps:
+- type: request
+  expectedMethod: GET
+  expectedPath: /api/v1/namespaces/edit-test/configmaps
+  expectedInput: 0.request
+  resultingStatusCode: 200
+  resultingOutput: 0.response

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -336,6 +336,9 @@ func (o *EditOptions) Run() error {
 		if err != nil {
 			return err
 		}
+		if len(infos) == 0 {
+			return errors.New("edit cancelled, no objects found.")
+		}
 		return editFn(infos)
 	case ApplyEditMode:
 		infos, err := o.OriginalResult.Infos()
@@ -500,11 +503,7 @@ func getPrinter(format string) *editPrinterOptions {
 	}
 }
 
-func (o *EditOptions) visitToPatch(
-	originalInfos []*resource.Info,
-	patchVisitor resource.Visitor,
-	results *editResults,
-) error {
+func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor resource.Visitor, results *editResults) error {
 	err := patchVisitor.Visit(func(info *resource.Info, incomingErr error) error {
 		editObjUID, err := meta.NewAccessor().UID(info.Object)
 		if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
`kubectl edit` will panic when adding an empty list.

> panic: runtime error: index out of range

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50147

**Special notes for your reviewer**:
/assign @errordeveloper @mengqiy @janetkuo @fabianofranz
/cc @rootfs @soltysh @sttts

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
not allowing "kubectl edit <resource>" when you got an empty list
```
