### PR TITLE
Remove deprecated ESIPP beta annotations

### DIFF
--- a/pkg/api/annotation_key_constants.go
+++ b/pkg/api/annotation_key_constants.go
@@ -89,20 +89,4 @@ const (
 	//
 	// Not all cloud providers support this annotation, though AWS & GCE do.
 	AnnotationLoadBalancerSourceRangesKey = "service.beta.kubernetes.io/load-balancer-source-ranges"
-
-	// AnnotationValueExternalTrafficLocal Value of annotation to specify local endpoints behavior.
-	AnnotationValueExternalTrafficLocal = "OnlyLocal"
-	// AnnotationValueExternalTrafficGlobal Value of annotation to specify global (legacy) behavior.
-	AnnotationValueExternalTrafficGlobal = "Global"
-
-	// TODO: The beta annotations have been deprecated, remove them when we release k8s 1.8.
-
-	// BetaAnnotationHealthCheckNodePort Annotation specifying the healthcheck nodePort for the service.
-	// If not specified, annotation is created by the service api backend with the allocated nodePort.
-	// Will use user-specified nodePort value if specified by the client.
-	BetaAnnotationHealthCheckNodePort = "service.beta.kubernetes.io/healthcheck-nodeport"
-
-	// BetaAnnotationExternalTraffic An annotation that denotes if this Service desires to route
-	// external traffic to local endpoints only. This preserves Source IP and avoids a second hop.
-	BetaAnnotationExternalTraffic = "service.beta.kubernetes.io/external-traffic"
 )

--- a/pkg/api/service/BUILD
+++ b/pkg/api/service/BUILD
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/util/net/sets:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
 
@@ -28,7 +27,6 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/util/net/sets:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/pkg/api/service/BUILD
+++ b/pkg/api/service/BUILD
@@ -26,7 +26,6 @@ go_test(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/util/net/sets:go_default_library",
-        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
     ],
 )
 

--- a/pkg/api/service/util.go
+++ b/pkg/api/service/util.go
@@ -77,26 +77,10 @@ func RequestsOnlyLocalTraffic(service *api.Service) bool {
 	return service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeLocal
 }
 
-// NeedsHealthCheck Check if service needs health check.
+// NeedsHealthCheck checks if service needs health check.
 func NeedsHealthCheck(service *api.Service) bool {
 	if service.Spec.Type != api.ServiceTypeLoadBalancer {
 		return false
 	}
 	return RequestsOnlyLocalTraffic(service)
-}
-
-// GetServiceHealthCheckNodePort Return health check node port for service, if one exists
-func GetServiceHealthCheckNodePort(service *api.Service) int32 {
-	return service.Spec.HealthCheckNodePort
-}
-
-// ClearExternalTrafficPolicy resets the ExternalTrafficPolicy field.
-func ClearExternalTrafficPolicy(service *api.Service) {
-	service.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyType("")
-}
-
-// SetServiceHealthCheckNodePort sets the given health check node port on service.
-// It does not check whether this service needs healthCheckNodePort.
-func SetServiceHealthCheckNodePort(service *api.Service, hcNodePort int32) {
-	service.Spec.HealthCheckNodePort = hcNodePort
 }

--- a/pkg/api/service/util.go
+++ b/pkg/api/service/util.go
@@ -18,13 +18,10 @@ package service
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"k8s.io/kubernetes/pkg/api"
 	netsets "k8s.io/kubernetes/pkg/util/net/sets"
-
-	"github.com/golang/glog"
 )
 
 const (
@@ -77,20 +74,6 @@ func RequestsOnlyLocalTraffic(service *api.Service) bool {
 		return false
 	}
 
-	// First check the beta annotation and then the first class field. This is so that
-	// existing Services continue to work till the user decides to transition to the
-	// first class field.
-	if l, ok := service.Annotations[api.BetaAnnotationExternalTraffic]; ok {
-		switch l {
-		case api.AnnotationValueExternalTrafficLocal:
-			return true
-		case api.AnnotationValueExternalTrafficGlobal:
-			return false
-		default:
-			glog.Errorf("Invalid value for annotation %v: %v", api.BetaAnnotationExternalTraffic, l)
-			return false
-		}
-	}
 	return service.Spec.ExternalTrafficPolicy == api.ServiceExternalTrafficPolicyTypeLocal
 }
 
