### PR TITLE
Fix storage tests for multizone test configuration.

### DIFF
--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -100,6 +100,8 @@ type VolumeTestConfig struct {
 	ServerNodeName string
 	// ClientNodeName is the spec.nodeName to run client pod on.  Default is any node.
 	ClientNodeName string
+	// NodeSelector to use in pod spec (server, client and injector pods).
+	NodeSelector map[string]string
 }
 
 // VolumeTest contains a volume to mount into a client pod and its
@@ -286,6 +288,7 @@ func StartVolumeServer(client clientset.Interface, config VolumeTestConfig) *v1.
 			Volumes:       volumes,
 			RestartPolicy: restartPolicy,
 			NodeName:      config.ServerNodeName,
+			NodeSelector:  config.NodeSelector,
 		},
 	}
 
@@ -390,8 +393,9 @@ func TestVolumeClient(client clientset.Interface, config VolumeTestConfig, fsGro
 					Level: "s0:c0,c1",
 				},
 			},
-			Volumes:  []v1.Volume{},
-			NodeName: config.ClientNodeName,
+			Volumes:      []v1.Volume{},
+			NodeName:     config.ClientNodeName,
+			NodeSelector: config.NodeSelector,
 		},
 	}
 	podsNamespacer := client.CoreV1().Pods(config.Namespace)
@@ -476,6 +480,7 @@ func InjectHtml(client clientset.Interface, config VolumeTestConfig, volume v1.V
 					VolumeSource: volume,
 				},
 			},
+			NodeSelector: config.NodeSelector,
 		},
 	}
 

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -54,6 +54,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -429,6 +430,11 @@ var _ = SIGDescribe("Volumes", func() {
 			config = framework.VolumeTestConfig{
 				Namespace: namespace.Name,
 				Prefix:    "pd",
+				// PD will be created in framework.TestContext.CloudConfig.Zone zone,
+				// so pods should be also scheduled there.
+				NodeSelector: map[string]string{
+					kubeletapis.LabelZoneFailureDomain: framework.TestContext.CloudConfig.Zone,
+				},
 			}
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies "[sig-storage] Volumes PD should be mountable with (ext3|ext4)" tests to schedule pods in zone, where PD is created.
This is to make the test work in multizone environment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
```
