### PR TITLE
Improve command description used for help output

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -73,8 +73,8 @@ func NewCmdExec(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *c
 	}
 	cmd := &cobra.Command{
 		Use:     "exec POD [-c CONTAINER] -- COMMAND [args...]",
-		Short:   i18n.T("Execute a command in a container"),
-		Long:    "Execute a command in a container.",
+		Short:   i18n.T("Execute a shell command in a container"),
+		Long:    "Execute a shell command in a container.",
 		Example: exec_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			argsLenAtDash := cmd.ArgsLenAtDash()


### PR DESCRIPTION
**What this PR does / why we need it**:

Help output from `kubectl help exec` references COMMAND. It is not immediately apparent what type of 'command' this is i.e is it a Kubernetes command? The commands accepted are shell commands, the help description can be made more clear by adding the adjective 'shell' to better describe 'command'.

**Special notes for your reviewer**:

This fix is aimed to assist Kubernetes newcomers.

**Release note**:
```release-note
NONE
```

/sig cli
/kind documentation
