### PR TITLE
Allow zsh completion to be autoloaded by compinit

### DIFF
--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -50,40 +50,37 @@ var (
 		completion of kubectl commands.  This can be done by sourcing it from
 		the .bash_profile.
 
-		Note: this requires the bash-completion framework, which is not installed
-		by default on Mac.  This can be installed by using homebrew:
-
-		    $ brew install bash-completion
-
-		Once installed, bash_completion must be evaluated.  This can be done by adding the
-		following line to the .bash_profile
-
-		    $ source $(brew --prefix)/etc/bash_completion
+		Detailed instructions on how to do this are available here:
+		https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion
 
 		Note for zsh users: [1] zsh completions are only supported in versions of zsh >= 5.2`))
 
 	completion_example = templates.Examples(i18n.T(`
-		# Install bash completion on a Mac using homebrew
-		brew install bash-completion
-		printf "
-# Bash completion support
-source $(brew --prefix)/etc/bash_completion
-" >> $HOME/.bash_profile
-		source $HOME/.bash_profile
+		# Installing bash completion on macOS using homebrew
+		## If running Bash 3.2 included with macOS
+		    brew install bash-completion
+		## or, if running Bash 4.1+
+		    brew install bash-completion@2
+		## If kubectl is installed via homebrew, this should start working immediately.
+		## If you've installed via other means, you may need add the completion to your completion directory
+		    kubectl completion bash > $(brew --prefix)/etc/bash_completion.d/kubectl
 
-		# Load the kubectl completion code for bash into the current shell
-		source <(kubectl completion bash)
 
-		# Write bash completion code to a file and source if from .bash_profile
-		kubectl completion bash > ~/.kube/completion.bash.inc
-		printf "
-# Kubectl shell completion
-source '$HOME/.kube/completion.bash.inc'
-" >> $HOME/.bash_profile
-		source $HOME/.bash_profile
+		# Installing bash completion on Linux
+		## Load the kubectl completion code for bash into the current shell
+		    source <(kubectl completion bash)
+		## Write bash completion code to a file and source if from .bash_profile
+		    kubectl completion bash > ~/.kube/completion.bash.inc
+		    printf "
+		      # Kubectl shell completion
+		      source '$HOME/.kube/completion.bash.inc'
+		      " >> $HOME/.bash_profile
+		    source $HOME/.bash_profile
 
 		# Load the kubectl completion code for zsh[1] into the current shell
-		source <(kubectl completion zsh)`))
+		    source <(kubectl completion zsh)
+		# Set the kubectl completion code for zsh[1] to autoload on startup
+		    kubectl completion zsh > "${fpath[1]}/_kubectl"`))
 )
 
 var (
@@ -141,8 +138,8 @@ func runCompletionBash(out io.Writer, boilerPlate string, kubectl *cobra.Command
 }
 
 func runCompletionZsh(out io.Writer, boilerPlate string, kubectl *cobra.Command) error {
-	zsh_head := `#compdef kubectl
-`
+	zsh_head := "#compdef kubectl\n"
+
 	out.Write([]byte(zsh_head))
 
 	if len(boilerPlate) == 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Allows the kubectl zsh autocompletion to be auto loaded by compinit. Had to move the the boilerplate down into the specific shell functions as the compdef needs to be the first line in the definition file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50560

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kubectl zsh autocompletion will work with compinit
```
