### PR TITLE
Automated cherry pick of #50098

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -343,8 +343,17 @@ func (r *crdHandler) getServingInfoFor(crd *apiextensions.CustomResourceDefiniti
 		storage:      storage,
 		requestScope: requestScope,
 	}
-	storageMap[crd.UID] = ret
-	r.customStorage.Store(storageMap)
+
+	storageMap2 := make(crdStorageMap, len(storageMap))
+
+	// Copy because we cannot write to storageMap without a race
+	// as it is used without locking elsewhere
+	for k, v := range storageMap {
+		storageMap2[k] = v
+	}
+
+	storageMap2[crd.UID] = ret
+	r.customStorage.Store(storageMap2)
 	return ret
 }
 


### PR DESCRIPTION
Cherry pick of #50098 on release-1.7.

#50098: fix data race in storage (during addition)