### PR TITLE
make cloud_node_controller stoppable

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -217,7 +217,7 @@ func StartControllers(s *options.CloudControllerManagerServer, kubeconfig *restc
 		s.NodeMonitorPeriod.Duration,
 		s.NodeStatusUpdateFrequency.Duration)
 
-	nodeController.Run()
+	go nodeController.Run(stop)
 	time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 
 	// Start the service controller

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -106,7 +106,7 @@ func NewCloudNodeController(
 
 // This controller deletes a node if kubelet is not reporting
 // and the node is gone from the cloud provider.
-func (cnc *CloudNodeController) Run() {
+func (cnc *CloudNodeController) Run(stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 
 	// The following loops run communicate with the APIServer with a worst case complexity
@@ -114,10 +114,12 @@ func (cnc *CloudNodeController) Run() {
 	// very infrequently. DO NOT MODIFY this to perform frequent operations.
 
 	// Start a loop to periodically update the node addresses obtained from the cloud
-	go wait.Until(cnc.UpdateNodeStatus, cnc.nodeStatusUpdateFrequency, wait.NeverStop)
+	go wait.Until(cnc.UpdateNodeStatus, cnc.nodeStatusUpdateFrequency, stopCh)
 
 	// Start a loop to periodically check if any nodes have been deleted from cloudprovider
-	go wait.Until(cnc.MonitorNode, cnc.nodeMonitorPeriod, wait.NeverStop)
+	go wait.Until(cnc.MonitorNode, cnc.nodeMonitorPeriod, stopCh)
+
+	<-stopCh
 }
 
 // UpdateNodeStatus updates the node status, such as node addresses

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -114,7 +114,9 @@ func TestNodeDeleted(t *testing.T) {
 	}
 	eventBroadcaster.StartLogging(glog.Infof)
 
-	cloudNodeController.Run()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cloudNodeController.Run(stopCh)
 
 	select {
 	case <-fnh.DeleteWaitChan:
@@ -555,7 +557,9 @@ func TestNodeAddresses(t *testing.T) {
 		},
 	}
 
-	cloudNodeController.Run()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cloudNodeController.Run(stopCh)
 
 	<-time.After(2 * time.Second)
 
@@ -663,7 +667,9 @@ func TestNodeProvidedIPAddresses(t *testing.T) {
 		t.Errorf("Node status unexpectedly updated")
 	}
 
-	cloudNodeController.Run()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go cloudNodeController.Run(stopCh)
 
 	<-time.After(2 * time.Second)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
make CloudNodController stoppable, which is in consistence with other controllers

related issue: #50666 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
