### PR TITLE
kubeadm should support external cloud provider

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -44,6 +44,7 @@ var cloudproviders = []string{
 	"aws",
 	"azure",
 	"cloudstack",
+	"external",
 	"gce",
 	"openstack",
 	"ovirt",


### PR DESCRIPTION
**What this PR does / why we need it**:
As part of the initiative for cloud controller managers, we need to set `--cloud-provider=external` in many of the kubernetes components. During this transitional period `kubeadm` should accept `external` as a valid cloud provider. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/48690

**Special notes for your reviewer**:

**Release note**:
```release-note
kubeadm supports external cloud providers
```

cc @luxas 
