### PR TITLE
Add selector for printing statefulset list

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -194,6 +194,7 @@ func AddHandlers(h printers.PrintHandler) {
 		{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
 		{Name: "Containers", Type: "string", Priority: 1, Description: "Names of each container in the template."},
 		{Name: "Images", Type: "string", Priority: 1, Description: "Images referenced by each container in the template."},
+		{Name: "Selector", Type: "string", Priority: 1, Description: appsv1beta1.StatefulSetSpec{}.SwaggerDoc()["selector"]},
 	}
 	h.TableHandler(statefulSetColumnDefinitions, printStatefulSet)
 	h.TableHandler(statefulSetColumnDefinitions, printStatefulSetList)
@@ -1002,7 +1003,11 @@ func printStatefulSet(obj *apps.StatefulSet, options printers.PrintOptions) ([]m
 	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, createTime)
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
-		row.Cells = append(row.Cells, names, images)
+		selector, err := metav1.LabelSelectorAsSelector(obj.Spec.Selector)
+		if err != nil {
+			return nil, err
+		}
+		row.Cells = append(row.Cells, names, images, selector.String())
 	}
 	return []metav1alpha1.TableRow{row}, nil
 }


### PR DESCRIPTION
Add selector for printing statefulset list

I think you need to add a selector for printing statefulset list, like job deployment and so on，Because the resource service needs to see it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
