### PR TITLE
fix apply_set_last_applied dry-run output issue

### DIFF
--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -222,9 +222,9 @@ func (o *SetLastAppliedOptions) formatPrinter(output string, buf []byte, w io.Wr
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(w, string(jsonBuffer.Bytes()))
+		fmt.Fprintf(w, "%s\n", jsonBuffer.String())
 	case "yaml":
-		fmt.Fprintf(w, string(yamlOutput))
+		fmt.Fprintf(w, "%s\n", string(yamlOutput))
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/50572

@kubernetes/sig-cli-bugs 

```release-note
NONE
```