### PR TITLE
replace sync.Mutex with atomic pkg to realize integer arithmetic exclusive

### DIFF
--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	batch "k8s.io/api/batch/v1"
@@ -550,7 +551,6 @@ func getStatus(pods []*v1.Pod) (succeeded, failed int32) {
 // pods according to what is specified in the job.Spec.
 // Does NOT modify <activePods>.
 func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *batch.Job) (int32, error) {
-	var activeLock sync.Mutex
 	active := int32(len(activePods))
 	parallelism := *job.Spec.Parallelism
 	jobKey, err := controller.KeyFunc(job)
@@ -581,15 +581,12 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 					// Decrement the expected number of deletes because the informer won't observe this deletion
 					glog.V(2).Infof("Failed to delete %v, decrementing expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
 					jm.expectations.DeletionObserved(jobKey)
-					activeLock.Lock()
-					active++
-					activeLock.Unlock()
+					atomic.AddInt32(&active, 1)
 					errCh <- err
 				}
 			}(i)
 		}
 		wait.Wait()
-
 	} else if active < parallelism {
 		wantActive := int32(0)
 		if job.Spec.Completions == nil {
@@ -640,9 +637,7 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 					// Decrement the expected number of creates because the informer won't observe this pod
 					glog.V(2).Infof("Failed creation, decrementing expectations for job %q/%q", job.Namespace, job.Name)
 					jm.expectations.CreationObserved(jobKey)
-					activeLock.Lock()
-					active--
-					activeLock.Unlock()
+					atomic.AddInt32(&active, -1)
 					errCh <- err
 				}
 			}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
optimize job_controller.go mutual exclusive integer arithmetic
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
atomic low-level atomic memory primitives useful for implementing synchronization algorithms. It is more efficient than higher sync.Mutex
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
