### PR TITLE
Add whitespace to improve error msg clarity

### DIFF
--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -65,7 +65,7 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to explain. ", validResources)
+		fmt.Fprintf(cmdErr, "You must specify the type of resource to explain. %s\n", validResources)
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently when `kubectl explain` is called without a resource the error message is tacked onto the end of the list of valid resources. The error is clearer if there is a new line after the valid resource list, this also causes the error to be left aligned instead of indented level with the valid resource list.

```release-note
NONE
```

/sig cli
/kind cleanup