### PR TITLE
Increase kibana CPU limit to sped up the startup

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
@@ -21,9 +21,9 @@ spec:
       - name: kibana-logging
         image: docker.elastic.co/kibana/kibana:5.5.1
         resources:
-          # keep request = limit to keep this container in guaranteed class
+          # need more cpu upon initialization, therefore burstable class
           limits:
-            cpu: 100m
+            cpu: 1000m
           requests:
             cpu: 100m
         env:


### PR DESCRIPTION
Similarly to Elasticsearch, Kibana requires some additional CPU during startup to build caches. 

Fixes https://github.com/kubernetes/kubernetes/issues/50610

/cc @piosz @coffeepac @aknuds1 