### PR TITLE
Add image e2e-net-amd64 to CommonImageWhiteList

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -59,6 +59,7 @@ var CommonImageWhiteList = sets.NewString(
 	"gcr.io/google_containers/hostexec:1.2",
 	"gcr.io/google_containers/volume-nfs:0.8",
 	"gcr.io/google_containers/volume-gluster:0.2",
+	"gcr.io/google_containers/e2e-net-amd64:1.0",
 )
 
 func svcByName(name string, port int) *v1.Service {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Add `gcr.io/google_containers/e2e-net-amd64:1.0` to white list to avoid timeout.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50590

**Special notes for your reviewer**:
/cc @bowei @Random-Liu 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
