### PR TITLE
Create the directory for cadvisor if needed

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"time"
 
@@ -108,7 +109,9 @@ func New(address string, port uint, runtime string, rootPath string) (Interface,
 
 	if _, err := os.Stat(rootPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("rootDirectory %q does not exist", rootPath)
+			if err := os.MkdirAll(path.Clean(rootPath), 0750); err != nil {
+				return nil, fmt.Errorf("error creating root directory %q: %v", rootPath, err)
+			}
 		} else {
 			return nil, fmt.Errorf("failed to Stat %q: %v", rootPath, err)
 		}


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In 6c7245d464250278882b59d68a97b0170201d35d, code was added to
bail out if the directory that cadvisor monitored did not exist.

However, this breaks the earlier assumption that kubelet created
directories when needed in pkg/kubelet/kubelet.go's setupDataDirs()
method. setupDataDirs() happens much later, so basically kubelet
exits now.

So since cadvisor really needs this directory, let us just create
it

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #50709

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
