### PR TITLE
mark created-by annotation as deprecated

### DIFF
--- a/pkg/api/annotation_key_constants.go
+++ b/pkg/api/annotation_key_constants.go
@@ -47,6 +47,8 @@ const (
 
 	// CreatedByAnnotation represents the key used to store the spec(json)
 	// used to create the resource.
+	// This field is deprecated in favor of ControllerRef (see #44407).
+	// TODO(#50720): Remove this field in v1.9.
 	CreatedByAnnotation = "kubernetes.io/created-by"
 
 	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)

--- a/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
+++ b/staging/src/k8s.io/api/core/v1/annotation_key_constants.go
@@ -47,6 +47,8 @@ const (
 
 	// CreatedByAnnotation represents the key used to store the spec(json)
 	// used to create the resource.
+	// This field is deprecated in favor of ControllerRef (see #44407).
+	// TODO(#50720): Remove this field in v1.9.
 	CreatedByAnnotation = "kubernetes.io/created-by"
 
 	// PreferAvoidPodsAnnotationKey represents the key of preferAvoidPods data (json serialized)


### PR DESCRIPTION
**What this PR does / why we need it**: This PR marks created-by annotation as deprecated in code comments.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #44407 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The `kubernetes.io/created-by` annotation is now deprecated and will be removed in v1.9. Use [ControllerRef](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/controller-ref.md) instead to determine which controller, if any, owns an object.
```
