### PR TITLE
RawExtension unmarshal will produce empty objects if the original object was nil #50323

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/embedded_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/embedded_test.go
@@ -197,8 +197,8 @@ func TestNestedObject(t *testing.T) {
 	if externalViaJSON.Kind == "" || externalViaJSON.APIVersion == "" || externalViaJSON.ID != "outer" {
 		t.Errorf("Expected objects to have type info set, got %#v", externalViaJSON)
 	}
-	if !reflect.DeepEqual(externalViaJSON.EmptyObject.Raw, []byte("null")) || len(externalViaJSON.Object.Raw) == 0 {
-		t.Errorf("Expected deserialization of nested objects into bytes, got %#v", externalViaJSON)
+	if len(externalViaJSON.EmptyObject.Raw) > 0 {
+		t.Errorf("Expected deserialization of empty nested objects into empty bytes, got %#v", externalViaJSON)
 	}
 
 	// test JSON decoding, too, since Decode uses yaml unmarshalling.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/extension.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/extension.go
@@ -17,6 +17,7 @@ limitations under the License.
 package runtime
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 )
@@ -25,7 +26,9 @@ func (re *RawExtension) UnmarshalJSON(in []byte) error {
 	if re == nil {
 		return errors.New("runtime.RawExtension: UnmarshalJSON on nil pointer")
 	}
-	re.Raw = append(re.Raw[0:0], in...)
+	if !bytes.Equal(in, []byte("null")) {
+		re.Raw = append(re.Raw[0:0], in...)
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
marshaled nil objects will be unmarshaled as nil objects instead of a byte array "null", which better represents the original object before marshaling

fixes #50323

@kubernetes/sig-api-machinery-bugs 