### PR TITLE
Improve GC discovery sync performance

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -339,7 +339,7 @@ func startGarbageCollectorController(ctx ControllerContext) (bool, error) {
 
 	// Periodically refresh the RESTMapper with new discovery information and sync
 	// the garbage collector.
-	go garbageCollector.Sync(restMapper, discoveryClient, 30*time.Second, ctx.Stop)
+	go garbageCollector.Sync(gcClientset.Discovery(), 30*time.Second, ctx.Stop)
 
 	return true, nil
 }

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -283,7 +283,8 @@ func newCronJob(name, schedule string) *batchv2alpha1.CronJob {
 					Completions: &completions,
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
-							RestartPolicy: v1.RestartPolicyOnFailure,
+							RestartPolicy:                 v1.RestartPolicyOnFailure,
+							TerminationGracePeriodSeconds: &zero,
 							Containers: []v1.Container{
 								{
 									Name:    "c",

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -265,7 +265,7 @@ func setup(t *testing.T, workerCount int) *testContext {
 	syncPeriod := 5 * time.Second
 	startGC := func(workers int) {
 		go gc.Run(workers, stopCh)
-		go gc.Sync(restMapper, discoveryClient, syncPeriod, stopCh)
+		go gc.Sync(clientSet.Discovery(), syncPeriod, stopCh)
 	}
 
 	if workerCount > 0 {


### PR DESCRIPTION
Improve GC discovery sync performance by only syncing when discovered
resource diffs are detected. Before, the GC worker pool was shut down
and monitors resynced unconditionally every sync period, leading to
significant processing delays causing test flakes where otherwise
reasonable GC timeouts were being exceeded.

Related to https://github.com/kubernetes/kubernetes/issues/49966.

/cc @kubernetes/sig-api-machinery-bugs

```release-note
NONE
```