### PR TITLE
Adding --fail-swap-on=false to hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -30,7 +30,7 @@ RUNTIME_CONFIG=${RUNTIME_CONFIG:-""}
 KUBELET_AUTHORIZATION_WEBHOOK=${KUBELET_AUTHORIZATION_WEBHOOK:-""}
 KUBELET_AUTHENTICATION_WEBHOOK=${KUBELET_AUTHENTICATION_WEBHOOK:-""}
 POD_MANIFEST_PATH=${POD_MANIFEST_PATH:-"/var/run/kubernetes/static-pods"}
-KUBELET_FLAGS=${KUBELET_FLAGS:-""}
+KUBELET_FLAGS=${KUBELET_FLAGS:-"--fail-swap-on=false"}
 # Name of the network plugin, eg: "kubenet"
 NET_PLUGIN=${NET_PLUGIN:-""}
 # Place the config files and binaries required by NET_PLUGIN in these directory,


### PR DESCRIPTION
After issue #47181 got merged kubelet started failing when
started by local-up-cluster.sh Adding this flag to allow kubelet to
start properly.