### PR TITLE
Fix comment of limitranges

### DIFF
--- a/pkg/registry/core/limitrange/storage/storage.go
+++ b/pkg/registry/core/limitrange/storage/storage.go
@@ -30,7 +30,7 @@ type REST struct {
 	*genericregistry.Store
 }
 
-// NewREST returns a RESTStorage object that will work against horizontal pod autoscalers.
+// NewREST returns a RESTStorage object that will work against limitranges.
 func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 	store := &genericregistry.Store{
 		Copier:                   api.Scheme,


### PR DESCRIPTION
**What this PR does / why we need it**:

The comment of limitrages' API seems to be copied from
pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
with the other implementation code.
It is a little difficult to understand what is the API, then this
PR fixes it.
