### PR TITLE
Added jdumars to OWNERS file for Azure cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/azure/OWNERS
+++ b/pkg/cloudprovider/providers/azure/OWNERS
@@ -1,3 +1,4 @@
 approvers:
 - brendandburns
 - colemickens
+- jdumars


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds GitHub user jdumars as an approver to pkg/cloudprovider/providers/azure 

Jaice Singer DuMars (me) is the program manager at Microsoft tasked with shepherding all upstream contributions from Microsoft into Kubernetes.  With the volume of work, and the impending breakout of cloud provider code, this helps distribute the review and approval load more evenly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

This was discussed with Brendan Burns prior to submitting the pre-approval.

**Release note**:
none