### PR TITLE
Fix error message of statefulset test

### DIFF
--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -46,7 +46,7 @@ func TestStatefulSetControllerCreates(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 3 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
 	}
 }
 
@@ -62,7 +62,7 @@ func TestStatefulSetControllerDeletes(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 3 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
 	}
 	*set.Spec.Replicas = 0
 	if err := scaleDownStatefulSetController(set, ssc, spc); err != nil {
@@ -74,7 +74,7 @@ func TestStatefulSetControllerDeletes(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 0 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 0", set.Status.Replicas)
 	}
 }
 
@@ -90,7 +90,7 @@ func TestStatefulSetControllerRespectsTermination(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 3 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
 	}
 	pods, err := spc.addTerminatingPod(set, 3)
 	if err != nil {
@@ -125,7 +125,7 @@ func TestStatefulSetControllerRespectsTermination(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 0 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 0", set.Status.Replicas)
 	}
 }
 
@@ -141,7 +141,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 		set = obj.(*apps.StatefulSet)
 	}
 	if set.Status.Replicas != 3 {
-		t.Error("Falied to scale statefulset to 3 replicas")
+		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
 	}
 	*set.Spec.Replicas = 5
 	fakeResourceVersion(set)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fix error message of statefulset test
It should be 0 replocas in the error message.
And fix typo from Falied to Failed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/50592

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
