### PR TITLE
Allow passing image description from e2e node test config

### DIFF
--- a/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
+++ b/test/e2e_node/jenkins/benchmark/benchmark-config.yaml
@@ -113,6 +113,7 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
   cos-docker112-resource1:
     image: cos-stable-60-9592-76-0
+    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"
@@ -120,6 +121,7 @@ images:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cos-docker112-resource2:
     image: cos-stable-60-9592-76-0
+    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"
@@ -127,6 +129,7 @@ images:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cos-docker112-resource3:
     image: cos-stable-60-9592-76-0
+    image_description: cos-stable-60-9592-76-0 with docker 1.12.6
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/cos-init-docker.yaml,gci-update-strategy=update_disabled,gci-docker-version=1.12.6"

--- a/test/e2e_node/remote/node_e2e.go
+++ b/test/e2e_node/remote/node_e2e.go
@@ -211,7 +211,7 @@ func (n *NodeE2ERemote) RunTest(host, workspace, results, imageDesc, junitFilePr
 	glog.V(2).Infof("Starting tests on %q", host)
 	cmd := getSSHCommand(" && ",
 		fmt.Sprintf("cd %s", workspace),
-		fmt.Sprintf("timeout -k 30s %fs ./ginkgo %s ./e2e_node.test -- --system-spec-name=%s --system-spec-file=%s --logtostderr --v 4 --node-name=%s --report-dir=%s --report-prefix=%s --image-description=%s %s",
+		fmt.Sprintf("timeout -k 30s %fs ./ginkgo %s ./e2e_node.test -- --system-spec-name=%s --system-spec-file=%s --logtostderr --v 4 --node-name=%s --report-dir=%s --report-prefix=%s --image-description=\"%s\" %s",
 			timeout.Seconds(), ginkgoArgs, systemSpecName, systemSpecFile, host, results, junitFilePrefix, imageDesc, testArgs),
 	)
 	return SSH(host, "sh", "-c", cmd)


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/42926

This is the follow up of https://github.com/kubernetes/kubernetes/pull/50479. In https://github.com/kubernetes/kubernetes/pull/50479, we added the tests for cos-m60 with docker 1.12.6. Those tests use the same image name as the existing ones (cos-m60 with docker 1.13.1). So we are not  distinguish them on node-perf-dash, which categories the tests by image names.

This PR fixes the issue by passing image description to the test.

Examples:

https://storage.googleapis.com/ygg-gke-dev-bucket/e2e-node-test/ci-kubernetes-node-kubelet-benchmark/22/artifacts/performance-cpu-cos-docker112-resource2-resource_35.json

https://storage.googleapis.com/ygg-gke-dev-bucket/e2e-node-test/ci-kubernetes-node-kubelet-benchmark/22/artifacts/performance-cpu-cos-resource2-resource_35.json

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
None
```

/assign @Random-Liu 