### PR TITLE
Change test to work around restmapper pluralization bug

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
@@ -35,7 +35,8 @@ import (
 
 //NewRandomNameCustomResourceDefinition generates a CRD with random name to avoid name conflict in e2e tests
 func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
-	gName := names.SimpleNameGenerator.GenerateName("foo")
+	// ensure the singular doesn't end in an s for now
+	gName := names.SimpleNameGenerator.GenerateName("foo") + "a"
 	return &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: gName + "s.mygroup.example.com"},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/50022

Works around the pluralization bug to unblock the queue.
Once the restmapper bug is fixed in https://github.com/kubernetes/kubernetes/pull/50012, we should add tests specifically for unconventional singular/plural word endings.