### PR TITLE
Create container log symlink for all containers

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -236,18 +236,21 @@ func (ds *dockerService) removeContainerLogSymlink(containerID string) error {
 // StartContainer starts the container.
 func (ds *dockerService) StartContainer(containerID string) error {
 	err := ds.client.StartContainer(containerID)
-	if err != nil {
-		err = transformStartContainerError(err)
-		return fmt.Errorf("failed to start container %q: %v", containerID, err)
-	}
-	// Create container log symlink.
-	if err := ds.createContainerLogSymlink(containerID); err != nil {
+
+	// Create container log symlink for all containers (including failed ones).
+	if linkError := ds.createContainerLogSymlink(containerID); linkError != nil {
 		// Do not stop the container if we failed to create symlink because:
 		//   1. This is not a critical failure.
 		//   2. We don't have enough information to properly stop container here.
 		// Kubelet will surface this error to user via an event.
-		return err
+		return linkError
 	}
+
+	if err != nil {
+		err = transformStartContainerError(err)
+		return fmt.Errorf("failed to start container %q: %v", containerID, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

dockershim only makes  log symlink for running containers now, we should also create the log symlink for failed containers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50499

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
