### PR TITLE
Automated cherry pick of #50514

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.0",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #50514 on release-1.7.

#50514: Bump Cluster Autoscaler to 0.6.1

