### PR TITLE
Update cli verification to match new conventions

### DIFF
--- a/pkg/kubectl/cmd/alpha.go
+++ b/pkg/kubectl/cmd/alpha.go
@@ -8,7 +8,7 @@ You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
+distributedc under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -76,24 +76,24 @@ var (
 
 	annotateExample = templates.Examples(i18n.T(`
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend'.
-    # If the same annotation is set multiple times, only the last value will be applied
-    kubectl annotate pods foo description='my frontend'
+    # If the same annotation is set multiple times, only the last value will be applied.
+    $ kubectl annotate pods foo description='my frontend'
 
-    # Update a pod identified by type and name in "pod.json"
-    kubectl annotate -f pod.json description='my frontend'
+    # Update a pod identified by type and name in "pod.json".
+    $ kubectl annotate -f pod.json description='my frontend'
 
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend running nginx', overwriting any existing value.
-    kubectl annotate --overwrite pods foo description='my frontend running nginx'
+    $ kubectl annotate --overwrite pods foo description='my frontend running nginx'
 
-    # Update all pods in the namespace
-    kubectl annotate pods --all description='my frontend running nginx'
+    # Update all pods in the namespace.
+    $ kubectl annotate pods --all description='my frontend running nginx'
 
     # Update pod 'foo' only if the resource is unchanged from version 1.
-    kubectl annotate pods foo description='my frontend running nginx' --resource-version=1
+    $ kubectl annotate pods foo description='my frontend running nginx' --resource-version=1
 
     # Update pod 'foo' by removing an annotation named 'description' if it exists.
     # Does not require the --overwrite flag.
-    kubectl annotate pods foo description-`))
+    $ kubectl annotate pods foo description-`))
 )
 
 func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/apiversions.go
+++ b/pkg/kubectl/cmd/apiversions.go
@@ -31,8 +31,8 @@ import (
 
 var (
 	apiversionsExample = templates.Examples(i18n.T(`
-		# Print the supported API versions
-		kubectl api-versions`))
+		# Print the supported API versions.
+		$ kubectl api-versions`))
 )
 
 func NewCmdApiVersions(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -80,17 +80,17 @@ var (
 
 	applyExample = templates.Examples(i18n.T(`
 		# Apply the configuration in pod.json to a pod.
-		kubectl apply -f ./pod.json
+		$ kubectl apply -f ./pod.json
 
 		# Apply the JSON passed into stdin to a pod.
-		cat pod.json | kubectl apply -f -
+		$ cat pod.json | kubectl apply -f -
 
-		# Note: --prune is still in Alpha
+		# Note: --prune is still in Alpha.
 		# Apply the configuration in manifest.yaml that matches label app=nginx and delete all the other resources that are not in the file and match label app=nginx.
-		kubectl apply --prune -f manifest.yaml -l app=nginx
+		$ kubectl apply --prune -f manifest.yaml -l app=nginx
 
 		# Apply the configuration in manifest.yaml and delete all the other configmaps that are not in the file.
-		kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap`))
+		$ kubectl apply --prune -f manifest.yaml --all --prune-whitelist=core/v1/ConfigMap`))
 
 	warningNoLastAppliedConfigAnnotation = "Warning: %[1]s apply should be used on resource created by either %[1]s create --save-config or %[1]s apply\n"
 )

--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -53,10 +53,10 @@ var (
 
 	applyEditLastAppliedExample = templates.Examples(`
 		# Edit the last-applied-configuration annotations by type/name in YAML.
-		kubectl apply edit-last-applied deployment/nginx
+		$ kubectl apply edit-last-applied deployment/nginx
 
 		# Edit the last-applied-configuration annotations by file in JSON.
-		kubectl apply edit-last-applied -f deploy.yaml -o json`)
+		$ kubectl apply edit-last-applied -f deploy.yaml -o json`)
 )
 
 func NewCmdApplyEditLastApplied(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -71,13 +71,13 @@ var (
 
 	applySetLastAppliedExample = templates.Examples(i18n.T(`
 		# Set the last-applied-configuration of a resource to match the contents of a file.
-		kubectl apply set-last-applied -f deploy.yaml
+		$ kubectl apply set-last-applied -f deploy.yaml
 
 		# Execute set-last-applied against each configuration file in a directory.
-		kubectl apply set-last-applied -f path/
+		$ kubectl apply set-last-applied -f path/
 
 		# Set the last-applied-configuration of a resource to match the contents of a file, will create the annotation if it does not already exist.
-		kubectl apply set-last-applied -f deploy.yaml --create-annotation=true
+		$ kubectl apply set-last-applied -f deploy.yaml --create-annotation=true
 		`))
 )
 

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -51,10 +51,10 @@ var (
 
 	applyViewLastAppliedExample = templates.Examples(i18n.T(`
 		# View the last-applied-configuration annotations by type/name in YAML.
-		kubectl apply view-last-applied deployment/nginx
+		$ kubectl apply view-last-applied deployment/nginx
 
-		# View the last-applied-configuration annotations by file in JSON
-		kubectl apply view-last-applied -f deploy.yaml -o json`))
+		# View the last-applied-configuration annotations by file in JSON.
+		$ kubectl apply view-last-applied -f deploy.yaml -o json`))
 )
 
 func NewCmdApplyViewLastApplied(f cmdutil.Factory, out, err io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -39,18 +39,17 @@ import (
 
 var (
 	attachExample = templates.Examples(i18n.T(`
-		# Get output from running pod 123456-7890, using the first container by default
-		kubectl attach 123456-7890
+		# Get output from running pod 123456-7890, using the first container by default.
+		$ kubectl attach 123456-7890
 
-		# Get output from ruby-container from pod 123456-7890
-		kubectl attach 123456-7890 -c ruby-container
+		# Get output from ruby-container from pod 123456-7890.
+		$ kubectl attach 123456-7890 -c ruby-container
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
-		# and sends stdout/stderr from 'bash' back to the client
-		kubectl attach 123456-7890 -c ruby-container -i -t
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890 and sends stdout/stderr from 'bash' back to the client.
+		$ kubectl attach 123456-7890 -c ruby-container -i -t.
 
-		# Get output from the first pod of a ReplicaSet named nginx
-		kubectl attach rs/nginx
+		# Get output from the first pod of a ReplicaSet named nginx.
+		$ kubectl attach rs/nginx
 		`))
 )
 

--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -62,23 +62,23 @@ var (
 		NAME is the name of a particular Kubernetes resource.`)
 
 	canIExample = templates.Examples(`
-		# Check to see if I can create pods in any namespace
-		kubectl auth can-i create pods --all-namespaces
+		# Check to see if I can create pods in any namespace.
+		$ kubectl auth can-i create pods --all-namespaces
 
-		# Check to see if I can list deployments in my current namespace
-		kubectl auth can-i list deployments.extensions
+		# Check to see if I can list deployments in my current namespace.
+		$ kubectl auth can-i list deployments.extensions
 
-		# Check to see if I can do everything in my current namespace ("*" means all)
-		kubectl auth can-i '*' '*'
+		# Check to see if I can do everything in my current namespace ("*" means all).
+		$ kubectl auth can-i '*' '*'
 
-		# Check to see if I can get the job named "bar" in namespace "foo"
-		kubectl auth can-i list jobs.batch/bar -n foo
+		# Check to see if I can get the job named "bar" in namespace "foo".
+		$ kubectl auth can-i list jobs.batch/bar -n foo
 
-		# Check to see if I can read pod logs
-		kubectl auth can-i get pods --subresource=log
+		# Check to see if I can read pod logs.
+		$ kubectl auth can-i get pods --subresource=log
 
-		# Check to see if I can access the URL /logs/
-		kubectl auth can-i get /logs/`)
+		# Check to see if I can access the URL /logs/.
+		$ kubectl auth can-i get /logs/`)
 )
 
 func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -38,11 +38,11 @@ var (
 		An autoscaler can automatically increase or decrease number of pods deployed within the system as needed.`))
 
 	autoscaleExample = templates.Examples(i18n.T(`
-		# Auto scale a deployment "foo", with the number of pods between 2 and 10, target CPU utilization specified so a default autoscaling policy will be used:
-		kubectl autoscale deployment foo --min=2 --max=10
+		# Auto scale a deployment "foo", with the number of pods between 2 and 10, target CPU utilization specified so a default autoscaling policy will be used.
+		$ kubectl autoscale deployment foo --min=2 --max=10
 
-		# Auto scale a replication controller "foo", with the number of pods between 1 and 5, target CPU utilization at 80%:
-		kubectl autoscale rc foo --max=5 --cpu-percent=80`))
+		# Auto scale a replication controller "foo", with the number of pods between 1 and 5, target CPU utilization at 80% .
+		$ kubectl autoscale rc foo --max=5 --cpu-percent=80`))
 )
 
 func NewCmdAutoscale(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -38,8 +38,8 @@ var (
   To further debug and diagnose cluster problems, use 'kubectl cluster-info dump'.`))
 
 	clusterinfoExample = templates.Examples(i18n.T(`
-		# Print the address of the master and cluster services
-		kubectl cluster-info`))
+		# Print the address of the master and cluster services.
+		$ kubectl cluster-info`))
 )
 
 func NewCmdClusterInfo(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -61,17 +61,17 @@ var (
     based on namespace and pod name.`))
 
 	dumpExample = templates.Examples(i18n.T(`
-    # Dump current cluster state to stdout
-    kubectl cluster-info dump
+    # Dump current cluster state to stdout.
+    $ kubectl cluster-info dump
 
-    # Dump current cluster state to /path/to/cluster-state
-    kubectl cluster-info dump --output-directory=/path/to/cluster-state
+    # Dump current cluster state to /path/to/cluster-state.
+    $ kubectl cluster-info dump --output-directory=/path/to/cluster-state
 
-    # Dump all namespaces to stdout
-    kubectl cluster-info dump --all-namespaces
+    # Dump all namespaces to stdout.
+    $ kubectl cluster-info dump --all-namespaces
 
-    # Dump a set of namespaces to /path/to/cluster-state
-    kubectl cluster-info dump --namespaces default,kube-system --output-directory=/path/to/cluster-state`))
+    # Dump a set of namespaces to /path/to/cluster-state.
+    $ kubectl cluster-info dump --namespaces default,kube-system --output-directory=/path/to/cluster-state`))
 )
 
 func setupOutputWriter(cmd *cobra.Command, defaultWriter io.Writer, filename string) io.Writer {

--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -63,27 +63,21 @@ var (
 		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2`))
 
 	completion_example = templates.Examples(i18n.T(`
-		# Install bash completion on a Mac using homebrew
-		brew install bash-completion
-		printf "
-# Bash completion support
-source $(brew --prefix)/etc/bash_completion
-" >> $HOME/.bash_profile
-		source $HOME/.bash_profile
+		# Install bash completion on a Mac using homebrew.
+		$ brew install bash-completion
+		$ printf "\n# Bash completion support\nsource $(brew --prefix)/etc/bash_completion" >> $HOME/.bash_profile
+		$ source $HOME/.bash_profile
 
-		# Load the kubectl completion code for bash into the current shell
-		source <(kubectl completion bash)
+		# Load the kubectl completion code for bash into the current shell.
+		$ source <(kubectl completion bash)
 
-		# Write bash completion code to a file and source if from .bash_profile
-		kubectl completion bash > ~/.kube/completion.bash.inc
-		printf "
-# Kubectl shell completion
-source '$HOME/.kube/completion.bash.inc'
-" >> $HOME/.bash_profile
-		source $HOME/.bash_profile
+		# Write bash completion code to a file and source if from .bash_profile .
+		$ kubectl completion bash > ~/.kube/completion.bash.inc
+		$ printf "\n# Kubectl shell completion\nsource '$HOME/.kube/completion.bash.inc'" >> $HOME/.bash_profile
+		$ source $HOME/.bash_profile
 
-		# Load the kubectl completion code for zsh[1] into the current shell
-		source <(kubectl completion zsh)`))
+		# Load the kubectl completion code for zsh[1] into the current shell.
+		$ source <(kubectl completion zsh)`))
 )
 
 var (

--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -73,24 +73,23 @@ var (
 		Bearer token and basic auth are mutually exclusive.`), clientcmd.FlagCertFile, clientcmd.FlagKeyFile, clientcmd.FlagBearerToken, clientcmd.FlagUsername, clientcmd.FlagPassword)
 
 	create_authinfo_example = templates.Examples(`
-		# Set only the "client-key" field on the "cluster-admin"
-		# entry, without touching other values:
-		kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
+		# Set only the "client-key" field on the "cluster-admin" entry, without touching other values.
+		$ kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
 
-		# Set basic auth for the "cluster-admin" entry
-		kubectl config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
+		# Set basic auth for the "cluster-admin" entry.
+		$ kubectl config set-credentials cluster-admin --username=admin --password=uXFGweU9l35qcif
 
-		# Embed client certificate data in the "cluster-admin" entry
-		kubectl config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true
+		# Embed client certificate data in the "cluster-admin" entry.
+		$ kubectl config set-credentials cluster-admin --client-certificate=~/.kube/admin.crt --embed-certs=true
 
-		# Enable the Google Compute Platform auth provider for the "cluster-admin" entry
-		kubectl config set-credentials cluster-admin --auth-provider=gcp
+		# Enable the Google Compute Platform auth provider for the "cluster-admin" entry.
+		$ kubectl config set-credentials cluster-admin --auth-provider=gcp
 
-		# Enable the OpenID Connect auth provider for the "cluster-admin" entry with additional args
-		kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-id=foo --auth-provider-arg=client-secret=bar
+		# Enable the OpenID Connect auth provider for the "cluster-admin" entry with additional args.
+		$ kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-id=foo --auth-provider-arg=client-secret=bar
 
-		# Remove the "client-secret" config value for the OpenID Connect auth provider for the "cluster-admin" entry
-		kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-secret-`)
+		# Remove the "client-secret" config value for the OpenID Connect auth provider for the "cluster-admin" entry.
+		$ kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-secret-`)
 )
 
 func NewCmdConfigSetAuthInfo(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/create_cluster.go
+++ b/pkg/kubectl/cmd/config/create_cluster.go
@@ -50,13 +50,13 @@ var (
 
 	create_cluster_example = templates.Examples(`
 		# Set only the server field on the e2e cluster entry without touching other values.
