### PR TITLE
Cleanup locking in configz

### DIFF
--- a/pkg/util/configz/configz.go
+++ b/pkg/util/configz/configz.go
@@ -75,9 +75,13 @@ func handle(w http.ResponseWriter, r *http.Request) {
 }
 
 func write(w io.Writer) error {
-	configsGuard.Lock()
-	defer configsGuard.Unlock()
-	b, err := json.Marshal(configs)
+	var b []byte
+	var err error
+	func() {
+		configsGuard.RLock()
+		defer configsGuard.RUnlock()
+		b, err = json.Marshal(configs)
+	}()
 	if err != nil {
 		return fmt.Errorf("error marshaling json: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reduce scope of lock in `write()` method
- Use the read lock in `write()` method

**Release note**:
```release-note
NONE
```
/kind cleanup

@mikedanese 

p.s. looks like the `Set()` method could be removed if the value is accepted as an argument to `New()`. I.e. looks like to code re-sets the value.