### PR TITLE
Bump Cluster Autoscaler to 0.6.1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1-beta2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Couple minor bugfixes and godep refresh.

Do not merge until I complete the tests.

```release-note
Cluster Autoscaler - fixes issues with taints and updates kube-proxy cpu request.
```