### PR TITLE
[OpenStack] Add more detail error message

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_client.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_client.go
@@ -28,7 +28,7 @@ func (os *OpenStack) NewNetworkV2() (*gophercloud.ServiceClient, error) {
 		Region: os.region,
 	})
 	if err != nil {
-		glog.Warningf("Failed to find network v2 endpoint: %v", err)
+		glog.Warningf("Failed to find network v2 endpoint for region %s: %v", os.region, err)
 		return nil, err
 	}
 	return network, nil
@@ -39,7 +39,7 @@ func (os *OpenStack) NewComputeV2() (*gophercloud.ServiceClient, error) {
 		Region: os.region,
 	})
 	if err != nil {
-		glog.Warningf("Failed to find compute v2 endpoint: %v", err)
+		glog.Warningf("Failed to find compute v2 endpoint for region %s: %v", os.region, err)
 		return nil, err
 	}
 	return compute, nil
@@ -50,7 +50,7 @@ func (os *OpenStack) NewBlockStorageV1() (*gophercloud.ServiceClient, error) {
 		Region: os.region,
 	})
 	if err != nil {
-		glog.Errorf("Unable to initialize cinder v1 client for region: %s", os.region)
+		glog.Errorf("Unable to initialize cinder v1 client for region %s: %v", os.region, err)
 		return nil, err
 	}
 	return storage, nil
@@ -61,7 +61,7 @@ func (os *OpenStack) NewBlockStorageV2() (*gophercloud.ServiceClient, error) {
 		Region: os.region,
 	})
 	if err != nil {
-		glog.Errorf("Unable to initialize cinder v2 client for region: %s", os.region)
+		glog.Errorf("Unable to initialize cinder v2 client for region %s: %v", os.region, err)
 		return nil, err
 	}
 	return storage, nil


### PR DESCRIPTION
I get same simple error messages "Unable to initialize cinder client
for region: RegionOne" from controller-manager, but I can not find the
reason. We should add more detail message "err" into glog.Errorf.

Currently NewBlockStorageV2() return err when failed to get cinder endpoint, but there is no code to output the message of err.

**Release note**:
```release-note
NONE
```
