### PR TITLE
Log name if Azure file share cannot be created

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_storage.go
+++ b/pkg/cloudprovider/providers/azure/azure_storage.go
@@ -48,7 +48,7 @@ func (az *Cloud) CreateFileShare(name, storageAccount, storageType, location str
 
 			err = az.createFileShare(account.Name, key, name, requestGB)
 			if err != nil {
-				glog.V(2).Infof("failed to create share in account %s: %v", account.Name, err)
+				glog.V(2).Infof("failed to create share %s in account %s: %v", name, account.Name, err)
 				continue
 			}
 			glog.V(4).Infof("created share %s in account %s", name, account.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: If the Azure storage provider fails to create a file share, it logs and error message 'failed to create share in account _foo_: _error-msg_'.  A user on the Slack azure-sig channel reported an error of "The specified resource name length is not within the permissible limits".  This PR adds logging of the name so that this error can be diagnosed in future.

**Which issue this PR fixes**: This was raised on Slack and has not been created as a GitHub issue.

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Changed the error log format when creating an Azure file share to include the name of the share.
```
