### PR TITLE
Bump gce metadata-proxy from 0.1.2 to 0.1.3

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google-containers/metadata-proxy:0.1.2
+        image: gcr.io/google-containers/metadata-proxy:0.1.3
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
**What this PR does / why we need it**: Bump metadata-proxy from 0.1.2 to 0.1.3 to incorporate fix for CVE 2016-9063, xref https://github.com/kubernetes/contrib/pull/2720

**Special notes for your reviewer**:

**Release note**:

```release-note
Bump metadata-proxy from 0.1.2 to 0.1.3 to incorporate fix for CVE 2016-9063, CVE-2017-7375, and CVE-2017-7376.
```
