### PR TITLE
Fix my incorrect username

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -10,7 +10,7 @@ approvers:
   - brendandburns
   - dchen1107
   - jbeda
-  - jregan # To modify BUILD files per proposal #598
+  - monopole # To move code per kubernetes/community#598
   - lavalamp
   - smarterclayton
   - thockin

--- a/build/visible_to/OWNERS
+++ b/build/visible_to/OWNERS
@@ -3,9 +3,9 @@ reviewers:
   - dchen1107
   - ixdy
   - jbeda
-  - jregan
   - lavalamp
   - mikedanese
+  - monopole
   - pwittrock
   - smarterclayton
   - thockin
@@ -15,9 +15,9 @@ approvers:
   - dchen1107
   - ixdy
   - jbeda
-  - jregan
   - lavalamp
   - mikedanese
+  - monopole
   - pwittrock
   - smarterclayton
   - thockin


### PR DESCRIPTION
My mistake - used goog username rather than github.

Again, this is for kubectl extraction, currently blocked by need for many approvers in, e.g. #48580 #48581 #47011, etc.