### PR TITLE
teach gce cloud to handle alpha/beta operations v2

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -88,6 +88,8 @@ go_test(
         "//pkg/cloudprovider:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
+        "//vendor/google.golang.org/api/compute/v0.alpha:go_default_library",
+        "//vendor/google.golang.org/api/compute/v0.beta:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -80,6 +80,11 @@ const (
 	gceComputeAPIEndpoint = "https://www.googleapis.com/compute/v1/"
 )
 
+// gceObject is an abstraction of all GCE API object in go client
+type gceObject interface {
+	MarshalJSON() ([]byte, error)
+}
+
 // GCECloud is an implementation of Interface, LoadBalancer and Instances for Google Compute Engine.
 type GCECloud struct {
 	// ClusterID contains functionality for getting (and initializing) the ingress-uid. Call GCECloud.Initialize()

--- a/pkg/cloudprovider/providers/gce/gce_op.go
+++ b/pkg/cloudprovider/providers/gce/gce_op.go
@@ -17,17 +17,20 @@ limitations under the License.
 package gce
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/golang/glog"
-	compute "google.golang.org/api/compute/v1"
+	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
+	computev1 "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 )
 
-func (gce *GCECloud) waitForOp(op *compute.Operation, getOperation func(operationName string) (*compute.Operation, error), mc *metricContext) error {
+func (gce *GCECloud) waitForOp(op *computev1.Operation, getOperation func(operationName string) (*computev1.Operation, error), mc *metricContext) error {
 	if op == nil {
 		return mc.Observe(fmt.Errorf("operation must not be nil"))
 	}
@@ -72,11 +75,11 @@ func (gce *GCECloud) waitForOp(op *compute.Operation, getOperation func(operatio
 	})
 }
 
-func opIsDone(op *compute.Operation) bool {
+func opIsDone(op *computev1.Operation) bool {
 	return op != nil && op.Status == "DONE"
 }
 
-func getErrorFromOp(op *compute.Operation) error {
+func getErrorFromOp(op *computev1.Operation) error {
 	if op != nil && op.Error != nil && len(op.Error.Errors) > 0 {
 		err := &googleapi.Error{
 			Code:    int(op.HttpErrorStatusCode),
@@ -89,20 +92,77 @@ func getErrorFromOp(op *compute.Operation) error {
 	return nil
 }
 
-func (gce *GCECloud) waitForGlobalOp(op *compute.Operation, mc *metricContext) error {
-	return gce.waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return gce.service.GlobalOperations.Get(gce.projectID, operationName).Do()
-	}, mc)
+func (gce *GCECloud) waitForGlobalOp(op gceObject, mc *metricContext) error {
+	switch v := op.(type) {
+	case *computealpha.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceAlpha.GlobalOperations.Get(gce.projectID, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computebeta.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceBeta.GlobalOperations.Get(gce.projectID, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computev1.Operation:
+		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
+			return gce.service.GlobalOperations.Get(gce.projectID, operationName).Do()
+		}, mc)
+	default:
+		return fmt.Errorf("unexpected type: %T", v)
+	}
 }
 
-func (gce *GCECloud) waitForRegionOp(op *compute.Operation, region string, mc *metricContext) error {
-	return gce.waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return gce.service.RegionOperations.Get(gce.projectID, region, operationName).Do()
-	}, mc)
+func (gce *GCECloud) waitForRegionOp(op gceObject, region string, mc *metricContext) error {
+	switch v := op.(type) {
+	case *computealpha.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceAlpha.RegionOperations.Get(gce.projectID, region, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computebeta.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceBeta.RegionOperations.Get(gce.projectID, region, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computev1.Operation:
+		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
+			return gce.service.RegionOperations.Get(gce.projectID, region, operationName).Do()
+		}, mc)
+	default:
+		return fmt.Errorf("unexpected type: %T", v)
+	}
 }
 
-func (gce *GCECloud) waitForZoneOp(op *compute.Operation, zone string, mc *metricContext) error {
-	return gce.waitForOp(op, func(operationName string) (*compute.Operation, error) {
-		return gce.service.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
-	}, mc)
+func (gce *GCECloud) waitForZoneOp(op gceObject, zone string, mc *metricContext) error {
+	switch v := op.(type) {
+	case *computealpha.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceAlpha.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computebeta.Operation:
+		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
+			op, err := gce.serviceBeta.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+			return convertToV1Operation(op), err
+		}, mc)
+	case *computev1.Operation:
+		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
+			return gce.service.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+		}, mc)
+	default:
+		return fmt.Errorf("unexpected type: %T", v)
+	}
+}
+
+func convertToV1Operation(object gceObject) *computev1.Operation {
+	enc, err := object.MarshalJSON()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to encode to json: %v", err))
+	}
+	var op computev1.Operation
+	if err := json.Unmarshal(enc, &op); err != nil {
+		panic(fmt.Sprintf("Failed to convert GCE apiObject %v to v1 operation: %v", object, err))
+	}
+	return &op
 }


### PR DESCRIPTION
Alternative to #50704 

This one feels cleaner. BUT, type assertion problems cannot be exposed at compile time. 

Please let me know what you think. This will set the precedence for consuming GCE alpha/beta API. 

cc: @thockin @yujuhong @saad-ali @MrHohn 

```release-note
NONE
```
