### PR TITLE
[Federation] Kubefed doc fix

### DIFF
--- a/federation/pkg/kubefed/BUILD
+++ b/federation/pkg/kubefed/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/resource:go_default_library",
+        "//pkg/util/i18n:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -26,8 +26,18 @@ import (
 	kubectl "k8s.io/kubernetes/pkg/kubectl/cmd"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/util/i18n"
 
 	"github.com/spf13/cobra"
+)
+
+var (
+	kubefedVersionExample = templates.Examples(i18n.T(`
+		# Print the client and server versions for the current context
+		kubefed version`))
+	kubefedOptionsExample = templates.Examples(i18n.T(`
+		# Print flags inherited by all commands
+		kubefed options`))
 )
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
@@ -66,8 +76,12 @@ func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defa
 	}
 	templates.ActsAsRootCommand(cmds, filters, groups...)
 
-	cmds.AddCommand(kubectl.NewCmdVersion(f, out))
-	cmds.AddCommand(kubectl.NewCmdOptions(out))
+	cmdVersion := kubectl.NewCmdVersion(f, out)
+	cmdVersion.Example = kubefedVersionExample
+	cmds.AddCommand(cmdVersion)
+	cmdOptions := kubectl.NewCmdOptions(out)
+	cmdOptions.Example = kubefedOptionsExample
+	cmds.AddCommand(cmdOptions)
 
 	return cmds
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/50615
@kubernetes/sig-federation-bugs 
@madhusudancs, would it be of any reason to have separate code for kubefed for the version and options subcommands (rather then using ```kubectl.NewCmdVersion()``` and ```kubectl.NewCmdOptions```). I dont see the need, but I might be missing something. 

**What this PR does / why we need it**:
Fixes https://github.com/kubernetes/kubernetes/issues/50615

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
