### PR TITLE
Reduce hollow-kubelet cpu request

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -60,7 +60,7 @@ spec:
           mountPath: /var/log
         resources:
           requests:
-            cpu: 50m
+            cpu: 40m
             memory: 100M
         securityContext:
           privileged: true


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/50366
This should make kubemark-500 fit in 6 nodes again. Checked that it should be enough.

cc @kubernetes/sig-scalability-misc