### PR TITLE
Enables the v1beta2 version of the apps API group by default

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -53531,7 +53531,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DaemonSet": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSet represents the configuration of a daemon set.",
+    "description": "DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -53563,7 +53563,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.DaemonSetList": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetList is a collection of daemon sets.",
+    "description": "DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -53597,7 +53597,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.DaemonSetSpec": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetSpec is the specification of a daemon set.",
+    "description": "DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -53627,7 +53627,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DaemonSetStatus": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -53683,7 +53683,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it.",
+    "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -53696,7 +53696,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.Deployment": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -53728,7 +53728,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.DeploymentCondition": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -53761,7 +53761,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DeploymentList": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentList is a list of Deployments.",
+    "description": "DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -53795,7 +53795,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.DeploymentSpec": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -53839,7 +53839,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DeploymentStatus": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -53888,7 +53888,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.DeploymentStrategy": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -53901,7 +53901,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.ReplicaSet": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -53933,7 +53933,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetCondition": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -53962,7 +53962,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetList": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetList is a collection of ReplicaSets.",
+    "description": "ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -53996,7 +53996,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetSpec": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -54019,7 +54019,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetStatus": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -54061,7 +54061,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of daemon set rolling update.",
+    "description": "Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -54070,7 +54070,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateDeployment": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of rolling update.",
+    "description": "Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
@@ -54083,7 +54083,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
     "properties": {
      "partition": {
       "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
@@ -54093,7 +54093,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.Scale": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Scale represents a scaling request for a resource.",
+    "description": "Scale represents a scaling request for a resource.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -54125,7 +54125,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.ScaleSpec": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleSpec describes the attributes of a scale subresource",
+    "description": "ScaleSpec describes the attributes of a scale subresource",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -54135,7 +54135,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.ScaleStatus": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleStatus represents the current status of a scale subresource.",
+    "description": "ScaleStatus represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
@@ -54159,7 +54159,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.StatefulSet": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -54190,7 +54190,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.StatefulSetList": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetList is a collection of StatefulSets.",
+    "description": "StatefulSetList is a collection of StatefulSets.",
     "required": [
      "items"
     ],
@@ -54222,7 +54222,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta2.StatefulSetSpec": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. A StatefulSetSpec is the specification of a StatefulSet.",
+    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
     "required": [
      "template",
      "serviceName"
@@ -54268,7 +54268,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.StatefulSetStatus": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetStatus represents the current state of a StatefulSet.",
+    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
     "required": [
      "replicas"
     ],
@@ -54314,7 +54314,7 @@
     }
    },
    "io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy": {
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "rollingUpdate": {
       "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -4634,7 +4634,7 @@
   "models": {
    "v1beta2.DaemonSetList": {
     "id": "v1beta2.DaemonSetList",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetList is a collection of daemon sets.",
+    "description": "DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -4676,7 +4676,7 @@
    },
    "v1beta2.DaemonSet": {
     "id": "v1beta2.DaemonSet",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSet represents the configuration of a daemon set.",
+    "description": "DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "kind": {
       "type": "string",
@@ -4940,7 +4940,7 @@
    },
    "v1beta2.DaemonSetSpec": {
     "id": "v1beta2.DaemonSetSpec",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetSpec is the specification of a daemon set.",
+    "description": "DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -6979,7 +6979,7 @@
    },
    "v1beta2.DaemonSetUpdateStrategy": {
     "id": "v1beta2.DaemonSetUpdateStrategy",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it.",
+    "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
     "properties": {
      "type": {
       "type": "string",
@@ -6993,7 +6993,7 @@
    },
    "v1beta2.RollingUpdateDaemonSet": {
     "id": "v1beta2.RollingUpdateDaemonSet",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of daemon set rolling update.",
+    "description": "Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -7003,7 +7003,7 @@
    },
    "v1beta2.DaemonSetStatus": {
     "id": "v1beta2.DaemonSetStatus",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -7129,7 +7129,7 @@
    },
    "v1beta2.DeploymentList": {
     "id": "v1beta2.DeploymentList",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentList is a list of Deployments.",
+    "description": "DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -7157,7 +7157,7 @@
    },
    "v1beta2.Deployment": {
     "id": "v1beta2.Deployment",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7183,7 +7183,7 @@
    },
    "v1beta2.DeploymentSpec": {
     "id": "v1beta2.DeploymentSpec",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -7228,7 +7228,7 @@
    },
    "v1beta2.DeploymentStrategy": {
     "id": "v1beta2.DeploymentStrategy",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -7242,7 +7242,7 @@
    },
    "v1beta2.RollingUpdateDeployment": {
     "id": "v1beta2.RollingUpdateDeployment",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of rolling update.",
+    "description": "Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -7256,7 +7256,7 @@
    },
    "v1beta2.DeploymentStatus": {
     "id": "v1beta2.DeploymentStatus",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -7304,7 +7304,7 @@
    },
    "v1beta2.DeploymentCondition": {
     "id": "v1beta2.DeploymentCondition",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -7338,7 +7338,7 @@
    },
    "v1beta2.Scale": {
     "id": "v1beta2.Scale",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. Scale represents a scaling request for a resource.",
+    "description": "Scale represents a scaling request for a resource.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7364,7 +7364,7 @@
    },
    "v1beta2.ScaleSpec": {
     "id": "v1beta2.ScaleSpec",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleSpec describes the attributes of a scale subresource",
+    "description": "ScaleSpec describes the attributes of a scale subresource",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -7375,7 +7375,7 @@
    },
    "v1beta2.ScaleStatus": {
     "id": "v1beta2.ScaleStatus",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleStatus represents the current status of a scale subresource.",
+    "description": "ScaleStatus represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
@@ -7397,7 +7397,7 @@
    },
    "v1beta2.ReplicaSetList": {
     "id": "v1beta2.ReplicaSetList",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetList is a collection of ReplicaSets.",
+    "description": "ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -7425,7 +7425,7 @@
    },
    "v1beta2.ReplicaSet": {
     "id": "v1beta2.ReplicaSet",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7451,7 +7451,7 @@
    },
    "v1beta2.ReplicaSetSpec": {
     "id": "v1beta2.ReplicaSetSpec",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -7475,7 +7475,7 @@
    },
    "v1beta2.ReplicaSetStatus": {
     "id": "v1beta2.ReplicaSetStatus",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -7516,7 +7516,7 @@
    },
    "v1beta2.ReplicaSetCondition": {
     "id": "v1beta2.ReplicaSetCondition",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -7546,7 +7546,7 @@
    },
    "v1beta2.StatefulSetList": {
     "id": "v1beta2.StatefulSetList",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetList is a collection of StatefulSets.",
+    "description": "StatefulSetList is a collection of StatefulSets.",
     "required": [
      "items"
     ],
@@ -7572,7 +7572,7 @@
    },
    "v1beta2.StatefulSet": {
     "id": "v1beta2.StatefulSet",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7597,7 +7597,7 @@
    },
    "v1beta2.StatefulSetSpec": {
     "id": "v1beta2.StatefulSetSpec",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. A StatefulSetSpec is the specification of a StatefulSet.",
+    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
     "required": [
      "template",
      "serviceName"
@@ -7724,7 +7724,7 @@
    },
    "v1beta2.StatefulSetUpdateStrategy": {
     "id": "v1beta2.StatefulSetUpdateStrategy",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "type": {
       "type": "string",
@@ -7738,7 +7738,7 @@
    },
    "v1beta2.RollingUpdateStatefulSetStrategy": {
     "id": "v1beta2.RollingUpdateStatefulSetStrategy",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
     "properties": {
      "partition": {
       "type": "integer",
@@ -7749,7 +7749,7 @@
    },
    "v1beta2.StatefulSetStatus": {
     "id": "v1beta2.StatefulSetStatus",
-    "description": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetStatus represents the current state of a StatefulSet.",
+    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
     "required": [
      "replicas"
     ],

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -618,7 +618,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta2_daemonsetlist">v1beta2.DaemonSetList</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetList is a collection of daemon sets.</p>
+<p>DaemonSetList is a collection of daemon sets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1088,7 +1088,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta2_statefulsetlist">v1beta2.StatefulSetList</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetList is a collection of StatefulSets.</p>
+<p>StatefulSetList is a collection of StatefulSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1201,7 +1201,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta2_scale">v1beta2.Scale</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. Scale represents a scaling request for a resource.</p>
+<p>Scale represents a scaling request for a resource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1263,7 +1263,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta2_rollingupdatedaemonset">v1beta2.RollingUpdateDaemonSet</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of daemon set rolling update.</p>
+<p>Spec to control the desired behavior of daemon set rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1512,7 +1512,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta2_statefulsetstatus">v1beta2.StatefulSetStatus</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetStatus represents the current state of a StatefulSet.</p>
+<p>StatefulSetStatus represents the current state of a StatefulSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1859,7 +1859,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_deploymentstrategy">v1beta2.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2049,7 +2049,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_deploymentstatus">v1beta2.DeploymentStatus</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2173,7 +2173,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_rollingupdatestatefulsetstrategy">v1beta2.RollingUpdateStatefulSetStrategy</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.</p>
+<p>RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2255,7 +2255,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_daemonsetstatus">v1beta2.DaemonSetStatus</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetStatus represents the current status of a daemon set.</p>
+<p>DaemonSetStatus represents the current status of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2667,7 +2667,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_deploymentcondition">v1beta2.DeploymentCondition</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2736,7 +2736,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_statefulsetspec">v1beta2.StatefulSetSpec</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. A StatefulSetSpec is the specification of a StatefulSet.</p>
+<p>A StatefulSetSpec is the specification of a StatefulSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2819,7 +2819,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_replicasetstatus">v1beta2.ReplicaSetStatus</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetStatus represents the current status of a ReplicaSet.</p>
+<p>ReplicaSetStatus represents the current status of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2888,7 +2888,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_daemonset">v1beta2.DaemonSet</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSet represents the configuration of a daemon set.</p>
+<p>DaemonSet represents the configuration of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3125,7 +3125,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_replicasetlist">v1beta2.ReplicaSetList</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetList is a collection of ReplicaSets.</p>
+<p>ReplicaSetList is a collection of ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3352,7 +3352,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta2_statefulset">v1beta2.StatefulSet</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSet represents a set of pods with consistent identities. Identities are defined as:<br>
+<p>StatefulSet represents a set of pods with consistent identities. Identities are defined as:<br>
  - Network: A single stable DNS and hostname.<br>
  - Storage: As many VolumeClaims as requested.<br>
 The StatefulSet guarantees that a given network identity will always map to the same storage identity.</p>
@@ -4823,7 +4823,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_replicaset">v1beta2.ReplicaSet</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSet represents the configuration of a ReplicaSet.</p>
+<p>ReplicaSet represents the configuration of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4926,7 +4926,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_scalestatus">v1beta2.ScaleStatus</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleStatus represents the current status of a scale subresource.</p>
+<p>ScaleStatus represents the current status of a scale subresource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5105,7 +5105,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_deploymentspec">v1beta2.DeploymentSpec</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6141,7 +6141,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_deployment">v1beta2.Deployment</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>Deployment enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6203,7 +6203,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_deploymentlist">v1beta2.DeploymentList</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentList is a list of Deployments.</p>
+<p>DeploymentList is a list of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6598,7 +6598,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_rollingupdatedeployment">v1beta2.RollingUpdateDeployment</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of rolling update.</p>
+<p>Spec to control the desired behavior of rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6680,7 +6680,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_scalespec">v1beta2.ScaleSpec</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleSpec describes the attributes of a scale subresource</p>
+<p>ScaleSpec describes the attributes of a scale subresource</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6748,7 +6748,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_daemonsetspec">v1beta2.DaemonSetSpec</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetSpec is the specification of a daemon set.</p>
+<p>DaemonSetSpec is the specification of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6860,7 +6860,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_replicasetcondition">v1beta2.ReplicaSetCondition</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetCondition describes the state of a replica set at a certain point.</p>
+<p>ReplicaSetCondition describes the state of a replica set at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6984,7 +6984,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_daemonsetupdatestrategy">v1beta2.DaemonSetUpdateStrategy</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it.</p>
+<p>DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7025,7 +7025,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_replicasetspec">v1beta2.ReplicaSetSpec</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetSpec is the specification of a ReplicaSet.</p>
+<p>ReplicaSetSpec is the specification of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7214,7 +7214,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta2_statefulsetupdatestrategy">v1beta2.StatefulSetUpdateStrategy</h3>
 <div class="paragraph">
-<p>WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.</p>
+<p>StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/api/authentication/v1beta1:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	authenticationv1beta1 "k8s.io/api/authentication/v1beta1"
 	authorizationapiv1 "k8s.io/api/authorization/v1"
@@ -390,8 +391,7 @@ func DefaultAPIResourceConfigSource() *serverstorage.ResourceConfig {
 		authenticationv1beta1.SchemeGroupVersion,
 		autoscalingapiv1.SchemeGroupVersion,
 		appsv1beta1.SchemeGroupVersion,
-		// TODO: enable apps/v1beta2 by default before 1.8 release, after the API changes are done
-		// appsv1beta2.SchemeGroupVersion,
+		appsv1beta2.SchemeGroupVersion,
 		policyapiv1beta1.SchemeGroupVersion,
 		rbacv1.SchemeGroupVersion,
 		rbacv1beta1.SchemeGroupVersion,

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -31,7 +31,6 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "v1beta2";
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSet represents the configuration of a daemon set.
 message DaemonSet {
   // Standard object's metadata.
@@ -53,7 +52,6 @@ message DaemonSet {
   optional DaemonSetStatus status = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetList is a collection of daemon sets.
 message DaemonSetList {
   // Standard list metadata.
@@ -65,7 +63,6 @@ message DaemonSetList {
   repeated DaemonSet items = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetSpec is the specification of a daemon set.
 message DaemonSetSpec {
   // A label query over pods that are managed by the daemon set.
@@ -100,7 +97,6 @@ message DaemonSetSpec {
   optional int32 revisionHistoryLimit = 6;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetStatus represents the current status of a daemon set.
 message DaemonSetStatus {
   // The number of nodes that are running at least 1
@@ -149,7 +145,7 @@ message DaemonSetStatus {
   optional int64 collisionCount = 9;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
+// DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
 message DaemonSetUpdateStrategy {
   // Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
   // +optional
@@ -164,7 +160,6 @@ message DaemonSetUpdateStrategy {
   optional RollingUpdateDaemonSet rollingUpdate = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 message Deployment {
   // Standard object metadata.
@@ -180,7 +175,6 @@ message Deployment {
   optional DeploymentStatus status = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentCondition describes the state of a deployment at a certain point.
 message DeploymentCondition {
   // Type of deployment condition.
@@ -202,7 +196,6 @@ message DeploymentCondition {
   optional string message = 5;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentList is a list of Deployments.
 message DeploymentList {
   // Standard list metadata.
@@ -213,7 +206,6 @@ message DeploymentList {
   repeated Deployment items = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 message DeploymentSpec {
   // Number of desired pods. This is a pointer to distinguish between explicit
@@ -259,7 +251,6 @@ message DeploymentSpec {
   optional int32 progressDeadlineSeconds = 9;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentStatus is the most recently observed status of the Deployment.
 message DeploymentStatus {
   // The generation observed by the deployment controller.
@@ -298,7 +289,6 @@ message DeploymentStatus {
   optional int64 collisionCount = 8;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 message DeploymentStrategy {
   // Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -314,7 +304,6 @@ message DeploymentStrategy {
   optional RollingUpdateDeployment rollingUpdate = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSet represents the configuration of a ReplicaSet.
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
@@ -337,7 +326,6 @@ message ReplicaSet {
   optional ReplicaSetStatus status = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 message ReplicaSetCondition {
   // Type of replica set condition.
@@ -359,7 +347,6 @@ message ReplicaSetCondition {
   optional string message = 5;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetList is a collection of ReplicaSets.
 message ReplicaSetList {
   // Standard list metadata.
@@ -372,7 +359,6 @@ message ReplicaSetList {
   repeated ReplicaSet items = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetSpec is the specification of a ReplicaSet.
 message ReplicaSetSpec {
   // Replicas is the number of desired replicas.
@@ -402,7 +388,6 @@ message ReplicaSetSpec {
   optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetStatus represents the current status of a ReplicaSet.
 message ReplicaSetStatus {
   // Replicas is the most recently oberved number of replicas.
@@ -432,7 +417,6 @@ message ReplicaSetStatus {
   repeated ReplicaSetCondition conditions = 6;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Spec to control the desired behavior of daemon set rolling update.
 message RollingUpdateDaemonSet {
   // The maximum number of DaemonSet pods that can be unavailable during the
@@ -453,7 +437,6 @@ message RollingUpdateDaemonSet {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Spec to control the desired behavior of rolling update.
 message RollingUpdateDeployment {
   // The maximum number of pods that can be unavailable during the update.
@@ -484,7 +467,6 @@ message RollingUpdateDeployment {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
 message RollingUpdateStatefulSetStrategy {
   // Partition indicates the ordinal at which the StatefulSet should be
@@ -494,7 +476,6 @@ message RollingUpdateStatefulSetStrategy {
   optional int32 partition = 1;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Scale represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
@@ -510,7 +491,6 @@ message Scale {
   optional ScaleStatus status = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ScaleSpec describes the attributes of a scale subresource
 message ScaleSpec {
   // desired number of instances for the scaled object.
@@ -518,7 +498,6 @@ message ScaleSpec {
   optional int32 replicas = 1;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ScaleStatus represents the current status of a scale subresource.
 message ScaleStatus {
   // actual number of observed instances of the scaled object.
@@ -538,7 +517,6 @@ message ScaleStatus {
   optional string targetSelector = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSet represents a set of pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
@@ -559,7 +537,6 @@ message StatefulSet {
   optional StatefulSetStatus status = 3;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
   // +optional
@@ -568,7 +545,6 @@ message StatefulSetList {
   repeated StatefulSet items = 2;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // A StatefulSetSpec is the specification of a StatefulSet.
 message StatefulSetSpec {
   // replicas is the desired number of replicas of the given Template.
@@ -631,7 +607,6 @@ message StatefulSetSpec {
   optional int32 revisionHistoryLimit = 8;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetStatus represents the current state of a StatefulSet.
 message StatefulSetStatus {
   // observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
@@ -668,7 +643,6 @@ message StatefulSetStatus {
   optional int64 collisionCount = 9;
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetUpdateStrategy indicates the strategy that the StatefulSet
 // controller will use to perform updates. It includes any additional parameters
 // necessary to perform the update for the indicated strategy.

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ const (
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ScaleSpec describes the attributes of a scale subresource
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
@@ -37,7 +36,6 @@ type ScaleSpec struct {
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ScaleStatus represents the current status of a scale subresource.
 type ScaleStatus struct {
 	// actual number of observed instances of the scaled object.
@@ -61,7 +59,6 @@ type ScaleStatus struct {
 // +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Scale represents a scaling request for a resource.
 type Scale struct {
 	metav1.TypeMeta `json:",inline"`
@@ -81,7 +78,6 @@ type Scale struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSet represents a set of pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
@@ -118,7 +114,6 @@ const (
 	ParallelPodManagement = "Parallel"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetUpdateStrategy indicates the strategy that the StatefulSet
 // controller will use to perform updates. It includes any additional parameters
 // necessary to perform the update for the indicated strategy.
@@ -151,7 +146,6 @@ const (
 	OnDeleteStatefulSetStrategyType = "OnDelete"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
 type RollingUpdateStatefulSetStrategy struct {
 	// Partition indicates the ordinal at which the StatefulSet should be
@@ -161,7 +155,6 @@ type RollingUpdateStatefulSetStrategy struct {
 	Partition *int32 `json:"partition,omitempty" protobuf:"varint,1,opt,name=partition"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // A StatefulSetSpec is the specification of a StatefulSet.
 type StatefulSetSpec struct {
 	// replicas is the desired number of replicas of the given Template.
@@ -224,7 +217,6 @@ type StatefulSetSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,8,opt,name=revisionHistoryLimit"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetStatus represents the current state of a StatefulSet.
 type StatefulSetStatus struct {
 	// observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
@@ -263,7 +255,6 @@ type StatefulSetStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -275,7 +266,6 @@ type StatefulSetList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
@@ -292,7 +282,6 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
@@ -345,7 +334,6 @@ const (
 	DefaultDeploymentUniqueLabelKey string = "pod-template-hash"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -371,7 +359,6 @@ const (
 	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Spec to control the desired behavior of rolling update.
 type RollingUpdateDeployment struct {
 	// The maximum number of pods that can be unavailable during the update.
@@ -402,7 +389,6 @@ type RollingUpdateDeployment struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty" protobuf:"bytes,2,opt,name=maxSurge"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentStatus is the most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// The generation observed by the deployment controller.
@@ -458,7 +444,6 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentCondition describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
@@ -477,7 +462,6 @@ type DeploymentCondition struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DeploymentList is a list of Deployments.
 type DeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -489,7 +473,7 @@ type DeploymentList struct {
 	Items []Deployment `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
+// DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.
 type DaemonSetUpdateStrategy struct {
 	// Type of daemon set update. Can be "RollingUpdate" or "OnDelete". Default is RollingUpdate.
 	// +optional
@@ -514,7 +498,6 @@ const (
 	OnDeleteDaemonSetStrategyType DaemonSetUpdateStrategyType = "OnDelete"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // Spec to control the desired behavior of daemon set rolling update.
 type RollingUpdateDaemonSet struct {
 	// The maximum number of DaemonSet pods that can be unavailable during the
@@ -535,7 +518,6 @@ type RollingUpdateDaemonSet struct {
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,1,opt,name=maxUnavailable"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetSpec is the specification of a daemon set.
 type DaemonSetSpec struct {
 	// A label query over pods that are managed by the daemon set.
@@ -570,7 +552,6 @@ type DaemonSetSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,6,opt,name=revisionHistoryLimit"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetStatus represents the current status of a daemon set.
 type DaemonSetStatus struct {
 	// The number of nodes that are running at least 1
@@ -622,7 +603,6 @@ type DaemonSetStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
@@ -660,7 +640,6 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -676,7 +655,6 @@ type DaemonSetList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSet represents the configuration of a ReplicaSet.
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
@@ -703,7 +681,6 @@ type ReplicaSet struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -717,7 +694,6 @@ type ReplicaSetList struct {
 	Items []ReplicaSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetSpec is the specification of a ReplicaSet.
 type ReplicaSetSpec struct {
 	// Replicas is the number of desired replicas.
@@ -747,7 +723,6 @@ type ReplicaSetSpec struct {
 	Template v1.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,3,opt,name=template"`
 }
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetStatus represents the current status of a ReplicaSet.
 type ReplicaSetStatus struct {
 	// Replicas is the most recently oberved number of replicas.
@@ -787,7 +762,6 @@ const (
 	ReplicaSetReplicaFailure ReplicaSetConditionType = "ReplicaFailure"
 )
 
-// WIP: This is not ready to be used and we plan to make breaking changes to it.
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 type ReplicaSetCondition struct {
 	// Type of replica set condition.

--- a/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
@@ -28,7 +28,7 @@ package v1beta2
 
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_DaemonSet = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSet represents the configuration of a daemon set.",
+	"":         "DaemonSet represents the configuration of a daemon set.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 	"status":   "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
@@ -39,7 +39,7 @@ func (DaemonSet) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetList = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetList is a collection of daemon sets.",
+	"":         "DaemonSetList is a collection of daemon sets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"items":    "A list of daemon sets.",
 }
@@ -49,7 +49,7 @@ func (DaemonSetList) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetSpec = map[string]string{
-	"":                     "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetSpec is the specification of a daemon set.",
+	"":                     "DaemonSetSpec is the specification of a daemon set.",
 	"selector":             "A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 	"template":             "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
 	"updateStrategy":       "An update strategy to replace existing DaemonSet pods with new pods.",
@@ -62,7 +62,7 @@ func (DaemonSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetStatus = map[string]string{
-	"": "WIP: This is not ready to be used and we plan to make breaking changes to it. DaemonSetStatus represents the current status of a daemon set.",
+	"": "DaemonSetStatus represents the current status of a daemon set.",
 	"currentNumberScheduled": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"numberMisscheduled":     "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"desiredNumberScheduled": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
@@ -79,7 +79,7 @@ func (DaemonSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetUpdateStrategy = map[string]string{
-	"":              "WIP: This is not ready to be used and we plan to make breaking changes to it.",
+	"":              "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
 	"type":          "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if type = \"RollingUpdate\".",
 }
@@ -89,7 +89,7 @@ func (DaemonSetUpdateStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_Deployment = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. Deployment enables declarative updates for Pods and ReplicaSets.",
+	"":         "Deployment enables declarative updates for Pods and ReplicaSets.",
 	"metadata": "Standard object metadata.",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
@@ -100,7 +100,7 @@ func (Deployment) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentCondition = map[string]string{
-	"":                   "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentCondition describes the state of a deployment at a certain point.",
+	"":                   "DeploymentCondition describes the state of a deployment at a certain point.",
 	"type":               "Type of deployment condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastUpdateTime":     "The last time this condition was updated.",
@@ -114,7 +114,7 @@ func (DeploymentCondition) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentList = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentList is a list of Deployments.",
+	"":         "DeploymentList is a list of Deployments.",
 	"metadata": "Standard list metadata.",
 	"items":    "Items is the list of Deployments.",
 }
@@ -124,7 +124,7 @@ func (DeploymentList) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentSpec = map[string]string{
-	"":                        "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentSpec is the specification of the desired behavior of the Deployment.",
+	"":                        "DeploymentSpec is the specification of the desired behavior of the Deployment.",
 	"replicas":                "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 	"selector":                "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
 	"template":                "Template describes the pods that will be created.",
@@ -140,7 +140,7 @@ func (DeploymentSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStatus = map[string]string{
-	"":                    "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStatus is the most recently observed status of the Deployment.",
+	"":                    "DeploymentStatus is the most recently observed status of the Deployment.",
 	"observedGeneration":  "The generation observed by the deployment controller.",
 	"replicas":            "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
 	"updatedReplicas":     "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
@@ -156,7 +156,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStrategy = map[string]string{
-	"":              "WIP: This is not ready to be used and we plan to make breaking changes to it. DeploymentStrategy describes how to replace existing pods with new ones.",
+	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
 }
@@ -166,7 +166,7 @@ func (DeploymentStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSet = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSet represents the configuration of a ReplicaSet.",
+	"":         "ReplicaSet represents the configuration of a ReplicaSet.",
 	"metadata": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 	"status":   "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
@@ -177,7 +177,7 @@ func (ReplicaSet) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetCondition = map[string]string{
-	"":                   "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetCondition describes the state of a replica set at a certain point.",
+	"":                   "ReplicaSetCondition describes the state of a replica set at a certain point.",
 	"type":               "Type of replica set condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "The last time the condition transitioned from one status to another.",
@@ -190,7 +190,7 @@ func (ReplicaSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetList = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetList is a collection of ReplicaSets.",
+	"":         "ReplicaSetList is a collection of ReplicaSets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
 	"items":    "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
 }
@@ -200,7 +200,7 @@ func (ReplicaSetList) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetSpec = map[string]string{
-	"":                "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetSpec is the specification of a ReplicaSet.",
+	"":                "ReplicaSetSpec is the specification of a ReplicaSet.",
 	"replicas":        "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"minReadySeconds": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
 	"selector":        "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
@@ -212,7 +212,7 @@ func (ReplicaSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetStatus = map[string]string{
-	"":                     "WIP: This is not ready to be used and we plan to make breaking changes to it. ReplicaSetStatus represents the current status of a ReplicaSet.",
+	"":                     "ReplicaSetStatus represents the current status of a ReplicaSet.",
 	"replicas":             "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"fullyLabeledReplicas": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
 	"readyReplicas":        "The number of ready replicas for this replica set.",
@@ -226,7 +226,7 @@ func (ReplicaSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateDaemonSet = map[string]string{
-	"":               "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of daemon set rolling update.",
+	"":               "Spec to control the desired behavior of daemon set rolling update.",
 	"maxUnavailable": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
 }
 
@@ -235,7 +235,7 @@ func (RollingUpdateDaemonSet) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateDeployment = map[string]string{
-	"":               "WIP: This is not ready to be used and we plan to make breaking changes to it. Spec to control the desired behavior of rolling update.",
+	"":               "Spec to control the desired behavior of rolling update.",
 	"maxUnavailable": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
 	"maxSurge":       "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
 }
@@ -245,7 +245,7 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateStatefulSetStrategy = map[string]string{
-	"":          "WIP: This is not ready to be used and we plan to make breaking changes to it. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+	"":          "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
 	"partition": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
 }
 
@@ -254,7 +254,7 @@ func (RollingUpdateStatefulSetStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_Scale = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. Scale represents a scaling request for a resource.",
+	"":         "Scale represents a scaling request for a resource.",
 	"metadata": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.",
 	"spec":     "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
 	"status":   "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
@@ -265,7 +265,7 @@ func (Scale) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleSpec = map[string]string{
-	"":         "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleSpec describes the attributes of a scale subresource",
+	"":         "ScaleSpec describes the attributes of a scale subresource",
 	"replicas": "desired number of instances for the scaled object.",
 }
 
@@ -274,7 +274,7 @@ func (ScaleSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleStatus = map[string]string{
-	"":               "WIP: This is not ready to be used and we plan to make breaking changes to it. ScaleStatus represents the current status of a scale subresource.",
+	"":               "ScaleStatus represents the current status of a scale subresource.",
 	"replicas":       "actual number of observed instances of the scaled object.",
 	"selector":       "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
 	"targetSelector": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
@@ -285,7 +285,7 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"":       "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
 	"spec":   "Spec defines the desired identities of pods in this set.",
 	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }
@@ -295,7 +295,7 @@ func (StatefulSet) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetList = map[string]string{
-	"": "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetList is a collection of StatefulSets.",
+	"": "StatefulSetList is a collection of StatefulSets.",
 }
 
 func (StatefulSetList) SwaggerDoc() map[string]string {
@@ -303,7 +303,7 @@ func (StatefulSetList) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetSpec = map[string]string{
-	"":                     "WIP: This is not ready to be used and we plan to make breaking changes to it. A StatefulSetSpec is the specification of a StatefulSet.",
+	"":                     "A StatefulSetSpec is the specification of a StatefulSet.",
 	"replicas":             "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
 	"selector":             "selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 	"template":             "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
@@ -319,7 +319,7 @@ func (StatefulSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetStatus = map[string]string{
-	"":                   "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetStatus represents the current state of a StatefulSet.",
+	"":                   "StatefulSetStatus represents the current state of a StatefulSet.",
 	"observedGeneration": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
 	"replicas":           "replicas is the number of Pods created by the StatefulSet controller.",
 	"readyReplicas":      "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
@@ -335,7 +335,7 @@ func (StatefulSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetUpdateStrategy = map[string]string{
-	"":              "WIP: This is not ready to be used and we plan to make breaking changes to it. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+	"":              "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
 	"type":          "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
 	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Enables the v1beta2 version of the apps API group by default

fixes # #50641

```release-note
apps/v1beta2 is enabled by default. DaemonSet, Deployment, ReplicaSet, and StatefulSet have been moved to this group version.
```