-		kubectl config set-cluster e2e --server=https://1.2.3.4
+		$ kubectl config set-cluster e2e --server=https://1.2.3.4
 
-		# Embed certificate authority data for the e2e cluster entry
-		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+		# Embed certificate authority data for the e2e cluster entry.
+		$ kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
 
-		# Disable cert checking for the dev cluster entry
-		kubectl config set-cluster e2e --insecure-skip-tls-verify=true`)
+		# Disable cert checking for the dev cluster entry.
+		$ kubectl config set-cluster e2e --insecure-skip-tls-verify=true`)
 )
 
 func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/create_context.go
+++ b/pkg/kubectl/cmd/config/create_context.go
@@ -46,8 +46,8 @@ var (
 		Specifying a name that already exists will merge new fields on top of existing values for those fields.`)
 
 	create_context_example = templates.Examples(`
-		# Set the user field on the gce context entry without touching other values
-		kubectl config set-context gce --user=cluster-admin`)
+		# Set the user field on the gce context entry without touching other values.
+		$ kubectl config set-context gce --user=cluster-admin`)
 )
 
 func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/current_context.go
+++ b/pkg/kubectl/cmd/config/current_context.go
@@ -37,8 +37,8 @@ var (
 		Displays the current-context`)
 
 	current_context_example = templates.Examples(`
-		# Display the current-context
-		kubectl config current-context`)
+		# Display the current-context.
+		$ kubectl config current-context`)
 )
 
 func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/delete_cluster.go
+++ b/pkg/kubectl/cmd/config/delete_cluster.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	delete_cluster_example = templates.Examples(`
-		# Delete the minikube cluster
-		kubectl config delete-cluster minikube`)
+		# Delete the minikube cluster.
+		$ kubectl config delete-cluster minikube`)
 )
 
 func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/delete_context.go
+++ b/pkg/kubectl/cmd/config/delete_context.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	delete_context_example = templates.Examples(`
-		# Delete the context for the minikube cluster
-		kubectl config delete-context minikube`)
+		# Delete the context for the minikube cluster.
+		$ kubectl config delete-context minikube`)
 )
 
 func NewCmdConfigDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/config/get_clusters.go
+++ b/pkg/kubectl/cmd/config/get_clusters.go
@@ -29,8 +29,8 @@ import (
 
 var (
 	get_clusters_example = templates.Examples(`
-		# List the clusters kubectl knows about
-		kubectl config get-clusters`)
+		# List the clusters kubectl knows about.
+		$ kubectl config get-clusters`)
 )
 
 // NewCmdConfigGetClusters creates a command object for the "get-clusters" action, which

--- a/pkg/kubectl/cmd/config/get_contexts.go
+++ b/pkg/kubectl/cmd/config/get_contexts.go
@@ -47,11 +47,11 @@ var (
 	getContextsLong = templates.LongDesc(`Displays one or many contexts from the kubeconfig file.`)
 
 	getContextsExample = templates.Examples(`
-		# List all the contexts in your kubeconfig file
-		kubectl config get-contexts
+		# List all the contexts in your kubeconfig file.
+		$ kubectl config get-contexts
 
 		# Describe one context in your kubeconfig file.
-		kubectl config get-contexts my-context`)
+		$ kubectl config get-contexts my-context`)
 )
 
 // NewCmdConfigGetContexts creates a command object for the "get-contexts" action, which

--- a/pkg/kubectl/cmd/config/rename_context.go
+++ b/pkg/kubectl/cmd/config/rename_context.go
@@ -52,8 +52,8 @@ var (
 		Note: In case the context being renamed is the 'current-context', this field will also be updated.`)
 
 	renameContextExample = templates.Examples(`
-		# Rename the context 'old-name' to 'new-name' in your kubeconfig file
-		kubectl config rename-context old-name new-name`)
+		# Rename the context 'old-name' to 'new-name' in your kubeconfig file.
+		$ kubectl config rename-context old-name new-name`)
 )
 
 // NewCmdConfigRenameContext creates a command object for the "rename-context" action

