### PR TITLE
Mark volume as detached when node does not exist for photon

### DIFF
--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -620,6 +620,10 @@ func (pc *PCCloud) DiskIsAttached(pdID string, nodeName k8stypes.NodeName) (bool
 	}
 
 	vmID, err := pc.InstanceID(nodeName)
+	if err == cloudprovider.InstanceNotFound {
+		glog.Infof("Instance %q does not exist, disk %s will be detached automatically.", nodeName, pdID)
+		return false, nil
+	}
 	if err != nil {
 		glog.Errorf("Photon Cloud Provider: pc.InstanceID failed for DiskIsAttached. Error[%v]", err)
 		return false, err
@@ -648,6 +652,11 @@ func (pc *PCCloud) DisksAreAttached(pdIDs []string, nodeName k8stypes.NodeName) 
 	}
 
 	vmID, err := pc.InstanceID(nodeName)
+	if err == cloudprovider.InstanceNotFound {
+		glog.Infof("Instance %q does not exist, its disks will be detached automatically.", nodeName)
+		// make all the disks as detached.
+		return attached, nil
+	}
 	if err != nil {
 		glog.Errorf("Photon Cloud Provider: pc.InstanceID failed for DiskIsAttached. Error[%v]", err)
 		return attached, err


### PR DESCRIPTION
If node does not exist, node's volumes will be detached
automatically and become available. So mark them detached and
return false without error.
Fix #50266

**Special notes for your reviewer**:
/assign @jingxu97 

**Release note**:
```release-note
NONE
```
