### PR TITLE
Use Fatalf instead of Errorf plus FailNow

### DIFF
--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -1516,13 +1516,11 @@ func TestUpdateRcWithRetries(t *testing.T) {
 func readOrDie(t *testing.T, req *http.Request, codec runtime.Codec) runtime.Object {
 	data, err := ioutil.ReadAll(req.Body)
 	if err != nil {
-		t.Errorf("Error reading: %v", err)
-		t.FailNow()
+		t.Fatalf("Error reading: %v", err)
 	}
 	obj, err := runtime.Decode(codec, data)
 	if err != nil {
-		t.Errorf("error decoding: %v", err)
-		t.FailNow()
+		t.Fatalf("error decoding: %v", err)
 	}
 	return obj
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Use Fatalf instead of Errorf plus FailNow

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->NONE
```release-note
```
