### PR TITLE
Fix AnnotationProvidedIPAddr annotation for externalCloudProvider

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -424,6 +424,9 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 	}
 
 	if kl.externalCloudProvider {
+		if kl.nodeIP != nil {
+			node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = kl.nodeIP.String()
+		}
 		// We rely on the external cloud provider to supply the addresses.
 		return nil
 	}
@@ -479,7 +482,6 @@ func (kl *Kubelet) setNodeAddress(node *v1.Node) error {
 		// 4) Try to get the IP from the network interface used as default gateway
 		if kl.nodeIP != nil {
 			ipAddr = kl.nodeIP
-			node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = kl.nodeIP.String()
 		} else if addr := net.ParseIP(kl.hostname); addr != nil {
 			ipAddr = addr
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
In #44258, it introduced `AnnotationProvidedIPAddr`. When kubelet has 'node-ip' parameter set, and cloud provider not set, this annotation would be populated, and then will be validated by cloud-controller-manager:
https://github.com/kubernetes/kubernetes/pull/44258/files#diff-6b0808bd1afb15f9f77986f4459601c2R465

Later with #47152, externalCloudProvider is checked and func returns before that annotation got set. In this case, that annotation will not get populated.

This fix is to bring that annotation assignment to a proper location.

Please correct me if I have any misunderstanding.
@wlan0 @ublubu 

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
