### PR TITLE
Base Fluentd image off debian:stretch-slim for systemd with LZ4

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -48,11 +48,11 @@ roleRef:
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-es
+  name: fluentd-es-v2.0.1
   namespace: kube-system
   labels:
     k8s-app: fluentd-es
-    version: v2.0.0
+    version: v2.0.1
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -61,7 +61,7 @@ spec:
       labels:
         k8s-app: fluentd-es
         kubernetes.io/cluster-service: "true"
-        version: v2.0.0
+        version: v2.0.1
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: fluentd-es
       containers:
       - name: fluentd-es
-        image: gcr.io/google-containers/fluentd-elasticsearch:v2.0.0
+        image: gcr.io/google-containers/fluentd-elasticsearch:v2.0.1
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Dockerfile
@@ -19,8 +19,10 @@
 # Note that fluentd is run with root permssion to allow access to
 # log files with root only access under /var/log/containers/*
 
-FROM gcr.io/google-containers/debian-base-amd64:0.1
+FROM debian:stretch-slim
 
+COPY clean-apt /usr/bin
+COPY clean-install /usr/bin
 COPY Gemfile /Gemfile
 
 # 1. Install & configure dependencies.
@@ -31,18 +33,13 @@ RUN BUILD_DEPS="make gcc g++ libc6-dev ruby-dev" \
     && clean-install $BUILD_DEPS \
                      ca-certificates \
                      libjemalloc1 \
-                     liblz4-1 \
                      ruby \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install --file Gemfile \
     && apt-get purge -y --auto-remove \
                      -o APT::AutoRemove::RecommendsImportant=false \
                      $BUILD_DEPS \
-    && rm -rf /tmp/* \
-              /var/lib/apt/lists/* \
-              /usr/lib/ruby/gems/*/cache/*.gem \
-              /var/log/* \
-              /var/tmp/* \
+    && clean-apt \
     # Ensure fluent has enough file descriptors
     && ulimit -n 65536
 

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/clean-apt
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/clean-apt
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY:	build push
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
 
-PREFIX = gcr.io/google-containers
-IMAGE = fluentd-elasticsearch
-TAG = v2.0.1
+set -o errexit
 
-build:
-	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
-
-push:
-	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)
+apt-get clean -y
+rm -rf \
+   /var/cache/debconf/* \
+   /var/lib/apt/lists/* \
+   /var/log/* \
+   /tmp/* \
+   /var/tmp/*

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/clean-install
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/clean-install
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 # Copyright 2017 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,14 +14,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY:	build push
+# A script encapsulating a common Dockerimage pattern for installing packages
+# and then cleaning up the unnecessary install artifacts.
+# e.g. clean-install iptables ebtables conntrack
 
-PREFIX = gcr.io/google-containers
-IMAGE = fluentd-elasticsearch
-TAG = v2.0.1
+set -o errexit
 
-build:
-	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
+if [ $# = 0 ]; then
+  echo >&2 "No packages specified"
+  exit 1
+fi
 
-push:
-	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)
+apt-get update
+apt-get install -y --no-install-recommends $@
+clean-apt

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/run.sh
@@ -20,10 +20,4 @@
 # For systems without journald
 mkdir -p /var/log/journal
 
-# Copy host libsystemd into image to avoid compatibility issues.
-if [ ! -z "$(ls /host/lib/libsystemd* 2>/dev/null)" ]; then
-  rm /lib/x86_64-linux-gnu/libsystemd*
-  cp -a /host/lib/libsystemd* /lib/x86_64-linux-gnu/
-fi
-
 /usr/local/bin/fluentd $@


### PR DESCRIPTION
To avoid having to copy libsystemd from host system, base off image with LZ4 capable systemd.

Fixes #50242.

```release-notes
fluentd-elasticsearch addon: change the fluentd base image to fix crashes on systems with non-standard systemd installation
```