### PR TITLE
add ut for pkg/api/toleration.go

### DIFF
--- a/pkg/api/BUILD
+++ b/pkg/api/BUILD
@@ -39,7 +39,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["taint_test.go"],
+    srcs = [
+        "taint_test.go",
+        "toleration_test.go",
+    ],
     library = ":go_default_library",
 )
 

--- a/pkg/api/toleration_test.go
+++ b/pkg/api/toleration_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import "testing"
+
+func TestMatchToleration(t *testing.T) {
+	testCases := []struct {
+		description       string
+		toleration        *Toleration
+		tolerationToMatch *Toleration
+		expectMatch       bool
+	}{
+		{
+			description: "two tolerations with same key,operator,value,effect should match",
+			toleration: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			tolerationToMatch: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			expectMatch: true,
+		},
+		{
+			description: "two tolerations with same key,operator,value but different effect cannot match",
+			toleration: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			tolerationToMatch: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoExecute,
+			},
+			expectMatch: false,
+		},
+		{
+			description: "two tolerations with same key,value,effect but different operator cannot match",
+			toleration: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			tolerationToMatch: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpExists,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			expectMatch: false,
+		},
+		{
+			description: "two tolerations with same key,operator,effect but different value cannot match",
+			toleration: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "bar",
+				Effect:   TaintEffectNoSchedule,
+			},
+			tolerationToMatch: &Toleration{
+				Key:      "foo",
+				Operator: TolerationOpEqual,
+				Value:    "different-value",
+				Effect:   TaintEffectNoSchedule,
+			},
+			expectMatch: false,
+		},
+	}
+	for _, test := range testCases {
+		if test.expectMatch != test.toleration.MatchToleration(test.tolerationToMatch) {
+			t.Errorf("[%s] expect toleration:\n%#v\nmatch toleration:\n%#v", test.description, test.toleration, test.tolerationToMatch)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
There is no ut for pkg/api/toleration.go. This PR aims to add ut for it.

related issue: #50827 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
