### PR TITLE
Bugfix: In the process of calculating quota usage, resource informer should be synced.

### DIFF
--- a/pkg/quota/generic/evaluator.go
+++ b/pkg/quota/generic/evaluator.go
@@ -41,6 +41,13 @@ func ListResourceUsingInformerFunc(f informers.SharedInformerFactory, resource s
 		if err != nil {
 			return nil, err
 		}
+
+		// when the informer has not synced, should return error
+		// otherwise, the quota will be exceeded.
+		if !informer.Informer().HasSynced() {
+			return nil, fmt.Errorf("%s hasn't been synced", resource.String())
+		}
+
 		return informer.Lister().ByNamespace(namespace).List(labelSelector)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
/kind bugfix

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #50442 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
