### PR TITLE
Adding support for internal IP for e2e tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3219,7 +3219,17 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*SSHResult,
 	}
 
 	if host == "" {
-		return nil, fmt.Errorf("couldn't find external IP address for node %s", node.Name)
+		// No external IPs were found, let's try to use internal as plan B
+		for _, a := range node.Status.Addresses {
+			if a.Type == v1.NodeInternalIP {
+				host = net.JoinHostPort(a.Address, sshPort)
+				break
+			}
+		}
+	}
+
+	if host == "" {
+		return nil, fmt.Errorf("couldn't find any IP address for node %s", node.Name)
 	}
 
 	Logf("SSH %q on %s(%s)", cmd, node.Name, host)


### PR DESCRIPTION
Currently IssueSSHComand in util.go only checks for External IP address
to ssh, this PR adds check for internal IP too.
Closes #50630
