### PR TITLE
Modify e2e.go to arbitrarily pick one of zones we have nodes in for multizone tests.

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -77,12 +77,24 @@ func setupProviderConfig() error {
 		if !framework.TestContext.CloudConfig.MultiZone {
 			managedZones = []string{zone}
 		}
-		cloudConfig.Provider, err = gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ApiEndpoint,
+
+		gceCloud, err := gcecloud.CreateGCECloud(framework.TestContext.CloudConfig.ApiEndpoint,
 			framework.TestContext.CloudConfig.ProjectID,
 			region, zone, managedZones, "" /* networkUrl */, "" /* subnetworkUrl */, nil, /* nodeTags */
 			"" /* nodeInstancePerfix */, nil /* tokenSource */, false /* useMetadataServer */)
 		if err != nil {
 			return fmt.Errorf("Error building GCE/GKE provider: %v", err)
+		}
+
+		cloudConfig.Provider = gceCloud
+
+		if cloudConfig.Zone == "" && framework.TestContext.CloudConfig.MultiZone {
+			zones, err := gceCloud.GetAllZones()
+			if err != nil {
+				return err
+			}
+
+			cloudConfig.Zone, _ = zones.PopAny()
 		}
 
 	case "aws":

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -144,7 +144,7 @@ type NodeTestContextType struct {
 type CloudConfig struct {
 	ApiEndpoint       string
 	ProjectID         string
-	Zone              string
+	Zone              string // for multizone tests, arbitrarily chosen zone
 	Region            string
 	MultiZone         bool
 	Cluster           string


### PR DESCRIPTION
**What this PR does / why we need it**:
When e2e runs in multizone configuration, zone config property can be empty.
This PR, in that case, overrides an empty value with arbitrarily chosen zone that we have nodes in.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
```
