### PR TITLE
Mark the volumes as detached when node does not exist

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -157,6 +157,9 @@ func (os *OpenStack) InstanceID() (string, error) {
 func (i *Instances) InstanceID(name types.NodeName) (string, error) {
 	srv, err := getServerByName(i.compute, name)
 	if err != nil {
+		if err == ErrNotFound {
+			return "", cloudprovider.InstanceNotFound
+		}
 		return "", err
 	}
 	// In the future it is possible to also return an endpoint as:


### PR DESCRIPTION
If node does not exist, node's volumes will be detached
automatically and become available. So mark them detached and do not return err.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#50200

**Release note**:
```release-note
NONE
```
