### PR TITLE
[Federation] Fix flake in TestUpdateClusterRace

### DIFF
--- a/federation/pkg/federation-controller/cluster/BUILD
+++ b/federation/pkg/federation-controller/cluster/BUILD
@@ -13,15 +13,12 @@ go_test(
     deps = [
         "//federation/apis/federation/v1beta1:go_default_library",
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
-        "//federation/pkg/federation-controller/util:go_default_library",
-        "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
-        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
     ],
 )
 
@@ -49,7 +46,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
-        "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/federation/pkg/federation-controller/cluster/cluster_client.go
+++ b/federation/pkg/federation-controller/cluster/cluster_client.go
@@ -107,6 +107,15 @@ func (self *ClusterClient) GetClusterHealthStatus() *federation_v1beta1.ClusterS
 			clusterStatus.Conditions = append(clusterStatus.Conditions, newClusterReadyCondition)
 		}
 	}
+
+	zones, region, err := self.GetClusterZones()
+	if err != nil {
+		glog.Warningf("Failed to get zones and region for cluster with client %v: %v", self, err)
+	} else {
+		clusterStatus.Zones = zones
+		clusterStatus.Region = region
+	}
+
 	return &clusterStatus
 }
 

--- a/federation/pkg/federation-controller/cluster/cluster_client.go
+++ b/federation/pkg/federation-controller/cluster/cluster_client.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
 	federation_v1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	"k8s.io/kubernetes/federation/pkg/federation-controller/util"
@@ -38,8 +37,7 @@ const (
 )
 
 type ClusterClient struct {
-	discoveryClient *discovery.DiscoveryClient
-	kubeClient      *clientset.Clientset
+	kubeClient *clientset.Clientset
 }
 
 func NewClusterClientSet(c *federation_v1beta1.Cluster) (*ClusterClient, error) {
@@ -49,10 +47,6 @@ func NewClusterClientSet(c *federation_v1beta1.Cluster) (*ClusterClient, error) 
 	}
 	var clusterClientSet = ClusterClient{}
 	if clusterConfig != nil {
-		clusterClientSet.discoveryClient = discovery.NewDiscoveryClientForConfigOrDie((restclient.AddUserAgent(clusterConfig, UserAgentName)))
-		if clusterClientSet.discoveryClient == nil {
-			return nil, nil
-		}
 		clusterClientSet.kubeClient = clientset.NewForConfigOrDie((restclient.AddUserAgent(clusterConfig, UserAgentName)))
 		if clusterClientSet.kubeClient == nil {
 			return nil, nil
@@ -97,7 +91,7 @@ func (self *ClusterClient) GetClusterHealthStatus() *federation_v1beta1.ClusterS
 		LastProbeTime:      currentTime,
 		LastTransitionTime: currentTime,
 	}
-	body, err := self.discoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
+	body, err := self.kubeClient.DiscoveryClient.RESTClient().Get().AbsPath("/healthz").Do().Raw()
 	if err != nil {
 		clusterStatus.Conditions = append(clusterStatus.Conditions, newNodeOfflineCondition)
 	} else {

--- a/federation/pkg/federation-controller/cluster/clustercontroller_test.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller_test.go
@@ -134,7 +134,7 @@ func TestUpdateClusterStatusOK(t *testing.T) {
 	}
 
 	manager := newClusterController(federationClientSet, 5)
-	err = manager.UpdateClusterStatus()
+	err = manager.updateClusterStatus()
 	if err != nil {
 		t.Errorf("Failed to Update Cluster Status: %v", err)
 	}
@@ -188,7 +188,6 @@ func TestUpdateClusterRace(t *testing.T) {
 
 	// try to trigger the race in UpdateClusterStatus
 	for i := 0; i < 10; i++ {
-		manager.GetClusterClient(federationCluster)
 		manager.addToClusterSet(federationCluster)
 		manager.delFromClusterSet(federationCluster)
 	}

--- a/federation/pkg/federation-controller/cluster/clustercontroller_test.go
+++ b/federation/pkg/federation-controller/cluster/clustercontroller_test.go
@@ -22,17 +22,15 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	federationv1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
-	controllerutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
-	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 )
 
@@ -125,15 +123,8 @@ func TestUpdateClusterStatusOK(t *testing.T) {
 	}
 	federationClientSet := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, "cluster-controller"))
 
-	// Override KubeconfigGetterForSecret to avoid having to setup service accounts and mount files with secret tokens.
-	originalGetter := controllerutil.KubeconfigGetterForSecret
-	controllerutil.KubeconfigGetterForSecret = func(s *api.Secret) clientcmd.KubeconfigGetter {
-		return func() (*clientcmdapi.Config, error) {
-			return &clientcmdapi.Config{}, nil
-		}
-	}
-
 	manager := newClusterController(federationClientSet, 5)
+	manager.addToClusterSet(federationCluster)
 	err = manager.updateClusterStatus()
 	if err != nil {
 		t.Errorf("Failed to Update Cluster Status: %v", err)
@@ -146,9 +137,6 @@ func TestUpdateClusterStatusOK(t *testing.T) {
 			t.Errorf("Failed to Update Cluster Status")
 		}
 	}
-
-	// Reset KubeconfigGetterForSecret
-	controllerutil.KubeconfigGetterForSecret = originalGetter
 }
 
 // Test races between informer's updates and routine updates of cluster status
@@ -170,21 +158,10 @@ func TestUpdateClusterRace(t *testing.T) {
 	}
 	federationClientSet := federationclientset.NewForConfigOrDie(restclient.AddUserAgent(restClientCfg, "cluster-controller"))
 
-	// Override KubeconfigGetterForSecret to avoid having to setup service accounts and mount files with secret tokens.
-	originalGetter := controllerutil.KubeconfigGetterForSecret
-	controllerutil.KubeconfigGetterForSecret = func(s *api.Secret) clientcmd.KubeconfigGetter {
-		return func() (*clientcmdapi.Config, error) {
-			return &clientcmdapi.Config{}, nil
-		}
-	}
+	manager := newClusterController(federationClientSet, 1*time.Millisecond)
 
-	manager := newClusterController(federationClientSet, 5)
-
-	go func() {
-		for {
-			manager.UpdateClusterStatus()
-		}
-	}()
+	stop := make(chan struct{})
+	manager.Run(stop)
 
 	// try to trigger the race in UpdateClusterStatus
 	for i := 0; i < 10; i++ {
@@ -192,6 +169,5 @@ func TestUpdateClusterRace(t *testing.T) {
 		manager.delFromClusterSet(federationCluster)
 	}
 
-	// Reset KubeconfigGetterForSecret
-	controllerutil.KubeconfigGetterForSecret = originalGetter
+	close(stop)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix #50262

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50262

**Special notes for your reviewer**:
Although we do locking/unlocking while using protected data in ClusterController, there are chances that `clusterClient` can be deleted as it is a pointer. Also its better to lock/unlock once for the function `UpdateClusterStatus` instead of multiple locks/unlocks.

**Release note**:
```
NONE
```

/assign @madhusudancs 
/cc @dminh @kubernetes/sig-federation-bugs 