--- a/pkg/kubectl/cmd/config/use_context.go
+++ b/pkg/kubectl/cmd/config/use_context.go
@@ -32,8 +32,8 @@ import (
 
 var (
 	use_context_example = templates.Examples(`
-		# Use the context for the minikube cluster
-		kubectl config use-context minikube`)
+		# Use the context for the minikube cluster.
+		$ kubectl config use-context minikube`)
 )
 
 type useContextOptions struct {

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -51,10 +51,10 @@ var (
 
 	view_example = templates.Examples(`
 		# Show Merged kubeconfig settings.
-		kubectl config view
+		$ kubectl config view
 
-		# Get the password for the e2e user
-		kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'`)
+		# Get the password for the e2e user.
+		$ kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'`)
 )
 
 func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -47,14 +47,13 @@ var (
 
 	convert_example = templates.Examples(i18n.T(`
 		# Convert 'pod.yaml' to latest version and print to stdout.
-		kubectl convert -f pod.yaml
+		$ kubectl convert -f pod.yaml
 
-		# Convert the live state of the resource specified by 'pod.yaml' to the latest version
-		# and print to stdout in json format.
-		kubectl convert -f pod.yaml --local -o json
+		# Convert the live state of the resource specified by 'pod.yaml' to the latest version and print to stdout in json format.
+		$ kubectl convert -f pod.yaml --local -o json
 
 		# Convert all files under current directory to latest version and create them all.
-		kubectl convert -f . | kubectl create -f -`))
+		$ kubectl convert -f . | kubectl create -f -`))
 )
 
 // NewCmdConvert creates a command object for the generic "convert" action, which

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -35,21 +35,21 @@ import (
 
 var (
 	cpExample = templates.Examples(i18n.T(`
-		# !!!Important Note!!!
-		# Requires that the 'tar' binary is present in your container
-		# image.  If 'tar' is not present, 'kubectl cp' will fail.
+		# !!!Important Note!!! .
+		# Requires that the 'tar' binary is present in your container image.
+		# If 'tar' is not present, 'kubectl cp' will fail.
 
-		# Copy /tmp/foo_dir local directory to /tmp/bar_dir in a remote pod in the default namespace
-		kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
+		# Copy /tmp/foo_dir local directory to /tmp/bar_dir in a remote pod in the default namespace.
+		$ kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
 
-		# Copy /tmp/foo local file to /tmp/bar in a remote pod in a specific container
-		kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
+		# Copy /tmp/foo local file to /tmp/bar in a remote pod in a specific container.
+		$ kubectl cp /tmp/foo <some-pod>:/tmp/bar -c <specific-container>
 
-		# Copy /tmp/foo local file to /tmp/bar in a remote pod in namespace <some-namespace>
-		kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
+		# Copy /tmp/foo local file to /tmp/bar in a remote pod in namespace <some-namespace>.
+		$ kubectl cp /tmp/foo <some-namespace>/<some-pod>:/tmp/bar
 
-		# Copy /tmp/foo from a remote pod to /tmp/bar locally
-		kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar`))
+		# Copy /tmp/foo from a remote pod to /tmp/bar locally.
+		$ kubectl cp <some-namespace>/<some-pod>:/tmp/foo /tmp/bar`))
 
 	cpUsageStr = dedent.Dedent(`
 		expected 'cp <file-spec-src> <file-spec-dest> [-c container]'.

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -46,13 +46,13 @@ var (
 
 	createExample = templates.Examples(i18n.T(`
 		# Create a pod using the data in pod.json.
-		kubectl create -f ./pod.json
+		$ kubectl create -f ./pod.json
 
 		# Create a pod based on the JSON passed into stdin.
-		cat pod.json | kubectl create -f -
+		$ cat pod.json | kubectl create -f -
 
 		# Edit the data in docker-registry.yaml in JSON using the v1 API format then create the resource using the edited data.
-		kubectl create -f docker-registry.yaml --edit --output-version=v1 -o json`))
+		$ kubectl create -f docker-registry.yaml --edit --output-version=v1 -o json`))
 )
 
 func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -33,20 +33,20 @@ var (
 		Create a ClusterRole.`))
 
 	clusterRoleExample = templates.Examples(i18n.T(`
-		# Create a ClusterRole named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
-		kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
+		# Create a ClusterRole named "pod-reader" that allows user to perform "get", "watch" and "list" on pods.
+		$ kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods
 
-		# Create a ClusterRole named "pod-reader" with ResourceName specified
-		kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods --resource-name=readablepod --resource-name=anotherpod
+		# Create a ClusterRole named "pod-reader" with ResourceName specified.
+		$ kubectl create clusterrole pod-reader --verb=get,list,watch --resource=pods --resource-name=readablepod --resource-name=anotherpod
 
-		# Create a ClusterRole named "foo" with API Group specified
-		kubectl create clusterrole foo --verb=get,list,watch --resource=rs.extensions
+		# Create a ClusterRole named "foo" with API Group specified.
+		$ kubectl create clusterrole foo --verb=get,list,watch --resource=rs.extensions
 
-		# Create a ClusterRole named "foo" with SubResource specified
-		kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
+		# Create a ClusterRole named "foo" with SubResource specified.
+		$ kubectl create clusterrole foo --verb=get,list,watch --resource=pods,pods/status
 
-		# Create a ClusterRole name "foo" with NonResourceURL specified
-		kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*`))
+		# Create a ClusterRole name "foo" with NonResourceURL specified.
+		$ kubectl create clusterrole "foo" --verb=get --non-resource-url=/logs/*`))
 
 	// Valid nonResource verb list for validation.
 	validNonResourceVerbs = []string{"*", "get", "post", "put", "delete", "patch", "head", "options"}

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -32,8 +32,8 @@ var (
 		Create a ClusterRoleBinding for a particular ClusterRole.`))
 
 	clusterRoleBindingExample = templates.Examples(i18n.T(`
-		  # Create a ClusterRoleBinding for user1, user2, and group1 using the cluster-admin ClusterRole
-		  kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1`))
+		  # Create a ClusterRoleBinding for user1, user2, and group1 using the cluster-admin ClusterRole.
+		  $ kubectl create clusterrolebinding cluster-admin --clusterrole=cluster-admin --user=user1 --user=user2 --group=group1`))
 )
 
 // ClusterRoleBinding is a command to ease creating ClusterRoleBindings.

--- a/pkg/kubectl/cmd/create_configmap.go
+++ b/pkg/kubectl/cmd/create_configmap.go
@@ -41,20 +41,20 @@ var (
 		symlinks, devices, pipes, etc).`))
 
 	configMapExample = templates.Examples(i18n.T(`
-		  # Create a new configmap named my-config based on folder bar
-		  kubectl create configmap my-config --from-file=path/to/bar
+		  # Create a new configmap named my-config based on folder bar.
+		  $ kubectl create configmap my-config --from-file=path/to/bar
 
-		  # Create a new configmap named my-config with specified keys instead of file basenames on disk
-		  kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
+		  # Create a new configmap named my-config with specified keys instead of file basenames on disk.
+		  $ kubectl create configmap my-config --from-file=key1=/path/to/bar/file1.txt --from-file=key2=/path/to/bar/file2.txt
 
-		  # Create a new configmap named my-config with key1=config1 and key2=config2
-		  kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
+		  # Create a new configmap named my-config with key1=config1 and key2=config2.
+		  $ kubectl create configmap my-config --from-literal=key1=config1 --from-literal=key2=config2
 
-		  # Create a new configmap named my-config from the key=value pairs in the file
-		  kubectl create configmap my-config --from-file=path/to/bar
+		  # Create a new configmap named my-config from the key=value pairs in the file.
+		  $ kubectl create configmap my-config --from-file=path/to/bar
 
-		  # Create a new configmap named my-config from an env file
-		  kubectl create configmap my-config --from-env-file=path/to/bar.env`))
+		  # Create a new configmap named my-config from an env file.
+		  $ kubectl create configmap my-config --from-env-file=path/to/bar.env`))
 )
 
 // ConfigMap is a command to ease creating ConfigMaps.

