### PR TITLE
Fix forkedjson.LookupPatchMetadata for pointers.

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/BUILD
@@ -3,11 +3,18 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
     name = "go_default_library",
     srcs = ["fields.go"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["fields_test.go"],
+    library = ":go_default_library",
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -28,6 +28,9 @@ const (
 // TODO: fix the returned errors to be introspectable.
 func LookupPatchMetadata(t reflect.Type, jsonField string) (
 	elemType reflect.Type, patchStrategies []string, patchMergeKey string, e error) {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
 	if t.Kind() == reflect.Map {
 		elemType = t.Elem()
 		return

--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields_test.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields_test.go
@@ -1,0 +1,30 @@
+package json
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestLookupPtrToStruct(t *testing.T) {
+	type Elem struct {
+		Key   string
+		Value string
+	}
+	type Outer struct {
+		Inner []Elem `json:"inner" patchStrategy:"merge" patchMergeKey:"key"`
+	}
+	outer := &Outer{}
+	elemType, patchStrategies, patchMergeKey, err := LookupPatchMetadata(reflect.TypeOf(outer), "inner")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if elemType != reflect.TypeOf([]Elem{}) {
+		t.Errorf("elemType = %v, want: %v", elemType, reflect.TypeOf([]Elem{}))
+	}
+	if !reflect.DeepEqual(patchStrategies, []string{"merge"}) {
+		t.Errorf("patchStrategies = %v, want: %v", patchStrategies, []string{"merge"})
+	}
+	if patchMergeKey != "key" {
+		t.Errorf("patchMergeKey = %v, want: %v", patchMergeKey, "key")
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug in `forkedjson.LookupPatchMetadata`. It is triggered when called with some API objects such as the `Selector` field (a pointer) in https://godoc.org/k8s.io/api/extensions/v1beta1#DeploymentSpec.

The provided test case fails without the lines added to `fields.go`.

**Which issue this PR fixes** N/A

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