@@ -104,45 +87,16 @@ func NeedsHealthCheck(service *api.Service) bool {
 
 // GetServiceHealthCheckNodePort Return health check node port for service, if one exists
 func GetServiceHealthCheckNodePort(service *api.Service) int32 {
-	// First check the beta annotation and then the first class field. This is so that
-	// existing Services continue to work till the user decides to transition to the
-	// first class field.
-	if l, ok := service.Annotations[api.BetaAnnotationHealthCheckNodePort]; ok {
-		p, err := strconv.Atoi(l)
-		if err != nil {
-			glog.Errorf("Failed to parse annotation %v: %v", api.BetaAnnotationHealthCheckNodePort, err)
-			return 0
-		}
-		return int32(p)
-	}
 	return service.Spec.HealthCheckNodePort
 }
 
 // ClearExternalTrafficPolicy resets the ExternalTrafficPolicy field.
 func ClearExternalTrafficPolicy(service *api.Service) {
-	// First check the beta annotation and then the first class field. This is so that
-	// existing Services continue to work till the user decides to transition to the
-	// first class field.
-	if _, ok := service.Annotations[api.BetaAnnotationExternalTraffic]; ok {
-		delete(service.Annotations, api.BetaAnnotationExternalTraffic)
-		return
-	}
 	service.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyType("")
 }
 
 // SetServiceHealthCheckNodePort sets the given health check node port on service.
 // It does not check whether this service needs healthCheckNodePort.
 func SetServiceHealthCheckNodePort(service *api.Service, hcNodePort int32) {
-	// First check the beta annotation and then the first class field. This is so that
-	// existing Services continue to work till the user decides to transition to the
-	// first class field.
-	if _, ok := service.Annotations[api.BetaAnnotationExternalTraffic]; ok {
-		if hcNodePort == 0 {
-			delete(service.Annotations, api.BetaAnnotationHealthCheckNodePort)
-		} else {
-			service.Annotations[api.BetaAnnotationHealthCheckNodePort] = fmt.Sprintf("%d", hcNodePort)
-		}
-		return
-	}
 	service.Spec.HealthCheckNodePort = hcNodePort
 }

--- a/pkg/api/service/util_test.go
+++ b/pkg/api/service/util_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"k8s.io/kubernetes/pkg/api"
 	netsets "k8s.io/kubernetes/pkg/util/net/sets"
 )
@@ -215,97 +213,4 @@ func TestNeedsHealthCheck(t *testing.T) {
 			ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeLocal,
 		},
 	})
