### PR TITLE
expose printers.AddHandler through clientcmd Factory

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -382,7 +382,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	}
 
 	cmds.AddCommand(alpha)
-	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out, err))
+	cmds.AddCommand(cmdconfig.NewCmdConfig(f, clientcmd.NewDefaultPathOptions(), out, err))
 	cmds.AddCommand(NewCmdPlugin(f, in, out, err))
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))

--- a/pkg/kubectl/cmd/cmd_test.go
+++ b/pkg/kubectl/cmd/cmd_test.go
@@ -41,7 +41,6 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/printers"
-	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	"k8s.io/kubernetes/pkg/util/strings"
 )
 
@@ -159,7 +158,7 @@ func Example_printReplicationControllerWithNamespace() {
 		WithNamespace: true,
 		ColumnLabels:  []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -212,7 +211,7 @@ func Example_printMultiContainersReplicationControllerWithWide() {
 		Wide:         true,
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -266,7 +265,7 @@ func Example_printReplicationController() {
 	p := printers.NewHumanReadablePrinter(nil, nil, printers.PrintOptions{
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -321,7 +320,7 @@ func Example_printPodWithWideFormat() {
 		Wide:         true,
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -364,7 +363,7 @@ func Example_printPodWithShowLabels() {
 		ShowLabels:   true,
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -501,7 +500,7 @@ func Example_printPodHideTerminated() {
 	p := printers.NewHumanReadablePrinter(nil, nil, printers.PrintOptions{
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -537,7 +536,7 @@ func Example_printPodShowAll() {
 		ShowAll:      true,
 		ColumnLabels: []string{},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,
@@ -566,7 +565,7 @@ func Example_printServiceWithNamespacesAndLabels() {
 		WithNamespace: true,
 		ColumnLabels:  []string{"l1"},
 	})
-	printersinternal.AddHandlers(p)
+	f.AddDefaultHandlers(p)
 	tf.Printer = p
 	tf.Client = &fake.RESTClient{
 		APIRegistry:          api.Registry,

--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -30,7 +30,7 @@ import (
 )
 
 // NewCmdConfig creates a command object for the "config" action, and adds all child commands to it.
-func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
+func NewCmdConfig(f cmdutil.Factory, pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
@@ -52,7 +52,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *co
 	// file paths are common to all sub commands
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
-	cmd.AddCommand(NewCmdConfigView(out, errOut, pathOptions))
+	cmd.AddCommand(NewCmdConfigView(f, out, errOut, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetAuthInfo(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetContext(out, pathOptions))

--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -865,7 +865,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf, buf)
+	cmd := NewCmdConfig(cmdutil.NewFactory(nil), clientcmd.NewDefaultPathOptions(), buf, buf)
 	cmd.SetArgs(argsToUse)
 	cmd.Execute()
 

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -57,7 +57,7 @@ var (
 		kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'`)
 )
 
-func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigView(f cmdutil.Factory, out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &ViewOptions{ConfigAccess: ConfigAccess}
 	// Default to yaml
 	defaultOutputFormat := "yaml"
@@ -81,7 +81,7 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 				cmd.Flags().Set("output", defaultOutputFormat)
 			}
 
-			printer, err := cmdutil.PrinterForCommand(cmd, nil, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, nil, []runtime.Decoder{latest.Codec}, printers.PrintOptions{})
+			printer, err := cmdutil.PrinterForCommand(f, cmd, nil, meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, nil, []runtime.Decoder{latest.Codec}, printers.PrintOptions{})
 			cmdutil.CheckErr(err)
 			printer = printers.NewVersionedPrinter(printer, latest.Scheme, latest.ExternalVersion)
 
@@ -93,8 +93,8 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 	cmd.Flags().Set("output", defaultOutputFormat)
 
 	options.Merge.Default(true)
-	f := cmd.Flags().VarPF(&options.Merge, "merge", "", "merge the full hierarchy of kubeconfig files")
-	f.NoOptDefVal = "true"
+	mergeFlags := cmd.Flags().VarPF(&options.Merge, "merge", "", "merge the full hierarchy of kubeconfig files")
+	mergeFlags.NoOptDefVal = "true"
 	cmd.Flags().BoolVar(&options.RawByteData, "raw", false, "display raw byte data")
 	cmd.Flags().BoolVar(&options.Flatten, "flatten", false, "flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)")
 	cmd.Flags().BoolVar(&options.Minify, "minify", false, "remove all information not used by current-context from the output")

--- a/pkg/kubectl/cmd/config/view_test.go
+++ b/pkg/kubectl/cmd/config/view_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 type viewClusterTest struct {
@@ -142,7 +143,7 @@ func (test viewClusterTest) run(t *testing.T) {
 	pathOptions.EnvVar = ""
 	buf := bytes.NewBuffer([]byte{})
 	errBuf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigView(buf, errBuf, pathOptions)
+	cmd := NewCmdConfigView(cmdutil.NewFactory(nil), buf, errBuf, pathOptions)
 	cmd.Flags().Parse(test.flags)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v,kubectl config view flags: %v", err, test.flags)

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/plugins"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/printers"
+	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 )
 
 // +k8s:deepcopy-gen=true
@@ -352,6 +353,27 @@ func (f *FakeFactory) Describer(*meta.RESTMapping) (printers.Describer, error) {
 
 func (f *FakeFactory) PrinterForCommand(cmd *cobra.Command, isLocal bool, outputOpts *printers.OutputOptions, options printers.PrintOptions) (printers.ResourcePrinter, error) {
 	return f.tf.Printer, f.tf.Err
+}
+
+func (f *FakeFactory) AddDefaultHandlers(p printers.PrintHandler) error {
+	handlers, err := printersinternal.DefaultHandlers()
+	if err != nil {
+		return err
+	}
+
+	for _, h := range handlers {
+		f.AddTableHandler(p, h)
+	}
+
+	return nil
+}
+
+func (f *FakeFactory) AddTableHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error {
+	return p.TableHandlerFromEntry(handlerEntry)
+}
+
+func (f *FakeFactory) AddHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error {
+	return p.HandlerFromEntry(handlerEntry)
 }
 
 func (f *FakeFactory) Printer(mapping *meta.RESTMapping, options printers.PrintOptions) (printers.ResourcePrinter, error) {
@@ -723,6 +745,27 @@ func (f *fakeAPIFactory) PrintObject(cmd *cobra.Command, isLocal bool, mapper me
 		return err
 	}
 	return printer.PrintObj(obj, out)
+}
+
+func (f *fakeAPIFactory) AddDefaultHandlers(p printers.PrintHandler) error {
+	handlers, err := printersinternal.DefaultHandlers()
+	if err != nil {
+		return err
+	}
+
+	for _, h := range handlers {
+		f.AddTableHandler(p, h)
+	}
+
+	return nil
+}
+
+func (f *fakeAPIFactory) AddTableHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error {
+	return p.TableHandlerFromEntry(handlerEntry)
+}
+
+func (f *fakeAPIFactory) AddHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error {
+	return p.HandlerFromEntry(handlerEntry)
 }
 
 func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, outputOpts *printers.OutputOptions, mapping *meta.RESTMapping, withNamespace bool) (printers.ResourcePrinter, error) {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -149,6 +149,16 @@ type ClientAccessFactory interface {
 	// SuggestedPodTemplateResources returns a list of resource types that declare a pod template
 	SuggestedPodTemplateResources() []schema.GroupResource
 
+	// AddDefaultHandlers receives a printers.PrintHandler
+	// and registers default printer handlers
+	AddDefaultHandlers(p printers.PrintHandler) error
+	// AddTableHandler receives a printers.PrintHandler, a list of metav1alpha1.TableColumnDefinitions
+	// and a resource print handler function and registers the print handler fn with the given printer.
+	AddTableHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error
+	// AddHandler receives a printers.PrintHandler, a list of columns, and a print function and
+	// registers the print function with the given printer.
+	AddHandler(p printers.PrintHandler, handlerEntry *printers.HandlerEntry) error
+
 	// Returns a Printer for formatting objects of the given type or an error.
 	Printer(mapping *meta.RESTMapping, options printers.PrintOptions) (printers.ResourcePrinter, error)
 	// Pauser marks the object in the info as paused. Currently supported only for Deployments.

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -65,7 +65,7 @@ func (f *ring2Factory) PrinterForCommand(cmd *cobra.Command, isLocal bool, outpu
 	// TODO: used by the custom column implementation and the name implementation, break this dependency
 	decoders := []runtime.Decoder{f.clientAccessFactory.Decoder(true), unstructured.UnstructuredJSONScheme}
 	encoder := f.clientAccessFactory.JSONEncoder()
-	return PrinterForCommand(cmd, outputOpts, mapper, typer, encoder, decoders, options)
+	return PrinterForCommand(f.clientAccessFactory, cmd, outputOpts, mapper, typer, encoder, decoders, options)
 }
 
 func (f *ring2Factory) PrinterForMapping(cmd *cobra.Command, isLocal bool, outputOpts *printers.OutputOptions, mapping *meta.RESTMapping, withNamespace bool) (printers.ResourcePrinter, error) {

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/printers"
-	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 
 	"github.com/spf13/cobra"
 )
@@ -110,7 +109,7 @@ func ValidateOutputArgs(cmd *cobra.Command) error {
 // returns the default printer for the command. Requires that printer flags have
 // been added to cmd (see AddPrinterFlags).
 // TODO: remove the dependency on cmd object
-func PrinterForCommand(cmd *cobra.Command, outputOpts *printers.OutputOptions, mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options printers.PrintOptions) (printers.ResourcePrinter, error) {
+func PrinterForCommand(f ClientAccessFactory, cmd *cobra.Command, outputOpts *printers.OutputOptions, mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options printers.PrintOptions) (printers.ResourcePrinter, error) {
 
 	if outputOpts == nil {
 		outputOpts = extractOutputOptions(cmd)
@@ -131,7 +130,7 @@ func PrinterForCommand(cmd *cobra.Command, outputOpts *printers.OutputOptions, m
 	// we execute AddHandlers() here before maybeWrapSortingPrinter so that we don't
 	// need to convert to delegatePrinter again then invoke AddHandlers()
 	if humanReadablePrinter, ok := printer.(*printers.HumanReadablePrinter); ok {
-		printersinternal.AddHandlers(humanReadablePrinter)
+		f.AddDefaultHandlers(humanReadablePrinter)
 	}
 
 	return maybeWrapSortingPrinter(cmd, printer), nil

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -62,9 +62,10 @@ import (
 
 const loadBalancerWidth = 16
 
-// AddHandlers adds print handlers for default Kubernetes types dealing with internal versions.
-// TODO: handle errors from Handler
-func AddHandlers(h printers.PrintHandler) {
+// DefaultHandlers returns a slice of *printers.HandlerEntry containing podColumnDefinitions and a printFunc.
+func DefaultHandlers() ([]*printers.HandlerEntry, error) {
+	handlers := []*printers.HandlerEntry{}
+
 	podColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Ready", Type: "string", Description: "The aggregate readiness state of this pod for accepting traffic."},
@@ -74,8 +75,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "IP", Type: "string", Priority: 1, Description: apiv1.PodStatus{}.SwaggerDoc()["podIP"]},
 		{Name: "Node", Type: "string", Priority: 1, Description: apiv1.PodSpec{}.SwaggerDoc()["nodeName"]},
 	}
-	h.TableHandler(podColumnDefinitions, printPodList)
-	h.TableHandler(podColumnDefinitions, printPod)
+	entry, err := printers.NewHandlerEntry(podColumnDefinitions, printPodList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(podColumnDefinitions, printPod)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	podTemplateColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -83,8 +93,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Description: "Images referenced by each container in the template."},
 		{Name: "Pod Labels", Type: "string", Description: "The labels for the pod template."},
 	}
-	h.TableHandler(podTemplateColumnDefinitions, printPodTemplate)
-	h.TableHandler(podTemplateColumnDefinitions, printPodTemplateList)
+	entry, err = printers.NewHandlerEntry(podTemplateColumnDefinitions, printPodTemplate)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(podTemplateColumnDefinitions, printPodTemplateList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	podDisruptionBudgetColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -93,8 +112,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Allowed Disruptions", Type: "integer", Description: "Calculated number of pods that may be disrupted at this time."},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(podDisruptionBudgetColumnDefinitions, printPodDisruptionBudget)
-	h.TableHandler(podDisruptionBudgetColumnDefinitions, printPodDisruptionBudgetList)
+	entry, err = printers.NewHandlerEntry(podDisruptionBudgetColumnDefinitions, printPodDisruptionBudget)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(podDisruptionBudgetColumnDefinitions, printPodDisruptionBudgetList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	replicationControllerColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -106,8 +134,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: apiv1.ReplicationControllerSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(replicationControllerColumnDefinitions, printReplicationController)
-	h.TableHandler(replicationControllerColumnDefinitions, printReplicationControllerList)
+	entry, err = printers.NewHandlerEntry(replicationControllerColumnDefinitions, printReplicationController)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(replicationControllerColumnDefinitions, printReplicationControllerList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	replicaSetColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -119,8 +156,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: extensionsv1beta1.ReplicaSetSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(replicaSetColumnDefinitions, printReplicaSet)
-	h.TableHandler(replicaSetColumnDefinitions, printReplicaSetList)
+	entry, err = printers.NewHandlerEntry(replicaSetColumnDefinitions, printReplicaSet)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(replicaSetColumnDefinitions, printReplicaSetList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	daemonSetColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -135,8 +181,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: extensionsv1beta1.DaemonSetSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(daemonSetColumnDefinitions, printDaemonSet)
-	h.TableHandler(daemonSetColumnDefinitions, printDaemonSetList)
+	entry, err = printers.NewHandlerEntry(daemonSetColumnDefinitions, printDaemonSet)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(daemonSetColumnDefinitions, printDaemonSetList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	jobColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -147,8 +202,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: batchv1.JobSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(jobColumnDefinitions, printJob)
-	h.TableHandler(jobColumnDefinitions, printJobList)
+	entry, err = printers.NewHandlerEntry(jobColumnDefinitions, printJob)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(jobColumnDefinitions, printJobList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	cronJobColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -161,8 +225,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: batchv1.JobSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(cronJobColumnDefinitions, printCronJob)
-	h.TableHandler(cronJobColumnDefinitions, printCronJobList)
+	entry, err = printers.NewHandlerEntry(cronJobColumnDefinitions, printCronJob)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(cronJobColumnDefinitions, printCronJobList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	serviceColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -173,9 +246,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 		{Name: "Selector", Type: "string", Priority: 1, Description: apiv1.ServiceSpec{}.SwaggerDoc()["selector"]},
 	}
+	entry, err = printers.NewHandlerEntry(serviceColumnDefinitions, printService)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
-	h.TableHandler(serviceColumnDefinitions, printService)
-	h.TableHandler(serviceColumnDefinitions, printServiceList)
+	entry, err = printers.NewHandlerEntry(serviceColumnDefinitions, printServiceList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	ingressColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -184,8 +265,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Ports", Type: "string", Description: "Ports of TLS configurations that open"},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(ingressColumnDefinitions, printIngress)
-	h.TableHandler(ingressColumnDefinitions, printIngressList)
+	entry, err = printers.NewHandlerEntry(ingressColumnDefinitions, printIngress)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(ingressColumnDefinitions, printIngressList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	statefulSetColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -195,16 +285,34 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Containers", Type: "string", Priority: 1, Description: "Names of each container in the template."},
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 	}
-	h.TableHandler(statefulSetColumnDefinitions, printStatefulSet)
-	h.TableHandler(statefulSetColumnDefinitions, printStatefulSetList)
+	entry, err = printers.NewHandlerEntry(statefulSetColumnDefinitions, printStatefulSet)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(statefulSetColumnDefinitions, printStatefulSetList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	endpointColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Endpoints", Type: "string", Description: apiv1.Endpoints{}.SwaggerDoc()["subsets"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(endpointColumnDefinitions, printEndpoints)
-	h.TableHandler(endpointColumnDefinitions, printEndpointsList)
+	entry, err = printers.NewHandlerEntry(endpointColumnDefinitions, printEndpoints)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(endpointColumnDefinitions, printEndpointsList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	nodeColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -216,9 +324,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Kernel-Version", Type: "string", Priority: 1, Description: apiv1.NodeSystemInfo{}.SwaggerDoc()["kernelVersion"]},
 		{Name: "Container-Runtime", Type: "string", Priority: 1, Description: apiv1.NodeSystemInfo{}.SwaggerDoc()["containerRuntimeVersion"]},
 	}
+	entry, err = printers.NewHandlerEntry(nodeColumnDefinitions, printNode)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
-	h.TableHandler(nodeColumnDefinitions, printNode)
-	h.TableHandler(nodeColumnDefinitions, printNodeList)
+	entry, err = printers.NewHandlerEntry(nodeColumnDefinitions, printNodeList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	eventColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Last Seen", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["lastTimestamp"]},
@@ -232,16 +348,34 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Source", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["source"]},
 		{Name: "Message", Type: "string", Description: apiv1.Event{}.SwaggerDoc()["message"]},
 	}
-	h.TableHandler(eventColumnDefinitions, printEvent)
-	h.TableHandler(eventColumnDefinitions, printEventList)
+	entry, err = printers.NewHandlerEntry(eventColumnDefinitions, printEvent)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(eventColumnDefinitions, printEventList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	namespaceColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Status", Type: "string", Description: "The status of the namespace"},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(namespaceColumnDefinitions, printNamespace)
-	h.TableHandler(namespaceColumnDefinitions, printNamespaceList)
+	entry, err = printers.NewHandlerEntry(namespaceColumnDefinitions, printNamespace)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(namespaceColumnDefinitions, printNamespaceList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	secretColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -249,16 +383,34 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Data", Type: "string", Description: apiv1.Secret{}.SwaggerDoc()["data"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(secretColumnDefinitions, printSecret)
-	h.TableHandler(secretColumnDefinitions, printSecretList)
+	entry, err = printers.NewHandlerEntry(secretColumnDefinitions, printSecret)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(secretColumnDefinitions, printSecretList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	serviceAccountColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Secrets", Type: "string", Description: apiv1.ServiceAccount{}.SwaggerDoc()["secrets"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(serviceAccountColumnDefinitions, printServiceAccount)
-	h.TableHandler(serviceAccountColumnDefinitions, printServiceAccountList)
+	entry, err = printers.NewHandlerEntry(serviceAccountColumnDefinitions, printServiceAccount)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(serviceAccountColumnDefinitions, printServiceAccountList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	persistentVolumeColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -271,8 +423,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Reason", Type: "string", Description: apiv1.PersistentVolumeStatus{}.SwaggerDoc()["reason"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(persistentVolumeColumnDefinitions, printPersistentVolume)
-	h.TableHandler(persistentVolumeColumnDefinitions, printPersistentVolumeList)
+	entry, err = printers.NewHandlerEntry(persistentVolumeColumnDefinitions, printPersistentVolume)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(persistentVolumeColumnDefinitions, printPersistentVolumeList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	persistentVolumeClaimColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -282,8 +443,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "StorageClass", Type: "string", Description: "StorageClass of the pvc"},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(persistentVolumeClaimColumnDefinitions, printPersistentVolumeClaim)
-	h.TableHandler(persistentVolumeClaimColumnDefinitions, printPersistentVolumeClaimList)
+	entry, err = printers.NewHandlerEntry(persistentVolumeClaimColumnDefinitions, printPersistentVolumeClaim)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(persistentVolumeClaimColumnDefinitions, printPersistentVolumeClaimList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	componentStatusColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -291,17 +461,34 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Message", Type: "string", Description: "Message of the component conditions"},
 		{Name: "Error", Type: "string", Description: "Error of the component conditions"},
 	}
-	h.TableHandler(componentStatusColumnDefinitions, printComponentStatus)
-	h.TableHandler(componentStatusColumnDefinitions, printComponentStatusList)
+	entry, err = printers.NewHandlerEntry(componentStatusColumnDefinitions, printComponentStatus)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(componentStatusColumnDefinitions, printComponentStatusList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	thirdPartyResourceColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Description", Type: "string", Description: extensionsv1beta1.ThirdPartyResource{}.SwaggerDoc()["description"]},
 		{Name: "Version(s)", Type: "string", Description: extensionsv1beta1.ThirdPartyResource{}.SwaggerDoc()["versions"]},
 	}
+	entry, err = printers.NewHandlerEntry(thirdPartyResourceColumnDefinitions, printThirdPartyResource)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
-	h.TableHandler(thirdPartyResourceColumnDefinitions, printThirdPartyResource)
-	h.TableHandler(thirdPartyResourceColumnDefinitions, printThirdPartyResourceList)
+	entry, err = printers.NewHandlerEntry(thirdPartyResourceColumnDefinitions, printThirdPartyResourceList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	deploymentColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -314,8 +501,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
 		{Name: "Selector", Type: "string", Priority: 1, Description: extensionsv1beta1.DeploymentSpec{}.SwaggerDoc()["selector"]},
 	}
-	h.TableHandler(deploymentColumnDefinitions, printDeployment)
-	h.TableHandler(deploymentColumnDefinitions, printDeploymentList)
+	entry, err = printers.NewHandlerEntry(deploymentColumnDefinitions, printDeployment)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(deploymentColumnDefinitions, printDeploymentList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	horizontalPodAutoscalerColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -326,16 +522,34 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Replicas", Type: "string", Description: autoscalingv2alpha1.HorizontalPodAutoscalerStatus{}.SwaggerDoc()["currentReplicas"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(horizontalPodAutoscalerColumnDefinitions, printHorizontalPodAutoscaler)
-	h.TableHandler(horizontalPodAutoscalerColumnDefinitions, printHorizontalPodAutoscalerList)
+	entry, err = printers.NewHandlerEntry(horizontalPodAutoscalerColumnDefinitions, printHorizontalPodAutoscaler)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(horizontalPodAutoscalerColumnDefinitions, printHorizontalPodAutoscalerList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	configMapColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Data", Type: "string", Description: apiv1.ConfigMap{}.SwaggerDoc()["data"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(configMapColumnDefinitions, printConfigMap)
-	h.TableHandler(configMapColumnDefinitions, printConfigMapList)
+	entry, err = printers.NewHandlerEntry(configMapColumnDefinitions, printConfigMap)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(configMapColumnDefinitions, printConfigMapList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	podSecurityPolicyColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -348,26 +562,63 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "ReadOnlyRootFs", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["readOnlyRootFilesystem"]},
 		{Name: "Volumes", Type: "string", Description: extensionsv1beta1.PodSecurityPolicySpec{}.SwaggerDoc()["volumes"]},
 	}
-	h.TableHandler(podSecurityPolicyColumnDefinitions, printPodSecurityPolicy)
-	h.TableHandler(podSecurityPolicyColumnDefinitions, printPodSecurityPolicyList)
+	entry, err = printers.NewHandlerEntry(podSecurityPolicyColumnDefinitions, printPodSecurityPolicy)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(podSecurityPolicyColumnDefinitions, printPodSecurityPolicyList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	clusterColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Status", Type: "string", Description: "Status of the cluster"},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(clusterColumnDefinitions, printCluster)
-	h.TableHandler(clusterColumnDefinitions, printClusterList)
+	entry, err = printers.NewHandlerEntry(clusterColumnDefinitions, printCluster)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(clusterColumnDefinitions, printClusterList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	networkPolicyColumnDefinitioins := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Pod-Selector", Type: "string", Description: extensionsv1beta1.NetworkPolicySpec{}.SwaggerDoc()["podSelector"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(networkPolicyColumnDefinitioins, printExtensionsNetworkPolicy)
-	h.TableHandler(networkPolicyColumnDefinitioins, printExtensionsNetworkPolicyList)
-	h.TableHandler(networkPolicyColumnDefinitioins, printNetworkPolicy)
-	h.TableHandler(networkPolicyColumnDefinitioins, printNetworkPolicyList)
+	entry, err = printers.NewHandlerEntry(networkPolicyColumnDefinitioins, printExtensionsNetworkPolicy)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(networkPolicyColumnDefinitioins, printExtensionsNetworkPolicyList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(networkPolicyColumnDefinitioins, printNetworkPolicy)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(networkPolicyColumnDefinitioins, printNetworkPolicyList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	roleBindingsColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -377,8 +628,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Groups", Type: "string", Priority: 1, Description: "Gruops in the roleBinding"},
 		{Name: "ServiceAccounts", Type: "string", Priority: 1, Description: "ServiceAccounts in the roleBinding"},
 	}
-	h.TableHandler(roleBindingsColumnDefinitions, printRoleBinding)
-	h.TableHandler(roleBindingsColumnDefinitions, printRoleBindingList)
+	entry, err = printers.NewHandlerEntry(roleBindingsColumnDefinitions, printRoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(roleBindingsColumnDefinitions, printRoleBindingList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	clusterRoleBindingsColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -388,8 +648,17 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Groups", Type: "string", Priority: 1, Description: "Gruops in the roleBinding"},
 		{Name: "ServiceAccounts", Type: "string", Priority: 1, Description: "ServiceAccounts in the roleBinding"},
 	}
-	h.TableHandler(clusterRoleBindingsColumnDefinitions, printClusterRoleBinding)
-	h.TableHandler(clusterRoleBindingsColumnDefinitions, printClusterRoleBindingList)
+	entry, err = printers.NewHandlerEntry(clusterRoleBindingsColumnDefinitions, printClusterRoleBinding)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(clusterRoleBindingsColumnDefinitions, printClusterRoleBindingList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	certificateSigningRequestColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -397,24 +666,44 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Requestor", Type: "string", Description: certificatesv1beta1.CertificateSigningRequestSpec{}.SwaggerDoc()["request"]},
 		{Name: "Condition", Type: "string", Description: certificatesv1beta1.CertificateSigningRequestStatus{}.SwaggerDoc()["conditions"]},
 	}
-	h.TableHandler(certificateSigningRequestColumnDefinitions, printCertificateSigningRequest)
-	h.TableHandler(certificateSigningRequestColumnDefinitions, printCertificateSigningRequestList)
+	entry, err = printers.NewHandlerEntry(certificateSigningRequestColumnDefinitions, printCertificateSigningRequest)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	entry, err = printers.NewHandlerEntry(certificateSigningRequestColumnDefinitions, printCertificateSigningRequestList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	storageClassColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Provisioner", Type: "string", Description: storagev1.StorageClass{}.SwaggerDoc()["provisioner"]},
 	}
+	entry, err = printers.NewHandlerEntry(storageClassColumnDefinitions, printStorageClass)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
-	h.TableHandler(storageClassColumnDefinitions, printStorageClass)
-	h.TableHandler(storageClassColumnDefinitions, printStorageClassList)
+	entry, err = printers.NewHandlerEntry(storageClassColumnDefinitions, printStorageClassList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	statusColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Status", Type: "string", Description: metav1.Status{}.SwaggerDoc()["status"]},
 		{Name: "Reason", Type: "string", Description: metav1.Status{}.SwaggerDoc()["reason"]},
 		{Name: "Message", Type: "string", Description: metav1.Status{}.SwaggerDoc()["Message"]},
 	}
-
-	h.TableHandler(statusColumnDefinitions, printStatus)
+	entry, err = printers.NewHandlerEntry(statusColumnDefinitions, printStatus)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
 	controllerRevisionColumnDefinition := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
@@ -422,20 +711,37 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Revision", Type: "string", Description: appsv1beta1.ControllerRevision{}.SwaggerDoc()["revision"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.TableHandler(controllerRevisionColumnDefinition, printControllerRevision)
-	h.TableHandler(controllerRevisionColumnDefinition, printControllerRevisionList)
+	entry, err = printers.NewHandlerEntry(controllerRevisionColumnDefinition, printControllerRevision)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
 
-	AddDefaultHandlers(h)
+	entry, err = printers.NewHandlerEntry(controllerRevisionColumnDefinition, printControllerRevisionList)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	return handlers, nil
 }
 
-// AddDefaultHandlers adds handlers that can work with most Kubernetes objects.
-func AddDefaultHandlers(h printers.PrintHandler) {
+// GenericHandlers returns handlers that can work with most Kubernetes objects.
+func GenericHandlers() ([]*printers.HandlerEntry, error) {
+	handlers := []*printers.HandlerEntry{}
+
 	// types without defined columns
 	objectMetaColumnDefinitions := []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 	}
-	h.DefaultTableHandler(objectMetaColumnDefinitions, printObjectMeta)
+	entry, err := printers.NewHandlerEntry(objectMetaColumnDefinitions, printObjectMeta)
+	if err != nil {
+		return nil, err
+	}
+	handlers = append(handlers, entry)
+
+	return handlers, nil
 }
 
 func printObjectMeta(obj runtime.Object, options printers.PrintOptions) ([]metav1alpha1.TableRow, error) {

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -78,7 +78,21 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGet
 		DeleteStrategy:      pod.Strategy,
 		ReturnDeletedObject: true,
 
-		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(printersinternal.AddHandlers)},
+		TableConvertor: printerstorage.TableConvertor{TablePrinter: printers.NewTablePrinter().With(func(printer printers.PrintHandler) {
+			handlers, err := printersinternal.DefaultHandlers()
+			if err == nil {
+				for _, h := range handlers {
+					printer.TableHandlerFromEntry(h)
+				}
+			}
+
+			genericHandlers, err := printersinternal.GenericHandlers()
+			if err == nil {
+				for _, h := range genericHandlers {
+					printer.DefaultTableHandler(h)
+				}
+			}
+		})},
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter, AttrFunc: pod.GetAttrs, TriggerFunc: pod.NodeNameTriggerFunc}
 	if err := store.CompleteWithOptions(options); err != nil {


### PR DESCRIPTION
Proposal: https://github.com/kubernetes/kubernetes/issues/50388
Depends on: https://github.com/kubernetes/kubernetes/pull/50113

Related doc: https://docs.google.com/a/redhat.com/document/d/15uieHE_QnfF9eEj-AAbAvo3xBqfyu5x1v5Cghzy4ZDI/edit?usp=sharing

**Release note**:
```release-note
NONE
```

Exposes [pkg/priners.PrintHandler#Handler](https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/humanreadable.go#L128) and [pkg/priners.PrintHandler#TableHandler](`pkg/priners.PrintHandler#Handler`) through the [cmdutil.Factory](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/util/factory.go)

@fabianofranz @kubernetes/sig-cli