### PR TITLE
Manual cherry-pick of #50636

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0
+  name: heapster-v1.4.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0
+      version: v1.4.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -65,7 +65,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: eventer
           command:
             - /eventer
@@ -103,7 +103,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -132,7 +132,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0
+  name: heapster-v1.4.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0
+      version: v1.4.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -66,7 +66,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: eventer
           command:
             - /eventer
@@ -104,7 +104,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -133,7 +133,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0
+  name: heapster-v1.4.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0
+      version: v1.4.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: eventer
           command:
             - /eventer
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -118,7 +118,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0
+  name: heapster-v1.4.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0
+      version: v1.4.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -55,8 +55,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-            - --sink=stackdriver:?cluster_name={{ cluster_name }}
-              # TODO: add --disable_export when it's merged into Heapster release
+            - --sink=stackdriver:?cluster_name={{ cluster_name }}&min_interval_sec=100&batch_export_timeout_sec=110
           volumeMounts:
             - name: ssl-certs
               mountPath: /etc/ssl/certs
@@ -109,7 +108,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.4.0
+  name: heapster-v1.4.1
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.4.0
+    version: v1.4.1
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.4.0
+      version: v1.4.1
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.4.0
+        version: v1.4.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.4.0
+        - image: gcr.io/google_containers/heapster-amd64:v1.4.1
           name: heapster
           livenessProbe:
             httpGet:
@@ -80,7 +80,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.4.0
+            - --deployment=heapster-v1.4.1
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
#50636: Bumped Heapster version to 1.4.1

```release-note
Bumped Heapster version to 1.4.1:
- handle gracefully problem when kubelet reports duplicated stats for the same container (see #47853) on Heapster side
- fixed bugs and improved performance in Stackdriver Sink
```
