### PR TITLE
Manual cherry-pick of #50290

### DIFF
--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -64,6 +64,26 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
+        - name: prom-to-sd
+          image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
+          command:
+            - /monitor
+            - --source=heapster:http://localhost:8082?whitelisted=stackdriver_requests_count,stackdriver_timeseries_count
+            - --stackdriver-prefix=container.googleapis.com/internal/addons
+            - --pod-id=$(POD_NAME)
+            - --namespace-id=$(POD_NAMESPACE)
+          volumeMounts:
+          - name: ssl-certs
+            mountPath: /etc/ssl/certs
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
         - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:


### PR DESCRIPTION
Cherry pick of #50290 on release-1.7.
#50290: Added monitoring sidecar for Heapster

```release-note
Collect metrics from Heapster in Stackdriver mode.
```