### PR TITLE
Remove deprecated lookup cache flags.

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -69,9 +69,6 @@ func NewCMServer() *CMServer {
 			ConcurrentDeploymentSyncs:                       5,
 			ConcurrentNamespaceSyncs:                        10,
 			ConcurrentSATokenSyncs:                          5,
-			LookupCacheSizeForRC:                            4096,
-			LookupCacheSizeForRS:                            4096,
-			LookupCacheSizeForDaemonSet:                     1024,
 			ServiceSyncPeriod:                               metav1.Duration{Duration: 5 * time.Minute},
 			RouteReconciliationPeriod:                       metav1.Duration{Duration: 10 * time.Second},
 			ResourceQuotaSyncPeriod:                         metav1.Duration{Duration: 5 * time.Minute},
@@ -144,15 +141,6 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.Int32Var(&s.ConcurrentDeploymentSyncs, "concurrent-deployment-syncs", s.ConcurrentDeploymentSyncs, "The number of deployment objects that are allowed to sync concurrently. Larger number = more responsive deployments, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentNamespaceSyncs, "concurrent-namespace-syncs", s.ConcurrentNamespaceSyncs, "The number of namespace objects that are allowed to sync concurrently. Larger number = more responsive namespace termination, but more CPU (and network) load")
 	fs.Int32Var(&s.ConcurrentSATokenSyncs, "concurrent-serviceaccount-token-syncs", s.ConcurrentSATokenSyncs, "The number of service account token objects that are allowed to sync concurrently. Larger number = more responsive token generation, but more CPU (and network) load")
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	fs.Int32Var(&s.LookupCacheSizeForRC, "replication-controller-lookup-cache-size", s.LookupCacheSizeForRC, "This flag is deprecated and will be removed in future releases. ReplicationController no longer requires a lookup cache.")
-	fs.MarkDeprecated("replication-controller-lookup-cache-size", "This flag is deprecated and will be removed in future releases. ReplicationController no longer requires a lookup cache.")
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	fs.Int32Var(&s.LookupCacheSizeForRS, "replicaset-lookup-cache-size", s.LookupCacheSizeForRS, "This flag is deprecated and will be removed in future releases. ReplicaSet no longer requires a lookup cache.")
-	fs.MarkDeprecated("replicaset-lookup-cache-size", "This flag is deprecated and will be removed in future releases. ReplicaSet no longer requires a lookup cache.")
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	fs.Int32Var(&s.LookupCacheSizeForDaemonSet, "daemonset-lookup-cache-size", s.LookupCacheSizeForDaemonSet, "This flag is deprecated and will be removed in future releases. DaemonSet no longer requires a lookup cache.")
-	fs.MarkDeprecated("daemonset-lookup-cache-size", "This flag is deprecated and will be removed in future releases. DaemonSet no longer requires a lookup cache.")
 	fs.DurationVar(&s.ServiceSyncPeriod.Duration, "service-sync-period", s.ServiceSyncPeriod.Duration, "The period for syncing services with their external load balancers")
 	fs.DurationVar(&s.NodeSyncPeriod.Duration, "node-sync-period", 0, ""+
 		"This flag is deprecated and will be removed in future releases. See node-monitor-period for Node health checking or "+

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -711,19 +711,6 @@ type KubeControllerManagerConfiguration struct {
 	ConcurrentSATokenSyncs int32
 	// lookupCacheSizeForRC is the size of lookup cache for replication controllers.
 	// Larger number = more responsive replica management, but more MEM load.
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	// DEPRECATED: This is no longer used.
-	LookupCacheSizeForRC int32
-	// lookupCacheSizeForRS is the size of lookup cache for replicatsets.
-	// Larger number = more responsive replica management, but more MEM load.
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	// DEPRECATED: This is no longer used.
-	LookupCacheSizeForRS int32
-	// lookupCacheSizeForDaemonSet is the size of lookup cache for daemonsets.
-	// Larger number = more responsive daemonset, but more MEM load.
-	// TODO(#43388): Remove the following flag 6 months after v1.6.0 is released.
-	// DEPRECATED: This is no longer used.
-	LookupCacheSizeForDaemonSet int32
 	// serviceSyncPeriod is the period for syncing services with their external
 	// load balancers.
 	ServiceSyncPeriod metav1.Duration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Remove deprecated lookup cache flags: `replication-controller-lookup-cache-size, replicaset-lookup-cache-size, daemonset-lookup-cache-size`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #43388

**Special notes for your reviewer**:
/cc @enisoc

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The following deprecated flags have been removed from `kube-controller-manager`: `replication-controller-lookup-cache-size`, `replicaset-lookup-cache-size`, and `daemonset-lookup-cache-size`. Make sure you no longer attempt to set them.
```
