### PR TITLE
Fix return 0 error in DefaultSubCommandRun

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4188,7 +4188,7 @@ run_plugins_tests() {
   kube::test::if_has_string "${output_message}" 'no plugins installed'
 
   # single plugins path
-  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin 2>&1)
+  output_message=$(! KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin 2>&1)
   kube::test::if_has_string "${output_message}" 'echo\s\+Echoes for test-cmd'
   kube::test::if_has_string "${output_message}" 'get\s\+The wonderful new plugin-based get!'
   kube::test::if_has_string "${output_message}" 'error\s\+The tremendous plugin that always fails!'
@@ -4225,7 +4225,7 @@ run_plugins_tests() {
   kube::test::if_has_string "${output_message}" 'error: exit status 1'
 
   # plugin tree
-  output_message=$(KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin tree 2>&1)
+  output_message=$(! KUBECTL_PLUGINS_PATH=test/fixtures/pkg/kubectl/plugins kubectl plugin tree 2>&1)
   kube::test::if_has_string "${output_message}" 'Plugin with a tree of commands'
   kube::test::if_has_string "${output_message}" 'child1\s\+The first child of a tree'
   kube::test::if_has_string "${output_message}" 'child2\s\+The second child of a tree'

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -778,6 +778,7 @@ func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
 		c.SetOutput(out)
 		RequireNoArguments(c, args)
 		c.Help()
+		CheckErr(ErrExit)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/50644
@mengqiy most of our command didn't return 1 when error, is because it invoke `DefaultSubCommandRun` which created in this pr https://github.com/kubernetes/kubernetes/pull/35206, I'm not sure if it's ok to directly add an `os.Exit` in that function, so also cc @juanvallejo @fabianofranz for review.

also @apelisse  @mengqiy  I think we don't have any test for check return value now ? cmiiw, I will add some test in test-cmd since it's easy to write scripts check return value, wdyt ?