--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -36,7 +36,7 @@ var (
 
 	deploymentExample = templates.Examples(i18n.T(`
 	# Create a new deployment named my-dep that runs the busybox image.
-	kubectl create deployment my-dep --image=busybox`))
+	$ kubectl create deployment my-dep --image=busybox`))
 )
 
 // NewCmdCreateDeployment is a macro command to create a new deployment.

--- a/pkg/kubectl/cmd/create_namespace.go
+++ b/pkg/kubectl/cmd/create_namespace.go
@@ -32,8 +32,8 @@ var (
 		Create a namespace with the specified name.`))
 
 	namespaceExample = templates.Examples(i18n.T(`
-	  # Create a new namespace named my-namespace
-	  kubectl create namespace my-namespace`))
+	  # Create a new namespace named my-namespace.
+	  $ kubectl create namespace my-namespace`))
 )
 
 // NewCmdCreateNamespace is a macro command to create a new namespace

--- a/pkg/kubectl/cmd/create_pdb.go
+++ b/pkg/kubectl/cmd/create_pdb.go
@@ -32,13 +32,11 @@ var (
 		Create a pod disruption budget with the specified name, selector, and desired minimum available pods`))
 
 	pdbExample = templates.Examples(i18n.T(`
-		# Create a pod disruption budget named my-pdb that will select all pods with the app=rails label
-		# and require at least one of them being available at any point in time.
-		kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=rails label and require at least one of them being available at any point in time.
+		$ kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
 
-		# Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label
-		# and require at least half of the pods selected to be available at any point in time.
-		kubectl create pdb my-pdb --selector=app=nginx --min-available=50%`))
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label and require at least half of the pods selected to be available at any point in time.
+		$ kubectl create pdb my-pdb --selector=app=nginx --min-available=50%`))
 )
 
 // NewCmdCreatePodDisruptionBudget is a macro command to create a new pod disruption budget.

--- a/pkg/kubectl/cmd/create_quota.go
+++ b/pkg/kubectl/cmd/create_quota.go
@@ -32,11 +32,11 @@ var (
 		Create a resourcequota with the specified name, hard limits and optional scopes`))
 
 	quotaExample = templates.Examples(i18n.T(`
-		# Create a new resourcequota named my-quota
-		kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
+		# Create a new resourcequota named my-quota.
+		$ kubectl create quota my-quota --hard=cpu=1,memory=1G,pods=2,services=3,replicationcontrollers=2,resourcequotas=1,secrets=5,persistentvolumeclaims=10
 
-		# Create a new resourcequota named best-effort
-		kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort`))
+		# Create a new resourcequota named best-effort.
+		$ kubectl create quota best-effort --hard=pods=100 --scopes=BestEffort`))
 )
 
 // NewCmdCreateQuota is a macro command to create a new quota

--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -39,17 +39,17 @@ var (
 		Create a role with single rule.`))
 
 	roleExample = templates.Examples(i18n.T(`
-		# Create a Role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods
-		kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
+		# Create a Role named "pod-reader" that allows user to perform "get", "watch" and "list" on pods.
+		$ kubectl create role pod-reader --verb=get --verb=list --verb=watch --resource=pods
 
-		# Create a Role named "pod-reader" with ResourceName specified
-		kubectl create role pod-reader --verb=get,list,watch --resource=pods --resource-name=readablepod --resource-name=anotherpod
+		# Create a Role named "pod-reader" with ResourceName specified.
+		$ kubectl create role pod-reader --verb=get,list,watch --resource=pods --resource-name=readablepod --resource-name=anotherpod
 
-		# Create a Role named "foo" with API Group specified
-		kubectl create role foo --verb=get,list,watch --resource=rs.extensions
+		# Create a Role named "foo" with API Group specified.
+		$ kubectl create role foo --verb=get,list,watch --resource=rs.extensions
 
-		# Create a Role named "foo" with SubResource specified
-		kubectl create role foo --verb=get,list,watch --resource=pods,pods/status`))
+		# Create a Role named "foo" with SubResource specified.
+		$ kubectl create role foo --verb=get,list,watch --resource=pods,pods/status`))
 
 	// Valid resource verb list for validation.
 	validResourceVerbs = []string{"*", "get", "delete", "list", "create", "update", "patch", "watch", "proxy", "deletecollection", "use", "bind", "impersonate"}

--- a/pkg/kubectl/cmd/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create_rolebinding.go
@@ -32,8 +32,8 @@ var (
 		Create a RoleBinding for a particular Role or ClusterRole.`))
 
 	roleBindingExample = templates.Examples(i18n.T(`
-		  # Create a RoleBinding for user1, user2, and group1 using the admin ClusterRole
-		  kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`))
+		  # Create a RoleBinding for user1, user2, and group1 using the admin ClusterRole.
+		  $ kubectl create rolebinding admin --clusterrole=admin --user=user1 --user=user2 --group=group1`))
 )
 
 // RoleBinding is a command to ease creating RoleBindings.

--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -56,17 +56,17 @@ var (
 		symlinks, devices, pipes, etc).`))
 
 	secretExample = templates.Examples(i18n.T(`
-	  # Create a new secret named my-secret with keys for each file in folder bar
-	  kubectl create secret generic my-secret --from-file=path/to/bar
+	  # Create a new secret named my-secret with keys for each file in folder bar.
+	  $ kubectl create secret generic my-secret --from-file=path/to/bar
 
-	  # Create a new secret named my-secret with specified keys instead of names on disk
-	  kubectl create secret generic my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
+	  # Create a new secret named my-secret with specified keys instead of names on disk.
+	  $ kubectl create secret generic my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-file=ssh-publickey=~/.ssh/id_rsa.pub
 
-	  # Create a new secret named my-secret with key1=supersecret and key2=topsecret
-	  kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
+	  # Create a new secret named my-secret with key1=supersecret and key2=topsecret.
+	  $ kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
 
-	  # Create a new secret named my-secret from an env file
-	  kubectl create secret generic my-secret --from-env-file=path/to/bar.env`))
+	  # Create a new secret named my-secret from an env file.
+	  $ kubectl create secret generic my-secret --from-env-file=path/to/bar.env`))
 )
 
 // NewCmdCreateSecretGeneric is a command to create generic secrets from files, directories, or literal values
@@ -137,8 +137,8 @@ var (
 		by creating a dockercfg secret and attaching it to your service account.`))
 
 	secretForDockerRegistryExample = templates.Examples(i18n.T(`
-		  # If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
-		  kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL`))
+		  # If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using.
+		  $ kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL`))
 )
 
 // NewCmdCreateSecretDockerRegistry is a macro command for creating secrets to work with Docker registries
@@ -207,8 +207,8 @@ var (
 		The public/private key pair must exist before hand. The public key certificate must be .PEM encoded and match the given private key.`))
 
 	secretForTLSExample = templates.Examples(i18n.T(`
-	  # Create a new TLS secret named tls-secret with the given key pair:
-	  kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`))
+	  # Create a new TLS secret named tls-secret with the given key pair.
+	  $ kubectl create secret tls tls-secret --cert=path/to/tls.cert --key=path/to/tls.key`))
 )
 
 // NewCmdCreateSecretTLS is a macro command for creating secrets to work with Docker registries

--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -50,11 +50,11 @@ var (
     Create a clusterIP service with the specified name.`))
 
 	serviceClusterIPExample = templates.Examples(i18n.T(`
-    # Create a new clusterIP service named my-cs
-    kubectl create service clusterip my-cs --tcp=5678:8080
+    # Create a new clusterIP service named my-cs.
+    $ kubectl create service clusterip my-cs --tcp=5678:8080
 
-    # Create a new clusterIP service named my-cs (in headless mode)
-    kubectl create service clusterip my-cs --clusterip="None"`))
+    # Create a new clusterIP service named my-cs (in headless mode).
+    $ kubectl create service clusterip my-cs --clusterip="None"`))
 )
 
 func addPortFlags(cmd *cobra.Command) {
@@ -117,8 +117,8 @@ var (
     Create a nodeport service with the specified name.`))
 
 	serviceNodePortExample = templates.Examples(i18n.T(`
-    # Create a new nodeport service named my-ns
-    kubectl create service nodeport my-ns --tcp=5678:8080`))
+    # Create a new nodeport service named my-ns.
+    $ kubectl create service nodeport my-ns --tcp=5678:8080`))
 )
 
 // NewCmdCreateServiceNodePort is a macro command for creating a NodePort service
@@ -174,8 +174,8 @@ var (
     Create a LoadBalancer service with the specified name.`))
 
 	serviceLoadBalancerExample = templates.Examples(i18n.T(`
-    # Create a new LoadBalancer service named my-lbs
-    kubectl create service loadbalancer my-lbs --tcp=5678:8080`))
+    # Create a new LoadBalancer service named my-lbs.
+    $ kubectl create service loadbalancer my-lbs --tcp=5678:8080`))
 )
 
 // NewCmdCreateServiceLoadBalancer is a macro command for creating a LoadBalancer service
@@ -233,8 +233,8 @@ var (
 	that exist off platform, on other clusters, or locally.`))
 
 	serviceExternalNameExample = templates.Examples(i18n.T(`
-	# Create a new ExternalName service named my-ns 
-	kubectl create service externalname my-ns --external-name bar.com`))
+	# Create a new ExternalName service named my-ns.
+	$ kubectl create service externalname my-ns --external-name bar.com`))
 )
 
 // NewCmdCreateServiceExternalName is a macro command for creating a ExternalName service

--- a/pkg/kubectl/cmd/create_serviceaccount.go
+++ b/pkg/kubectl/cmd/create_serviceaccount.go
@@ -32,8 +32,8 @@ var (
 		Create a service account with the specified name.`))
 
 	serviceAccountExample = templates.Examples(i18n.T(`
-	  # Create a new service account named my-service-account
-	  kubectl create serviceaccount my-service-account`))
+	  # Create a new service account named my-service-account.
+	  $ kubectl create serviceaccount my-service-account`))
 )
 
 // NewCmdCreateServiceAccount is a macro command to create a new service account

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -66,25 +66,25 @@ var (
 
 	delete_example = templates.Examples(i18n.T(`
 		# Delete a pod using the type and name specified in pod.json.
-		kubectl delete -f ./pod.json
+		$ kubectl delete -f ./pod.json
 
 		# Delete a pod based on the type and name in the JSON passed into stdin.
