### PR TITLE
Modify fed-apiserver help text

### DIFF
--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -63,9 +63,9 @@ func NewAPIServerCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "federation-apiserver",
 		Long: `The Kubernetes federation API server validates and configures data
-for the api objects which include pods, services, replicationcontrollers, and
+for the API objects which include deployments, services, replicasets, and
 others. The API Server services REST operations and provides the frontend to the
-cluster's shared state through which all other components interact.`,
+clusters' shared state through which all other components interact.`,
 		Run: func(cmd *cobra.Command, args []string) {
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

The federation-apiserver acutally doesn't have explicit support to
replicationcontrollers, which is being replaced by replicasets.
This patch revises the command help to avoid confusion.

**Release note**:
NONE