### PR TITLE
Implementation of the Device Plugin Manager

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -75,6 +75,13 @@ const (
 	// Works only with Docker Container Runtime.
 	Accelerators utilfeature.Feature = "Accelerators"
 
+	// owner: @vishh
+	// alpha: v1.8
+	//
+	// Enables support for Device Plugins
+	// Only Nvidia GPUs are supported as of v1.8.
+	DevicePlugins utilfeature.Feature = "DevicePlugins"
+
 	// owner: @gmarek
 	// alpha: v1.6
 	//
@@ -150,6 +157,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
 	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
 	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},
+	DevicePlugins:                               {Default: false, PreRelease: utilfeature.Alpha},
 	TaintBasedEvictions:                         {Default: false, PreRelease: utilfeature.Alpha},
 	RotateKubeletServerCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
 	RotateKubeletClientCertificate:              {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -252,6 +252,7 @@ filegroup(
         "//pkg/kubelet/configmap:all-srcs",
         "//pkg/kubelet/container:all-srcs",
         "//pkg/kubelet/custommetrics:all-srcs",
+        "//pkg/kubelet/deviceplugin:all-srcs",
         "//pkg/kubelet/dockershim:all-srcs",
         "//pkg/kubelet/envvars:all-srcs",
         "//pkg/kubelet/events:all-srcs",

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//pkg/fieldpath:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/apis/cri:go_default_library",
+        "//pkg/kubelet/apis/deviceplugin/v1alpha1:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1alpha1:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",

--- a/pkg/kubelet/apis/deviceplugin/v1alpha1/constants.go
+++ b/pkg/kubelet/apis/deviceplugin/v1alpha1/constants.go
@@ -30,4 +30,22 @@ const (
 	DevicePluginPath = "/var/lib/kubelet/device-plugins/"
 	// KubeletSocket is the path of the Kubelet registry socket
 	KubeletSocket = DevicePluginPath + "kubelet.sock"
+
+	// InvalidChars are the characters that may not appear in a Vendor or Kind field
+	InvalidChars = "/ "
+
+	// ErrFailedToDialDevicePlugin is the error raised when the device plugin could not be
+	// reached on the registered socket
+	ErrFailedToDialDevicePlugin = "Failed to dial device plugin:"
+	// ErrUnsuportedVersion is the error raised when the device plugin uses an API version not
+	// supported by the Kubelet registry
+	ErrUnsuportedVersion = "Unsupported version"
+	// ErrDevicePluginAlreadyExists is the error raised when a device plugin with the
+	// same Resource Name tries to register itself
+	ErrDevicePluginAlreadyExists = "Another device plugin already registered this Resource Name"
+	// ErrInvalidResourceName is the error raised when a device plugin is registering
+	// itself with an invalid ResourceName
+	ErrInvalidResourceName = "The Resource Name is invalid"
+	// ErrEmptyResourceName is the error raised when the resource name field is empty
+	ErrEmptyResourceName = "Invalid Empty ResourceName"
 )

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -13,6 +13,7 @@ go_library(
         "container_manager.go",
         "container_manager_stub.go",
         "container_manager_unsupported.go",
+        "device_plugin_handler.go",
         "helpers_unsupported.go",
         "pod_container_manager_stub.go",
         "pod_container_manager_unsupported.go",
@@ -32,8 +33,10 @@ go_library(
         "//conditions:default": [],
     }),
     deps = [
+        "//pkg/kubelet/apis/deviceplugin/v1alpha1:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
+        "//pkg/kubelet/deviceplugin:go_default_library",
         "//pkg/kubelet/eviction/api:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	// TODO: Migrate kubelet to either use its own internal objects or client library.
 	"k8s.io/api/core/v1"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 
@@ -66,6 +67,16 @@ type ContainerManager interface {
 	// UpdateQOSCgroups performs housekeeping updates to ensure that the top
 	// level QoS containers have their desired state in a thread-safe way
 	UpdateQOSCgroups() error
+
+	// SetDevicePluginHandler sets the device plugin handler
+	SetDevicePluginHandler(DevicePluginHandler)
+
+	// GetDevicePluginHandler returns the DevicePluginHandler
+	GetDevicePluginHandler() DevicePluginHandler
+}
+
+type DevicePluginHandler interface {
+	Devices() map[string][]*pluginapi.Device
 }
 
 type NodeConfig struct {

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -118,6 +118,8 @@ type containerManagerImpl struct {
 	recorder record.EventRecorder
 	// Interface for QoS cgroup management
 	qosContainerManager QOSContainerManager
+
+	devicePluginHdler DevicePluginHandler
 }
 
 type features struct {
@@ -833,4 +835,14 @@ func (cm *containerManagerImpl) GetCapacity() v1.ResourceList {
 	cm.RLock()
 	defer cm.RUnlock()
 	return cm.capacity
+}
+
+// GetDevicePluginHandler returns the DevicePluginHandler
+func (m *containerManagerImpl) GetDevicePluginHandler() DevicePluginHandler {
+	return m.devicePluginHdler
+}
+
+// SetDevicePluginHandler sets the DevicePluginHandler
+func (m *containerManagerImpl) SetDevicePluginHandler(d DevicePluginHandler) {
+	m.devicePluginHdler = d
 }

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -66,6 +66,15 @@ func (cm *containerManagerStub) NewPodContainerManager() PodContainerManager {
 	return &podContainerManagerStub{}
 }
 
+// GetDevicePluginHandler returns the DevicePluginHandler
+func (m *containerManagerStub) GetDevicePluginHandler() DevicePluginHandler {
+	return nil
+}
+
+// SetDevicePluginHandler sets the DevicePluginHandler
+func (m *containerManagerStub) SetDevicePluginHandler(d DevicePluginHandler) {
+}
+
 func NewStubContainerManager() ContainerManager {
 	return &containerManagerStub{}
 }

--- a/pkg/kubelet/cm/container_manager_unsupported.go
+++ b/pkg/kubelet/cm/container_manager_unsupported.go
@@ -72,6 +72,15 @@ func (cm *unsupportedContainerManager) NewPodContainerManager() PodContainerMana
 	return &unsupportedPodContainerManager{}
 }
 
+// GetDevicePluginHandler returns the DevicePluginHandler
+func (m *containerManagerStub) GetDevicePluginHandler() DevicePluginHandler {
+	return nil
+}
+
+// SetDevicePluginHandler sets the DevicePluginHandler
+func (m *containerManagerStub) SetDevicePluginHandler(d DevicePluginHandler) {
+}
+
 func NewContainerManager(_ mount.Interface, _ cadvisor.Interface, _ NodeConfig, failSwapOn bool, recorder record.EventRecorder) (ContainerManager, error) {
 	return &unsupportedContainerManager{}, nil
 }

--- a/pkg/kubelet/cm/device_plugin_handler.go
+++ b/pkg/kubelet/cm/device_plugin_handler.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cm
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+	"k8s.io/kubernetes/pkg/kubelet/deviceplugin"
+)
+
+type DevicePluginHandlerImpl struct {
+	devicePluginManager deviceplugin.Manager
+}
+
+// NewDevicePluginHandler create a DevicePluginHandler
+func NewDevicePluginHandler() (*DevicePluginHandlerImpl, error) {
+	glog.V(2).Infof("Starting Device Plugin Handler")
+
+	mgr, err := deviceplugin.NewManagerImpl(pluginapi.DevicePluginPath,
+		func(r string, a, u, d []*pluginapi.Device) {})
+
+	if err != nil {
+		return nil, fmt.Errorf("Failed to initialize device plugin: %+v", err)
+	}
+
+	if err := mgr.Start(); err != nil {
+		return nil, err
+	}
+
+	return &DevicePluginHandlerImpl{
+		devicePluginManager: mgr,
+	}, nil
+}
+
+// TODO cache this
+func (h *DevicePluginHandlerImpl) Devices() map[string][]*pluginapi.Device {
+	return h.devicePluginManager.Devices()
+}

--- a/pkg/kubelet/deviceplugin/BUILD
+++ b/pkg/kubelet/deviceplugin/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "endpoint.go",
+        "manager.go",
+        "types.go",
+        "utils.go",
+    ],
+    tags = ["automanaged"],
+    deps = [
+        "//pkg/kubelet/apis/deviceplugin/v1alpha1:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/golang.org/x/net/context:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/kubelet/deviceplugin/BUILD
+++ b/pkg/kubelet/deviceplugin/BUILD
@@ -5,6 +5,7 @@ licenses(["notice"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -12,6 +13,7 @@ go_library(
     srcs = [
         "endpoint.go",
         "manager.go",
+        "mock_device_plugin.go",
         "types.go",
         "utils.go",
     ],
@@ -35,4 +37,18 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "endpoint_test.go",
+        "manager_test.go",
+        "utils_test.go",
+    ],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/kubelet/apis/deviceplugin/v1alpha1:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+    ],
 )

--- a/pkg/kubelet/deviceplugin/endpoint.go
+++ b/pkg/kubelet/deviceplugin/endpoint.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+type endpoint struct {
+	client pluginapi.DevicePluginClient
+
+	socketPath   string
+	resourceName string
+
+	devices map[string]*pluginapi.Device
+	mutex   sync.Mutex
+
+	callback MonitorCallback
+
+	cancel context.CancelFunc
+	ctx    context.Context
+}
+
+func newEndpoint(socketPath, resourceName string, callback MonitorCallback) (*endpoint, error) {
+	client, err := dial(socketPath)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, stop := context.WithCancel(context.Background())
+
+	return &endpoint{
+		client: client,
+
+		socketPath:   socketPath,
+		resourceName: resourceName,
+
+		devices:  nil,
+		callback: callback,
+
+		cancel: stop,
+		ctx:    ctx,
+	}, nil
+}
+
+func (e *endpoint) list() (pluginapi.DevicePlugin_ListAndWatchClient, error) {
+	glog.V(2).Infof("Starting ListAndWatch")
+
+	stream, err := e.client.ListAndWatch(e.ctx, &pluginapi.Empty{})
+	if err != nil {
+		glog.Errorf(ErrListAndWatch, e.resourceName, err)
+
+		return nil, err
+	}
+
+	devs, err := stream.Recv()
+	if err != nil {
+		glog.Errorf(ErrListAndWatch, e.resourceName, err)
+		return nil, err
+	}
+
+	devices := make(map[string]*pluginapi.Device)
+	for _, d := range devs.Devices {
+		devices[d.ID] = d
+	}
+
+	e.mutex.Lock()
+	e.devices = devices
+	e.mutex.Unlock()
+
+	return stream, nil
+}
+
+func (e *endpoint) listAndWatch(stream pluginapi.DevicePlugin_ListAndWatchClient) {
+	glog.V(2).Infof("Starting ListAndWatch")
+
+	devices := make(map[string]*pluginapi.Device)
+
+	e.mutex.Lock()
+	for _, d := range e.devices {
+		devices[d.ID] = CloneDevice(d)
+	}
+	e.mutex.Unlock()
+
+	for {
+		response, err := stream.Recv()
+		if err != nil {
+			glog.Errorf(ErrListAndWatch, e.resourceName, err)
+			return
+		}
+
+		devs := response.Devices
+		glog.V(2).Infof("State pushed for device plugin %s", e.resourceName)
+
+		newDevs := make(map[string]*pluginapi.Device)
+		var added, updated []*pluginapi.Device
+
+		for _, d := range devs {
+			dOld, ok := devices[d.ID]
+			newDevs[d.ID] = d
+
+			if !ok {
+				glog.V(2).Infof("New device for Endpoint %s: %v", e.resourceName, d)
+
+				devices[d.ID] = d
+				added = append(added, CloneDevice(d))
+
+				continue
+			}
+
+			if d.Health == dOld.Health {
+				continue
+			}
+
+			if d.Health == pluginapi.Unhealthy {
+				glog.Errorf("Device %s is now Unhealthy", d.ID)
+			} else if d.Health == pluginapi.Healthy {
+				glog.V(2).Infof("Device %s is now Healthy", d.ID)
+			}
+
+			devices[d.ID] = d
+			updated = append(updated, CloneDevice(d))
+		}
+
+		var deleted []*pluginapi.Device
+		for id, d := range devices {
+			if _, ok := newDevs[id]; ok {
+				continue
+			}
+
+			glog.Errorf("Device %s was deleted", d.ID)
+
+			deleted = append(deleted, CloneDevice(d))
+			delete(devices, id)
+		}
+
+		e.mutex.Lock()
+		e.devices = devices
+		e.mutex.Unlock()
+
+		e.callback(e.resourceName, added, updated, deleted)
+	}
+
+}
+
+func (e *endpoint) allocate(devs []*pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+	var ids []string
+	for _, d := range devs {
+		ids = append(ids, d.ID)
+	}
+
+	return e.client.Allocate(context.Background(), &pluginapi.AllocateRequest{
+		DevicesIDs: ids,
+	})
+}
+
+func (e *endpoint) stop() {
+	e.cancel()
+}
+
+func dial(unixSocketPath string) (pluginapi.DevicePluginClient, error) {
+	c, err := grpc.Dial(unixSocketPath, grpc.WithInsecure(),
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		}),
+	)
+
+	if err != nil {
+		return nil, fmt.Errorf(pluginapi.ErrFailedToDialDevicePlugin+" %v", err)
+	}
+
+	return pluginapi.NewDevicePluginClient(c), nil
+}

--- a/pkg/kubelet/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/deviceplugin/endpoint_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package deviceplugin
 
 import (
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -25,11 +27,14 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
 )
 
-const (
-	socket = "/tmp/mock.sock"
+var (
+	esocketName = "mock.sock"
 )
 
 func TestNewEndpoint(t *testing.T) {
+	wd, _ := os.Getwd()
+	socket := path.Join(wd, esocketName)
+
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
 	}
@@ -39,6 +44,9 @@ func TestNewEndpoint(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
+	wd, _ := os.Getwd()
+	socket := path.Join(wd, esocketName)
+
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
 	}
@@ -62,6 +70,9 @@ func TestList(t *testing.T) {
 }
 
 func TestListAndWatch(t *testing.T) {
+	wd, _ := os.Getwd()
+	socket := path.Join(wd, esocketName)
+
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
 		{ID: "AnotherDeviceId", Health: pluginapi.Healthy},

--- a/pkg/kubelet/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/deviceplugin/endpoint_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+const (
+	socket = "/tmp/mock.sock"
+)
+
+func TestNewEndpoint(t *testing.T) {
+	devs := []*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+	}
+
+	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []*pluginapi.Device) {})
+	defer ecleanup(t, p, e)
+}
+
+func TestList(t *testing.T) {
+	devs := []*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+	}
+
+	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []*pluginapi.Device) {})
+	defer ecleanup(t, p, e)
+
+	_, err := e.list()
+	require.NoError(t, err)
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	require.Len(t, e.devices, 1)
+
+	d, ok := e.devices[devs[0].ID]
+	require.True(t, ok)
+
+	require.Equal(t, d.ID, devs[0].ID)
+	require.Equal(t, d.Health, devs[0].Health)
+}
+
+func TestListAndWatch(t *testing.T) {
+	devs := []*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+		{ID: "AnotherDeviceId", Health: pluginapi.Healthy},
+	}
+
+	updated := []*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Unhealthy},
+		{ID: "AThirdDeviceId", Health: pluginapi.Healthy},
+	}
+
+	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []*pluginapi.Device) {
+		require.Len(t, a, 1)
+		require.Len(t, u, 1)
+		require.Len(t, r, 1)
+
+		require.Equal(t, a[0].ID, updated[1].ID)
+
+		require.Equal(t, u[0].ID, updated[0].ID)
+		require.Equal(t, u[0].Health, updated[0].Health)
+
+		require.Equal(t, r[0].ID, devs[1].ID)
+	})
+	defer ecleanup(t, p, e)
+
+	s, err := e.list()
+	require.NoError(t, err)
+
+	go e.listAndWatch(s)
+	p.Update(updated)
+	time.Sleep(time.Second)
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	require.Len(t, e.devices, 2)
+	for _, dref := range updated {
+		d, ok := e.devices[dref.ID]
+
+		require.True(t, ok)
+		require.Equal(t, d.ID, dref.ID)
+		require.Equal(t, d.Health, dref.Health)
+	}
+
+}
+
+func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string, callback MonitorCallback) (*MockDevicePlugin, *endpoint) {
+	p := NewMockDevicePlugin(devs, socket)
+
+	err := p.Start()
+	require.NoError(t, err)
+
+	e, err := newEndpoint(socket, "mock", func(n string, a, u, r []*pluginapi.Device) {})
+	require.NoError(t, err)
+
+	return p, e
+}
+
+func ecleanup(t *testing.T, p *MockDevicePlugin, e *endpoint) {
+	p.Stop()
+	e.stop()
+}