-		cat pod.json | kubectl delete -f -
+		$ cat pod.json | kubectl delete -f -
 
-		# Delete pods and services with same names "baz" and "foo"
-		kubectl delete pod,service baz foo
+		# Delete pods and services with same names "baz" and "foo".
+		$ kubectl delete pod,service baz foo
 
 		# Delete pods and services with label name=myLabel.
-		kubectl delete pods,services -l name=myLabel
+		$ kubectl delete pods,services -l name=myLabel
 
-		# Delete a pod with minimal delay
-		kubectl delete pod foo --now
+		# Delete a pod with minimal delay.
+		$ kubectl delete pod foo --now
 
-		# Force delete a pod on a dead node
-		kubectl delete pod foo --grace-period=0 --force
+		# Force delete a pod on a dead node.
+		$ kubectl delete pod foo --grace-period=0 --force
 
-		# Delete all pods
-		kubectl delete pods --all`))
+		# Delete all pods.
+		$ kubectl delete pods --all`))
 )
 
 type DeleteOptions struct {

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -50,24 +50,23 @@ var (
 		` + validResources)
 
 	describe_example = templates.Examples(i18n.T(`
-		# Describe a node
-		kubectl describe nodes kubernetes-node-emt8.c.myproject.internal
+		# Describe a node.
+		$ kubectl describe nodes kubernetes-node-emt8.c.myproject.internal
 
-		# Describe a pod
-		kubectl describe pods/nginx
+		# Describe a pod.
+		$ kubectl describe pods/nginx
 
-		# Describe a pod identified by type and name in "pod.json"
-		kubectl describe -f pod.json
+		# Describe a pod identified by type and name in "pod.json".
+		$ kubectl describe -f pod.json
 
-		# Describe all pods
-		kubectl describe pods
+		# Describe all pods.
+		$ kubectl describe pods
 
-		# Describe pods by label name=myLabel
-		kubectl describe po -l name=myLabel
+		# Describe pods by label name=myLabel.
+		$ kubectl describe po -l name=myLabel
 
-		# Describe all pods managed by the 'frontend' replication controller (rc-created pods
-		# get the name of the rc as a prefix in the pod the name).
-		kubectl describe pods frontend`))
+		# Describe all pods managed by the 'frontend' replication controller (rc-created pods get the name of the rc as a prefix in the pod the name).
+		$ kubectl describe pods frontend`))
 )
 
 func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"math"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -95,7 +96,7 @@ var (
 
 	cordon_example = templates.Examples(i18n.T(`
 		# Mark node "foo" as unschedulable.
-		kubectl cordon foo`))
+		$ kubectl cordon foo`))
 )
 
 func NewCmdCordon(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -57,17 +57,17 @@ var (
 		saved copy to include the latest resource version.`))
 
 	editExample = templates.Examples(i18n.T(`
-		# Edit the service named 'docker-registry':
-		kubectl edit svc/docker-registry
+		# Edit the service named 'docker-registry'.
+		$ kubectl edit svc/docker-registry
 
-		# Use an alternative editor
-		KUBE_EDITOR="nano" kubectl edit svc/docker-registry
+		# Use an alternative editor.
+		$ KUBE_EDITOR="nano" kubectl edit svc/docker-registry
 
-		# Edit the job 'myjob' in JSON using the v1 API format:
-		kubectl edit job.v1.batch/myjob -o json
+		# Edit the job 'myjob' in JSON using the v1 API format.
+		$ kubectl edit job.v1.batch/myjob -o json
 
-		# Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation:
-		kubectl edit deployment/mydeployment -o yaml --save-config`))
+		# Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation.
+		$ kubectl edit deployment/mydeployment -o yaml --save-config`))
 )
 
 func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -38,22 +38,19 @@ import (
 
 var (
 	exec_example = templates.Examples(i18n.T(`
-		# Get output from running 'date' from pod 123456-7890, using the first container by default
-		kubectl exec 123456-7890 date
+		# Get output from running 'date' from pod 123456-7890, using the first container by default.
+		$ kubectl exec 123456-7890 date
 
-		# Get output from running 'date' in ruby-container from pod 123456-7890
-		kubectl exec 123456-7890 -c ruby-container date
+		# Get output from running 'date' in ruby-container from pod 123456-7890.
+		$ kubectl exec 123456-7890 -c ruby-container date
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
-		# and sends stdout/stderr from 'bash' back to the client
-		kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890 and sends stdout/stderr from 'bash' back to the client.
+		$ kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il
 
 		# List contents of /usr from the first container of pod 123456-7890 and sort by modification time.
-		# If the command you want to execute in the pod has any flags in common (e.g. -i),
-		# you must use two dashes (--) to separate your command's flags/arguments.
-		# Also note, do not surround your command and its flags/arguments with quotes
-		# unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
-		kubectl exec 123456-7890 -i -t -- ls -t /usr
+		# If the command you want to execute in the pod has any flags in common (e.g. -i), you must use two dashes (--) to separate your command's flags/arguments.
+		# Also note, do not surround your command and its flags/arguments with quotes unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
+		$ kubectl exec 123456-7890 -i -t -- ls -t /usr
 		`))
 )
 

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -37,11 +37,11 @@ var (
 		` + validResources)
 
 	explainExamples = templates.Examples(i18n.T(`
-		# Get the documentation of the resource and its fields
-		kubectl explain pods
+		# Get the documentation of the resource and its fields.
+		$ kubectl explain pods
 
-		# Get the documentation of a specific field of a resource
-		kubectl explain pods.spec.containers`))
+		# Get the documentation of a specific field of a resource.
+		$ kubectl explain pods.spec.containers`))
 )
 
 // NewCmdExplain returns a cobra command for swagger docs

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -51,25 +51,25 @@ var (
 
 	exposeExample = templates.Examples(i18n.T(`
 		# Create a service for a replicated nginx, which serves on port 80 and connects to the containers on port 8000.
-		kubectl expose rc nginx --port=80 --target-port=8000
+		$ kubectl expose rc nginx --port=80 --target-port=8000
 
 		# Create a service for a replication controller identified by type and name specified in "nginx-controller.yaml", which serves on port 80 and connects to the containers on port 8000.
-		kubectl expose -f nginx-controller.yaml --port=80 --target-port=8000
+		$ kubectl expose -f nginx-controller.yaml --port=80 --target-port=8000
 
-		# Create a service for a pod valid-pod, which serves on port 444 with the name "frontend"
-		kubectl expose pod valid-pod --port=444 --name=frontend
+		# Create a service for a pod valid-pod, which serves on port 444 with the name "frontend".
+		$ kubectl expose pod valid-pod --port=444 --name=frontend
 
-		# Create a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx-https"
-		kubectl expose service nginx --port=443 --target-port=8443 --name=nginx-https
+		# Create a second service based on the above service, exposing the container port 8443 as port 443 with the name "nginx-https".
+		 $ kubectl expose service nginx --port=443 --target-port=8443 --name=nginx-https
 
 		# Create a service for a replicated streaming application on port 4100 balancing UDP traffic and named 'video-stream'.
-		kubectl expose rc streamer --port=4100 --protocol=udp --name=video-stream
+		$ kubectl expose rc streamer --port=4100 --protocol=udp --name=video-stream
 
 		# Create a service for a replicated nginx using replica set, which serves on port 80 and connects to the containers on port 8000.
-		kubectl expose rs nginx --port=80 --target-port=8000
+		$ kubectl expose rs nginx --port=80 --target-port=8000
 
 		# Create a service for an nginx deployment, which serves on port 80 and connects to the containers on port 8000.
