### PR TITLE
Add StatefuleSet case  to scaleExample

### DIFF
--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	scaleLong = templates.LongDesc(i18n.T(`
-		Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
+		Set a new size for a Deployment, ReplicaSet, Replication Controller, Job, or StatefulSet.
 
 		Scale also allows users to specify one or more preconditions for the scale action.
 
@@ -53,7 +53,10 @@ var (
 		kubectl scale --replicas=5 rc/foo rc/bar rc/baz
 
 		# Scale job named 'cron' to 3.
-		kubectl scale --replicas=3 job/cron`))
+		kubectl scale --replicas=3 job/cron
+
+		# Scale statefulset named 'web' to 3.
+		kubectl scale --replicas=3  statefulset/web`))
 )
 
 // NewCmdScale returns a cobra command with the appropriate configuration and flags to run scale


### PR DESCRIPTION
Add StatefuleSet to scaleExample.
When I use the scale function to help, you can view all the resources can scale, including not shown here statefulset.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
