### PR TITLE
Make examples uniform with rest of kubectl

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -41,21 +41,16 @@ var (
 		the remote kubernetes API Server port, except for the path matching the static content path.`))
 
 	proxyExample = templates.Examples(i18n.T(`
-		# To proxy all of the kubernetes api and nothing else, use:
+		# Proxy all of the kubernetes api and nothing else.
+		kubectl proxy --api-prefix=/
 
-		    $ kubectl proxy --api-prefix=/
+		# Proxy only part of the kubernetes api and also some static files.
+		# This lets you 'curl localhost:8001/api/v1/pods'.
+		kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
 
-		# To proxy only part of the kubernetes api and also some static files:
-
-		    $ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
-
-		# The above lets you 'curl localhost:8001/api/v1/pods'.
-
-		# To proxy the entire kubernetes api at a different root, use:
-
-		    $ kubectl proxy --api-prefix=/custom/
-
-		# The above lets you 'curl localhost:8001/custom/api/v1/pods'
+		# Proxy the entire kubernetes api at a different root.
+		# This lets you 'curl localhost:8001/custom/api/v1/pods'
+		kubectl proxy --api-prefix=/custom/
 
 		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 		kubectl proxy --port=8011 --www=./local/www/
@@ -65,7 +60,7 @@ var (
 		kubectl proxy --port=0
 
 		# Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
-		# This makes e.g. the pods api available at localhost:8001/k8s-api/v1/pods/
+		# This makes the pod's api available at localhost:8001/k8s-api/v1/pods/
 		kubectl proxy --api-prefix=/k8s-api`))
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl proxy --help` has non-uniform layout for command examples. `kubectl` would be cleaner if all examples followed a uniform layout. This PR updates the command examples in line with the rest of the `kubectl` commands.

**Special notes for your reviewer**:

PR effects output of `kubectl proxy --help` only.


**Release note:**

```release-note
Clean up non-uniform output from kubectl proxy --help command
```

/sig cli
/kind documentation
/kind cleanup