### PR TITLE
[WIP] Make testing.StartTestServer close cleanly

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -87,8 +87,8 @@ func createAggregatorConfig(kubeAPIServerConfig genericapiserver.Config, command
 	return aggregatorConfig, nil
 }
 
-func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget, apiExtensionInformers apiextensionsinformers.SharedInformerFactory) (*aggregatorapiserver.APIAggregator, error) {
-	aggregatorServer, err := aggregatorConfig.Complete().NewWithDelegate(delegateAPIServer)
+func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget, apiExtensionInformers apiextensionsinformers.SharedInformerFactory, stopCh <-chan struct{}) (*aggregatorapiserver.APIAggregator, error) {
+	aggregatorServer, err := aggregatorConfig.Complete().NewWithDelegate(delegateAPIServer, stopCh)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -48,8 +48,8 @@ func createAPIExtensionsConfig(kubeAPIServerConfig genericapiserver.Config, comm
 
 }
 
-func createAPIExtensionsServer(apiextensionsConfig *apiextensionsapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget) (*apiextensionsapiserver.CustomResourceDefinitions, error) {
-	apiextensionsServer, err := apiextensionsConfig.Complete().New(delegateAPIServer)
+func createAPIExtensionsServer(apiextensionsConfig *apiextensionsapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget, stopCh <-chan struct{}) (*apiextensionsapiserver.CustomResourceDefinitions, error) {
+	apiextensionsServer, err := apiextensionsConfig.Complete().New(delegateAPIServer, stopCh)
 	if err != nil {
 		return nil, err
 	}

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -235,7 +235,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		cachesize.SetWatchCacheSizes(s.GenericServerRunOptions.WatchCacheSizes)
 	}
 
-	m, err := genericConfig.Complete().New("federation", genericapiserver.EmptyDelegate)
+	m, err := genericConfig.Complete().New("federation", genericapiserver.EmptyDelegate, stopCh)
 	if err != nil {
 		return err
 	}

--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -40,6 +40,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &federation.Cluster{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -40,6 +40,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &federation.Cluster{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo)

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -143,6 +143,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -210,12 +210,12 @@ func (c *Config) SkipComplete() completedConfig {
 // Certain config fields will be set to a default value if unset.
 // Certain config fields must be specified, including:
 //   KubeletClientConfig
-func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*Master, error) {
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget, stopCh <-chan struct{}) (*Master, error) {
 	if reflect.DeepEqual(c.KubeletClientConfig, kubeletclient.KubeletClientConfig{}) {
 		return nil, fmt.Errorf("Master.New() called with empty config.KubeletClientConfig")
 	}
 
-	s, err := c.Config.GenericConfig.SkipComplete().New("kube-apiserver", delegationTarget) // completion is done in Complete, no need for a second time
+	s, err := c.Config.GenericConfig.SkipComplete().New("kube-apiserver", delegationTarget, stopCh) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/master/master_openapi_test.go
+++ b/pkg/master/master_openapi_test.go
@@ -27,6 +27,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/util/wait"
 	apirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/kubernetes/pkg/api"
@@ -54,7 +55,7 @@ func TestValidOpenAPISpec(t *testing.T) {
 	}
 	config.GenericConfig.SwaggerConfig = genericapiserver.DefaultSwaggerConfig()
 
-	master, err := config.Complete().New(genericapiserver.EmptyDelegate)
+	master, err := config.Complete().New(genericapiserver.EmptyDelegate, wait.NeverStop)
 	if err != nil {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -180,7 +181,7 @@ func TestCertificatesRestStorageStrategies(t *testing.T) {
 func newMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdserver, config, assert := setUp(t)
 
-	master, err := config.Complete().New(genericapiserver.EmptyDelegate)
+	master, err := config.Complete().New(genericapiserver.EmptyDelegate, wait.NeverStop)
 	if err != nil {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}
@@ -206,7 +207,7 @@ func limitedAPIResourceConfigSource() *serverstorage.ResourceConfig {
 func newLimitedMaster(t *testing.T) (*Master, *etcdtesting.EtcdTestServer, Config, *assert.Assertions) {
 	etcdserver, config, assert := setUp(t)
 	config.APIResourceConfigSource = limitedAPIResourceConfigSource()
-	master, err := config.Complete().New(genericapiserver.EmptyDelegate)
+	master, err := config.Complete().New(genericapiserver.EmptyDelegate, wait.NeverStop)
 	if err != nil {
 		t.Fatalf("Error in bringing up the master: %v", err)
 	}

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -103,6 +103,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.StatefulSet{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -137,6 +141,8 @@ func (r *ScaleREST) GroupVersionKind() schema.GroupVersionKind {
 func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
+
+func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	ss, err := r.registry.GetStatefulSet(ctx, name, options)

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -103,6 +103,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &apps.StatefulSet{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -142,6 +143,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
 
+// Destroy releases resources
 func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -39,6 +39,8 @@ func (r *REST) New() runtime.Object {
 	return &authentication.TokenReview{}
 }
 
+func (r *REST) Destroy() {}
+
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	tokenReview, ok := obj.(*authentication.TokenReview)
 	if !ok {

--- a/pkg/registry/authentication/tokenreview/storage.go
+++ b/pkg/registry/authentication/tokenreview/storage.go
@@ -39,6 +39,7 @@ func (r *REST) New() runtime.Object {
 	return &authentication.TokenReview{}
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {}
 
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {

--- a/pkg/registry/authorization/localsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/localsubjectaccessreview/rest.go
@@ -40,6 +40,7 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.LocalSubjectAccessReview{}
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {}
 
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {

--- a/pkg/registry/authorization/localsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/localsubjectaccessreview/rest.go
@@ -40,6 +40,8 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.LocalSubjectAccessReview{}
 }
 
+func (r *REST) Destroy() {}
+
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	localSubjectAccessReview, ok := obj.(*authorizationapi.LocalSubjectAccessReview)
 	if !ok {

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -40,6 +40,7 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectAccessReview{}
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {}
 
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {

--- a/pkg/registry/authorization/selfsubjectaccessreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectaccessreview/rest.go
@@ -40,6 +40,8 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectAccessReview{}
 }
 
+func (r *REST) Destroy() {}
+
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	selfSAR, ok := obj.(*authorizationapi.SelfSubjectAccessReview)
 	if !ok {

--- a/pkg/registry/authorization/selfsubjectrulesreview/rest.go
+++ b/pkg/registry/authorization/selfsubjectrulesreview/rest.go
@@ -41,6 +41,8 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SelfSubjectRulesReview{}
 }
 
+func (r *REST) Destroy() {}
+
 // Create attempts to get self subject rules in specific namespace.
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	selfSRR, ok := obj.(*authorizationapi.SelfSubjectRulesReview)

--- a/pkg/registry/authorization/subjectaccessreview/rest.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest.go
@@ -40,6 +40,8 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SubjectAccessReview{}
 }
 
+func (r *REST) Destroy() {}
+
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	subjectAccessReview, ok := obj.(*authorizationapi.SubjectAccessReview)
 	if !ok {

--- a/pkg/registry/authorization/subjectaccessreview/rest.go
+++ b/pkg/registry/authorization/subjectaccessreview/rest.go
@@ -40,6 +40,7 @@ func (r *REST) New() runtime.Object {
 	return &authorizationapi.SubjectAccessReview{}
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {}
 
 func (r *REST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -81,6 +81,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &autoscaling.HorizontalPodAutoscaler{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -81,6 +81,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &autoscaling.HorizontalPodAutoscaler{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -79,6 +79,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.CronJob{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -79,6 +79,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.CronJob{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -96,6 +96,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.Job{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -96,6 +96,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &batch.Job{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -81,6 +81,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo)
@@ -93,6 +97,10 @@ type ApprovalREST struct {
 
 func (r *ApprovalREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
+}
+
+func (r *ApprovalREST) Destroy() {
+	r.store.Destroy()
 }
 
 // Update alters the approval subset of an object.

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -81,6 +81,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -99,6 +100,7 @@ func (r *ApprovalREST) New() runtime.Object {
 	return &certificates.CertificateSigningRequest{}
 }
 
+// Destroy releases resources
 func (r *ApprovalREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -44,6 +44,8 @@ func (rs *REST) New() runtime.Object {
 	return &api.ComponentStatus{}
 }
 
+func (rs *REST) Destroy() {}
+
 func (rs *REST) NewList() runtime.Object {
 	return &api.ComponentStatusList{}
 }

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -44,6 +44,7 @@ func (rs *REST) New() runtime.Object {
 	return &api.ComponentStatus{}
 }
 
+// Destroy releases resources
 func (rs *REST) Destroy() {}
 
 func (rs *REST) NewList() runtime.Object {

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -84,6 +84,10 @@ func (r *REST) New() runtime.Object {
 	return r.store.New()
 }
 
+func (r *REST) Destroy() {
+	r.store.Destroy()
+}
+
 func (r *REST) NewList() runtime.Object {
 	return r.store.NewList()
 }
@@ -216,6 +220,10 @@ func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -228,6 +236,10 @@ func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo 
 
 func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
+}
+
+func (r *FinalizeREST) Destroy() {
+	r.store.Destroy()
 }
 
 // Update alters the status finalizers subset of an object.

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -84,6 +84,7 @@ func (r *REST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {
 	r.store.Destroy()
 }
@@ -220,6 +221,7 @@ func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -238,6 +240,7 @@ func (r *FinalizeREST) New() runtime.Object {
 	return r.store.New()
 }
 
+// Destroy releases resources
 func (r *FinalizeREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -50,6 +50,10 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Node{}
 }
 
+func (r *ProxyREST) Destroy() {
+	r.Store.Destroy()
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods

--- a/pkg/registry/core/node/rest/proxy.go
+++ b/pkg/registry/core/node/rest/proxy.go
@@ -50,6 +50,7 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Node{}
 }
 
+// Destroy releases resources
 func (r *ProxyREST) Destroy() {
 	r.Store.Destroy()
 }

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -63,6 +63,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Node{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -63,6 +63,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Node{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -75,6 +75,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolume{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -75,6 +75,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolume{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -75,6 +75,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolumeClaim{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -75,6 +75,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.PersistentVolumeClaim{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -46,6 +46,10 @@ func (r *LogREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+func (r *LogREST) Destroy() {
+	r.Store.Destroy()
+}
+
 // LogREST implements StorageMetadata
 func (r *LogREST) ProducesMIMETypes(verb string) []string {
 	// Since the default list does not include "plain/text", we need to

--- a/pkg/registry/core/pod/rest/log.go
+++ b/pkg/registry/core/pod/rest/log.go
@@ -46,6 +46,7 @@ func (r *LogREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *LogREST) Destroy() {
 	r.Store.Destroy()
 }

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -51,6 +51,10 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+func (r *ProxyREST) Destroy() {
+	r.Store.Destroy()
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods
@@ -93,6 +97,10 @@ func (r *AttachREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+func (r *AttachREST) Destroy() {
+	r.Store.Destroy()
+}
+
 // Connect returns a handler for the pod exec proxy
 func (r *AttachREST) Connect(ctx genericapirequest.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	attachOpts, ok := opts.(*api.PodAttachOptions)
@@ -130,6 +138,10 @@ func (r *ExecREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+func (r *ExecREST) Destroy() {
+	r.Store.Destroy()
+}
+
 // Connect returns a handler for the pod exec proxy
 func (r *ExecREST) Connect(ctx genericapirequest.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
 	execOpts, ok := opts.(*api.PodExecOptions)
@@ -165,6 +177,10 @@ var _ = rest.Connecter(&PortForwardREST{})
 // New returns an empty pod object
 func (r *PortForwardREST) New() runtime.Object {
 	return &api.Pod{}
+}
+
+func (r *PortForwardREST) Destroy() {
+	r.Store.Destroy()
 }
 
 // NewConnectOptions returns the versioned object that represents the

--- a/pkg/registry/core/pod/rest/subresources.go
+++ b/pkg/registry/core/pod/rest/subresources.go
@@ -51,6 +51,7 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *ProxyREST) Destroy() {
 	r.Store.Destroy()
 }
@@ -97,6 +98,7 @@ func (r *AttachREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *AttachREST) Destroy() {
 	r.Store.Destroy()
 }
@@ -138,6 +140,7 @@ func (r *ExecREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *ExecREST) Destroy() {
 	r.Store.Destroy()
 }
@@ -179,6 +182,7 @@ func (r *PortForwardREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *PortForwardREST) Destroy() {
 	r.Store.Destroy()
 }

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -70,6 +70,7 @@ func (r *EvictionREST) New() runtime.Object {
 	return &policy.Eviction{}
 }
 
+// Destroy releases resources
 func (r *EvictionREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -70,6 +70,10 @@ func (r *EvictionREST) New() runtime.Object {
 	return &policy.Eviction{}
 }
 
+func (r *EvictionREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Create attempts to create a new eviction.  That is, it tries to evict a pod.
 func (r *EvictionREST) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	eviction := obj.(*policy.Eviction)

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -135,6 +135,7 @@ func (r *BindingREST) New() runtime.Object {
 	return &api.Binding{}
 }
 
+// Destroy releases resources
 func (r *BindingREST) Destroy() {
 	r.store.Destroy()
 }
@@ -213,6 +214,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Pod{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -135,6 +135,10 @@ func (r *BindingREST) New() runtime.Object {
 	return &api.Binding{}
 }
 
+func (r *BindingREST) Destroy() {
+	r.store.Destroy()
+}
+
 var _ = rest.Creater(&BindingREST{})
 
 // Create ensures a pod is bound to a specific host.
@@ -207,6 +211,10 @@ type StatusREST struct {
 // New creates a new pod resource
 func (r *StatusREST) New() runtime.Object {
 	return &api.Pod{}
+}
+
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
 }
 
 // Get retrieves the object from the storage. It is required to support Patch.

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -114,6 +114,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ReplicationController{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -139,6 +143,9 @@ func (r *ScaleREST) GroupVersionKind() schema.GroupVersionKind {
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
+}
+
+func (r *ScaleREST) Destroy() {
 }
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -114,6 +114,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ReplicationController{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -145,6 +146,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
 }
 
+// Destroy releases resources
 func (r *ScaleREST) Destroy() {
 }
 

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -74,6 +74,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ResourceQuota{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -74,6 +74,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.ResourceQuota{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -46,6 +46,7 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Service{}
 }
 
+// Destroy releases resources
 func (r *ProxyREST) Destroy() {
 	r.ServiceRest.Destroy()
 }

--- a/pkg/registry/core/service/proxy.go
+++ b/pkg/registry/core/service/proxy.go
@@ -46,6 +46,10 @@ func (r *ProxyREST) New() runtime.Object {
 	return &api.Service{}
 }
 
+func (r *ProxyREST) Destroy() {
+	r.ServiceRest.Destroy()
+}
+
 // ConnectMethods returns the list of HTTP methods that can be proxied
 func (r *ProxyREST) ConnectMethods() []string {
 	return proxyMethods

--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -219,6 +219,7 @@ func (*REST) New() runtime.Object {
 	return &api.Service{}
 }
 
+// Destroy releases resources
 func (r *REST) Destroy() {}
 
 func (*REST) NewList() runtime.Object {

--- a/pkg/registry/core/service/rest.go
+++ b/pkg/registry/core/service/rest.go
@@ -219,6 +219,8 @@ func (*REST) New() runtime.Object {
 	return &api.Service{}
 }
 
+func (r *REST) Destroy() {}
+
 func (*REST) NewList() runtime.Object {
 	return &api.ServiceList{}
 }

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -86,6 +86,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Service{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -86,6 +86,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &api.Service{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/extensions/controller/storage/storage.go
+++ b/pkg/registry/extensions/controller/storage/storage.go
@@ -61,6 +61,8 @@ func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
 
+func (r *ScaleREST) Destroy() {}
+
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	rc, err := (*r.registry).GetController(ctx, name, options)
 	if err != nil {
@@ -127,3 +129,5 @@ type RcREST struct{}
 func (r *RcREST) New() runtime.Object {
 	return &extensions.ReplicationControllerDummy{}
 }
+
+func (r *RcREST) Destroy() {}

--- a/pkg/registry/extensions/controller/storage/storage.go
+++ b/pkg/registry/extensions/controller/storage/storage.go
@@ -61,6 +61,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
 
+// Destroy releases resources
 func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -130,4 +131,5 @@ func (r *RcREST) New() runtime.Object {
 	return &extensions.ReplicationControllerDummy{}
 }
 
+// Destroy releases resources
 func (r *RcREST) Destroy() {}

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -87,6 +87,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.DaemonSet{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -87,6 +87,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.DaemonSet{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -109,6 +109,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.Deployment{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -127,6 +131,11 @@ type RollbackREST struct {
 // New creates a rollback
 func (r *RollbackREST) New() runtime.Object {
 	return &extensions.DeploymentRollback{}
+}
+
+// Destroy the storage
+func (r *RollbackREST) Destroy() {
+	r.store.Destroy()
 }
 
 var _ = rest.Creater(&RollbackREST{})
@@ -204,6 +213,9 @@ func (r *ScaleREST) GroupVersionKind() schema.GroupVersionKind {
 // New creates a new Scale object
 func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
+}
+
+func (r *ScaleREST) Destroy() {
 }
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -109,6 +109,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.Deployment{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -133,7 +134,7 @@ func (r *RollbackREST) New() runtime.Object {
 	return &extensions.DeploymentRollback{}
 }
 
-// Destroy the storage
+// Destroy releases resources
 func (r *RollbackREST) Destroy() {
 	r.store.Destroy()
 }
@@ -215,8 +216,8 @@ func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
 
-func (r *ScaleREST) Destroy() {
-}
+// Destroy releases resources
+func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	deployment, err := r.registry.GetDeployment(ctx, name, options)

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -79,6 +79,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.Ingress{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -79,6 +79,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.Ingress{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -113,6 +113,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.ReplicaSet{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }
@@ -144,6 +145,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
 
+// Destroy releases resources
 func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -113,6 +113,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &extensions.ReplicaSet{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)
@@ -139,6 +143,8 @@ func (r *ScaleREST) GroupVersionKind() schema.GroupVersionKind {
 func (r *ScaleREST) New() runtime.Object {
 	return &extensions.Scale{}
 }
+
+func (r *ScaleREST) Destroy() {}
 
 func (r *ScaleREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	rs, err := r.registry.GetReplicaSet(ctx, name, options)

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -76,6 +76,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &policyapi.PodDisruptionBudget{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Get retrieves the object from the storage. It is required to support Patch.
 func (r *StatusREST) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	return r.store.Get(ctx, name, options)

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -76,6 +76,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &policyapi.PodDisruptionBudget{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -40,6 +40,7 @@ func NewStorage(s rest.StandardStorage, ruleResolver rbacregistryvalidation.Auth
 	return &Storage{s, ruleResolver}
 }
 
+// Destroy releases resources
 func (s *Storage) Destroy() {}
 
 func (s *Storage) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {

--- a/pkg/registry/rbac/clusterrole/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrole/policybased/storage.go
@@ -40,6 +40,8 @@ func NewStorage(s rest.StandardStorage, ruleResolver rbacregistryvalidation.Auth
 	return &Storage{s, ruleResolver}
 }
 
+func (s *Storage) Destroy() {}
+
 func (s *Storage) Create(ctx genericapirequest.Context, obj runtime.Object, includeUninitialized bool) (runtime.Object, error) {
 	if rbacregistry.EscalationAllowed(ctx) {
 		return s.StandardStorage.Create(ctx, obj, includeUninitialized)

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -96,4 +96,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
 
+// Destroy releases resources
 func (s *Storage) Destroy() {}

--- a/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/policybased/storage.go
@@ -95,3 +95,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
+
+func (s *Storage) Destroy() {}

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -312,4 +312,5 @@ func (p RESTStorageProvider) GroupName() string {
 	return rbac.GroupName
 }
 
+// Destroy releases resources
 func (p RESTStorageProvider) Destroy() {}

--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -311,3 +311,5 @@ func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 func (p RESTStorageProvider) GroupName() string {
 	return rbac.GroupName
 }
+
+func (p RESTStorageProvider) Destroy() {}

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -75,3 +75,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
+
+func (s *Storage) Destroy() {}

--- a/pkg/registry/rbac/role/policybased/storage.go
+++ b/pkg/registry/rbac/role/policybased/storage.go
@@ -76,4 +76,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
 
+// Destroy releases resources
 func (s *Storage) Destroy() {}

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -108,3 +108,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
+
+func (s *Storage) Destroy() {}

--- a/pkg/registry/rbac/rolebinding/policybased/storage.go
+++ b/pkg/registry/rbac/rolebinding/policybased/storage.go
@@ -109,4 +109,5 @@ func (s *Storage) Update(ctx genericapirequest.Context, name string, obj rest.Up
 	return s.StandardStorage.Update(ctx, name, nonEscalatingInfo)
 }
 
+// Destroy releases resources
 func (s *Storage) Destroy() {}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -114,8 +114,8 @@ func (c *Config) SkipComplete() completedConfig {
 }
 
 // New returns a new instance of CustomResourceDefinitions from the given config.
-func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget) (*CustomResourceDefinitions, error) {
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New("apiextensions-apiserver", delegationTarget) // completion is done in Complete, no need for a second time
+func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget, stopCh <-chan struct{}) (*CustomResourceDefinitions, error) {
+	genericServer, err := c.Config.GenericConfig.SkipComplete().New("apiextensions-apiserver", delegationTarget, stopCh) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -127,7 +127,7 @@ func (o CustomResourceDefinitionsServerOptions) RunCustomResourceDefinitionsServ
 		return err
 	}
 
-	server, err := config.Complete().New(genericapiserver.EmptyDelegate)
+	server, err := config.Complete().New(genericapiserver.EmptyDelegate, stopCh)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -167,6 +167,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiextensions.CustomResourceDefinition{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresourcedefinition/etcd.go
@@ -167,6 +167,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiextensions.CustomResourceDefinition{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/start.go
@@ -97,7 +97,7 @@ func DefaultServerConfig() (*extensionsapiserver.Config, error) {
 
 func StartServer(config *extensionsapiserver.Config) (chan struct{}, clientset.Interface, dynamic.ClientPool, error) {
 	stopCh := make(chan struct{})
-	server, err := config.Complete().New(genericapiserver.EmptyDelegate)
+	server, err := config.Complete().New(genericapiserver.EmptyDelegate, stopCh)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -516,6 +516,7 @@ func (storage *SimpleRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
 
+// Destroy releases resources
 func (storage *SimpleRESTStorage) Destroy() {}
 
 func (storage *SimpleRESTStorage) NewList() runtime.Object {
@@ -621,6 +622,7 @@ func (s *ConnecterRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
 
+// Destroy releases resources
 func (s *ConnecterRESTStorage) Destroy() {}
 
 func (s *ConnecterRESTStorage) Connect(ctx request.Context, id string, options runtime.Object, responder rest.Responder) (http.Handler, error) {
@@ -746,6 +748,7 @@ func (storage *SimpleTypedStorage) New() runtime.Object {
 	return storage.baseType
 }
 
+// Destroy releases resources
 func (storage *SimpleTypedStorage) Destroy() {}
 
 func (storage *SimpleTypedStorage) Get(ctx request.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -887,6 +890,7 @@ func (UnimplementedRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
 
+// Destroy releases resources
 func (UnimplementedRESTStorage) Destroy() {}
 
 // TestUnimplementedRESTStorage ensures that if a rest.Storage does not implement a given
@@ -3875,6 +3879,7 @@ func (storage *SimpleXGSubresourceRESTStorage) New() runtime.Object {
 	return &genericapitesting.SimpleXGSubresource{}
 }
 
+// Destroy releases resources
 func (storage *SimpleXGSubresourceRESTStorage) Destroy() {}
 
 func (storage *SimpleXGSubresourceRESTStorage) Get(ctx request.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -516,6 +516,8 @@ func (storage *SimpleRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
 
+func (storage *SimpleRESTStorage) Destroy() {}
+
 func (storage *SimpleRESTStorage) NewList() runtime.Object {
 	return &genericapitesting.SimpleList{}
 }
@@ -618,6 +620,8 @@ var _ = rest.Connecter(&ConnecterRESTStorage{})
 func (s *ConnecterRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
+
+func (s *ConnecterRESTStorage) Destroy() {}
 
 func (s *ConnecterRESTStorage) Connect(ctx request.Context, id string, options runtime.Object, responder rest.Responder) (http.Handler, error) {
 	s.receivedConnectOptions = options
@@ -741,6 +745,8 @@ type SimpleTypedStorage struct {
 func (storage *SimpleTypedStorage) New() runtime.Object {
 	return storage.baseType
 }
+
+func (storage *SimpleTypedStorage) Destroy() {}
 
 func (storage *SimpleTypedStorage) Get(ctx request.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {
 	storage.checkContext(ctx)
@@ -880,6 +886,8 @@ type UnimplementedRESTStorage struct{}
 func (UnimplementedRESTStorage) New() runtime.Object {
 	return &genericapitesting.Simple{}
 }
+
+func (UnimplementedRESTStorage) Destroy() {}
 
 // TestUnimplementedRESTStorage ensures that if a rest.Storage does not implement a given
 // method, that it is literally not registered with the server.  In the past,
@@ -3866,6 +3874,8 @@ type SimpleXGSubresourceRESTStorage struct {
 func (storage *SimpleXGSubresourceRESTStorage) New() runtime.Object {
 	return &genericapitesting.SimpleXGSubresource{}
 }
+
+func (storage *SimpleXGSubresourceRESTStorage) Destroy() {}
 
 func (storage *SimpleXGSubresourceRESTStorage) Get(ctx request.Context, id string, options *metav1.GetOptions) (runtime.Object, error) {
 	return storage.item.DeepCopyObject(), nil

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -237,6 +237,13 @@ func (e *Store) New() runtime.Object {
 	return e.NewFunc()
 }
 
+func (e *Store) Destroy() {
+	if e.DestroyFunc != nil {
+		e.DestroyFunc()
+		e.DestroyFunc = nil
+	}
+}
+
 // NewList implements rest.Lister.
 func (e *Store) NewList() runtime.Object {
 	return e.NewListFunc()

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -237,6 +237,7 @@ func (e *Store) New() runtime.Object {
 	return e.NewFunc()
 }
 
+// Destroy releases resources
 func (e *Store) Destroy() {
 	if e.DestroyFunc != nil {
 		e.DestroyFunc()

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -56,6 +56,10 @@ type Storage interface {
 	// New returns an empty object that can be used with Create and Update after request data has been put into it.
 	// This object must be a pointer type for use with Codec.DecodeInto([]byte, runtime.Object)
 	New() runtime.Object
+
+	// Destroy should clean up any resources that the underlying
+	// storage mechanism maintains or consumes.
+	Destroy()
 }
 
 // KindProvider specifies a different kind for its API than for its internal storage.  This is necessary for external

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -23,6 +23,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -388,8 +388,8 @@ func (c *Config) SkipComplete() completedConfig {
 }
 
 // New creates a new server which logically combines the handling chain with the passed server.
-// name is used to differentiate for logging. The handler chain in particular can be difficult as it starts delgating.
-func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*GenericAPIServer, error) {
+// name is used to differentiate for logging.  The handler chain in particular can be difficult as it starts delgating.
+func (c completedConfig) New(name string, delegationTarget DelegationTarget, stopCh <-chan struct{}) (*GenericAPIServer, error) {
 	// The delegationTarget and the config must agree on the RequestContextMapper
 
 	if c.Serializer == nil {
@@ -434,6 +434,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		DiscoveryGroupManager: discovery.NewRootAPIsHandler(c.DiscoveryAddresses, c.Serializer, c.RequestContextMapper),
 
 		enableAPIResponseCompression: c.EnableAPIResponseCompression,
+		stopCh: stopCh,
 	}
 
 	for k, v := range delegationTarget.PostStartHooks() {

--- a/staging/src/k8s.io/apiserver/pkg/server/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/client-go/informers"
@@ -52,7 +53,7 @@ func TestNewWithDelegate(t *testing.T) {
 		return fmt.Errorf("delegate failed healthcheck")
 	}))
 
-	delegateServer, err := delegateConfig.SkipComplete().New("test", EmptyDelegate)
+	delegateServer, err := delegateConfig.SkipComplete().New("test", EmptyDelegate, wait.NeverStop)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +82,7 @@ func TestNewWithDelegate(t *testing.T) {
 		return fmt.Errorf("wrapping failed healthcheck")
 	}))
 
-	wrappingServer, err := wrappingConfig.Complete().New("test", delegateServer)
+	wrappingServer, err := wrappingConfig.Complete().New("test", delegateServer, wait.NeverStop)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -315,6 +315,16 @@ func (s *GenericAPIServer) EffectiveSecurePort() int {
 
 // installAPIResources is a private method for installing the REST storage backing each api groupversionresource
 func (s *GenericAPIServer) installAPIResources(apiPrefix string, apiGroupInfo *APIGroupInfo) error {
+	go func() {
+		<-s.stopCh
+
+		for _, m := range apiGroupInfo.VersionedResourcesStorageMap {
+			for _, storage := range m {
+				storage.Destroy()
+			}
+		}
+	}()
+
 	for _, groupVersion := range apiGroupInfo.GroupMeta.GroupVersions {
 		if len(apiGroupInfo.VersionedResourcesStorageMap[groupVersion.Version]) == 0 {
 			glog.Warningf("Skipping API %v because it has no resources.", groupVersion)
@@ -350,11 +360,6 @@ func (s *GenericAPIServer) InstallLegacyAPIGroup(apiPrefix string, apiGroupInfo 
 	// Install the version handler.
 	// Add a handler at /<apiPrefix> to enumerate the supported api versions.
 	s.Handler.GoRestfulContainer.Add(discovery.NewLegacyRootAPIHandler(s.discoveryAddresses, s.Serializer, apiPrefix, apiVersions, s.requestContextMapper).WebService())
-
-	go func() {
-		<-s.stopCh
-		destroyStorage(apiGroupInfo)
-	}()
 
 	return nil
 }
@@ -400,11 +405,6 @@ func (s *GenericAPIServer) InstallAPIGroup(apiGroupInfo *APIGroupInfo) error {
 
 	s.DiscoveryGroupManager.AddGroup(apiGroup)
 	s.Handler.GoRestfulContainer.Add(discovery.NewAPIGroupHandler(s.Serializer, apiGroup, s.requestContextMapper).WebService())
-
-	go func() {
-		<-s.stopCh
-		destroyStorage(apiGroupInfo)
-	}()
 
 	return nil
 }
@@ -457,13 +457,5 @@ func NewDefaultAPIGroupInfo(group string, registry *registered.APIRegistrationMa
 		Scheme:                 scheme,
 		ParameterCodec:         parameterCodec,
 		NegotiatedSerializer:   codecs,
-	}
-}
-
-func destroyStorage(apiGroupInfo *APIGroupInfo) {
-	for _, stores := range apiGroupInfo.VersionedResourcesStorageMap {
-		for _, store := range stores {
-			store.Destroy()
-		}
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -480,6 +480,7 @@ func (p *testGetterStorage) New() runtime.Object {
 	}
 }
 
+// Destroy releases resources
 func (p *testGetterStorage) Destroy() {}
 
 func (p *testGetterStorage) Get(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
@@ -499,6 +500,7 @@ func (p *testNoVerbsStorage) New() runtime.Object {
 	}
 }
 
+// Destroy releases resources
 func (p *testNoVerbsStorage) Destroy() {}
 
 func fakeVersion() version.Info {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -15,6 +15,7 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -40,6 +40,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/server"
@@ -487,7 +488,7 @@ NextTest:
 				return
 			}
 
-			s, err := config.Complete().New("test", server.EmptyDelegate)
+			s, err := config.Complete().New("test", server.EmptyDelegate, wait.NeverStop)
 			if err != nil {
 				t.Errorf("%q - failed creating the server: %v", title, err)
 				return

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -144,13 +144,13 @@ func (c *Config) SkipComplete() completedConfig {
 }
 
 // New returns a new instance of APIAggregator from the given config.
-func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.DelegationTarget) (*APIAggregator, error) {
+func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.DelegationTarget, stopCh <-chan struct{}) (*APIAggregator, error) {
 	// Prevent generic API server to install OpenAPI handler. Aggregator server
 	// has its own customized OpenAPI handler.
 	openApiConfig := c.Config.GenericConfig.OpenAPIConfig
 	c.Config.GenericConfig.OpenAPIConfig = nil
 
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New("kube-aggregator", delegationTarget) // completion is done in Complete, no need for a second time
+	genericServer, err := c.Config.GenericConfig.SkipComplete().New("kube-aggregator", delegationTarget, stopCh) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -165,7 +165,7 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	server, err := config.Complete().NewWithDelegate(genericapiserver.EmptyDelegate)
+	server, err := config.Complete().NewWithDelegate(genericapiserver.EmptyDelegate, stopCh)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -72,6 +72,7 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiregistration.APIService{}
 }
 
+// Destroy releases resources
 func (r *StatusREST) Destroy() {
 	r.store.Destroy()
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/registry/apiservice/etcd/etcd.go
@@ -72,6 +72,10 @@ func (r *StatusREST) New() runtime.Object {
 	return &apiregistration.APIService{}
 }
 
+func (r *StatusREST) Destroy() {
+	r.store.Destroy()
+}
+
 // Update alters the status subset of an object.
 func (r *StatusREST) Update(ctx genericapirequest.Context, name string, objInfo rest.UpdatedObjectInfo) (runtime.Object, bool, error) {
 	return r.store.Update(ctx, name, objInfo)

--- a/staging/src/k8s.io/sample-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apiserver/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apiserver/apiserver.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -95,7 +96,7 @@ func (c *Config) SkipComplete() completedConfig {
 
 // New returns a new instance of WardleServer from the given config.
 func (c completedConfig) New() (*WardleServer, error) {
-	genericServer, err := c.Config.GenericConfig.SkipComplete().New("sample-apiserver", genericapiserver.EmptyDelegate) // completion is done in Complete, no need for a second time
+	genericServer, err := c.Config.GenericConfig.SkipComplete().New("sample-apiserver", genericapiserver.EmptyDelegate, wait.NeverStop) // completion is done in Complete, no need for a second time
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/BUILD
@@ -8,10 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["registry.go"],
-    deps = [
-        "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
-    ],
+    deps = ["//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library"],
 )
 
 filegroup(

--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/registry.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
-	"k8s.io/apiserver/pkg/registry/rest"
 )
 
 // REST implements a RESTStorage for API services against etcd
@@ -31,7 +30,7 @@ type REST struct {
 // RESTInPeace is just a simple function that panics on error.
 // Otherwise returns the given storage object. It is meant to be
 // a wrapper for wardle registries.
-func RESTInPeace(storage rest.StandardStorage, err error) rest.StandardStorage {
+func RESTInPeace(storage *REST, err error) *REST {
 	if err != nil {
 		err = fmt.Errorf("unable to create REST storage for a resource due to %v, will die", err)
 		panic(err)

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -685,14 +685,14 @@ func startRealMasterOrDie(t *testing.T, certDir string) (*allClient, clientv3.KV
 			if err != nil {
 				t.Fatal(err)
 			}
-			kubeAPIServerConfig, sharedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport)
+			kubeAPIServerConfig, sharedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport, wait.NeverStop)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			kubeAPIServerConfig.APIResourceConfigSource = &allResourceSource{} // force enable all resources
 
-			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers)
+			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers, wait.NeverStop)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -116,13 +116,13 @@ func TestAggregatedAPIServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			kubeAPIServerConfig, sharedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport)
+			kubeAPIServerConfig, sharedInformers, _, _, _, err := app.CreateKubeAPIServerConfig(kubeAPIServerOptions, tunneler, proxyTransport, wait.NeverStop)
 			if err != nil {
 				t.Fatal(err)
 			}
 			kubeClientConfigValue.Store(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
 
-			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers)
+			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers, wait.NeverStop)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -250,7 +250,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	}
 	masterConfig.GenericConfig.SharedInformerFactory = extinformers.NewSharedInformerFactory(clientset, masterConfig.GenericConfig.LoopbackClientConfig.Timeout)
 
-	m, err = masterConfig.Complete().New(genericapiserver.EmptyDelegate, wait.NeverStop)
+	m, err = masterConfig.Complete().New(genericapiserver.EmptyDelegate, stopCh)
 	if err != nil {
 		closeFn()
 		glog.Fatalf("error in bringing up the master: %v", err)

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -250,7 +250,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	}
 	masterConfig.GenericConfig.SharedInformerFactory = extinformers.NewSharedInformerFactory(clientset, masterConfig.GenericConfig.LoopbackClientConfig.Timeout)
 
-	m, err = masterConfig.Complete().New(genericapiserver.EmptyDelegate)
+	m, err = masterConfig.Complete().New(genericapiserver.EmptyDelegate, wait.NeverStop)
 	if err != nil {
 		closeFn()
 		glog.Fatalf("error in bringing up the master: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that the test apiserver closes cleanly. Without this
change there are many repeated reconnection attempts to etcd, at
sub-second intervals, accompanied by a lot of log spam indicating that
the connection could not be made. This also results in the
accumulation of many 1000s of goroutines and they in turn prevent
effective use of the test server across multiple test functions within
the same process.

This PR introduces Storage.Destroy() and the test server now closes
all its stores when it is being shutdown.

Prior to this change there are ~1500+ goroutines remaining after the
server stops. With the change there are ~200 remaining; this is a
stepping-stone on the way to reducing that further.

**Which issue this PR fixes**

Fixes #49489

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