--- a/pkg/kubelet/deviceplugin/manager.go
+++ b/pkg/kubelet/deviceplugin/manager.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+// NewManagerImpl creates a new manager on the socket `socketPath` and can
+// rebuild state from devices and available []Device.
+// f is the callback that is called when a device becomes unhealthy
+// socketPath is present for testing purposes in production this is pluginapi.KubeletSocket
+func NewManagerImpl(socketPath string, f MonitorCallback) (*ManagerImpl, error) {
+	glog.V(2).Infof("Creating Device Plugin manager at %s", socketPath)
+
+	if socketPath == "" || !filepath.IsAbs(socketPath) {
+		return nil, fmt.Errorf(ErrBadSocket+" %v", socketPath)
+	}
+
+	dir, file := filepath.Split(socketPath)
+	return &ManagerImpl{
+		Endpoints: make(map[string]*endpoint),
+
+		socketname: file,
+		socketdir:  dir,
+		callback:   f,
+	}, nil
+}
+
+// Start starts the Device Plugin Manager
+func (m *ManagerImpl) Start() error {
+	glog.V(2).Infof("Starting Device Plugin manager")
+
+	socketPath := filepath.Join(m.socketdir, m.socketname)
+	os.MkdirAll(m.socketdir, 0755)
+
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		glog.Errorf(ErrRemoveSocket+" %+v", err)
+		return err
+	}
+
+	s, err := net.Listen("unix", socketPath)
+	if err != nil {
+		glog.Errorf(ErrListenSocket+" %+v", err)
+		return err
+	}
+
+	m.server = grpc.NewServer([]grpc.ServerOption{}...)
+
+	pluginapi.RegisterRegistrationServer(m.server, m)
+	go m.server.Serve(s)
+
+	return nil
+}
+
+// Devices is the map of devices that are known by the Device
+// Plugin manager with the Kind of the devices as key
+func (m *ManagerImpl) Devices() map[string][]*pluginapi.Device {
+	glog.V(2).Infof("Devices called")
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	devs := make(map[string][]*pluginapi.Device)
+	for k, e := range m.Endpoints {
+		glog.V(2).Infof("Endpoint: %+v: %+v", k, e)
+		e.mutex.Lock()
+		devs[k] = copyDevices(e.devices)
+		e.mutex.Unlock()
+	}
+
+	return devs
+}
+
+// Allocate is the call that you can use to allocate a set of Devices
+func (m *ManagerImpl) Allocate(resourceName string,
+	devs []*pluginapi.Device) (*pluginapi.AllocateResponse, error) {
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if len(devs) == 0 {
+		return nil, nil
+	}
+
+	glog.Infof("Recieved request for devices %v for device plugin %s",
+		devs, resourceName)
+
+	e, ok := m.Endpoints[resourceName]
+	if !ok {
+		return nil, fmt.Errorf("Unknown Device Plugin %s", resourceName)
+	}
+
+	return e.allocate(devs)
+}
+
+// Register registers a device plugin
+func (m *ManagerImpl) Register(ctx context.Context,
+	r *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
+
+	glog.V(2).Infof("Got request for Device Plugin %s", r.ResourceName)
+
+	if r.Version != pluginapi.Version {
+		return &pluginapi.Empty{},
+			fmt.Errorf(pluginapi.ErrUnsuportedVersion)
+	}
+
+	if err := IsResourceNameValid(r.ResourceName); err != nil {
+		return &pluginapi.Empty{}, err
+	}
+
+	if _, ok := m.Endpoints[r.ResourceName]; ok {
+		return &pluginapi.Empty{},
+			fmt.Errorf(pluginapi.ErrDevicePluginAlreadyExists)
+	}
+
+	go m.addEndpoint(r)
+
+	return &pluginapi.Empty{}, nil
+}
+
+// Stop is the function that can stop the gRPC server
+func (m *ManagerImpl) Stop() error {
+	for _, e := range m.Endpoints {
+		e.stop()
+	}
+
+	m.server.Stop()
+
+	return nil
+}
+
+func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
+	socketPath := filepath.Join(m.socketdir, r.Endpoint)
+
+	e, err := newEndpoint(socketPath, r.ResourceName, m.callback)
+	if err != nil {
+		glog.Errorf("Failed to dial device plugin with request %v: %v", r, err)
+		return
+	}
+
+	stream, err := e.list()
+	if err != nil {
+		glog.Errorf("Failed to List devices for plugin %v: %v", r.ResourceName, err)
+		return
+	}
+
+	go func() {
+		e.listAndWatch(stream)
+
+		m.mutex.Lock()
+		e.mutex.Lock()
+
+		delete(m.Endpoints, r.ResourceName)
+		glog.V(2).Infof("Unregistered endpoint %v", e)
+
+		e.mutex.Unlock()
+		m.mutex.Unlock()
+	}()
+
+	m.mutex.Lock()
+	e.mutex.Lock()
+
+	m.Endpoints[r.ResourceName] = e
+	glog.V(2).Infof("Registered endpoint %v", e)
+
+	e.mutex.Unlock()
+	m.mutex.Unlock()
+
+}

