### PR TITLE
remove leaked socket file after unit test

### DIFF
--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -120,7 +120,9 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 // their various strategies properly wired up. This surfaced as a bug where strategies defined Export functions, but
 // they were never used outside of unit tests because the export strategies were not assigned inside the Store.
 func TestLegacyRestStorageStrategies(t *testing.T) {
-	_, _, masterCfg, _ := newMaster(t)
+	_, etcdserver, masterCfg, _ := newMaster(t)
+	defer etcdserver.Terminate(t)
+
 	storageProvider := corerest.LegacyRESTStorageProvider{
 		StorageFactory:       masterCfg.StorageFactory,
 		ProxyTransport:       masterCfg.ProxyTransport,
@@ -154,7 +156,9 @@ func TestLegacyRestStorageStrategies(t *testing.T) {
 }
 
 func TestCertificatesRestStorageStrategies(t *testing.T) {
-	_, _, masterCfg, _ := newMaster(t)
+	_, etcdserver, masterCfg, _ := newMaster(t)
+	defer etcdserver.Terminate(t)
+
 	certStorageProvider := certificatesrest.RESTStorageProvider{}
 	apiGroupInfo, _ := certStorageProvider.NewRESTStorage(masterCfg.APIResourceConfigSource, masterCfg.GenericConfig.RESTOptionsGetter)
 


### PR DESCRIPTION
Before this change:
```
$ make test WHAT=k8s.io/kubernetes/pkg/master
+++ [0816 11:19:03] Running tests without code coverage
ok  	k8s.io/kubernetes/pkg/master	27.953s
$ find -type s
./pkg/master/127.0.0.1:2100324511
./pkg/master/127.0.0.1:2100424511
./pkg/master/localhost:8235197834378812860
./pkg/master/localhost:82351978343788128600
./pkg/master/127.0.0.1:2100524511
./pkg/master/127.0.0.1:2100624511
./pkg/master/localhost:1155389051645284688
./pkg/master/localhost:11553890516452846880
```
**Release note**:

```
NONE
```
