### PR TITLE
Add YAML example to kubectl patch.

### DIFF
--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -57,23 +57,26 @@ type PatchOptions struct {
 
 var (
 	patchLong = templates.LongDesc(i18n.T(`
-		Update field(s) of a resource using strategic merge patch
+		Update field(s) of a resource using strategic merge patch, a JSON merge patch, or a JSON patch.
 
 		JSON and YAML formats are accepted.
 
 		Please refer to the models in https://htmlpreview.github.io/?https://github.com/kubernetes/kubernetes/blob/HEAD/docs/api-reference/v1/definitions.html to find if a field is mutable.`))
 
 	patchExample = templates.Examples(i18n.T(`
-		# Partially update a node using strategic merge patch
+		# Partially update a node using a strategic merge patch. Specify the patch as JSON.
 		kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}'
 
-		# Partially update a node identified by the type and name specified in "node.json" using strategic merge patch
+		# Partially update a node using a strategic merge patch. Specify the patch as YAML.
+		kubectl patch node k8s-node-1 -p $'spec:\n unschedulable: true'
+
+		# Partially update a node identified by the type and name specified in "node.json" using strategic merge patch.
 		kubectl patch -f node.json -p '{"spec":{"unschedulable":true}}'
 
-		# Update a container's image; spec.containers[*].name is required because it's a merge key
+		# Update a container's image; spec.containers[*].name is required because it's a merge key.
 		kubectl patch pod valid-pod -p '{"spec":{"containers":[{"name":"kubernetes-serve-hostname","image":"new image"}]}}'
 
-		# Update a container's image using a json patch with positional arrays
+		# Update a container's image using a json patch with positional arrays.
 		kubectl patch pod valid-pod --type='json' -p='[{"op": "replace", "path": "/spec/containers/0/image", "value":"new image"}]'`))
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:
A YAML example has been requested for the kubectl patch reference doc.

fixes #458

**Special notes for your reviewer**:

* Added a YAML example.
* Updated the description to include JSON patch and JSON merge patch.

**Release note**:
```release-note
NONE
```