### PR TITLE
Kubectl run

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -327,7 +327,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 		leaveStdinOpen := cmdutil.GetFlagBool(cmd, "leave-stdin-open")
 		waitForExitCode := !leaveStdinOpen && restartPolicy == api.RestartPolicyNever
 		if waitForExitCode {
-			pod, err = waitForPodTerminated(clientset.Core(), attachablePod.Namespace, attachablePod.Name)
+			pod, err = waitForPod(clientset.Core(), attachablePod.Namespace, attachablePod.Name, conditions.PodCompleted)
 			if err != nil {
 				return err
 			}
@@ -425,33 +425,17 @@ func waitForPod(podClient coreclient.PodsGetter, ns, name string, exitCondition 
 		}
 		return err
 	})
+
+	// Fix generic not found error.
+	if err != nil && errors.IsNotFound(err) {
+		err = errors.NewNotFound(api.Resource("pods"), name)
+	}
+
 	return result, err
 }
 
-func waitForPodRunning(podClient coreclient.PodsGetter, ns, name string) (*api.Pod, error) {
-	pod, err := waitForPod(podClient, ns, name, conditions.PodRunningAndReady)
-
-	// fix generic not found error with empty name in PodRunningAndReady
-	if err != nil && errors.IsNotFound(err) {
-		return nil, errors.NewNotFound(api.Resource("pods"), name)
-	}
-
-	return pod, err
-}
-
-func waitForPodTerminated(podClient coreclient.PodsGetter, ns, name string) (*api.Pod, error) {
-	pod, err := waitForPod(podClient, ns, name, conditions.PodCompleted)
-
-	// fix generic not found error with empty name in PodCompleted
-	if err != nil && errors.IsNotFound(err) {
-		return nil, errors.NewNotFound(api.Resource("pods"), name)
-	}
-
-	return pod, err
-}
-
 func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, name string, opts *AttachOptions) error {
-	pod, err := waitForPodRunning(podClient, ns, name)
+	pod, err := waitForPod(podClient, ns, name, conditions.PodRunningAndReady)
 	if err != nil && err != conditions.ErrPodCompleted {
 		return err
 	}

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -439,42 +439,44 @@ func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, nam
 	if err != nil && err != conditions.ErrPodCompleted {
 		return err
 	}
-	ctrName, err := opts.GetContainerName(pod)
-	if err != nil {
-		return err
-	}
+
 	if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
-		req, err := f.LogsForObject(pod, &api.PodLogOptions{Container: ctrName}, opts.GetPodTimeout)
-		if err != nil {
-			return err
-		}
-		readCloser, err := req.Stream()
-		if err != nil {
-			return err
-		}
-		defer readCloser.Close()
-		_, err = io.Copy(opts.Out, readCloser)
-		return err
+		return logOpts(f, pod, opts)
 	}
 
 	opts.PodClient = podClient
-
 	opts.PodName = name
 	opts.Namespace = ns
+
 	// TODO: opts.Run sets opts.Err to nil, we need to find a better way
 	stderr := opts.Err
 	if err := opts.Run(); err != nil {
 		fmt.Fprintf(stderr, "Error attaching, falling back to logs: %v\n", err)
-		req, err := f.LogsForObject(pod, &api.PodLogOptions{Container: ctrName}, opts.GetPodTimeout)
-		if err != nil {
-			return err
-		}
-		readCloser, err := req.Stream()
-		if err != nil {
-			return err
-		}
-		defer readCloser.Close()
-		_, err = io.Copy(opts.Out, readCloser)
+		return logOpts(f, pod, opts)
+	}
+	return nil
+}
+
+// logOpts logs output from opts to the pods log.
+func logOpts(f cmdutil.Factory, pod *api.Pod, opts *AttachOptions) error {
+	ctrName, err := opts.GetContainerName(pod)
+	if err != nil {
+		return err
+	}
+
+	req, err := f.LogsForObject(pod, &api.PodLogOptions{Container: ctrName}, opts.GetPodTimeout)
+	if err != nil {
+		return err
+	}
+
+	readCloser, err := req.Stream()
+	if err != nil {
+		return err
+	}
+	defer readCloser.Close()
+
+	_, err = io.Copy(opts.Out, readCloser)
+	if err != nil {
 		return err
 	}
 	return nil

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -448,12 +448,14 @@ func handleAttachPod(f cmdutil.Factory, podClient coreclient.PodsGetter, ns, nam
 	opts.PodName = name
 	opts.Namespace = ns
 
-	// TODO: opts.Run sets opts.Err to nil, we need to find a better way
-	stderr := opts.Err
-	if err := opts.Run(); err != nil {
-		fmt.Fprintf(stderr, "Error attaching, falling back to logs: %v\n", err)
+	// opts.Run sets opts.Err to nil
+	save := opts.Err
+	err = opts.Run()
+	opts.Err = save
+	if err != nil {
 		return logOpts(f, pod, opts)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`pkg/kubectl/cmd/run.go` could do with a bit of refactoring. This PR refactors `run.go` spread over three commits.

Commit 1 Removes two helper functions which have duplicate code that can be safely added to the calling function. This does add an extra parameter to two call sites but maintains current logic.

Commit 2 Logging code is duplicated within a single function, factor logging code out into a separate function.

Commit 3 io.Writer variable is clobbered by function call, currently code saves writer and passes it to print function on error. Code contains a TODO note directing code to be fixed. We can simply save the writer before the call and restore it afterwards. This allows the normal logging functions to be called.

**Special notes for your reviewer**:

The diff is a bit convoluted because the refactorings (commit 1 and 2) [re]move code in consecutive functions. I'm quite new around here, is this grouping of commits ok? Commit 3 is dependent on commit 2 since the effected code is within the refactored function.

-->
```release-note
NONE
```

/sig cli
/kind cleanup