### PR TITLE
Log error from ensureDNSRecords

### DIFF
--- a/federation/pkg/federation-controller/service/dns/dns.go
+++ b/federation/pkg/federation-controller/service/dns/dns.go
@@ -182,6 +182,7 @@ func (s *ServiceDNSController) workerFunction() bool {
 	for _, clusterIngress := range ingress.Items {
 		err = s.ensureDNSRecords(clusterIngress.Cluster, service)
 		if err != nil {
+			runtime.HandleError(fmt.Errorf("Error when ensuring DNS records for service %s/%s: %v", service.Namespace, service.Name, err))
 			s.deliverService(service, 0, true)
 		}
 	}


### PR DESCRIPTION
Hiding errors is not a good idea. It took me some time to figure it out why my coredns is not working. It turned out that I had wrong etcd configuration but errors about it were hidden.

```release-note
NONE
```
