### PR TITLE
Bugfix: Use local JSON log buffer in parseDockerJSONLog.

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -280,16 +280,14 @@ func parseCRILog(log []byte, msg *logMessage) error {
 	return nil
 }
 
-// dockerJSONLog is the JSON log buffer used in parseDockerJSONLog.
-var dockerJSONLog = &jsonlog.JSONLog{}
-
 // parseDockerJSONLog parses logs in Docker JSON log format. Docker JSON log format
 // example:
 //   {"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
 //   {"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
 func parseDockerJSONLog(log []byte, msg *logMessage) error {
-	dockerJSONLog.Reset()
-	l := dockerJSONLog
+	var l = &jsonlog.JSONLog{}
+	l.Reset()
+
 	// TODO: JSON decoding is fairly expensive, we should evaluate this.
 	if err := json.Unmarshal(log, l); err != nil {
 		return fmt.Errorf("failed with %v to unmarshal log %q", err, l)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The issue described in #47800 is due to a race condition in `ReadLogs`: Because the JSON log buffer (`dockerJSONLog`) is package-scoped, any two goroutines modifying the buffer could race and overwrite the other's changes. In particular, one goroutine could unmarshal a JSON log line into the buffer, then another goroutine could `Reset()` the buffer, and the resulting `Stream` would be empty (`""`). This empty `Stream` is caught in a `case` block and raises an `unexpected stream type` error.

This PR creates a new buffer for each execution of `parseDockerJSONLog`, so each goroutine is guaranteed to have a local instance of the buffer.

**Which issue this PR fixes**: fixes #47800

**Release note**:
```release-note
Fixed an issue (#47800) where `kubectl logs -f` failed with `unexpected stream type ""`.
```
