### PR TITLE
Automated cherry pick of #50028 #50106 upstream release 1.7

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -186,14 +186,14 @@ func (sched *Scheduler) schedule(pod *v1.Pod) (string, error) {
 }
 
 // assume signals to the cache that a pod is already in the cache, so that binding can be asnychronous.
-func (sched *Scheduler) assume(pod *v1.Pod, host string) error {
+// assume modifies `assumed`.
+func (sched *Scheduler) assume(assumed *v1.Pod, host string) error {
 	// Optimistically assume that the binding will succeed and send it to apiserver
 	// in the background.
 	// If the binding fails, scheduler will release resources allocated to assumed pod
 	// immediately.
-	assumed := *pod
 	assumed.Spec.NodeName = host
-	if err := sched.config.SchedulerCache.AssumePod(&assumed); err != nil {
+	if err := sched.config.SchedulerCache.AssumePod(assumed); err != nil {
 		glog.Errorf("scheduler cache AssumePod failed: %v", err)
 		// TODO: This means that a given pod is already in cache (which means it
 		// is either assumed or already added). This is most probably result of a
@@ -208,7 +208,7 @@ func (sched *Scheduler) assume(pod *v1.Pod, host string) error {
 	// predicates in equivalence cache.
 	// If the binding fails, these invalidated item will not break anything.
 	if sched.config.Ecache != nil {
-		sched.config.Ecache.InvalidateCachedPredicateItemForPodAdd(pod, host)
+		sched.config.Ecache.InvalidateCachedPredicateItemForPodAdd(assumed, host)
 	}
 	return nil
 }
@@ -263,15 +263,17 @@ func (sched *Scheduler) scheduleOne() {
 
 	// Tell the cache to assume that a pod now is running on a given node, even though it hasn't been bound yet.
 	// This allows us to keep scheduling without waiting on binding to occur.
-	err = sched.assume(pod, suggestedHost)
+	assumedPod := *pod
+	// assume modifies `assumedPod` by setting NodeName=suggestedHost
+	err = sched.assume(&assumedPod, suggestedHost)
 	if err != nil {
 		return
 	}
 
 	// bind the pod to its host asynchronously (we can do this b/c of the assumption step above).
 	go func() {
-		err := sched.bind(pod, &v1.Binding{
-			ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name, UID: pod.UID},
+		err := sched.bind(&assumedPod, &v1.Binding{
+			ObjectMeta: metav1.ObjectMeta{Namespace: assumedPod.Namespace, Name: assumedPod.Name, UID: assumedPod.UID},
 			Target: v1.ObjectReference{
 				Kind: "Node",
 				Name: suggestedHost,

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -36,8 +36,6 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/util"
 
-	"fmt"
-
 	"github.com/golang/glog"
 )
 
@@ -195,12 +193,20 @@ func (sched *Scheduler) assume(assumed *v1.Pod, host string) error {
 	assumed.Spec.NodeName = host
 	if err := sched.config.SchedulerCache.AssumePod(assumed); err != nil {
 		glog.Errorf("scheduler cache AssumePod failed: %v", err)
-		// TODO: This means that a given pod is already in cache (which means it
-		// is either assumed or already added). This is most probably result of a
-		// BUG in retrying logic. As a temporary workaround (which doesn't fully
-		// fix the problem, but should reduce its impact), we simply return here,
-		// as binding doesn't make sense anyway.
-		// This should be fixed properly though.
+
+		// This is most probably result of a BUG in retrying logic.
+		// We report an error here so that pod scheduling can be retried.
+		// This relies on the fact that Error will check if the pod has been bound
+		// to a node and if so will not add it back to the unscheduled pods queue
+		// (otherwise this would cause an infinite loop).
+		sched.config.Error(assumed, err)
+		sched.config.Recorder.Eventf(assumed, v1.EventTypeWarning, "FailedScheduling", "AssumePod failed: %v", err)
+		sched.config.PodConditionUpdater.Update(assumed, &v1.PodCondition{
+			Type:    v1.PodScheduled,
+			Status:  v1.ConditionFalse,
+			Reason:  "SchedulerError",
+			Message: err.Error(),
+		})
 		return err
 	}
 
@@ -221,12 +227,12 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 	// it's atomic with setting host.
 	err := sched.config.Binder.Bind(b)
 	if err := sched.config.SchedulerCache.FinishBinding(assumed); err != nil {
-		return fmt.Errorf("scheduler cache FinishBinding failed: %v", err)
+		glog.Errorf("scheduler cache FinishBinding failed: %v", err)
 	}
 	if err != nil {
 		glog.V(1).Infof("Failed to bind pod: %v/%v", assumed.Namespace, assumed.Name)
 		if err := sched.config.SchedulerCache.ForgetPod(assumed); err != nil {
-			return fmt.Errorf("scheduler cache ForgetPod failed: %v", err)
+			glog.Errorf("scheduler cache ForgetPod failed: %v", err)
 		}
 		sched.config.Error(assumed, err)
 		sched.config.Recorder.Eventf(assumed, v1.EventTypeWarning, "FailedScheduling", "Binding rejected: %v", err)
@@ -237,6 +243,7 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 		})
 		return err
 	}
+
 	metrics.BindingLatency.Observe(metrics.SinceInMicroseconds(bindingStart))
 	sched.config.Recorder.Eventf(assumed, v1.EventTypeNormal, "Scheduled", "Successfully assigned %v to %v", assumed.Name, b.Target.Name)
 	return nil

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -116,6 +116,7 @@ func TestScheduler(t *testing.T) {
 		sendPod          *v1.Pod
 		algo             algorithm.ScheduleAlgorithm
 		expectErrorPod   *v1.Pod
+		expectForgetPod  *v1.Pod
 		expectAssumedPod *v1.Pod
 		expectError      error
 		expectBind       *v1.Binding
@@ -140,7 +141,8 @@ func TestScheduler(t *testing.T) {
 			expectAssumedPod: podWithID("foo", testNode.Name),
 			injectBindError:  errB,
 			expectError:      errB,
-			expectErrorPod:   podWithID("foo", ""),
+			expectErrorPod:   podWithID("foo", testNode.Name),
+			expectForgetPod:  podWithID("foo", testNode.Name),
 			eventReason:      "FailedScheduling",
 		}, {
 			sendPod:     deletingPod("foo"),
@@ -152,11 +154,15 @@ func TestScheduler(t *testing.T) {
 	for i, item := range table {
 		var gotError error
 		var gotPod *v1.Pod
+		var gotForgetPod *v1.Pod
 		var gotAssumedPod *v1.Pod
 		var gotBinding *v1.Binding
 		configurator := &FakeConfigurator{
 			Config: &Config{
 				SchedulerCache: &schedulertesting.FakeCache{
+					ForgetFunc: func(pod *v1.Pod) {
+						gotForgetPod = pod
+					},
 					AssumeFunc: func(pod *v1.Pod) {
 						gotAssumedPod = pod
 					},
@@ -196,6 +202,9 @@ func TestScheduler(t *testing.T) {
 		}
 		if e, a := item.expectErrorPod, gotPod; !reflect.DeepEqual(e, a) {
 			t.Errorf("%v: error pod: wanted %v, got %v", i, e, a)
+		}
+		if e, a := item.expectForgetPod, gotForgetPod; !reflect.DeepEqual(e, a) {
+			t.Errorf("%v: forget pod: wanted %v, got %v", i, e, a)
 		}
 		if e, a := item.expectError, gotError; !reflect.DeepEqual(e, a) {
 			t.Errorf("%v: error: wanted %v, got %v", i, e, a)

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -25,6 +25,7 @@ import (
 // FakeCache is used for testing
 type FakeCache struct {
 	AssumeFunc func(*v1.Pod)
+	ForgetFunc func(*v1.Pod)
 }
 
 func (f *FakeCache) AssumePod(pod *v1.Pod) error {
@@ -34,7 +35,10 @@ func (f *FakeCache) AssumePod(pod *v1.Pod) error {
 
 func (f *FakeCache) FinishBinding(pod *v1.Pod) error { return nil }
 
-func (f *FakeCache) ForgetPod(pod *v1.Pod) error { return nil }
+func (f *FakeCache) ForgetPod(pod *v1.Pod) error {
+	f.ForgetFunc(pod)
+	return nil
+}
 
 func (f *FakeCache) AddPod(pod *v1.Pod) error { return nil }
 


### PR DESCRIPTION
Cherry pick of #50028 and #50106 on release-1.7.

#50028: Fix incorrect call to 'bind' in scheduler
#50106: Retry scheduling pods after errors more consistently in scheduler