-		kubectl expose deployment nginx --port=80 --target-port=8000`))
+		$ kubectl expose deployment nginx --port=80 --target-port=8000`))
 )
 
 func NewCmdExposeService(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -65,31 +65,31 @@ var (
 
 	getExample = templates.Examples(i18n.T(`
 		# List all pods in ps output format.
-		kubectl get pods
+		$ kubectl get pods
 
 		# List all pods in ps output format with more information (such as node name).
-		kubectl get pods -o wide
+		$ kubectl get pods -o wide
 
 		# List a single replication controller with specified NAME in ps output format.
-		kubectl get replicationcontroller web
+		$ kubectl get replicationcontroller web
 
 		# List a single pod in JSON output format.
-		kubectl get -o json pod web-pod-13je7
+		$ kubectl get -o json pod web-pod-13je7
 
 		# List a pod identified by type and name specified in "pod.yaml" in JSON output format.
-		kubectl get -f pod.yaml -o json
+		$ kubectl get -f pod.yaml -o json
 
 		# Return only the phase value of the specified pod.
-		kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
+		$ kubectl get -o template pod/web-pod-13je7 --template={{.status.phase}}
 
 		# List all replication controllers and services together in ps output format.
-		kubectl get rc,services
+		$ kubectl get rc,services
 
 		# List one or more resources by their type and names.
-		kubectl get rc/web service/frontend pods/web-pod-13je7
+		$ kubectl get rc/web service/frontend pods/web-pod-13je7
 
 		# List all resources with different types.
-		kubectl get all`))
+		$ kubectl get all`))
 )
 
 const (

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -75,23 +75,23 @@ var (
 
 	labelExample = templates.Examples(i18n.T(`
 		# Update pod 'foo' with the label 'unhealthy' and the value 'true'.
-		kubectl label pods foo unhealthy=true
+		$ kubectl label pods foo unhealthy=true
 
 		# Update pod 'foo' with the label 'status' and the value 'unhealthy', overwriting any existing value.
-		kubectl label --overwrite pods foo status=unhealthy
+		$ kubectl label --overwrite pods foo status=unhealthy
 
-		# Update all pods in the namespace
-		kubectl label pods --all status=unhealthy
+		# Update all pods in the namespace.
+		$ kubectl label pods --all status=unhealthy
 
-		# Update a pod identified by the type and name in "pod.json"
-		kubectl label -f pod.json status=unhealthy
+		# Update a pod identified by the type and name in "pod.json".
+		$ kubectl label -f pod.json status=unhealthy
 
 		# Update pod 'foo' only if the resource is unchanged from version 1.
-		kubectl label pods foo status=unhealthy --resource-version=1
+		$ kubectl label pods foo status=unhealthy --resource-version=1
 
 		# Update pod 'foo' by removing a label named 'bar' if it exists.
 		# Does not require the --overwrite flag.
-		kubectl label pods foo bar-`))
+		$ kubectl label pods foo bar-`))
 )
 
 func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -38,29 +38,29 @@ import (
 
 var (
 	logsExample = templates.Examples(i18n.T(`
-		# Return snapshot logs from pod nginx with only one container
-		kubectl logs nginx
+		# Return snapshot logs from pod nginx with only one container.
+		$ kubectl logs nginx
 
-		# Return snapshot logs for the pods defined by label app=nginx
-		kubectl logs -lapp=nginx
+		# Return snapshot logs for the pods defined by label app=nginx.
+		$ kubectl logs -lapp=nginx
 
-		# Return snapshot of previous terminated ruby container logs from pod web-1
-		kubectl logs -p -c ruby web-1
+		# Return snapshot of previous terminated ruby container logs from pod web-1.
+		$ kubectl logs -p -c ruby web-1
 
-		# Begin streaming the logs of the ruby container in pod web-1
-		kubectl logs -f -c ruby web-1
+		# Begin streaming the logs of the ruby container in pod web-1.
+		$ kubectl logs -f -c ruby web-1
 
-		# Display only the most recent 20 lines of output in pod nginx
-		kubectl logs --tail=20 nginx
+		# Display only the most recent 20 lines of output in pod nginx.
+		$ kubectl logs --tail=20 nginx
 
-		# Show all logs from pod nginx written in the last hour
-		kubectl logs --since=1h nginx
+		# Show all logs from pod nginx written in the last hour.
+		$ kubectl logs --since=1h nginx
 
-		# Return snapshot logs from first container of a job named hello
-		kubectl logs job/hello
+		# Return snapshot logs from first container of a job named hello.
+		$ kubectl logs job/hello
 
-		# Return snapshot logs from container nginx-1 of a deployment named nginx
-		kubectl logs deployment/nginx -c nginx-1`))
+		# Return snapshot logs from container nginx-1 of a deployment named nginx.
+		$ kubectl logs deployment/nginx -c nginx-1`))
 
 	selectorTail int64 = 10
 )

--- a/pkg/kubectl/cmd/options.go
+++ b/pkg/kubectl/cmd/options.go
@@ -27,8 +27,8 @@ import (
 
 var (
 	optionsExample = templates.Examples(i18n.T(`
-		# Print flags inherited by all commands
-		kubectl options`))
+		# Print flags inherited by all commands.
+		$ kubectl options`))
 )
 
 // NewCmdOptions implements the options command

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -64,17 +64,17 @@ var (
 		Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`))
 
 	patchExample = templates.Examples(i18n.T(`
-		# Partially update a node using strategic merge patch
-		kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
+		# Partially update a node using strategic merge patch.
+		$ kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
 
-		# Partially update a node identified by the type and name specified in "node.json" using strategic merge patch
-		kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
+		# Partially update a node identified by the type and name specified in "node.json" using strategic merge patch.
+		$ kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
 
-		# Update a container's image; spec.containers[*].name is required because it's a merge key
-		kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
+		# Update a container's image; spec.containers[*].name is required because it's a merge key.
+		$ kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
 
-		# Update a container's image using a json patch with positional arrays
-		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'`))
+		# Update a container's image using a json patch with positional arrays.
+		$ kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'`))
 )
 
 func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -52,17 +52,17 @@ type PortForwardOptions struct {
 
 var (
 	portforwardExample = templates.Examples(i18n.T(`
-		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod
-		kubectl port-forward mypod 5000 6000
+		# Listen on ports 5000 and 6000 locally, forwarding data to/from ports 5000 and 6000 in the pod.
+		$ kubectl port-forward mypod 5000 6000
 
-		# Listen on port 8888 locally, forwarding to 5000 in the pod
-		kubectl port-forward mypod 8888:5000
+		# Listen on port 8888 locally, forwarding to 5000 in the pod.
+		$ kubectl port-forward mypod 8888:5000
 
-		# Listen on a random port locally, forwarding to 5000 in the pod
-		kubectl port-forward mypod :5000
+		# Listen on a random port locally, forwarding to 5000 in the pod.
+		$ kubectl port-forward mypod :5000
 
-		# Listen on a random port locally, forwarding to 5000 in the pod
-		kubectl port-forward mypod 0:5000`))
+		# Listen on a random port locally, forwarding to 5000 in the pod.
+		$ kubectl port-forward mypod 0:5000`))
 )
 
 func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -41,32 +41,27 @@ var (
 		the remote kubernetes API Server port, except for the path matching the static content path.`))
 
 	proxyExample = templates.Examples(i18n.T(`
-		# To proxy all of the kubernetes api and nothing else, use:
+		# Proxy all of the kubernetes api and nothing else.
+		$ kubectl proxy --api-prefix=/
 
-		    $ kubectl proxy --api-prefix=/
+		# Proxy only part of the kubernetes api and also some static files.
+		# This lets you 'curl localhost:8001/api/v1/pods'.
+		$ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
 
-		# To proxy only part of the kubernetes api and also some static files:
+		# Proxy the entire kubernetes api at a different root.
+		# This lets you 'curl localhost:8001/custom/api/v1/pods'.
+		$ kubectl proxy --api-prefix=/custom/
 
-		    $ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
-
-		# The above lets you 'curl localhost:8001/api/v1/pods'.
-
-		# To proxy the entire kubernetes api at a different root, use:
-
-		    $ kubectl proxy --api-prefix=/custom/
-
-		# The above lets you 'curl localhost:8001/custom/api/v1/pods'
-
-		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
-		kubectl proxy --port=8011 --www=./local/www/
+		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/ .
+		$ kubectl proxy --port=8011 --www=./local/www/
 
 		# Run a proxy to kubernetes apiserver on an arbitrary local port.
 		# The chosen port for the server will be output to stdout.
-		kubectl proxy --port=0
+		$ kubectl proxy --port=0
 
-		# Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api
-		# This makes e.g. the pods api available at localhost:8001/k8s-api/v1/pods/
-		kubectl proxy --api-prefix=/k8s-api`))
+		# Run a proxy to kubernetes apiserver, changing the api prefix to k8s-api.
+		# This makes e.g. the pods api available at localhost:8001/k8s-api/v1/pods/.
+		$ kubectl proxy --api-prefix=/k8s-api`))
 )
 
 func NewCmdProxy(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -49,16 +49,16 @@ var (
 
 	replaceExample = templates.Examples(i18n.T(`
 		# Replace a pod using the data in pod.json.
-		kubectl replace -f ./pod.json
+		$ kubectl replace -f ./pod.json
 
 		# Replace a pod based on the JSON passed into stdin.
-		cat pod.json | kubectl replace -f -
+		$ cat pod.json | kubectl replace -f -
 
-		# Update a single-container pod's image version (tag) to v4
-		kubectl get pod mypod -o yaml | sed 's/\(image: myimage\):.*$/\1:v4/' | kubectl replace -f -
+		# Update a single-container pod's image version (tag) to v4.
+		$ kubectl get pod mypod -o yaml | sed 's/\(image: myimage\):.*$/\1:v4/' | kubectl replace -f -
 
