### PR TITLE
Clean up diskLooksUnformatted literal

### DIFF
--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -399,7 +399,7 @@ func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, 
 	return mountErr
 }
 
-// diskLooksUnformatted uses 'lsblk' to see if the given disk is unformated
+// getDiskFormat uses 'lsblk' to see if the given disk is unformated
 func (mounter *SafeFormatAndMount) getDiskFormat(disk string) (string, error) {
 	args := []string{"-n", "-o", "FSTYPE", disk}
 	cmd := mounter.Runner.Command("lsblk", args...)

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -61,7 +61,3 @@ func (mounter *Mounter) PathIsDevice(pathname string) (bool, error) {
 func (mounter *SafeFormatAndMount) formatAndMount(source string, target string, fstype string, options []string) error {
 	return nil
 }
-
-func (mounter *SafeFormatAndMount) diskLooksUnformatted(disk string) (bool, error) {
-	return true, nil
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
#16948 moved the `formatAndMount` function to mount_linux.go, but `diskLooksUnformatted` does not necessarily need to appear in mount_unsupported.go
#31515 Renames `diskLooksUnformatted` to `getDiskFormat`, but did not update the comment

This is to do the small cleanup.

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