-}
-
-func TestGetServiceHealthCheckNodePort(t *testing.T) {
-	checkGetServiceHealthCheckNodePort := func(healthCheckNodePort int32, service *api.Service) {
-		res := GetServiceHealthCheckNodePort(service)
-		if res != healthCheckNodePort {
-			t.Errorf("Expected health check node port = %v, got %v",
-				healthCheckNodePort, res)
-		}
-	}
-
-	checkGetServiceHealthCheckNodePort(0, &api.Service{
-		Spec: api.ServiceSpec{
-			Type: api.ServiceTypeClusterIP,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(0, &api.Service{
-		Spec: api.ServiceSpec{
-			Type: api.ServiceTypeNodePort,
-			ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeCluster,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(0, &api.Service{
-		Spec: api.ServiceSpec{
-			Type: api.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeCluster,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(34567, &api.Service{
-		Spec: api.ServiceSpec{
-			Type: api.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeLocal,
-			HealthCheckNodePort:   int32(34567),
-		},
-	})
-}
-
-func TestClearExternalTrafficPolicy(t *testing.T) {
-	testCases := []struct {
-		inputService *api.Service
-	}{
-		// First class fields cases.
-		{
-			&api.Service{
-				Spec: api.ServiceSpec{
-					Type: api.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-		},
-	}
-
-	for i, tc := range testCases {
-		ClearExternalTrafficPolicy(tc.inputService)
-		if tc.inputService.Spec.ExternalTrafficPolicy != "" {
-			t.Errorf("%v: failed to clear ExternalTrafficPolicy", i)
-			spew.Dump(tc)
-		}
-	}
-}
-
-func TestSetServiceHealthCheckNodePort(t *testing.T) {
-	testCases := []struct {
-		inputService *api.Service
-		hcNodePort   int32
-	}{
-		// First class fields cases.
-		{
-			&api.Service{
-				Spec: api.ServiceSpec{
-					Type: api.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-			30012,
-		},
-		{
-			&api.Service{
-				Spec: api.ServiceSpec{
-					Type: api.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: api.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-			0,
-		},
-	}
-
-	for i, tc := range testCases {
-		SetServiceHealthCheckNodePort(tc.inputService, tc.hcNodePort)
-		if tc.inputService.Spec.HealthCheckNodePort != tc.hcNodePort {
-			t.Errorf("%v: got HealthCheckNodePort %v, want %v", i, tc.inputService.Spec.HealthCheckNodePort, tc.hcNodePort)
-		}
-	}
 }

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -115,10 +115,7 @@ func SetDefaults_Service(obj *v1.Service) {
 	}
 	// Defaults ExternalTrafficPolicy field for NodePort / LoadBalancer service
 	// to Global for consistency.
-	if _, ok := obj.Annotations[v1.BetaAnnotationExternalTraffic]; ok {
-		// Don't default this field if beta annotation exists.
-		return
-	} else if (obj.Spec.Type == v1.ServiceTypeNodePort ||
+	if (obj.Spec.Type == v1.ServiceTypeNodePort ||
 		obj.Spec.Type == v1.ServiceTypeLoadBalancer) &&
 		obj.Spec.ExternalTrafficPolicy == "" {
 		obj.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeCluster

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -896,18 +896,6 @@ func TestSetDefaulServiceExternalTraffic(t *testing.T) {
 	if out.Spec.ExternalTrafficPolicy != v1.ServiceExternalTrafficPolicyTypeCluster {
 		t.Errorf("Expected ExternalTrafficPolicy to be %v, got %v", v1.ServiceExternalTrafficPolicyTypeCluster, out.Spec.ExternalTrafficPolicy)
 	}
-
-	in = &v1.Service{
-		Spec: v1.ServiceSpec{Type: v1.ServiceTypeLoadBalancer},
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{v1.BetaAnnotationExternalTraffic: v1.AnnotationValueExternalTrafficLocal},
-		},
-	}
-	obj = roundTrip(t, runtime.Object(in))
-	out = obj.(*v1.Service)
-	if out.Spec.ExternalTrafficPolicy != "" {
-		t.Errorf("Expected ExternalTrafficPolicy to be empty, got %v", out.Spec.ExternalTrafficPolicy)
-	}
 }
 
 func TestSetDefaultNamespace(t *testing.T) {

--- a/pkg/api/v1/service/BUILD
+++ b/pkg/api/v1/service/BUILD
@@ -25,7 +25,6 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//pkg/util/net/sets:go_default_library",
-        "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/api/v1/service/BUILD
+++ b/pkg/api/v1/service/BUILD
@@ -14,7 +14,6 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/util/net/sets:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
@@ -28,7 +27,6 @@ go_test(
         "//pkg/util/net/sets:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/pkg/api/v1/service/util.go
+++ b/pkg/api/v1/service/util.go
@@ -76,7 +76,7 @@ func RequestsOnlyLocalTraffic(service *v1.Service) bool {
 	return service.Spec.ExternalTrafficPolicy == v1.ServiceExternalTrafficPolicyTypeLocal
 }
 
-// NeedsHealthCheck Check if service needs health check.
+// NeedsHealthCheck checks if service needs health check.
 func NeedsHealthCheck(service *v1.Service) bool {
 	if service.Spec.Type != v1.ServiceTypeLoadBalancer {
 		return false
@@ -84,28 +84,12 @@ func NeedsHealthCheck(service *v1.Service) bool {
 	return RequestsOnlyLocalTraffic(service)
 }
 
-// GetServiceHealthCheckNodePort Return health check node port for service, if one exists
-func GetServiceHealthCheckNodePort(service *v1.Service) int32 {
-	return service.Spec.HealthCheckNodePort
-}
-
-// ClearExternalTrafficPolicy resets the ExternalTrafficPolicy field.
-func ClearExternalTrafficPolicy(service *v1.Service) {
-	service.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyType("")
-}
-
-// SetServiceHealthCheckNodePort sets the given health check node port on service.
-// It does not check whether this service needs healthCheckNodePort.
-func SetServiceHealthCheckNodePort(service *v1.Service, hcNodePort int32) {
-	service.Spec.HealthCheckNodePort = hcNodePort
-}
-
-// GetServiceHealthCheckPathPort Return the path and nodePort programmed into the Cloud LB Health Check
+// GetServiceHealthCheckPathPort returns the path and nodePort programmed into the Cloud LB Health Check
 func GetServiceHealthCheckPathPort(service *v1.Service) (string, int32) {
 	if !NeedsHealthCheck(service) {
 		return "", 0
 	}
-	port := GetServiceHealthCheckNodePort(service)
+	port := service.Spec.HealthCheckNodePort
 	if port == 0 {
 		return "", 0
 	}

--- a/pkg/api/v1/service/util_test.go
+++ b/pkg/api/v1/service/util_test.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
-
 	"k8s.io/api/core/v1"
 	netsets "k8s.io/kubernetes/pkg/util/net/sets"
 )
@@ -215,97 +213,4 @@ func TestNeedsHealthCheck(t *testing.T) {
 			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
 		},
 	})
-}
-
-func TestGetServiceHealthCheckNodePort(t *testing.T) {
-	checkGetServiceHealthCheckNodePort := func(healthCheckNodePort int32, service *v1.Service) {
-		res := GetServiceHealthCheckNodePort(service)
-		if res != healthCheckNodePort {
-			t.Errorf("Expected health check node port = %v, got %v",
-				healthCheckNodePort, res)
-		}
-	}
-
-	checkGetServiceHealthCheckNodePort(0, &v1.Service{
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeClusterIP,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(0, &v1.Service{
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeNodePort,
-			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(0, &v1.Service{
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-		},
-	})
-	checkGetServiceHealthCheckNodePort(34567, &v1.Service{
-		Spec: v1.ServiceSpec{
-			Type: v1.ServiceTypeLoadBalancer,
-			ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeLocal,
-			HealthCheckNodePort:   int32(34567),
-		},
-	})
-}
-
-func TestClearExternalTrafficPolicy(t *testing.T) {
-	testCases := []struct {
-		inputService *v1.Service
-	}{
-		// First class fields cases.
-		{
-			&v1.Service{
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-		},
-	}
-
-	for i, tc := range testCases {
-		ClearExternalTrafficPolicy(tc.inputService)
-		if tc.inputService.Spec.ExternalTrafficPolicy != "" {
-			t.Errorf("%v: failed to clear ExternalTrafficPolicy", i)
-			spew.Dump(tc)
-		}
-	}
-}
-
-func TestSetServiceHealthCheckNodePort(t *testing.T) {
-	testCases := []struct {
-		inputService *v1.Service
-		hcNodePort   int32
-	}{
-		// First class fields cases.
-		{
-			&v1.Service{
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-			30012,
-		},
-		{
-			&v1.Service{
-				Spec: v1.ServiceSpec{
-					Type: v1.ServiceTypeClusterIP,
-					ExternalTrafficPolicy: v1.ServiceExternalTrafficPolicyTypeCluster,
-				},
-			},
-			0,
-		},
-	}
-
-	for i, tc := range testCases {
-		SetServiceHealthCheckNodePort(tc.inputService, tc.hcNodePort)
-		if tc.inputService.Spec.HealthCheckNodePort != tc.hcNodePort {
-			t.Errorf("%v: got HealthCheckNodePort %v, want %v", i, tc.inputService.Spec.HealthCheckNodePort, tc.hcNodePort)
-		}
-	}
 }

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -24,7 +24,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -2964,7 +2963,6 @@ func ValidateService(service *api.Service) field.ErrorList {
 	}
 
 	allErrs = append(allErrs, validateServiceExternalTrafficFieldsValue(service)...)
-	allErrs = append(allErrs, validateServiceExternalTrafficAPIVersion(service)...)
 
 	return allErrs
 }
@@ -3012,25 +3010,6 @@ func validateServicePort(sp *api.ServicePort, requireName, isHeadlessService boo
 func validateServiceExternalTrafficFieldsValue(service *api.Service) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// Check beta annotations.
-	if l, ok := service.Annotations[api.BetaAnnotationExternalTraffic]; ok {
-		if l != api.AnnotationValueExternalTrafficLocal &&
-			l != api.AnnotationValueExternalTrafficGlobal {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "annotations").Key(api.BetaAnnotationExternalTraffic), l,
-				fmt.Sprintf("ExternalTraffic must be %v or %v", api.AnnotationValueExternalTrafficLocal, api.AnnotationValueExternalTrafficGlobal)))
-		}
-	}
-	if l, ok := service.Annotations[api.BetaAnnotationHealthCheckNodePort]; ok {
-		p, err := strconv.Atoi(l)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "annotations").Key(api.BetaAnnotationHealthCheckNodePort), l,
-				"HealthCheckNodePort must be a valid port number"))
-		} else if p <= 0 {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "annotations").Key(api.BetaAnnotationHealthCheckNodePort), l,
-				"HealthCheckNodePort must be greater than 0"))
-		}
-	}
-
 	// Check first class fields.
 	if service.Spec.ExternalTrafficPolicy != "" &&
 		service.Spec.ExternalTrafficPolicy != api.ServiceExternalTrafficPolicyTypeCluster &&
@@ -3041,54 +3020,6 @@ func validateServiceExternalTrafficFieldsValue(service *api.Service) field.Error
 	if service.Spec.HealthCheckNodePort < 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheckNodePort"), service.Spec.HealthCheckNodePort,
 			"HealthCheckNodePort must be not less than 0"))
-	}
-
-	return allErrs
-}
-
-// serviceExternalTrafficStatus stores flags indicating whether ExternalTraffic
-// related beta annotations and GA fields are set on service.
-type serviceExternalTrafficStatus struct {
-	betaExternalTrafficIsSet bool
-	betaHealthCheckIsSet     bool
-	gaExternalTrafficIsSet   bool
-	gaHealthCheckIsSet       bool
-}
-
-func (s *serviceExternalTrafficStatus) useBetaExternalTrafficWithGA() bool {
-	return s.betaExternalTrafficIsSet && (s.gaExternalTrafficIsSet || s.gaHealthCheckIsSet)
-}
-
-func (s *serviceExternalTrafficStatus) useBetaHealthCheckWithGA() bool {
-	return s.betaHealthCheckIsSet && (s.gaExternalTrafficIsSet || s.gaHealthCheckIsSet)
-}
-
-func getServiceExternalTrafficStatus(service *api.Service) *serviceExternalTrafficStatus {
-	s := serviceExternalTrafficStatus{}
-	_, s.betaExternalTrafficIsSet = service.Annotations[api.BetaAnnotationExternalTraffic]
-	_, s.betaHealthCheckIsSet = service.Annotations[api.BetaAnnotationHealthCheckNodePort]
-	s.gaExternalTrafficIsSet = service.Spec.ExternalTrafficPolicy != ""
-	s.gaHealthCheckIsSet = service.Spec.HealthCheckNodePort != 0
-	return &s
-}
-
-// validateServiceExternalTrafficAPIVersion checks if user mixes ExternalTraffic
-// API versions.
-func validateServiceExternalTrafficAPIVersion(service *api.Service) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	status := getServiceExternalTrafficStatus(service)
-
-	if status.useBetaExternalTrafficWithGA() {
-		fieldPath := field.NewPath("metadata", "annotations").Key(api.BetaAnnotationExternalTraffic)
-		msg := fmt.Sprintf("please replace the beta annotation with 'ExternalTrafficPolicy' field")
-		allErrs = append(allErrs, field.Invalid(fieldPath, api.BetaAnnotationExternalTraffic, msg))
-	}
-
-	if status.useBetaHealthCheckWithGA() {
-		fieldPath := field.NewPath("metadata", "annotations").Key(api.BetaAnnotationHealthCheckNodePort)
-		msg := fmt.Sprintf("please replace the beta annotation with 'HealthCheckNodePort' field")
-		allErrs = append(allErrs, field.Invalid(fieldPath, api.BetaAnnotationHealthCheckNodePort, msg))
 	}
 
 	return allErrs

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -6451,48 +6451,6 @@ func TestValidateService(t *testing.T) {
 		},
 		// ESIPP section begins.
 		{
-			name: "LoadBalancer allows onlyLocal beta annotations",
-			tweakSvc: func(s *api.Service) {
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-			},
-			numErrs: 0,
-		},
-		{
-			name: "invalid externalTraffic beta annotation",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = "invalid"
-			},
-			numErrs: 1,
-		},
-		{
-			name: "nagative healthCheckNodePort beta annotation",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				s.Annotations[api.BetaAnnotationHealthCheckNodePort] = "-1"
-			},
-			numErrs: 1,
-		},
-		{
-			name: "invalid healthCheckNodePort beta annotation",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				s.Annotations[api.BetaAnnotationHealthCheckNodePort] = "whatisthis"
-			},
-			numErrs: 1,
-		},
-		{
-			name: "valid healthCheckNodePort beta annotation",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				s.Annotations[api.BetaAnnotationHealthCheckNodePort] = "31100"
-			},
-			numErrs: 0,
-		},
-		{
 			name: "invalid externalTraffic field",
 			tweakSvc: func(s *api.Service) {
 				s.Spec.Type = api.ServiceTypeLoadBalancer
@@ -6517,33 +6475,6 @@ func TestValidateService(t *testing.T) {
 				s.Spec.HealthCheckNodePort = 31100
 			},
 			numErrs: 0,
-		},
-		{
-			name: "disallows use ExternalTraffic beta annotation with first class field",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				s.Spec.HealthCheckNodePort = 3001
-			},
-			numErrs: 1,
-		},
-		{
-			name: "disallows duplicated ExternalTraffic beta annotation with first class field",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				s.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
-			},
-			numErrs: 1,
-		},
-		{
-			name: "disallows use HealthCheckNodePort beta annotation with first class field",
-			tweakSvc: func(s *api.Service) {
-				s.Spec.Type = api.ServiceTypeLoadBalancer
-				s.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
-				s.Annotations[api.BetaAnnotationHealthCheckNodePort] = "3001"
-			},
-			numErrs: 1,
 		},
 		// ESIPP section ends.
 	}
@@ -8004,50 +7935,6 @@ func TestValidateServiceUpdate(t *testing.T) {
 				newSvc.Spec.Type = api.ServiceTypeLoadBalancer
 			},
 			numErrs: 1,
-		},
-		{
-			name: "Service allows removing onlyLocal beta annotations",
-			tweakSvc: func(oldSvc, newSvc *api.Service) {
-				oldSvc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = "3001"
-			},
-			numErrs: 0,
-		},
-		{
-			name: "Service allows modifying onlyLocal beta annotations",
-			tweakSvc: func(oldSvc, newSvc *api.Service) {
-				oldSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				oldSvc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = "3001"
-				newSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				newSvc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficGlobal
-				newSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort]
-			},
-			numErrs: 0,
-		},
-		{
-			name: "Service disallows promoting one of the onlyLocal pair to GA",
-			tweakSvc: func(oldSvc, newSvc *api.Service) {
-				oldSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				oldSvc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = "3001"
-				newSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				newSvc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
-				newSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort]
-			},
-			numErrs: 1,
-		},
-		{
-			name: "Service allows changing both onlyLocal annotations from beta to GA",
-			tweakSvc: func(oldSvc, newSvc *api.Service) {
-				oldSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				oldSvc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
-				oldSvc.Annotations[api.BetaAnnotationHealthCheckNodePort] = "3001"
-				newSvc.Spec.Type = api.ServiceTypeLoadBalancer
-				newSvc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
-				newSvc.Spec.HealthCheckNodePort = 3001
-			},
-			numErrs: 0,
 		},
 		{
 			name: "`None` ClusterIP cannot be changed",

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -211,7 +211,7 @@ func newServiceInfo(svcPortName proxy.ServicePortName, port *api.ServicePort, se
 	copy(info.externalIPs, service.Spec.ExternalIPs)
 
 	if apiservice.NeedsHealthCheck(service) {
-		p := apiservice.GetServiceHealthCheckNodePort(service)
+		p := service.Spec.HealthCheckNodePort
 		if p == 0 {
 			glog.Errorf("Service %q has no healthcheck nodeport", svcPortName.NamespacedName.String())
 		} else {

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -867,7 +867,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 			svc.Status.LoadBalancer.Ingress = []api.LoadBalancerIngress{{
 				IP: svcLBIP,
 			}}
-			svc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
+			svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
 		}),
 	)
 
@@ -958,7 +958,7 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 				Protocol: api.ProtocolTCP,
 				NodePort: int32(svcNodePort),
 			}}