-		# Force replace, delete and then re-create the resource
-		kubectl replace --force -f ./pod.json`))
+		# Force replace, delete and then re-create the resource.
+		$ kubectl replace --force -f ./pod.json`))
 )
 
 func NewCmdReplace(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -52,20 +52,19 @@ var (
 
 	rollingUpdateExample = templates.Examples(i18n.T(`
 		# Update pods of frontend-v1 using new replication controller data in frontend-v2.json.
-		kubectl rolling-update frontend-v1 -f frontend-v2.json
+		$ kubectl rolling-update frontend-v1 -f frontend-v2.json
 
 		# Update pods of frontend-v1 using JSON data passed into stdin.
-		cat frontend-v2.json | kubectl rolling-update frontend-v1 -f -
+		$ cat frontend-v2.json | kubectl rolling-update frontend-v1 -f -
 
-		# Update the pods of frontend-v1 to frontend-v2 by just changing the image, and switching the
-		# name of the replication controller.
-		kubectl rolling-update frontend-v1 frontend-v2 --image=image:v2
+		# Update the pods of frontend-v1 to frontend-v2 by just changing the image, and switching the name of the replication controller.
+		$ kubectl rolling-update frontend-v1 frontend-v2 --image=image:v2
 
 		# Update the pods of frontend by just changing the image, and keeping the old name.
-		kubectl rolling-update frontend --image=image:v2
+		$ kubectl rolling-update frontend --image=image:v2
 
 		# Abort and reverse an existing rollout in progress (from frontend-v1 to frontend-v2).
-		kubectl rolling-update frontend-v1 frontend-v2 --rollback`))
+		$ kubectl rolling-update frontend-v1 frontend-v2 --rollback`))
 )
 
 var (

--- a/pkg/kubectl/cmd/rollout/rollout.go
+++ b/pkg/kubectl/cmd/rollout/rollout.go
@@ -31,11 +31,11 @@ var (
 		Manage the rollout of a resource.` + rollout_valid_resources)
 
 	rollout_example = templates.Examples(`
-		# Rollback to the previous deployment
-		kubectl rollout undo deployment/abc
+		# Rollback to the previous deployment.
+		$ kubectl rollout undo deployment/abcm
 		
-		# Check the rollout status of a daemonset
-		kubectl rollout status daemonset/foo`)
+		# Check the rollout status of a daemonset.
+		$ kubectl rollout status daemonset/foo`)
 
 	rollout_valid_resources = dedent.Dedent(`
 		Valid resource types include:

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -34,11 +34,11 @@ var (
 		View previous rollout revisions and configurations.`)
 
 	history_example = templates.Examples(`
-		# View the rollout history of a deployment
-		kubectl rollout history deployment/abc
+		# View the rollout history of a deployment.
+		$ kubectl rollout history deployment/abc
 
-		# View the details of daemonset revision 3
-		kubectl rollout history daemonset/abc --revision=3`)
+		# View the details of daemonset revision 3.
+		$ kubectl rollout history daemonset/abc --revision=3`)
 )
 
 func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -57,10 +57,9 @@ var (
 		Currently only deployments support being paused.`)
 
 	pause_example = templates.Examples(`
-		# Mark the nginx deployment as paused. Any current state of
-		# the deployment will continue its function, new updates to the deployment will not
-		# have an effect as long as the deployment is paused.
-		kubectl rollout pause deployment/nginx`)
+		# Mark the nginx deployment as paused. 
+		# Any current state of the deployment will continue its function, new updates to the deployment will not have an effect as long as the deployment is paused.
+		$ kubectl rollout pause deployment/nginx`)
 )
 
 func NewCmdRolloutPause(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -57,8 +57,8 @@ var (
 		Currently only deployments support being resumed.`)
 
 	resume_example = templates.Examples(`
-		# Resume an already paused deployment
-		kubectl rollout resume deployment/nginx`)
+		# Resume an already paused deployment.
+		$ kubectl rollout resume deployment/nginx`)
 )
 
 func NewCmdRolloutResume(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -43,8 +43,8 @@ var (
 		use --revision=N where N is the revision you need to watch for.`)
 
 	status_example = templates.Examples(`
-		# Watch the rollout status of a deployment
-		kubectl rollout status deployment/nginx`)
+		# Watch the rollout status of a deployment.
+		$ kubectl rollout status deployment/nginx`)
 )
 
 func NewCmdRolloutStatus(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -51,14 +51,14 @@ var (
 		Rollback to a previous rollout.`)
 
 	undo_example = templates.Examples(`
-		# Rollback to the previous deployment
-		kubectl rollout undo deployment/abc
+		# Rollback to the previous deployment.
+		$ kubectl rollout undo deployment/abc
 
-		# Rollback to daemonset revision 3
-		kubectl rollout undo daemonset/abc --to-revision=3
+		# Rollback to daemonset revision 3.
+		$ kubectl rollout undo daemonset/abc --to-revision=3
 
-		# Rollback to the previous deployment with dry-run
-		kubectl rollout undo --dry-run=true deployment/abc`)
+		# Rollback to the previous deployment with dry-run.
+		$ kubectl rollout undo --dry-run=true deployment/abc`)
 )
 
 func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -53,40 +53,40 @@ var (
 
 	runExample = templates.Examples(i18n.T(`
 		# Start a single instance of nginx.
-		kubectl run nginx --image=nginx
+		$ kubectl run nginx --image=nginx
 
-		# Start a single instance of hazelcast and let the container expose port 5701 .
-		kubectl run hazelcast --image=hazelcast --port=5701
+		# Start a single instance of hazelcast and let the container expose port 5701.
+		$ kubectl run hazelcast --image=hazelcast --port=5701
 
 		# Start a single instance of hazelcast and set environment variables "DNS_DOMAIN=cluster" and "POD_NAMESPACE=default" in the container.
-		kubectl run hazelcast --image=hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
+		$ kubectl run hazelcast --image=hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
 
 		# Start a single instance of hazelcast and set labels "app=hazelcast" and "env=prod" in the container.
-		kubectl run hazelcast --image=nginx --labels="app=hazelcast,env=prod"
+		$ kubectl run hazelcast --image=nginx --labels="app=hazelcast,env=prod"
 
 		# Start a replicated instance of nginx.
-		kubectl run nginx --image=nginx --replicas=5
+		$ kubectl run nginx --image=nginx --replicas=5
 
 		# Dry run. Print the corresponding API objects without creating them.
-		kubectl run nginx --image=nginx --dry-run
+		$ kubectl run nginx --image=nginx --dry-run
 
 		# Start a single instance of nginx, but overload the spec of the deployment with a partial set of values parsed from JSON.
-		kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
+		$ kubectl run nginx --image=nginx --overrides='{ "apiVersion": "v1", "spec": { ... } }'
 
 		# Start a pod of busybox and keep it in the foreground, don't restart it if it exits.
-		kubectl run -i -t busybox --image=busybox --restart=Never
+		$ kubectl run -i -t busybox --image=busybox --restart=Never
 
 		# Start the nginx container using the default command, but use custom arguments (arg1 .. argN) for that command.
-		kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
+		$ kubectl run nginx --image=nginx -- <arg1> <arg2> ... <argN>
 
 		# Start the nginx container using a different command and custom arguments.
-		kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
+		$ kubectl run nginx --image=nginx --command -- <cmd> <arg1> ... <argN>
 
 		# Start the perl container to compute π to 2000 places and print it out.
-		kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
+		$ kubectl run pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'
 
 		# Start the cron job to compute π to 2000 places and print it out every 5 minutes.
-		kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'`))
+		$ kubectl run pi --schedule="0/5 * * * ?" --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)'`))
 )
 
 type RunObject struct {

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -41,19 +41,19 @@ var (
 
 	scaleExample = templates.Examples(i18n.T(`
 		# Scale a replicaset named 'foo' to 3.
-		kubectl scale --replicas=3 rs/foo
+		$ kubectl scale --replicas=3 rs/foo
 
 		# Scale a resource identified by type and name specified in "foo.yaml" to 3.
-		kubectl scale --replicas=3 -f foo.yaml
+		$ kubectl scale --replicas=3 -f foo.yaml
 
 		# If the deployment named mysql's current size is 2, scale mysql to 3.
-		kubectl scale --current-replicas=2 --replicas=3 deployment/mysql
+		$ kubectl scale --current-replicas=2 --replicas=3 deployment/mysql
 
 		# Scale multiple replication controllers.
-		kubectl scale --replicas=5 rc/foo rc/bar rc/baz
+		$ kubectl scale --replicas=5 rc/foo rc/bar rc/baz
 
 		# Scale job named 'cron' to 3.
-		kubectl scale --replicas=3 job/cron`))
+		$ kubectl scale --replicas=3 job/cron`))
 )
 
 // NewCmdScale returns a cobra command with the appropriate configuration and flags to run scale

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -72,16 +72,16 @@ var (
 
 	image_example = templates.Examples(`
 		# Set a deployment's nginx container image to 'nginx:1.9.1', and its busybox container image to 'busybox'.
-		kubectl set image deployment/nginx busybox=busybox nginx=nginx:1.9.1
+		$ kubectl set image deployment/nginx busybox=busybox nginx=nginx:1.9.1
 
-		# Update all deployments' and rc's nginx container's image to 'nginx:1.9.1'
-		kubectl set image deployments,rc nginx=nginx:1.9.1 --all
+		# Update all deployments' and rc's nginx container's image to 'nginx:1.9.1'.
+		$ kubectl set image deployments,rc nginx=nginx:1.9.1 --all
 
-		# Update image of all containers of daemonset abc to 'nginx:1.9.1'
-		kubectl set image daemonset abc *=nginx:1.9.1
+		# Update image of all containers of daemonset abc to 'nginx:1.9.1'.
+		$ kubectl set image daemonset abc *=nginx:1.9.1
 
-		# Print result (in yaml format) of updating nginx container image from local file, without hitting the server
-		kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml`)
+		# Print result (in yaml format) of updating nginx container image from local file, without hitting the server.
+		$ kubectl set image -f path/to/file.yaml nginx=nginx:1.9.1 --local -o yaml`)
 )
 
 func NewCmdImage(f cmdutil.Factory, out, err io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -44,17 +44,17 @@ var (
 		Possible resources include (case insensitive): %s.`)
 
 	resources_example = templates.Examples(`
-		# Set a deployments nginx container cpu limits to "200m" and memory to "512Mi"
-		kubectl set resources deployment nginx -c=nginx --limits=cpu=200m,memory=512Mi
+		# Set a deployments nginx container cpu limits to "200m" and memory to "512Mi".
+		$ kubectl set resources deployment nginx -c=nginx --limits=cpu=200m,memory=512Mi
 
-		# Set the resource request and limits for all containers in nginx
-		kubectl set resources deployment nginx --limits=cpu=200m,memory=512Mi --requests=cpu=100m,memory=256Mi
+		# Set the resource request and limits for all containers in nginx.
+		$ kubectl set resources deployment nginx --limits=cpu=200m,memory=512Mi --requests=cpu=100m,memory=256Mi
 
-		# Remove the resource requests for resources on containers in nginx
-		kubectl set resources deployment nginx --limits=cpu=0,memory=0 --requests=cpu=0,memory=0
+		# Remove the resource requests for resources on containers in nginx.
+		$ kubectl set resources deployment nginx --limits=cpu=0,memory=0 --requests=cpu=0,memory=0
 
-		# Print the result (in yaml format) of updating nginx container limits from a local, without hitting the server
-		kubectl set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --local -o yaml`)
+		# Print the result (in yaml format) of updating nginx container limits from a local, without hitting the server.
+		$ kubectl set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --local -o yaml`)
 )
 
 // ResourcesOptions is the start of the data required to perform the operation. As new fields are added, add them here instead of

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -66,9 +66,11 @@ var (
 		If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
         Note: currently selectors can only be set on Service objects.`)
 	selectorExample = templates.Examples(`
-        # set the labels and selector before creating a deployment/service pair.
-        kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
-        kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
+        	# Set the selector before creating a deployment/service pair.
+        	$ kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
+
+		# Set the label before creating a deployment/service pair.
+        	$ kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
 )
 
 // NewCmdSelector is the "set selector" command.

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -40,14 +40,14 @@ var (
 	Update User, Group or ServiceAccount in a RoleBinding/ClusterRoleBinding.`)
 
 	subject_example = templates.Examples(`
-	# Update a ClusterRoleBinding for serviceaccount1
-	kubectl set subject clusterrolebinding admin --serviceaccount=namespace:serviceaccount1
+	# Update a ClusterRoleBinding for serviceaccount1.
+	$ kubectl set subject clusterrolebinding admin --serviceaccount=namespace:serviceaccount1
 
-	# Update a RoleBinding for user1, user2, and group1
-	kubectl set subject rolebinding admin --user=user1 --user=user2 --group=group1
+	# Update a RoleBinding for user1, user2, and group1.
+	$ kubectl set subject rolebinding admin --user=user1 --user=user2 --group=group1
 
-	# Print the result (in yaml format) of updating rolebinding subjects from a local, without hitting the server
-	kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | kubectl set subject --local -f - --user=foo -o yaml`)
+	# Print the result (in yaml format) of updating rolebinding subjects from a local, without hitting the server.
+	$ kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | kubectl set subject --local -f - --user=foo -o yaml`)
 )
 
 type updateSubjects func(existings []rbac.Subject, targets []rbac.Subject) (bool, []rbac.Subject)

