### PR TITLE
Bugfix: set resources only for fluentd-gcp container.

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1606,7 +1606,7 @@ function wait-for-apiserver-and-update-fluentd {
   kubectl set resources --dry-run --local -f ${fluentd_gcp_yaml} \
     --limits=memory=${FLUENTD_GCP_MEMORY_LIMIT} \
     --requests=cpu=${FLUENTD_GCP_CPU_REQUEST},memory=${FLUENTD_GCP_MEMORY_REQUEST} \
-    -o yaml > ${fluentd_gcp_yaml}.tmp
+    --containers=fluentd-gcp -o yaml > ${fluentd_gcp_yaml}.tmp
   mv ${fluentd_gcp_yaml}.tmp ${fluentd_gcp_yaml}
 }
 


### PR DESCRIPTION
There is more than one container in fluentd-gcp deployment. Previous
implementation was setting resources for all containers, not just
the fluent-gcp one.

**What this PR does / why we need it**:

Bugfix; https://github.com/kubernetes/kubernetes/pull/49009 without this is eating more resources.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50366

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