-			svc.Annotations[api.BetaAnnotationExternalTraffic] = api.AnnotationValueExternalTrafficLocal
+			svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
 		}),
 	)
 
@@ -1069,10 +1069,6 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 			}
 		}),
 		makeTestService("somewhere", "only-local-load-balancer", func(svc *api.Service) {
-			svc.ObjectMeta.Annotations = map[string]string{
-				api.BetaAnnotationExternalTraffic:     api.AnnotationValueExternalTrafficLocal,
-				api.BetaAnnotationHealthCheckNodePort: "345",
-			}
 			svc.Spec.Type = api.ServiceTypeLoadBalancer
 			svc.Spec.ClusterIP = "172.16.55.12"
 			svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1083,6 +1079,8 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 					{IP: "10.1.2.3"},
 				},
 			}
+			svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
+			svc.Spec.HealthCheckNodePort = 345
 		}),
 	}
 
@@ -1214,10 +1212,6 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 		svc.Spec.Ports = addTestPort(svc.Spec.Ports, "somethingelse", "TCP", 1235, 5321, 0)
 	})
 	servicev2 := makeTestService("somewhere", "some-service", func(svc *api.Service) {
-		svc.ObjectMeta.Annotations = map[string]string{
-			api.BetaAnnotationExternalTraffic:     api.AnnotationValueExternalTrafficLocal,
-			api.BetaAnnotationHealthCheckNodePort: "345",
-		}
 		svc.Spec.Type = api.ServiceTypeLoadBalancer
 		svc.Spec.ClusterIP = "172.16.55.4"
 		svc.Spec.LoadBalancerIP = "5.6.7.8"
@@ -1228,6 +1222,8 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 				{IP: "10.1.2.3"},
 			},
 		}
