### PR TITLE
Fix kube-proxy to use proper iptables commands for IPv6 operation

### DIFF
--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -20,6 +20,7 @@ package iptables
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"os"
 	"strings"
@@ -34,17 +35,71 @@ import (
 
 const TestLockfilePath = "xtables.lock"
 
-func getIPTablesCommand(protocol Protocol) string {
+func protocolStr(protocol Protocol) string {
 	if protocol == ProtocolIpv4 {
-		return cmdIPTables
+		return "IPv4"
 	}
-	if protocol == ProtocolIpv6 {
-		return cmdIp6tables
+	return "IPv6"
+}
+
+func testIPTablesVersionCmds(t *testing.T, protocol Protocol) {
+	version := " v1.9.22"
+	iptablesCmd := iptablesCommand(protocol)
+	iptablesRestoreCmd := iptablesRestoreCommand(protocol)
+	protoStr := protocolStr(protocol)
+
+	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+			// iptables version response (for runner instantiation)
+			func() ([]byte, error) { return []byte(iptablesCmd + version), nil },
+			// iptables-restore version response (for runner instantiation)
+			func() ([]byte, error) { return []byte(iptablesRestoreCmd + version), nil },
+			// iptables version  response (for call to runner.GetVersion())
+			func() ([]byte, error) { return []byte(iptablesCmd + version), nil },
+		},
 	}
-	panic("Unknown protocol")
+	fexec := fakeexec.FakeExec{
+		CommandScript: []fakeexec.FakeCommandAction{
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+		},
+	}
+	runner := New(&fexec, dbus.NewFake(nil, nil), protocol)
+	defer runner.Destroy()
+
+	// Check that proper iptables version command was used during runner instantiation
+	if !sets.NewString(fcmd.CombinedOutputLog[0]...).HasAll(iptablesCmd, "--version") {
+		t.Errorf("%s runner instantiate: Expected cmd '%s --version', Got '%s'", protoStr, iptablesCmd, fcmd.CombinedOutputLog[0])
+	}
+
+	// Check that proper iptables restore version command was used during runner instantiation
+	if !sets.NewString(fcmd.CombinedOutputLog[1]...).HasAll(iptablesRestoreCmd, "--version") {
+		t.Errorf("%s runner instantiate: Expected cmd '%s --version', Got '%s'", protoStr, iptablesRestoreCmd, fcmd.CombinedOutputLog[1])
+	}
+
+	_, err := runner.GetVersion()
+	if err != nil {
+		t.Errorf("%s GetVersion: Expected success, got %v", protoStr, err)
+	}
+
+	// Check that proper iptables version command was used for runner.GetVersion
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll(iptablesCmd, "--version") {
+		t.Errorf("%s GetVersion: Expected cmd '%s --version', Got '%s'", protoStr, iptablesCmd, fcmd.CombinedOutputLog[2])
+	}
+}
+
+func TestIPTablesVersionCmdsIPv4(t *testing.T) {
+	testIPTablesVersionCmds(t, ProtocolIpv4)
+}
+
+func TestIPTablesVersionCmdsIPv6(t *testing.T) {
+	testIPTablesVersionCmds(t, ProtocolIpv6)
 }
 
 func testEnsureChain(t *testing.T, protocol Protocol) {
+	protoStr := protocolStr(protocol)
+
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			// iptables version check
@@ -73,30 +128,30 @@ func testEnsureChain(t *testing.T, protocol Protocol) {
 	// Success.
 	exists, err := runner.EnsureChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s new chain: Expected success, got %v", protoStr, err)
 	}
 	if exists {
-		t.Errorf("expected exists = false")
+		t.Errorf("%s new chain: Expected exists = false", protoStr)
 	}
 	if fcmd.CombinedOutputCalls != 3 {
-		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+		t.Errorf("%s new chain: Expected 3 CombinedOutput() calls, got %d", protoStr, fcmd.CombinedOutputCalls)
 	}
-	cmd := getIPTablesCommand(protocol)
+	cmd := iptablesCommand(protocol)
 	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll(cmd, "-t", "nat", "-N", "FOOBAR") {
-		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+		t.Errorf("%s new chain: Expected cmd containing '%s -t nat -N FOOBAR', got %s", protoStr, cmd, fcmd.CombinedOutputLog[2])
 	}
 	// Exists.
 	exists, err = runner.EnsureChain(TableNAT, Chain("FOOBAR"))
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s existing chain: Expected success, got %v", protoStr, err)
 	}
 	if !exists {
-		t.Errorf("expected exists = true")
+		t.Errorf("%s existing chain: Expected exists = true", protoStr)
 	}
-	// Failure.
+	// Simulate failure.
 	_, err = runner.EnsureChain(TableNAT, Chain("FOOBAR"))
 	if err == nil {
-		t.Errorf("expected failure")
+		t.Errorf("%s: Expected failure", protoStr)
 	}
 }
 