--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+const (
+	msocket = "/tmp/server.sock"
+)
+
+func TestNewManagerImpl(t *testing.T) {
+	_, err := NewManagerImpl("", func(n string, a, u, r []*pluginapi.Device) {})
+	require.Error(t, err)
+
+	_, err = NewManagerImpl(msocket, func(n string, a, u, r []*pluginapi.Device) {})
+	require.NoError(t, err)
+}
+
+func TestNewManagerImplStart(t *testing.T) {
+	_, err := NewManagerImpl(msocket, func(n string, a, u, r []*pluginapi.Device) {})
+	require.NoError(t, err)
+}
+
+func setup(t *testing.T, devs []*pluginapi.Device, pluginSocket, serverSocket string, callback MonitorCallback) (Manager, *MockDevicePlugin) {
+	m, err := NewManagerImpl(serverSocket, callback)
+	require.NoError(t, err)
+
+	p := NewMockDevicePlugin(devs, pluginSocket)
+	err = p.Start()
+	require.NoError(t, err)
+
+	return m, p
+}
+
+func cleanup(t *testing.T, m Manager, p *MockDevicePlugin) {
+	p.Stop()
+	m.Stop()
+}

--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package deviceplugin
 
 import (
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -25,19 +27,25 @@ import (
 )
 
 const (
-	msocket = "/tmp/server.sock"
+	msocketName = "/tmp/server.sock"
 )
 
 func TestNewManagerImpl(t *testing.T) {
+	wd, _ := os.Getwd()
+	socket := path.Join(wd, msocketName)
+
 	_, err := NewManagerImpl("", func(n string, a, u, r []*pluginapi.Device) {})
 	require.Error(t, err)
 
-	_, err = NewManagerImpl(msocket, func(n string, a, u, r []*pluginapi.Device) {})
+	_, err = NewManagerImpl(socket, func(n string, a, u, r []*pluginapi.Device) {})
 	require.NoError(t, err)
 }
 
 func TestNewManagerImplStart(t *testing.T) {
-	_, err := NewManagerImpl(msocket, func(n string, a, u, r []*pluginapi.Device) {})
+	wd, _ := os.Getwd()
+	socket := path.Join(wd, msocketName)
+
+	_, err := NewManagerImpl(socket, func(n string, a, u, r []*pluginapi.Device) {})
 	require.NoError(t, err)
 }
 

--- a/pkg/kubelet/deviceplugin/mock_device_plugin.go
+++ b/pkg/kubelet/deviceplugin/mock_device_plugin.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"log"
+	"net"
+	"os"
+
+	"golang.org/x/net/context"
+	"google.golang.org/grpc"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+// MockDevicePlugin is a mock device plugin
+type MockDevicePlugin struct {
+	devs   []*pluginapi.Device
+	socket string
+
+	stop   chan interface{}
+	update chan []*pluginapi.Device
+
+	server *grpc.Server
+}
+
+// NewMockDevicePlugin returns an initialized MockDevicePlugin
+func NewMockDevicePlugin(devs []*pluginapi.Device, socket string) *MockDevicePlugin {
+	return &MockDevicePlugin{
+		devs:   devs,
+		socket: socket,
+
+		stop:   make(chan interface{}),
+		update: make(chan []*pluginapi.Device),
+	}
+}
+
+// Start starts the gRPC server of the device plugin
+func (m *MockDevicePlugin) Start() error {
+	err := m.cleanup()
+	if err != nil {
+		return err
+	}
+
+	sock, err := net.Listen("unix", m.socket)
+	if err != nil {
+		return err
+	}
+
+	m.server = grpc.NewServer([]grpc.ServerOption{}...)
+	pluginapi.RegisterDevicePluginServer(m.server, m)
+
+	go m.server.Serve(sock)
+	log.Println("Starting to serve on", m.socket)
+
+	return nil
+}
+
+// Stop stops the gRPC server
+func (m *MockDevicePlugin) Stop() error {
+	m.server.Stop()
+
+	return m.cleanup()
+}
+
+// ListAndWatch lists devices and update that list according to the Update call
+func (m *MockDevicePlugin) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
+	log.Println("ListAndWatch")
+	var devs []*pluginapi.Device
+
+	for _, d := range m.devs {
+		devs = append(devs, &pluginapi.Device{
+			ID:     d.ID,
+			Health: pluginapi.Healthy,
+		})
+	}
+
+	s.Send(&pluginapi.ListAndWatchResponse{Devices: devs})
+
+	for {
+		select {
+		case <-m.stop:
+			return nil
+		case updated := <-m.update:
+			s.Send(&pluginapi.ListAndWatchResponse{Devices: updated})
+		}
+	}
+}
+
+// Update allows the device plugin to send new devices through ListAndWatch
+func (m *MockDevicePlugin) Update(devs []*pluginapi.Device) {
+	m.update <- devs
+}
+
+// Allocate does a mock allocation
+func (m *MockDevicePlugin) Allocate(ctx context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
+	log.Printf("Allocate, %+v", r)
+
+	var response pluginapi.AllocateResponse
+	return &response, nil
+}
+
+func (m *MockDevicePlugin) cleanup() error {
+	if err := os.Remove(m.socket); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/kubelet/deviceplugin/types.go
+++ b/pkg/kubelet/deviceplugin/types.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"sync"
+
+	"google.golang.org/grpc"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+// MonitorCallback is the function called when a device becomes
+// unhealthy (or healthy again)
+// Updated contains the most recent state of the Device
+type MonitorCallback func(resourceName string, added, updated, deleted []*pluginapi.Device)
+
+// Manager manages the Device Plugins running on a machine
+type Manager interface {
+	// Start starts the gRPC service
+	Start() error
+	// Devices is the map of devices that have registered themselves
+	// against the manager.
+	// The map key is the ResourceName of the device plugins
+	Devices() map[string][]*pluginapi.Device
+
+	// Allocate is calls the gRPC Allocate on the device plugin
+	Allocate(string, []*pluginapi.Device) (*pluginapi.AllocateResponse, error)
+
+	// Stop stops the manager
+	Stop() error
+}
+
+// ManagerImpl is the structure in charge of managing Device Plugins
+type ManagerImpl struct {
+	socketname string
+	socketdir  string
+
+	Endpoints map[string]*endpoint // Key is ResourceName
+	mutex     sync.Mutex
+
+	callback MonitorCallback
+
+	server *grpc.Server
+}
+
+const (
+	// ErrDevicePluginUnknown is the error raised when the device Plugin returned by Monitor is not know by the Device Plugin manager
+	ErrDevicePluginUnknown = "Manager does not have device plugin for device:"
+	// ErrDeviceUnknown is the error raised when the device returned by Monitor is not know by the Device Plugin manager
+	ErrDeviceUnknown = "Could not find device in it's Device Plugin's Device List:"
+	// ErrBadSocket is the error raised when the registry socket path is not absolute
+	ErrBadSocket = "Bad socketPath, must be an absolute path:"
+	// ErrRemoveSocket is the error raised when the registry could not remove the existing socket
+	ErrRemoveSocket = "Failed to remove socket while starting device plugin registry, with error"
+	// ErrListenSocket is the error raised when the registry could not listen on the socket
+	ErrListenSocket = "Failed to listen to socket while starting device plugin registry, with error"
+	// ErrListAndWatch is the error raised when ListAndWatch ended unsuccessfully
+	ErrListAndWatch = "ListAndWatch ended unexpectedly for device plugin %s with error %v"
+)

--- a/pkg/kubelet/deviceplugin/utils.go
+++ b/pkg/kubelet/deviceplugin/utils.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"fmt"
+	"strings"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+// CloneDevice clones a pluginapi.Device
+func CloneDevice(d *pluginapi.Device) *pluginapi.Device {
+	return &pluginapi.Device{
+		ID:     d.ID,
+		Health: d.Health,
+	}
+
+}
+
+func copyDevices(devs map[string]*pluginapi.Device) []*pluginapi.Device {
+	var clones []*pluginapi.Device
+
+	for _, d := range devs {
+		clones = append(clones, CloneDevice(d))
+	}
+
+	return clones
+}
+
+// GetDevice returns the Device if a boolean signaling if the device was found or not
+func GetDevice(d *pluginapi.Device, devs []*pluginapi.Device) (*pluginapi.Device, bool) {
+	name := DeviceKey(d)
+
+	for _, d := range devs {
+		if DeviceKey(d) != name {
+			continue
+		}
+
+		return d, true
+	}
+
+	return nil, false
+}
+
+// IsResourceNameValid returns an error if the resource is invalid,
+func IsResourceNameValid(resourceName string) error {
+	if resourceName == "" {
+		return fmt.Errorf(pluginapi.ErrEmptyResourceName)
+	}
+
+	if strings.ContainsAny(resourceName, pluginapi.InvalidChars) {
+		return fmt.Errorf(pluginapi.ErrInvalidResourceName)
+	}
+
+	return nil
+}
+
+// DeviceKey returns the Key of a device
+func DeviceKey(d *pluginapi.Device) string {
+	return d.ID
+}

--- a/pkg/kubelet/deviceplugin/utils_test.go
+++ b/pkg/kubelet/deviceplugin/utils_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
+)
+
+func TestCloneDevice(t *testing.T) {
+	d := CloneDevice(&pluginapi.Device{ID: "ADeviceId", Health: pluginapi.Healthy})
+
+	require.Equal(t, d.ID, "ADeviceId")
+	require.Equal(t, d.Health, pluginapi.Healthy)
+}
+
+func TestCopyDevices(t *testing.T) {
+	d := map[string]*pluginapi.Device{
+		"ADeviceId": {ID: "ADeviceId", Health: pluginapi.Healthy},
+	}
+
+	devs := copyDevices(d)
+	require.Len(t, devs, 1)
+}
+
+func TestGetDevice(t *testing.T) {
+	devs := []*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+	}
+
+	_, ok := GetDevice(&pluginapi.Device{ID: "AnotherDeviceId"}, devs)
+	require.False(t, ok)
+
+	d, ok := GetDevice(&pluginapi.Device{ID: "ADeviceId"}, devs)
+	require.True(t, ok)
+	require.Equal(t, d, devs[0])
+}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -741,6 +741,13 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		return nil, err
 	}
 
