### PR TITLE
Automated cherry pick of #50537

### DIFF
--- a/federation/pkg/kubefed/util/BUILD
+++ b/federation/pkg/kubefed/util/BUILD
@@ -16,6 +16,8 @@ go_library(
         "//federation/client/clientset_generated/federation_clientset:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
+        "//pkg/apis/rbac/v1alpha1:go_default_library",
+        "//pkg/apis/rbac/v1beta1:go_default_library",
         "//pkg/client/clientset_generated/internalclientset:go_default_library",
         "//pkg/kubectl/cmd:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/50534

Cherry pick of #50537 on release-1.7.

#50537: select an RBAC version for kubefed it knows how to speak

```release-note
fixes kubefed's ability to create RBAC roles in version-skewed clusters
```