### PR TITLE
Update RegisterMandatoryFitPredicate to avoid double register.

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -176,7 +176,6 @@ func defaultPredicates() sets.String {
 		factory.RegisterFitPredicate("CheckNodeDiskPressure", predicates.CheckNodeDiskPressurePredicate),
 
 		// Fit is determied by node condtions: not ready, network unavailable and out of disk.
-		factory.RegisterFitPredicate("CheckNodeCondition", predicates.CheckNodeConditionPredicate),
 		factory.RegisterMandatoryFitPredicate("CheckNodeCondition", predicates.CheckNodeConditionPredicate),
 
 		// Fit is determined by volume zone requirements.

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -323,7 +323,7 @@ func getFitPredicateFunctions(names sets.String, args PluginFactoryArgs) (map[st
 	}
 
 	// Always include mandatory fit predicates.
-	for _, name := range mandatoryFitPredicates.List() {
+	for name := range mandatoryFitPredicates {
 		if factory, found := fitPredicateMap[name]; found {
 			predicates[name] = factory(args)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/50362 , we introduced `RegisterMandatoryFitPredicate` to make some predicates always included by scheduler. This PRs is to improve it by avoiding double register: `RegisterFitPredicate` and `RegisterMandatoryFitPredicate` 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50360 

**Release note**:

```release-note
None
```