+	devicePluginHdlr, err := cm.NewDevicePluginHandler()
+	if err != nil {
+		return nil, err
+	}
+
+	klet.containerManager.SetDevicePluginHandler(devicePluginHdlr)
+
 	// If the experimentalMounterPathFlag is set, we do not want to
 	// check node capabilities since the mount path is not the default
 	if len(kubeCfg.ExperimentalMounterPath) != 0 {

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -741,13 +741,15 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		return nil, err
 	}
 
-	devicePluginHdlr, err := cm.NewDevicePluginHandler()
-	if err != nil {
-		return nil, err
+	if utilfeature.DefaultFeatureGate.Enabled(features.DevicePlugins) {
+		devicePluginHdlr, err := cm.NewDevicePluginHandler()
+		if err != nil {
+			return nil, err
+		}
+
+		klet.containerManager.SetDevicePluginHandler(devicePluginHdlr)
+
 	}
-
-	klet.containerManager.SetDevicePluginHandler(devicePluginHdlr)
-
 	// If the experimentalMounterPathFlag is set, we do not want to
 	// check node capabilities since the mount path is not the default
 	if len(kubeCfg.ExperimentalMounterPath) != 0 {

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/features"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/util"
@@ -596,6 +597,27 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 			value.Set(0)
 		}
 		node.Status.Allocatable[k] = value
+	}
+
+	hdlr := kl.containerManager.GetDevicePluginHandler()
+	if hdlr == nil {
+		return
+	}
+
+	for k, v := range hdlr.Devices() {
+		key := v1.ResourceName(v1.ResourceOpaqueIntPrefix + k)
+
+		var n int64
+		n = 0
+
+		for _, d := range v {
+			if d.Health == pluginapi.Unhealthy {
+				continue
+			}
+			n++
+		}
+
+		node.Status.Capacity[key] = *resource.NewQuantity(n, resource.DecimalSI)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the kubelet Device Plugin Manager.
- Design document: kubernetes/community#695
- PR tracking: [kubernetes/features#368](https://github.com/kubernetes/features/issues/368#issuecomment-321625420)

This part of the code is a module completely separate from Kubelet.
It is a manager handling registration, allocation and health check of Device plugins.

- The interface offered to kubelet can be found in the types.go file.
- The manager.go implements this interface and acts as a gRPC server.
- The endpoint.go is the handler for one device plugin and is in charge of storing the - associated devices and watching for any health change.

**Special notes for your reviewer**:
- Please ignore commits up to f3befaf (Generated files) as these commits are being reviewed in #49342
- @vishh @jiayingz 
- Will add tests shortly

**Release note**:
```
None
```