--- a/pkg/kubectl/cmd/stop.go
+++ b/pkg/kubectl/cmd/stop.go
@@ -39,16 +39,16 @@ var (
 
 	stopExample = templates.Examples(i18n.T(`
 		# Shut down foo.
-		kubectl stop replicationcontroller foo
+		$ kubectl stop replicationcontroller foo
 
 		# Stop pods and services with label name=myLabel.
-		kubectl stop pods,services -l name=myLabel
+		$ kubectl stop pods,services -l name=myLabel
 
-		# Shut down the service defined in service.json
-		kubectl stop -f service.json
+		# Shut down the service defined in service.json.
+		$ kubectl stop -f service.json
 
-		# Shut down all resources in the path/to/resources directory
-		kubectl stop -f path/to/resources`))
+		# Shut down all resources in the path/to/resources directory.
+		$ kubectl stop -f path/to/resources`))
 )
 
 func NewCmdStop(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -65,16 +65,16 @@ var (
 	taintExample = templates.Examples(i18n.T(`
 		# Update node 'foo' with a taint with key 'dedicated' and value 'special-user' and effect 'NoSchedule'.
 		# If a taint with that key and effect already exists, its value is replaced as specified.
-		kubectl taint nodes foo dedicated=special-user:NoSchedule
+		$ kubectl taint nodes foo dedicated=special-user:NoSchedule
 
 		# Remove from node 'foo' the taint with key 'dedicated' and effect 'NoSchedule' if one exists.
-		kubectl taint nodes foo dedicated:NoSchedule-
+		$ kubectl taint nodes foo dedicated:NoSchedule-
 
-		# Remove from node 'foo' all the taints with key 'dedicated'
-		kubectl taint nodes foo dedicated-
+		# Remove from node 'foo' all the taints with key 'dedicated'.
+		$ kubectl taint nodes foo dedicated-
 
-		# Add a taint with key 'dedicated' on nodes having label mylabel=X
-		kubectl taint node -l myLabel=X  dedicated=foo:PreferNoSchedule`))
+		# Add a taint with key 'dedicated' on nodes having label mylabel=X.
+		$ kubectl taint node -l myLabel=X  dedicated=foo:PreferNoSchedule`))
 )
 
 func NewCmdTaint(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -63,11 +63,11 @@ var (
 		The top-node command allows you to see the resource consumption of nodes.`))
 
 	topNodeExample = templates.Examples(i18n.T(`
-		  # Show metrics for all nodes
-		  kubectl top node
+		  # Show metrics for all nodes.
+		  $ kubectl top node
 
-		  # Show metrics for a given node
-		  kubectl top node NODE_NAME`))
+		  # Show metrics for a given node.
+		  $ kubectl top node NODE_NAME`))
 )
 
 func NewCmdTopNode(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -59,17 +59,17 @@ var (
 		since pod creation.`))
 
 	topPodExample = templates.Examples(i18n.T(`
-		# Show metrics for all pods in the default namespace
-		kubectl top pod
+		# Show metrics for all pods in the default namespace.
+		$ kubectl top pod
 
-		# Show metrics for all pods in the given namespace
-		kubectl top pod --namespace=NAMESPACE
+		# Show metrics for all pods in the given namespace.
+		$ kubectl top pod --namespace=NAMESPACE
 
-		# Show metrics for a given pod and its containers
-		kubectl top pod POD_NAME --containers
+		# Show metrics for a given pod and its containers.
+		$ kubectl top pod POD_NAME --containers
 
-		# Show metrics for the pods defined by label name=myLabel
-		kubectl top pod -l name=myLabel`))
+		# Show metrics for the pods defined by label name=myLabel.
+		$ kubectl top pod -l name=myLabel`))
 )
 
 func NewCmdTopPod(f cmdutil.Factory, out io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/util/sanity/cmd_sanity_test.go
+++ b/pkg/kubectl/cmd/util/sanity/cmd_sanity_test.go
@@ -1,0 +1,19 @@
+package sanity
+
+import "testing"
+
+func Test(t *testing.T) {
+	var tests = []struct {
+		s    string
+		want bool
+	}{
+		{"# Correct", true},
+		{"# incorrect", false},
+		{"", false}, // test defensive programming
+	}
+	for _, test := range tests {
+		if got := thirdCharacterIsCapital(test.s); got != test.want {
+			t.Errorf("thirdCharacterIsCapital(%s) = %q", got)
+		}
+	}
+}

--- a/pkg/kubectl/cmd/version.go
+++ b/pkg/kubectl/cmd/version.go
@@ -47,8 +47,8 @@ type VersionOptions struct {
 
 var (
 	versionExample = templates.Examples(i18n.T(`
-		# Print the client and server versions for the current context
-		kubectl version`))
+		# Print the client and server versions for the current context.
+		$ kubectl version`))
 )
 
 func NewCmdVersion(f cmdutil.Factory, out io.Writer) *cobra.Command {


### PR DESCRIPTION
**What this PR does / why we need it**:

PR [885](https://github.com/kubernetes/community/pull/885) merged recently updating the conventions for cli Examples (arguments to `templates.Examples()`). This PR updates `cmd_sanity.go` so that the new conventions are verified when running `hack/verify-cli-conventions.sh`. This PR also fixes up all the warnings thrown by the additional verification.

**Special notes for your reviewer**:

Idea for this PR suggested by @fabianofranz in the comments of  [885](https://github.com/kubernetes/community/pull/885).

Unspecified by the conventions (and as far as I can tell in the k8s project) was when to wrap lines. The choice was made to wrap lines only after the end of a sentence (this relates to Example comments only).

All Examples should now be reasonably uniform. If it is decided the format needs modification this PR should at least make it easier to do so by script instead of by hand.

**Release note**:
```release-note
Clean up and make uniform all examples in kubectl help command.
```

/sig cli
/kind documentation
/kind cleanup