### PR TITLE
Refactor kubectl factory test case with sets.String

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -114,6 +114,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/util/flag"
 	manualfake "k8s.io/client-go/rest/fake"
@@ -88,22 +89,16 @@ func TestPortsForObject(t *testing.T) {
 		},
 	}
 
-	expected := []string{"101"}
-	got, err := f.PortsForObject(pod)
+	expected := sets.NewString("101")
+	ports, err := f.PortsForObject(pod)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	if len(expected) != len(got) {
-		t.Fatalf("Ports size mismatch! Expected %d, got %d", len(expected), len(got))
-	}
 
-	sort.Strings(expected)
-	sort.Strings(got)
+	got := sets.NewString(ports...)
 
-	for i, port := range got {
-		if port != expected[i] {
-			t.Fatalf("Port mismatch! Expected %s, got %s", expected[i], port)
-		}
+	if !expected.Equal(got) {
+		t.Fatalf("Ports mismatch! Expected %v, got %v", expected, got)
 	}
 }
 
@@ -130,22 +125,18 @@ func TestProtocolsForObject(t *testing.T) {
 		},
 	}
 
-	expected := "101/TCP,102/UDP"
+	expected := sets.NewString("101/TCP", "102/UDP")
 	protocolsMap, err := f.ProtocolsForObject(pod)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	got := kubectl.MakeProtocols(protocolsMap)
-	expectedSlice := strings.Split(expected, ",")
-	gotSlice := strings.Split(got, ",")
 
-	sort.Strings(expectedSlice)
-	sort.Strings(gotSlice)
+	protocolsString := kubectl.MakeProtocols(protocolsMap)
+	protocolsStrings := strings.Split(protocolsString, ",")
+	got := sets.NewString(protocolsStrings...)
 
-	for i, protocol := range gotSlice {
-		if protocol != expectedSlice[i] {
-			t.Fatalf("Protocols mismatch! Expected %s, got %s", expectedSlice[i], protocol)
-		}
+	if !expected.Equal(got) {
+		t.Fatalf("Protocols mismatch! Expected %v, got %v", expected, got)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
change to make got and want use sets.String instead, since that is both safe and more clearly shows the intent.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
