### PR TITLE
Automated cherry pick of #50310

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -848,7 +848,13 @@ function create-master() {
   # Sets MASTER_ROOT_DISK_SIZE that is used by create-master-instance
   get-master-root-disk-size
 
-  create-master-instance "${MASTER_RESERVED_IP}" &
+  if [[ "${NUM_NODES}" -ge "50" ]]; then
+    # We block on master creation for large clusters to avoid doing too much
+    # unnecessary work in case master start-up fails (like creation of nodes).
+    create-master-instance "${MASTER_RESERVED_IP}"
+  else
+    create-master-instance "${MASTER_RESERVED_IP}" &
+  fi
 }
 
 # Adds master replica to etcd cluster.


### PR DESCRIPTION
Cherry pick of #50310 on release-1.6.

#50310: Block on master-creation step for large clusters (>50 nodes)