### PR TITLE
[DaemonSet] Consider pods that are terminating instead of counting them as unavailable

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -682,8 +682,8 @@ func (dsc *DaemonSetsController) getNodesToDaemonPods(ds *extensions.DaemonSet) 
 	// Group Pods by Node name.
 	nodeToDaemonPods := make(map[string][]*v1.Pod)
 	for _, pod := range claimedPods {
-		// Skip terminating pods
-		if pod.DeletionTimestamp != nil {
+		// Skip terminated pods, consider terminating pods ie: pods serving terminationGracePeriod
+		if pod.DeletionTimestamp != nil && pod.DeletionTimestamp.Before(metav1.Now()) {
 			continue
 		}
 		nodeName := pod.Spec.NodeName

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"sync"
 	"testing"
+	"time"
 
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -1630,6 +1631,12 @@ func TestGetNodesToDaemonPods(t *testing.T) {
 			newPod("matching-orphan-0-", "node-0", simpleDaemonSetLabel, nil),
 			newPod("matching-owned-1-", "node-1", simpleDaemonSetLabel, ds),
 			newPod("matching-orphan-1-", "node-1", simpleDaemonSetLabel, nil),
+			func() *v1.Pod {
+				pod := newPod("matching-owned-2-set-for-deletion-but-not-deleted", "node-1", simpleDaemonSetLabel, ds)
+				now := metav1.NewTime(time.Now().Add(30 * time.Second))
+				pod.DeletionTimestamp = &now
+				return pod
+			}(),
 		}
 		failedPod := newPod("matching-owned-failed-pod-1-", "node-1", simpleDaemonSetLabel, ds)
 		failedPod.Status = v1.PodStatus{Phase: v1.PodFailed}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Currently, pods whose `DeletionTimestamp` is set are counted as unavailable.  Due to this new daemonSet pods are created in the same node while the old one is still serving its `terminationGracePeriod`.

 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
#50477
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
