### PR TITLE
Automated cherry pick of #50511

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,10 +29,11 @@ subjects:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.1.4
+  name: event-exporter
   namespace: kube-system
   labels:
     k8s-app: event-exporter
+    version: v0.1.5
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -41,16 +42,17 @@ spec:
     metadata:
       labels:
         k8s-app: event-exporter
+        version: v0.1.5
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       # TODO: Add resources in 1.8
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.4
+        image: gcr.io/google-containers/event-exporter:v0.1.5
         command:
         - '/event-exporter'
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.1.2-r2
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
         command:
           - /monitor
           - --component=event_exporter


### PR DESCRIPTION
Cherry pick of #50511 on release-1.7.

#50511: Update Stackdriver event exporter version

```release-note
fluentd-gcp addon: Fix a bug in the event-exporter, when repeated events were not sent to Stackdriver.
```