### PR TITLE
Cloud Controller Manager now sets Node.Spec.ProviderID

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -284,6 +284,18 @@ func (cnc *CloudNodeController) AddCloudNode(obj interface{}) {
 			return err
 		}
 
+		if curNode.Spec.ProviderID == "" {
+			providerID, err := cloudprovider.GetInstanceProviderID(cnc.cloud, types.NodeName(curNode.Name))
+			if err == nil {
+				curNode.Spec.ProviderID = providerID
+			} else {
+				// we should attempt to set providerID on curNode, but
+				// we can continue if we fail since we will attempt to set
+				// node addresses given the node name in getNodeAddressesByProviderIDOrName
+				glog.Errorf("failed to set node provider id: %v", err)
+			}
+		}
+
 		nodeAddresses, err := getNodeAddressesByProviderIDOrName(instances, curNode)
 		if err != nil {
 			glog.Errorf("%v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Cloud Controller Manager now sets `Node.Spec.ProviderID`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/49836. 

**Special notes for your reviewer**:
* As part of an effort to move cloud controller manager into beta https://github.com/kubernetes/kubernetes/issues/48690. 
