### PR TITLE
Remove duplicate command example

### DIFF
--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -59,10 +59,7 @@ var (
 		kubectl port-forward mypod 8888:5000
 
 		# Listen on a random port locally, forwarding to 5000 in the pod
-		kubectl port-forward mypod :5000
-
-		# Listen on a random port locally, forwarding to 5000 in the pod
-		kubectl port-forward mypod 0:5000`))
+		kubectl port-forward mypod :5000`))
 )
 
 func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Command {


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl port-forward --help` currently contains a duplicate example. This PR removes the duplicate.

```release-note
/release-note Remove duplicate command example from `kubectl port-forward --help`
```

/sig cli
/kind cleanup
/kind documentation
