### PR TITLE
Automated cherry pick of #49118 upstream release 1.7

### DIFF
--- a/pkg/volume/flexvolume/unmounter.go
+++ b/pkg/volume/flexvolume/unmounter.go
@@ -51,22 +51,14 @@ func (f *flexVolumeUnmounter) TearDownAt(dir string) error {
 		return nil
 	}
 
-	notmnt, err := isNotMounted(f.mounter, dir)
+	call := f.plugin.NewDriverCall(unmountCmd)
+	call.Append(dir)
+	_, err := call.Run()
+	if isCmdNotSupportedErr(err) {
+		err = (*unmounterDefaults)(f).TearDownAt(dir)
+	}
 	if err != nil {
 		return err
-	}
-	if notmnt {
-		glog.Warningf("Warning: Path: %v already unmounted", dir)
-	} else {
-		call := f.plugin.NewDriverCall(unmountCmd)
-		call.Append(dir)
-		_, err := call.Run()
-		if isCmdNotSupportedErr(err) {
-			err = (*unmounterDefaults)(f).TearDownAt(dir)
-		}
-		if err != nil {
-			return err
-		}
 	}
 
 	// Flexvolume driver may remove the directory. Ignore if it does.


### PR DESCRIPTION
Cherry pick of #49118  on release-1.7.

#49118 : Allow unmounting bind-mounted directories

```release-note
It is now posible to use flexVolumes to bind mount directories and files.
```