### PR TITLE
Small improvement in ban flunder admission plugin.

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = ["admission.go"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/admission/wardleinitializer:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/sample-apiserver/pkg/admission/wardleinitializer"
@@ -52,7 +53,12 @@ func (d *disallowFlunder) Admit(a admission.Attributes) error {
 		return nil
 	}
 
-	flunderName := a.GetName()
+	metaAccessor, err := meta.Accessor(a.GetObject())
+	if err != nil {
+		return err
+	}
+	flunderName := metaAccessor.GetName()
+
 	fischers, err := d.lister.List(labels.Everything())
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission_test.go
@@ -135,7 +135,7 @@ func TestBanflunderAdmissionPlugin(t *testing.T) {
 				nil,
 				scenario.admissionInputKind,
 				scenario.admissionInput.ObjectMeta.Namespace,
-				scenario.admissionInput.ObjectMeta.Name,
+				"",
 				scenario.admissionInputResource,
 				"",
 				admission.Create,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
After the changes a name will be taken directly from meta field.
Previously a name was taken via attributes.GetName() method,
which in turns derived a name from a URL address.
This didn't work as we don't allow to pass a name when POSTing a resource.

#47868

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