@@ -500,7 +555,7 @@ func TestGetIPTablesHasCheckCommand(t *testing.T) {
 				func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			},
 		}
-		version, err := getIPTablesVersionString(&fexec)
+		version, err := getIPTablesVersionString(&fexec, ProtocolIpv4)
 		if (err != nil) != testCase.Err {
 			t.Errorf("Expected error: %v, Got error: %v", testCase.Err, err)
 		}
@@ -513,8 +568,37 @@ func TestGetIPTablesHasCheckCommand(t *testing.T) {
 	}
 }
 
+func TestIPTablesCommands(t *testing.T) {
+	testCases := []struct {
+		funcName    string
+		protocol    Protocol
+		expectedCmd string
+	}{
+		{"iptablesCommand", ProtocolIpv4, cmdIPTables},
+		{"iptablesCommand", ProtocolIpv6, cmdIP6Tables},
+		{"iptablesSaveCommand", ProtocolIpv4, cmdIPTablesSave},
+		{"iptablesSaveCommand", ProtocolIpv6, cmdIP6TablesSave},
+		{"iptablesRestoreCommand", ProtocolIpv4, cmdIPTablesRestore},
+		{"iptablesRestoreCommand", ProtocolIpv6, cmdIP6TablesRestore},
+	}
+	for _, testCase := range testCases {
+		var cmd string
+		switch testCase.funcName {
+		case "iptablesCommand":
+			cmd = iptablesCommand(testCase.protocol)
+		case "iptablesSaveCommand":
+			cmd = iptablesSaveCommand(testCase.protocol)
+		case "iptablesRestoreCommand":
+			cmd = iptablesRestoreCommand(testCase.protocol)
+		}
+		if cmd != testCase.expectedCmd {
+			t.Errorf("Function: %s, Expected result: %s, Actual result: %s", testCase.funcName, testCase.expectedCmd, cmd)
+		}
+	}
+}
+
 func TestCheckRuleWithoutCheckPresent(t *testing.T) {
-	iptables_save_output := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
+	iptablesSaveOutput := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
 *nat
 :PREROUTING ACCEPT [2136997:197881818]
 :POSTROUTING ACCEPT [4284525:258542680]
@@ -526,7 +610,7 @@ COMMIT
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			// Success.
-			func() ([]byte, error) { return []byte(iptables_save_output), nil },
+			func() ([]byte, error) { return []byte(iptablesSaveOutput), nil },
 		},
 	}
 	fexec := fakeexec.FakeExec{
@@ -557,7 +641,7 @@ COMMIT
 }
 
 func TestCheckRuleWithoutCheckAbsent(t *testing.T) {
-	iptables_save_output := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
+	iptablesSaveOutput := `# Generated by iptables-save v1.4.7 on Wed Oct 29 14:56:01 2014
 *nat
 :PREROUTING ACCEPT [2136997:197881818]
 :POSTROUTING ACCEPT [4284525:258542680]
@@ -569,7 +653,7 @@ COMMIT
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			// Success.
-			func() ([]byte, error) { return []byte(iptables_save_output), nil },
+			func() ([]byte, error) { return []byte(iptablesSaveOutput), nil },
 		},
 	}
 	fexec := fakeexec.FakeExec{
@@ -835,21 +919,27 @@ func TestReload(t *testing.T) {
 	}
 }
 
-func TestSaveInto(t *testing.T) {
-	output := `# Generated by iptables-save v1.6.0 on Thu Jan 19 11:38:09 2017
+func testSaveInto(t *testing.T, protocol Protocol) {
+	version := " v1.9.22"
+	iptablesCmd := iptablesCommand(protocol)
+	iptablesSaveCmd := iptablesSaveCommand(protocol)
+	iptablesRestoreCmd := iptablesRestoreCommand(protocol)
+	protoStr := protocolStr(protocol)
+
+	output := fmt.Sprintf(`# Generated by %s on Thu Jan 19 11:38:09 2017
 *filter
 :INPUT ACCEPT [15079:38410730]
 :FORWARD ACCEPT [0:0]
 :OUTPUT ACCEPT [11045:521562]
 COMMIT
-# Completed on Thu Jan 19 11:38:09 2017`
+# Completed on Thu Jan 19 11:38:09 2017`, iptablesSaveCmd+version)
 
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			// iptables version check
-			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			func() ([]byte, error) { return []byte(iptablesCmd + version), nil },
 			// iptables-restore version check
-			func() ([]byte, error) { return []byte("iptables-restore v1.9.22"), nil },
+			func() ([]byte, error) { return []byte(iptablesRestoreCmd + version), nil },
 		},
 		RunScript: []fakeexec.FakeRunAction{
 			func() ([]byte, []byte, error) { return []byte(output), nil, nil },
@@ -864,45 +954,58 @@ COMMIT
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	runner := New(&fexec, dbus.NewFake(nil, nil), protocol)
 	defer runner.Destroy()
 	buffer := bytes.NewBuffer(nil)
 
 	// Success.
 	err := runner.SaveInto(TableNAT, buffer)
 	if err != nil {
-		t.Fatalf("expected success, got %v", err)
+		t.Fatalf("%s: Expected success, got %v", protoStr, err)
 	}
 
 	if string(buffer.Bytes()[:len(output)]) != output {
-		t.Errorf("expected output to be equal to mocked one, got %v", buffer.Bytes())
+		t.Errorf("%s: Expected output '%s', got '%v'", protoStr, output, buffer.Bytes())
 	}
 
 	if fcmd.CombinedOutputCalls != 2 {
-		t.Errorf("expected 2 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+		t.Errorf("%s: Expected 2 CombinedOutput() calls, got %d", protoStr, fcmd.CombinedOutputCalls)
 	}
 	if fcmd.RunCalls != 1 {
-		t.Errorf("expected 1 Run() call, got %d", fcmd.RunCalls)
+		t.Errorf("%s: Expected 1 Run() call, got %d", protoStr, fcmd.RunCalls)
 	}
-	if !sets.NewString(fcmd.RunLog[0]...).HasAll("iptables-save", "-t", "nat") {
-		t.Errorf("wrong Run() log, got %s", fcmd.RunLog[0])
+	if !sets.NewString(fcmd.RunLog[0]...).HasAll(iptablesSaveCmd, "-t", "nat") {
+		t.Errorf("%s: Expected cmd containing '%s -t nat', got '%s'", protoStr, iptablesSaveCmd, fcmd.RunLog[0])
 	}
 
 	// Failure.
 	buffer.Reset()
 	err = runner.SaveInto(TableNAT, buffer)
 	if err == nil {
-		t.Errorf("expected failure")
+		t.Errorf("%s: Expected failure", protoStr)
 	}
 }
 
-func TestRestore(t *testing.T) {
+func TestSaveIntoIPv4(t *testing.T) {
+	testSaveInto(t, ProtocolIpv4)
+}
+
+func TestSaveIntoIPv6(t *testing.T) {
+	testSaveInto(t, ProtocolIpv6)
+}
+
+func testRestore(t *testing.T, protocol Protocol) {
+	version := " v1.9.22"
+	iptablesCmd := iptablesCommand(protocol)
+	iptablesRestoreCmd := iptablesRestoreCommand(protocol)
+	protoStr := protocolStr(protocol)
+
 	fcmd := fakeexec.FakeCmd{
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
 			// iptables version check
-			func() ([]byte, error) { return []byte("iptables v1.9.22"), nil },
+			func() ([]byte, error) { return []byte(iptablesCmd + version), nil },
 			// iptables-restore version check
-			func() ([]byte, error) { return []byte("iptables-restore v1.9.22"), nil },
+			func() ([]byte, error) { return []byte(iptablesRestoreCmd + version), nil },
 			func() ([]byte, error) { return []byte{}, nil },
 			func() ([]byte, error) { return []byte{}, nil },
 			func() ([]byte, error) { return []byte{}, nil },
@@ -921,62 +1024,70 @@ func TestRestore(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
-	runner := New(&fexec, dbus.NewFake(nil, nil), ProtocolIpv4)
+	runner := New(&fexec, dbus.NewFake(nil, nil), protocol)
 	defer runner.Destroy()
 
 	// both flags true
 	err := runner.Restore(TableNAT, []byte{}, FlushTables, RestoreCounters)
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s flush,restore: Expected success, got %v", protoStr, err)
 	}
 
 	commandSet := sets.NewString(fcmd.CombinedOutputLog[2]...)
-	if !commandSet.HasAll("iptables-restore", "-T", string(TableNAT), "--counters") || commandSet.HasAny("--noflush") {
-		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[1])
+	if !commandSet.HasAll(iptablesRestoreCmd, "-T", string(TableNAT), "--counters") || commandSet.HasAny("--noflush") {
+		t.Errorf("%s flush, restore: Expected cmd containing '%s -T %s --counters', got '%s'", protoStr, iptablesRestoreCmd, string(TableNAT), fcmd.CombinedOutputLog[2])
 	}
 
 	// FlushTables, NoRestoreCounters
 	err = runner.Restore(TableNAT, []byte{}, FlushTables, NoRestoreCounters)
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s flush, no restore: Expected success, got %v", protoStr, err)
 	}
 
 	commandSet = sets.NewString(fcmd.CombinedOutputLog[3]...)
-	if !commandSet.HasAll("iptables-restore", "-T", string(TableNAT)) || commandSet.HasAny("--noflush", "--counters") {
-		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
+	if !commandSet.HasAll(iptablesRestoreCmd, "-T", string(TableNAT)) || commandSet.HasAny("--noflush", "--counters") {
+		t.Errorf("%s flush, no restore: Expected cmd containing '--noflush' or '--counters', got '%s'", protoStr, fcmd.CombinedOutputLog[3])
 	}
 
 	// NoFlushTables, RestoreCounters
 	err = runner.Restore(TableNAT, []byte{}, NoFlushTables, RestoreCounters)
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s no flush, restore: Expected success, got %v", protoStr, err)
 	}
 
 	commandSet = sets.NewString(fcmd.CombinedOutputLog[4]...)
-	if !commandSet.HasAll("iptables-restore", "-T", string(TableNAT), "--noflush", "--counters") {
-		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[3])
+	if !commandSet.HasAll(iptablesRestoreCmd, "-T", string(TableNAT), "--noflush", "--counters") {
+		t.Errorf("%s no flush, restore: Expected cmd containing '--noflush' and '--counters', got '%s'", protoStr, fcmd.CombinedOutputLog[4])
 	}
 
 	// NoFlushTables, NoRestoreCounters
 	err = runner.Restore(TableNAT, []byte{}, NoFlushTables, NoRestoreCounters)
 	if err != nil {
-		t.Errorf("expected success, got %v", err)
+		t.Errorf("%s no flush, no restore: Expected success, got %v", protoStr, err)
 	}
 
 	commandSet = sets.NewString(fcmd.CombinedOutputLog[5]...)
-	if !commandSet.HasAll("iptables-restore", "-T", string(TableNAT), "--noflush") || commandSet.HasAny("--counters") {
-		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[4])
+	if !commandSet.HasAll(iptablesRestoreCmd, "-T", string(TableNAT), "--noflush") || commandSet.HasAny("--counters") {
+		t.Errorf("%s no flush, no restore: Expected cmd containing '%s -T %s --noflush', got '%s'", protoStr, iptablesRestoreCmd, string(TableNAT), fcmd.CombinedOutputLog[5])
 	}
 
 	if fcmd.CombinedOutputCalls != 6 {
-		t.Errorf("expected 6 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
+		t.Errorf("%s: Expected 6 total CombinedOutput() calls, got %d", protoStr, fcmd.CombinedOutputCalls)
 	}
 
 	// Failure.
 	err = runner.Restore(TableNAT, []byte{}, FlushTables, RestoreCounters)
 	if err == nil {
-		t.Errorf("expected failure")
+		t.Errorf("%s Expected a failure", protoStr)
 	}
+}
+
+func TestRestoreIPv4(t *testing.T) {
+	testRestore(t, ProtocolIpv4)
+}
+
+func TestRestoreIPv6(t *testing.T) {
+	testRestore(t, ProtocolIpv6)
 }
 
 // TestRestoreAll tests only the simplest use case, as flag handling code is already tested in TestRestore


### PR DESCRIPTION
For iptables save and restore operations, kube-proxy currently uses
the IPv4 versions of the iptables save and restore utilities
(iptables-save and iptables-restore, respectively). For IPv6 operation,
the IPv6 versions of these utilities need to be used
(ip6tables-save and ip6tables-restore, respectively).

Both this change and PR #48551 are needed to get Kubernetes services
to work in an IPv6-only Kubernetes cluster (along with setting
'--bind-address ::0' on the kube-proxy command line. This change
was alluded to in a discussion on services for issue #1443.

fixes #50474

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This change modifies kube-proxy so that it uses the proper commands for iptables save and
iptables restore for IPv6 operation. Currently kube-proxy uses 'iptables-save' and 'iptables-restore'
regardless of whether it is being used in IPv4 or IPv6 mode. This change fixes kube-proxy so
that it uses 'ip6tables-save' and 'ip6tables-restore' commands when kube-proxy is being run
in IPv6 mode.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50474

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
