### PR TITLE
Removes redundant prefix in cluster-lifecycle e2e test names

### DIFF
--- a/test/e2e/lifecycle/cluster_upgrade.go
+++ b/test/e2e/lifecycle/cluster_upgrade.go
@@ -59,13 +59,13 @@ var statefulsetUpgradeTests = []upgrades.Test{
 	&upgrades.CassandraUpgradeTest{},
 }
 
-var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
+var _ = SIGDescribe("Upgrade [Feature:Upgrade]", func() {
 	f := framework.NewDefaultFramework("cluster-upgrade")
 
 	// Create the frameworks here because we can only create them
 	// in a "Describe".
 	testFrameworks := createUpgradeFrameworks(upgradeTests)
-	SIGDescribe("master upgrade", func() {
+	Describe("master upgrade", func() {
 		It("should maintain a functioning cluster [Feature:MasterUpgrade]", func() {
 			upgCtx, err := getUpgradeContext(f.ClientSet.Discovery(), framework.TestContext.UpgradeTarget)
 			framework.ExpectNoError(err)
@@ -88,7 +88,7 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 		})
 	})
 
-	SIGDescribe("node upgrade", func() {
+	Describe("node upgrade", func() {
 		It("should maintain a functioning cluster [Feature:NodeUpgrade]", func() {
 			upgCtx, err := getUpgradeContext(f.ClientSet.Discovery(), framework.TestContext.UpgradeTarget)
 			framework.ExpectNoError(err)
@@ -110,7 +110,7 @@ var _ = framework.KubeDescribe("Upgrade [Feature:Upgrade]", func() {
 		})
 	})
 
-	SIGDescribe("cluster upgrade", func() {
+	Describe("cluster upgrade", func() {
 		It("should maintain a functioning cluster [Feature:ClusterUpgrade]", func() {
 			upgCtx, err := getUpgradeContext(f.ClientSet.Discovery(), framework.TestContext.UpgradeTarget)
 			framework.ExpectNoError(err)
@@ -139,7 +139,7 @@ var _ = SIGDescribe("Downgrade [Feature:Downgrade]", func() {
 	// in a "Describe".
 	testFrameworks := createUpgradeFrameworks(upgradeTests)
 
-	SIGDescribe("cluster downgrade", func() {
+	Describe("cluster downgrade", func() {
 		It("should maintain a functioning cluster [Feature:ClusterDowngrade]", func() {
 			upgCtx, err := getUpgradeContext(f.ClientSet.Discovery(), framework.TestContext.UpgradeTarget)
 			framework.ExpectNoError(err)
@@ -169,7 +169,7 @@ var _ = SIGDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
 	// Create the frameworks here because we can only create them
 	// in a "Describe".
 	testFrameworks := createUpgradeFrameworks(upgradeTests)
-	SIGDescribe("etcd upgrade", func() {
+	Describe("etcd upgrade", func() {
 		It("should maintain a functioning cluster", func() {
 			upgCtx, err := getUpgradeContext(f.ClientSet.Discovery(), "")
 			framework.ExpectNoError(err)

--- a/test/e2e/lifecycle/resize_nodes.go
+++ b/test/e2e/lifecycle/resize_nodes.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Nodes [Disruptive]", func() {
 	})
 
 	// Slow issue #13323 (8 min)
-	SIGDescribe("Resize [Slow]", func() {
+	Describe("Resize [Slow]", func() {
 		var skipped bool
 
 		BeforeEach(func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Removes redundant prefix in cluster-lifecycle e2e test names

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Umbrella issue #49161
xref: #50054

**Special notes for your reviewer**:
/cc @jbeda 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
