### PR TITLE
Fix for Policy based volume provisioning failure due to long VM Name in vSphere cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
@@ -18,6 +18,7 @@ package diskmanagers
 
 import (
 	"fmt"
+	"hash/fnv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -95,7 +96,9 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	var dummyVM *vclib.VirtualMachine
 	// Check if VM already exist in the folder.
 	// If VM is already present, use it, else create a new dummy VM.
-	dummyVMFullName := vclib.DummyVMPrefixName + "-" + vmdisk.volumeOptions.Name
+	fnvHash := fnv.New32a()
+	fnvHash.Write([]byte(vmdisk.volumeOptions.Name))
+	dummyVMFullName := vclib.DummyVMPrefixName + "-" + fmt.Sprint(fnvHash.Sum32())
 	dummyVM, err = datastore.Datacenter.GetVMByPath(ctx, vmdisk.vmOptions.VMFolder.InventoryPath+"/"+dummyVMFullName)
 	if err != nil {
 		// Create a dummy VM


### PR DESCRIPTION
Dummy VM is used for SPBM policy based provisioning feature of vSphere cloud provider.
Dummy VM name is generated based on kubernetes cluster name and pv name. It can easily go beyond 
vSphere's limitation of 80 characters for vmName.

To solve the long VM name failure hash is used instead of vSphere-k8s-clusterName-PvName

**Which issue this PR fixes** 
https://github.com/vmware/kubernetes/issues/176

**Release note:**
```release-note
Bug fix for the long VM name for storage policy based (SPBM) volume provisioning.
```

@BaluDontu @divyenpatel @luomiao @tusharnt 
