### PR TITLE
Modify autoscale's printer

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1579,10 +1579,10 @@ func printHorizontalPodAutoscaler(obj *autoscaling.HorizontalPodAutoscaler, opti
 	reference := fmt.Sprintf("%s/%s",
 		obj.Spec.ScaleTargetRef.Kind,
 		obj.Spec.ScaleTargetRef.Name)
-	minPods := "<unset>"
+	minPods := int32(1)
 	metrics := formatHPAMetrics(obj.Spec.Metrics, obj.Status.CurrentMetrics)
 	if obj.Spec.MinReplicas != nil {
-		minPods = fmt.Sprintf("%d", *obj.Spec.MinReplicas)
+		minPods = *obj.Spec.MinReplicas
 	}
 	maxPods := obj.Spec.MaxReplicas
 	currentReplicas := obj.Status.CurrentReplicas

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -2047,7 +2047,7 @@ func TestPrintHPA(t *testing.T) {
 					DesiredReplicas: 5,
 				},
 			},
-			"some-hpa\tReplicationController/some-rc\t<none>\t<unset>\t10\t4\t<unknown>\n",
+			"some-hpa\tReplicationController/some-rc\t<none>\t1\t10\t4\t<unknown>\n",
 		},
 		// pods source type (no current)
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/autoscaling/types.go#L80
If we don's set MinReplicas, its default value is 1.
Not \<unset\>
![image](https://user-images.githubusercontent.com/5154334/29112514-ade33e9a-7d20-11e7-8da3-bc77957bf982.png)

So I think replace <unset> with 1 is preferred.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
