### PR TITLE
Add explicit API kind and version to the audit policy file on GCE

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -524,6 +524,8 @@ function create-master-audit-policy {
       - group: "storage.k8s.io"'
 
   cat <<EOF >"${path}"
+apiVersion: audit.k8s.io/v1alpha1
+kind: Policy
 rules:
   # The following requests were manually identified as high-volume and low-risk,
   # so drop them.


### PR DESCRIPTION
Adds an explicit API version and kind to the audit policy file in GCE configuration scripts. It's a prerequisite for https://github.com/kubernetes/kubernetes/pull/49115

/cc @tallclair @piosz 