### PR TITLE
Set Cluster Autoscaler version to 0.6.1-beta2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.7.0-alpha1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1-beta2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
To stabilise CA e2e tests.