### PR TITLE
fix kubectl set resource/selector/subject output

### DIFF
--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -70,7 +70,7 @@ type ResourcesOptions struct {
 	Err               io.Writer
 	Selector          string
 	ContainerSelector string
-	ShortOutput       bool
+	Output            string
 	All               bool
 	Record            bool
 	ChangeCause       string
@@ -129,7 +129,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	o.Mapper, o.Typer = f.Object()
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
 	o.Encoder = f.JSONEncoder()
-	o.ShortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
+	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.Record = cmdutil.GetRecordFlag(cmd)
 	o.Local = cmdutil.GetFlagBool(cmd, "local")
 	o.ChangeCause = f.Command(cmd, false)
@@ -243,7 +243,12 @@ func (o *ResourcesOptions) Run() error {
 			}
 		}
 		info.Refresh(obj, true)
-		cmdutil.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, false, "resource requirements updated")
+
+		shortOutput := o.Output == "name"
+		if len(o.Output) > 0 && !shortOutput {
+			return o.PrintObject(o.Cmd, o.Local, o.Mapper, info.Object, o.Out)
+		}
+		cmdutil.PrintSuccess(o.Mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "resource requirements updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -44,6 +44,7 @@ type SelectorOptions struct {
 	all         bool
 	record      bool
 	changeCause string
+	output      string
 
 	resources []string
 	selector  *metav1.LabelSelector
@@ -106,6 +107,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 	o.all = cmdutil.GetFlagBool(cmd, "all")
 	o.record = cmdutil.GetRecordFlag(cmd)
 	o.dryrun = cmdutil.GetDryRunFlag(cmd)
+	o.output = cmdutil.GetFlagString(cmd, "output")
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
@@ -194,7 +196,12 @@ func (o *SelectorOptions) RunSelector() error {
 		}
 
 		info.Refresh(patched, true)
-		cmdutil.PrintSuccess(o.mapper, false, o.out, info.Mapping.Resource, info.Name, o.dryrun, "selector updated")
+
+		shortOutput := o.output == "name"
+		if len(o.output) > 0 && !shortOutput {
+			return o.PrintObject(info.Object)
+		}
+		cmdutil.PrintSuccess(o.mapper, shortOutput, o.out, info.Mapping.Resource, info.Name, o.dryrun, "selector updated")
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -65,7 +65,7 @@ type SubjectOptions struct {
 	Err               io.Writer
 	Selector          string
 	ContainerSelector string
-	ShortOutput       bool
+	Output            string
 	All               bool
 	DryRun            bool
 	Local             bool
@@ -112,7 +112,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	o.Local = cmdutil.GetFlagBool(cmd, "local")
 	o.Mapper, o.Typer = f.Object()
 	o.Encoder = f.JSONEncoder()
-	o.ShortOutput = cmdutil.GetFlagString(cmd, "output") == "name"
+	o.Output = cmdutil.GetFlagString(cmd, "output")
 	o.DryRun = cmdutil.GetDryRunFlag(cmd)
 	o.PrintObject = func(mapper meta.RESTMapper, obj runtime.Object, out io.Writer) error {
 		return f.PrintObject(cmd, o.Local, mapper, obj, out)
@@ -235,7 +235,11 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 		}
 		info.Refresh(obj, true)
 
-		cmdutil.PrintSuccess(o.Mapper, o.ShortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
+		shortOutput := o.Output == "name"
+		if len(o.Output) > 0 && !shortOutput {
+			return o.PrintObject(o.Mapper, info.Object, o.Out)
+		}
+		cmdutil.PrintSuccess(o.Mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
 	}
 	return utilerrors.NewAggregate(allErrs)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
kubectl set resource/selector/subject -o yaml doesn't return the expected format

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubectl/issues/51

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
