### PR TITLE
[WIP] Create interface nodeEvictor

### DIFF
--- a/pkg/controller/node/BUILD
+++ b/pkg/controller/node/BUILD
@@ -45,6 +45,7 @@ go_library(
         "doc.go",
         "metrics.go",
         "node_controller.go",
+        "node_evictor.go",
     ],
     deps = [
         "//pkg/api/v1/node:go_default_library",

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -200,10 +200,6 @@ type Controller struct {
 	// tainted nodes, if they're not tolerated.
 	runTaintManager bool
 
-	// if set to true Controller will taint Nodes with 'TaintNodeNotReady' and 'TaintNodeUnreachable'
-	// taints instead of evicting Pods itself.
-	useTaintBasedEvictions bool
-
 	// if set to true, NodeController will taint Nodes based on its condition for 'NetworkUnavailable',
 	// 'MemoryPressure', 'OutOfDisk' and 'DiskPressure'.
 	taintNodeByCondition bool
@@ -298,7 +294,6 @@ func NewNodeController(
 		unhealthyZoneThreshold:      unhealthyZoneThreshold,
 		zoneStates:                  make(map[string]ZoneState),
 		runTaintManager:             runTaintManager,
-		useTaintBasedEvictions:      useTaintBasedEvictions && runTaintManager,
 	}
 
 	if useTaintBasedEvictions {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -170,8 +170,8 @@ type Controller struct {
 	// workers that evicts pods from unresponsive nodes.
 	zonePodEvictor map[string]*scheduler.RateLimitedTimedQueue
 	// workers that are responsible for tainting nodes.
-	zoneNoExecuteTainer map[string]*scheduler.RateLimitedTimedQueue
-	podEvictionTimeout  time.Duration
+	zoneNoExecuteTainter map[string]*scheduler.RateLimitedTimedQueue
+	podEvictionTimeout   time.Duration
 	// The maximum duration before a pod evicted from a node can be forcefully terminated.
 	maximumGracePeriod time.Duration
 	recorder           record.EventRecorder
@@ -473,9 +473,9 @@ func (nc *Controller) doNoScheduleTaintingPass(node *v1.Node) error {
 func (nc *Controller) doNoExecuteTaintingPass() {
 	nc.evictorLock.Lock()
 	defer nc.evictorLock.Unlock()
-	for k := range nc.zoneNoExecuteTainer {
+	for k := range nc.zoneNoExecuteTainter {
 		// Function should return 'false' and a time after which it should be retried, or 'true' if it shouldn't (it succeeded).
-		nc.zoneNoExecuteTainer[k].Try(func(value scheduler.TimedValue) (bool, time.Duration) {
+		nc.zoneNoExecuteTainter[k].Try(func(value scheduler.TimedValue) (bool, time.Duration) {
 			node, err := nc.nodeLister.Get(value.Value)
 			if apierrors.IsNotFound(err) {
 				glog.Warningf("Node %v no longer present in nodeLister!", value.Value)
@@ -555,7 +555,7 @@ func (nc *Controller) addPodEvictorForNewZone(node *v1.Node) {
 				scheduler.NewRateLimitedTimedQueue(
 					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
 		} else {
-			nc.zoneNoExecuteTainer[zone] =
+			nc.zoneNoExecuteTainter[zone] =
 				scheduler.NewRateLimitedTimedQueue(
 					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
 		}
@@ -793,7 +793,7 @@ func (nc *Controller) handleDisruption(zoneToNodeConditions map[string][]*v1.Nod
 			// We stop all evictions.
 			for k := range nc.zoneStates {
 				if nc.useTaintBasedEvictions {
-					nc.zoneNoExecuteTainer[k].SwapLimiter(0)
+					nc.zoneNoExecuteTainter[k].SwapLimiter(0)
 				} else {
 					nc.zonePodEvictor[k].SwapLimiter(0)
 				}
@@ -840,13 +840,13 @@ func (nc *Controller) setLimiterInZone(zone string, zoneSize int, state ZoneStat
 	switch state {
 	case stateNormal:
 		if nc.useTaintBasedEvictions {
-			nc.zoneNoExecuteTainer[zone].SwapLimiter(nc.evictionLimiterQPS)
+			nc.zoneNoExecuteTainter[zone].SwapLimiter(nc.evictionLimiterQPS)
 		} else {
 			nc.zonePodEvictor[zone].SwapLimiter(nc.evictionLimiterQPS)
 		}
 	case statePartialDisruption:
 		if nc.useTaintBasedEvictions {
-			nc.zoneNoExecuteTainer[zone].SwapLimiter(
+			nc.zoneNoExecuteTainter[zone].SwapLimiter(
 				nc.enterPartialDisruptionFunc(zoneSize))
 		} else {
 			nc.zonePodEvictor[zone].SwapLimiter(
@@ -854,7 +854,7 @@ func (nc *Controller) setLimiterInZone(zone string, zoneSize int, state ZoneStat
 		}
 	case stateFullDisruption:
 		if nc.useTaintBasedEvictions {
-			nc.zoneNoExecuteTainer[zone].SwapLimiter(
+			nc.zoneNoExecuteTainter[zone].SwapLimiter(
 				nc.enterFullDisruptionFunc(zoneSize))
 		} else {
 			nc.zonePodEvictor[zone].SwapLimiter(
@@ -1094,7 +1094,7 @@ func (nc *Controller) evictPods(node *v1.Node) bool {
 func (nc *Controller) markNodeForTainting(node *v1.Node) bool {
 	nc.evictorLock.Lock()
 	defer nc.evictorLock.Unlock()
-	return nc.zoneNoExecuteTainer[utilnode.GetZoneKey(node)].Add(node.Name, string(node.UID))
+	return nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Add(node.Name, string(node.UID))
 }
 
 func (nc *Controller) markNodeAsReachable(node *v1.Node) (bool, error) {
@@ -1110,7 +1110,7 @@ func (nc *Controller) markNodeAsReachable(node *v1.Node) (bool, error) {
 		glog.Errorf("Failed to remove taint from node %v: %v", node.Name, err)
 		return false, err
 	}
-	return nc.zoneNoExecuteTainer[utilnode.GetZoneKey(node)].Remove(node.Name), nil
+	return nc.zoneNoExecuteTainter[utilnode.GetZoneKey(node)].Remove(node.Name), nil
 }
 
 // HealthyQPSFunc returns the default value for cluster eviction rate - we take

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -544,16 +544,7 @@ func (nc *Controller) Run(stopCh <-chan struct{}) {
 		go nc.taintManager.Run(wait.NeverStop)
 	}
 
-	if nc.useTaintBasedEvictions {
-		// Handling taint based evictions. Because we don't want a dedicated logic in TaintManager for NC-originated
-		// taints and we normally don't rate limit evictions caused by taints, we need to rate limit adding taints.
-		go wait.Until(nc.doNoExecuteTaintingPass, scheduler.NodeEvictionPeriod, wait.NeverStop)
-	} else {
-		// Managing eviction of nodes:
-		// When we delete pods off a node, if the node was not empty at the time we then
-		// queue an eviction watcher. If we hit an error, retry deletion.
-		go wait.Until(nc.doEvictionPass, scheduler.NodeEvictionPeriod, wait.NeverStop)
-	}
+	nc.nodeEvictor.startEvictionLoop()
 
 	<-stopCh
 }

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -683,17 +683,12 @@ func (nc *Controller) monitorNodeStatus() error {
 			}
 			if observedReadyCondition.Status == v1.ConditionTrue {
 				if nc.useTaintBasedEvictions {
-					removed, err := nc.markNodeAsReachable(node)
-					if err != nil {
-						glog.Errorf("Failed to remove taints from node %v. Will retry in next iteration.", node.Name)
-					}
+					removed, _ := nc.markNodeAsHealthy(node)
 					if removed {
 						glog.V(2).Infof("Node %s is healthy again, removing all taints", node.Name)
 					}
 				} else {
-					if nc.cancelPodEviction(node) {
-						glog.V(2).Infof("Node %s is ready again, cancelled pod eviction", node.Name)
-					}
+					nc.cancelPodEviction(node)
 				}
 			}
 
@@ -778,10 +773,7 @@ func (nc *Controller) handleDisruption(zoneToNodeConditions map[string][]*v1.Nod
 			glog.V(0).Info("Controller detected that all Nodes are not-Ready. Entering master disruption mode.")
 			for i := range nodes {
 				if nc.useTaintBasedEvictions {
-					_, err := nc.markNodeAsReachable(nodes[i])
-					if err != nil {
-						glog.Errorf("Failed to remove taints from Node %v", nodes[i].Name)
-					}
+					nc.markNodeAsHealthy(nodes[i])
 				} else {
 					nc.cancelPodEviction(nodes[i])
 				}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -36,7 +36,6 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/flowcontrol"
 
 	"k8s.io/api/core/v1"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -554,15 +553,8 @@ func (nc *Controller) addPodEvictorForNewZone(node *v1.Node) {
 	zone := utilnode.GetZoneKey(node)
 	if _, found := nc.zoneStates[zone]; !found {
 		nc.zoneStates[zone] = stateInitial
-		if !nc.useTaintBasedEvictions {
-			nc.zonePodEvictor[zone] =
-				scheduler.NewRateLimitedTimedQueue(
-					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
-		} else {
-			nc.zoneNoExecuteTainter[zone] =
-				scheduler.NewRateLimitedTimedQueue(
-					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
-		}
+		nc.nodeEvictor.addZoneWorker(zone)
+
 		// Init the metric for the new zone.
 		glog.Infof("Initializing eviction metric for zone: %v", zone)
 		evictionsNumber.WithLabelValues(zone).Add(0)

--- a/pkg/controller/node/node_evictor.go
+++ b/pkg/controller/node/node_evictor.go
@@ -17,10 +17,16 @@ limitations under the License.
 package node
 
 import (
+	"time"
+
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/controller/node/scheduler"
+	"k8s.io/kubernetes/pkg/controller/node/util"
+	taintutils "k8s.io/kubernetes/pkg/util/taints"
 )
 
 type nodeEvictor interface {
@@ -34,6 +40,12 @@ type nodeEvictor interface {
 
 	// setLimiterForZone sets queue limiter for zone within map of pod evictors/tainters.
 	setLimiterForZone(newQPS float32, zone string)
+
+	checkEvictionTimeoutAgainstDecisionTimestamp(
+		node *v1.Node,
+		observedReadyCondition v1.NodeCondition,
+		decisionTimestamp metav1.Time,
+		gracePeriod time.Duration)
 }
 
 // taintBasedNodeEvictor satisfies the Evictor interface
@@ -93,4 +105,80 @@ func (ev *taintBasedNodeEvictor) setLimiterForZone(newQPS float32, zone string) 
 
 func (ev *defaultNodeEvictor) setLimiterForZone(newQPS float32, zone string) {
 	ev.nc.zonePodEvictor[zone].SwapLimiter(newQPS)
+}
+
+func (ev *taintBasedNodeEvictor) checkEvictionTimeoutAgainstDecisionTimestamp(
+	node *v1.Node,
+	observedReadyCondition v1.NodeCondition,
+	decisionTimestamp metav1.Time,
+	gracePeriod time.Duration) {
+
+	switch observedReadyCondition.Status {
+	case v1.ConditionFalse:
+		// We want to update the taint straight away if Node is already tainted with the UnreachableTaint.
+		if taintutils.TaintExists(node.Spec.Taints, UnreachableTaintTemplate) {
+			taintToAdd := *NotReadyTaintTemplate
+			if !util.SwapNodeControllerTaint(ev.nc.kubeClient, &taintToAdd, UnreachableTaintTemplate, node) {
+				glog.Errorf("Failed to instantly swap UnreachableTaint to NotReadyTaint. Will try again in the next cycle.")
+			}
+		} else if ev.nc.markNodeForTainting(node) {
+			glog.V(2).Infof("Node %v is NotReady as of %v. Adding it to the Taint queue.",
+				node.Name, decisionTimestamp,
+			)
+		}
+
+	case v1.ConditionUnknown:
+		// We want to update the taint straight away if Node is already tainted with the UnreachableTaint
+		if taintutils.TaintExists(node.Spec.Taints, NotReadyTaintTemplate) {
+			taintToAdd := *UnreachableTaintTemplate
+			if !util.SwapNodeControllerTaint(ev.nc.kubeClient, &taintToAdd, NotReadyTaintTemplate, node) {
+				glog.Errorf("Failed to instantly swap UnreachableTaint to NotReadyTaint. Will try again in the next cycle.")
+			}
+		} else if ev.nc.markNodeForTainting(node) {
+			glog.V(2).Infof("Node %v is unresponsive as of %v. Adding it to the Taint queue.",
+				node.Name, decisionTimestamp,
+			)
+		}
+	case v1.ConditionTrue:
+		removed, _ := ev.nc.markNodeAsHealthy(node) // Error path already logged.
+		if removed {
+			glog.V(2).Infof("Node %s is healthy again, removing all taints", node.Name)
+		}
+	}
+}
+
+func (ev *defaultNodeEvictor) checkEvictionTimeoutAgainstDecisionTimestamp(
+	node *v1.Node,
+	observedReadyCondition v1.NodeCondition,
+	decisionTimestamp metav1.Time,
+	gracePeriod time.Duration) {
+
+	switch observedReadyCondition.Status {
+	case v1.ConditionFalse:
+		if decisionTimestamp.After(ev.nc.nodeStatusMap[node.Name].readyTransitionTimestamp.Add(ev.nc.podEvictionTimeout)) {
+			if ev.nc.evictPods(node) {
+				glog.V(2).Infof("Node is NotReady. Adding Pods on Node %s to eviction queue: %v is later than %v + %v",
+					node.Name,
+					decisionTimestamp,
+					ev.nc.nodeStatusMap[node.Name].readyTransitionTimestamp,
+					ev.nc.podEvictionTimeout,
+				)
+			}
+		}
+
+	case v1.ConditionUnknown:
+		if decisionTimestamp.After(ev.nc.nodeStatusMap[node.Name].probeTimestamp.Add(ev.nc.podEvictionTimeout)) {
+			if ev.nc.evictPods(node) {
+				glog.V(2).Infof("Node is unresponsive. Adding Pods on Node %s to eviction queues: %v is later than %v + %v",
+					node.Name,
+					decisionTimestamp,
+					ev.nc.nodeStatusMap[node.Name].readyTransitionTimestamp,
+					ev.nc.podEvictionTimeout-gracePeriod,
+				)
+			}
+		}
+
+	case v1.ConditionTrue:
+		ev.nc.cancelPodEviction(node)
+	}
 }

--- a/pkg/controller/node/node_evictor.go
+++ b/pkg/controller/node/node_evictor.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+type nodeEvictor interface {
+}
+
+// taintBasedNodeEvictor satisfies the Evictor interface
+type taintBasedNodeEvictor struct {
+	nc *Controller
+}
+
+// defaultNodeEvictor satisfies the Evictor interface
+type defaultNodeEvictor struct {
+	nc *Controller
+}
+
+func newTaintBasedNodeEvictor(nc *Controller) *taintBasedNodeEvictor {
+	return &taintBasedNodeEvictor{nc}
+}
+
+func newDefaultNodeEvictor(nc *Controller) *defaultNodeEvictor {
+	return &defaultNodeEvictor{nc}
+}

--- a/pkg/controller/node/node_evictor.go
+++ b/pkg/controller/node/node_evictor.go
@@ -31,6 +31,9 @@ type nodeEvictor interface {
 	addZoneWorker(zone string)
 
 	cancelPodEvictionOrMarkNodeAsHealthy(node *v1.Node)
+
+	// setLimiterForZone sets queue limiter for zone within map of pod evictors/tainters.
+	setLimiterForZone(newQPS float32, zone string)
 }
 
 // taintBasedNodeEvictor satisfies the Evictor interface
@@ -82,4 +85,12 @@ func (ev *taintBasedNodeEvictor) cancelPodEvictionOrMarkNodeAsHealthy(node *v1.N
 
 func (ev *defaultNodeEvictor) cancelPodEvictionOrMarkNodeAsHealthy(node *v1.Node) {
 	ev.nc.cancelPodEviction(node)
+}
+
+func (ev *taintBasedNodeEvictor) setLimiterForZone(newQPS float32, zone string) {
+	ev.nc.zoneNoExecuteTainter[zone].SwapLimiter(newQPS)
+}
+
+func (ev *defaultNodeEvictor) setLimiterForZone(newQPS float32, zone string) {
+	ev.nc.zonePodEvictor[zone].SwapLimiter(newQPS)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As outlined in #48987 `NodeController` uses `useTaintBasedEvictions` to distinguish taint-based-eviction and default-pod-eviction. This PR adds an interface `nodeEvictor`; then implements two types,`defaultNodeEvictor` and `taintBasedNodeEvictor`, which satisfy the interface. All the logic that is currently contained within `if/else` branches on `uesTaintBasedEvictions` is then moved into the newly defined types with the appropriate functions added to the interface.

**Which issue this PR fixes** : 
fixes #48987 

**Special notes for your reviewer**:

The PR is marked with WIP for review. Each additional function is added in a separate commit. This means the code removed and the code replaced are close together to ease review. Function names are a bit unwieldy, open to suggested improvements. 

`make  test WHAT=./pkg/controller/node` passes for each commit.

**Release note**:
```release-note
NONE
```

/sig node
/kind cleanup