+		svc.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyTypeLocal
+		svc.Spec.HealthCheckNodePort = 345
 	})
 
 	fp.OnServiceAdd(servicev1)

--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -279,12 +279,7 @@ func (rs *REST) healthCheckNodePortUpdate(oldService, service *api.Service) (boo
 	case neededHealthCheckNodePort && needsHealthCheckNodePort:
 		if oldHealthCheckNodePort != newHealthCheckNodePort {
 			glog.Warningf("Attempt to change value of health check node port DENIED")
-			var fldPath *field.Path
-			if _, ok := service.Annotations[api.BetaAnnotationHealthCheckNodePort]; ok {
-				fldPath = field.NewPath("metadata", "annotations").Key(api.BetaAnnotationHealthCheckNodePort)
-			} else {
-				fldPath = field.NewPath("spec", "healthCheckNodePort")
-			}
+			fldPath := field.NewPath("spec", "healthCheckNodePort")
 			el := field.ErrorList{field.Invalid(fldPath, newHealthCheckNodePort,
 				"cannot change healthCheckNodePort on loadBalancer service with externalTraffic=Local during update")}
 			return false, errors.NewInvalid(api.Kind("Service"), service.Name, el)

--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -183,7 +183,7 @@ func (rs *REST) Delete(ctx genericapirequest.Context, id string) (runtime.Object
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ExternalTrafficLocalOnly) &&
 		apiservice.NeedsHealthCheck(service) {
-		nodePort := apiservice.GetServiceHealthCheckNodePort(service)
+		nodePort := service.Spec.HealthCheckNodePort
 		if nodePort > 0 {
 			err := rs.serviceNodePorts.Release(int(nodePort))
 			if err != nil {
@@ -238,7 +238,7 @@ func externalTrafficPolicyUpdate(oldService, service *api.Service) {
 	}
 	if neededExternalTraffic && !needsExternalTraffic {
 		// Clear ExternalTrafficPolicy to prevent confusion from ineffective field.
-		apiservice.ClearExternalTrafficPolicy(service)
+		service.Spec.ExternalTrafficPolicy = api.ServiceExternalTrafficPolicyType("")
 	}
 }
 
@@ -246,10 +246,10 @@ func externalTrafficPolicyUpdate(oldService, service *api.Service) {
 // and adjusts HealthCheckNodePort during service update if needed.
 func (rs *REST) healthCheckNodePortUpdate(oldService, service *api.Service) (bool, error) {
 	neededHealthCheckNodePort := apiservice.NeedsHealthCheck(oldService)
-	oldHealthCheckNodePort := apiservice.GetServiceHealthCheckNodePort(oldService)
+	oldHealthCheckNodePort := oldService.Spec.HealthCheckNodePort
 
 	needsHealthCheckNodePort := apiservice.NeedsHealthCheck(service)
-	newHealthCheckNodePort := apiservice.GetServiceHealthCheckNodePort(service)
+	newHealthCheckNodePort := service.Spec.HealthCheckNodePort
 
 	switch {
 	// Case 1: Transition from don't need HealthCheckNodePort to needs HealthCheckNodePort.
@@ -272,7 +272,7 @@ func (rs *REST) healthCheckNodePortUpdate(oldService, service *api.Service) (boo
 		}
 		glog.Infof("Freed health check nodePort: %d", oldHealthCheckNodePort)
 		// Clear the HealthCheckNodePort field.
-		apiservice.SetServiceHealthCheckNodePort(service, 0)
+		service.Spec.HealthCheckNodePort = 0
 
 	// Case 3: Remain in needs HealthCheckNodePort.
 	// Reject changing the value of the HealthCheckNodePort field.
@@ -475,7 +475,7 @@ func findRequestedNodePort(port int, servicePorts []api.ServicePort) int {
 
 // allocateHealthCheckNodePort allocates health check node port to service.
 func (rs *REST) allocateHealthCheckNodePort(service *api.Service) error {
-	healthCheckNodePort := apiservice.GetServiceHealthCheckNodePort(service)
+	healthCheckNodePort := service.Spec.HealthCheckNodePort
 	if healthCheckNodePort != 0 {
 		// If the request has a health check nodePort in mind, attempt to reserve it.
 		err := rs.serviceNodePorts.Allocate(int(healthCheckNodePort))
@@ -490,7 +490,7 @@ func (rs *REST) allocateHealthCheckNodePort(service *api.Service) error {
 		if err != nil {
 			return fmt.Errorf("failed to allocate a HealthCheck NodePort %v: %v", healthCheckNodePort, err)
 		}
-		apiservice.SetServiceHealthCheckNodePort(service, int32(healthCheckNodePort))
+		service.Spec.HealthCheckNodePort = int32(healthCheckNodePort)
 		glog.Infof("Reserved allocated nodePort: %d", healthCheckNodePort)
 	}
 	return nil

--- a/pkg/registry/core/service/rest_test.go
+++ b/pkg/registry/core/service/rest_test.go
@@ -993,7 +993,7 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortAllocation(t *testing.
 	if !service.NeedsHealthCheck(created_service) {
 		t.Errorf("Expecting health check needed, returned health check not needed instead")
 	}
-	port := service.GetServiceHealthCheckNodePort(created_service)
+	port := created_service.Spec.HealthCheckNodePort
 	if port == 0 {
 		t.Errorf("Failed to allocate health check node port and set the HealthCheckNodePort")
 	} else {
@@ -1031,7 +1031,7 @@ func TestServiceRegistryExternalTrafficHealthCheckNodePortUserAllocation(t *test
 	if !service.NeedsHealthCheck(created_service) {
 		t.Errorf("Expecting health check needed, returned health check not needed instead")
 	}
-	port := service.GetServiceHealthCheckNodePort(created_service)
+	port := created_service.Spec.HealthCheckNodePort
 	if port == 0 {
 		t.Errorf("Failed to allocate health check node port and set the HealthCheckNodePort")
 	}
@@ -1098,7 +1098,7 @@ func TestServiceRegistryExternalTrafficGlobal(t *testing.T) {
 		t.Errorf("Expecting health check not needed, returned health check needed instead")
 	}
 	// Make sure the service does not have the health check node port allocated
-	port := service.GetServiceHealthCheckNodePort(created_service)
+	port := created_service.Spec.HealthCheckNodePort
 	if port != 0 {
 		// Release the node port at the end of the test case.
 		storage.serviceNodePorts.Release(int(port))

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -89,20 +89,4 @@ const (
 	//
 	// Not all cloud providers support this annotation, though AWS & GCE do.
 	AnnotationLoadBalancerSourceRangesKey = "service.beta.kubernetes.io/load-balancer-source-ranges"
-
-	// AnnotationValueExternalTrafficLocal Value of annotation to specify local endpoints behavior.
-	AnnotationValueExternalTrafficLocal = "OnlyLocal"
-	// AnnotationValueExternalTrafficGlobal Value of annotation to specify global (legacy) behavior.
-	AnnotationValueExternalTrafficGlobal = "Global"
-
-	// TODO: The beta annotations have been deprecated, remove them when we release k8s 1.8.
-
-	// BetaAnnotationHealthCheckNodePort Annotation specifying the healthcheck nodePort for the service.
-	// If not specified, annotation is created by the service api backend with the allocated nodePort.
-	// Will use user-specified nodePort value if specified by the client.
-	BetaAnnotationHealthCheckNodePort = "service.beta.kubernetes.io/healthcheck-nodeport"
-
-	// BetaAnnotationExternalTraffic An annotation that denotes if this Service desires to route
-	// external traffic to local endpoints only. This preserves Source IP and avoids a second hop.
-	BetaAnnotationExternalTraffic = "service.beta.kubernetes.io/external-traffic"
 )

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -48,7 +48,6 @@ go_library(
         "//pkg/api/v1/helper:go_default_library",
         "//pkg/api/v1/node:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/componentconfig:go_default_library",
         "//pkg/apis/extensions:go_default_library",

--- a/test/e2e/framework/firewall_util.go
+++ b/test/e2e/framework/firewall_util.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	apiservice "k8s.io/kubernetes/pkg/api/v1/service"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 
@@ -87,7 +86,7 @@ func ConstructHealthCheckFirewallForLBService(clusterID string, svc *v1.Service,
 	fw.SourceRanges = gcecloud.LoadBalancerSrcRanges()
 	healthCheckPort := gcecloud.GetNodesHealthCheckPort()
 	if !isNodesHealthCheck {
-		healthCheckPort = apiservice.GetServiceHealthCheckNodePort(svc)
+		healthCheckPort = svc.Spec.HealthCheckNodePort
 	}
 	fw.Allowed = []*compute.FirewallAllowed{
 		{

--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -31,7 +31,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
-        "//pkg/api/v1/service:go_default_library",
         "//pkg/apis/networking:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/cloudprovider:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Remove deprecated ESIPP beta annotations.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50187

**Special notes for your reviewer**:
/assign @MrHohn
/sig network

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Beta annotations `service.beta.kubernetes.io/external-traffic` and `service.beta.kubernetes.io/healthcheck-nodeport` have been removed. Please use fields `service.spec.externalTrafficPolicy` and `service.spec.healthCheckNodePort` instead.
```
