### PR TITLE
support imagePullSecrets and imagePullPolicy in kubefed init

### DIFF
--- a/federation/pkg/kubefed/init/init_test.go
+++ b/federation/pkg/kubefed/init/init_test.go
@@ -96,6 +96,8 @@ func TestInitFederation(t *testing.T) {
 		apiserverServiceType         v1.ServiceType
 		advertiseAddress             string
 		serverImage                  string
+		imagePullPolicy              string
+		imagePullSecrets             string
 		etcdImage                    string
 		etcdPVCapacity               string
 		etcdPVStorageClass           string
@@ -119,6 +121,7 @@ func TestInitFederation(t *testing.T) {
 			lbIP:                  lbIP,
 			apiserverServiceType:  v1.ServiceTypeLoadBalancer,
 			serverImage:           "example.test/foo:bar",
+			imagePullPolicy:       "IfNotPresent",
 			etcdPVCapacity:        "5Gi",
 			etcdPersistence:       "true",
 			expectedErr:           "",
@@ -137,6 +140,7 @@ func TestInitFederation(t *testing.T) {
 			lbIP:                 lbIP,
 			apiserverServiceType: v1.ServiceTypeLoadBalancer,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdPVCapacity:       "", //test for default value of pvc-size
 			etcdPersistence:      "true",
 			expectedErr:          "",
@@ -150,6 +154,7 @@ func TestInitFederation(t *testing.T) {
 			lbIP:                 lbIP,
 			apiserverServiceType: v1.ServiceTypeLoadBalancer,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdPVCapacity:       "",
 			etcdPersistence:      "true",
 			expectedErr:          "",
@@ -163,6 +168,7 @@ func TestInitFederation(t *testing.T) {
 			lbIP:                 lbIP,
 			apiserverServiceType: v1.ServiceTypeLoadBalancer,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "false",
 			expectedErr:          "",
@@ -175,6 +181,7 @@ func TestInitFederation(t *testing.T) {
 			dnsZoneName:          "example.test.",
 			apiserverServiceType: v1.ServiceTypeNodePort,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
@@ -188,6 +195,7 @@ func TestInitFederation(t *testing.T) {
 			apiserverServiceType: v1.ServiceTypeNodePort,
 			advertiseAddress:     nodeIP,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdPVCapacity:       "5Gi",
 			etcdPersistence:      "true",
 			expectedErr:          "",
@@ -201,6 +209,7 @@ func TestInitFederation(t *testing.T) {
 			apiserverServiceType: v1.ServiceTypeNodePort,
 			advertiseAddress:     nodeIP,
 			serverImage:          "example.test/foo:bar",
+			imagePullPolicy:      "IfNotPresent",
 			etcdImage:            "gcr.io/google_containers/etcd:latest",
 			etcdPVCapacity:       "5Gi",
 			etcdPVStorageClass:   "fast",
@@ -247,8 +256,11 @@ func TestInitFederation(t *testing.T) {
 		if tc.etcdImage == "" {
 			tc.etcdImage = defaultEtcdImage
 		}
+		if tc.imagePullPolicy == "" {
+			tc.imagePullPolicy = "IfNotPresent"
+		}
 
-		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.serverImage, tc.etcdImage, tc.dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.etcdPVStorageClass, tc.apiserverArgOverrides, tc.cmArgOverrides, tmpDirPath, tc.apiserverEnableHTTPBasicAuth, tc.apiserverEnableTokenAuth, tc.isRBACAPIAvailable, tc.nodeSelector)
+		hostFactory, err := fakeInitHostFactory(tc.apiserverServiceType, tc.federation, util.DefaultFederationSystemNamespace, tc.advertiseAddress, tc.lbIP, tc.dnsZoneName, tc.serverImage, tc.etcdImage, tc.dnsProvider, tc.dnsProviderConfig, tc.etcdPersistence, tc.etcdPVCapacity, tc.etcdPVStorageClass, tc.apiserverArgOverrides, tc.cmArgOverrides, tmpDirPath, tc.apiserverEnableHTTPBasicAuth, tc.apiserverEnableTokenAuth, tc.isRBACAPIAvailable, tc.nodeSelector, tc.imagePullPolicy, tc.imagePullSecrets)
 		if err != nil {
 			t.Fatalf("[%d] unexpected error: %v", i, err)
 		}
@@ -265,6 +277,7 @@ func TestInitFederation(t *testing.T) {
 		cmd.Flags().Set("dns-zone-name", tc.dnsZoneName)
 		cmd.Flags().Set("image", tc.serverImage)
 		cmd.Flags().Set("etcd-image", tc.etcdImage)
+		cmd.Flags().Set("image-pull-policy", tc.imagePullPolicy)
 		cmd.Flags().Set("dns-provider", tc.dnsProvider)
 		cmd.Flags().Set("apiserver-arg-overrides", tc.apiserverArgOverrides)
 		cmd.Flags().Set("controllermanager-arg-overrides", tc.cmArgOverrides)
@@ -280,6 +293,9 @@ func TestInitFederation(t *testing.T) {
 		}
 		if tc.etcdPersistence != "true" {
 			cmd.Flags().Set("etcd-persistent-storage", tc.etcdPersistence)
+		}
+		if tc.imagePullSecrets != "" {
+			cmd.Flags().Set("image-pull-secrets", tc.imagePullSecrets)
 		}
 		if tc.apiserverServiceType != v1.ServiceTypeLoadBalancer {
 			cmd.Flags().Set(apiserverServiceTypeFlag, string(tc.apiserverServiceType))
@@ -626,7 +642,7 @@ func TestCertsHTTPS(t *testing.T) {
 	}
 }
 
-func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, namespaceName, advertiseAddress, lbIp, dnsZoneName, serverImage, etcdImage, dnsProvider, dnsProviderConfig, etcdPersistence, etcdPVCapacity, etcdPVStorageClass, apiserverOverrideArg, cmOverrideArg, tmpDirPath string, apiserverEnableHTTPBasicAuth, apiserverEnableTokenAuth, isRBACAPIAvailable bool, nodeSelectorString string) (cmdutil.Factory, error) {
+func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, namespaceName, advertiseAddress, lbIp, dnsZoneName, serverImage, etcdImage, dnsProvider, dnsProviderConfig, etcdPersistence, etcdPVCapacity, etcdPVStorageClass, apiserverOverrideArg, cmOverrideArg, tmpDirPath string, apiserverEnableHTTPBasicAuth, apiserverEnableTokenAuth, isRBACAPIAvailable bool, nodeSelectorString string, imagePullPolicy, imagePullSecrets string) (cmdutil.Factory, error) {
 	svcName := federationName + "-apiserver"
 	svcUrlPrefix := "/api/v1/namespaces/federation-system/services"
 	credSecretName := svcName + "-credentials"
@@ -922,9 +938,10 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:    "apiserver",
-							Image:   serverImage,
-							Command: apiserverCommand,
+							Name:            "apiserver",
+							Image:           serverImage,
+							ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
+							Command:         apiserverCommand,
 							Ports: []v1.ContainerPort{
 								{
 									Name:          apiServerSecurePortName,
@@ -954,6 +971,11 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 						},
 					},
 					NodeSelector: nodeSelector,
+					ImagePullSecrets: []v1.LocalObjectReference{
+						{
+							Name: imagePullSecrets,
+						},
+					},
 					Volumes: []v1.Volume{
 						{
 							Name: credSecretName,
@@ -1040,9 +1062,10 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:    "controller-manager",
-							Image:   serverImage,
-							Command: cmCommand,
+							Name:            "controller-manager",
+							Image:           serverImage,
+							ImagePullPolicy: v1.PullPolicy(imagePullPolicy),
+							Command:         cmCommand,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      cmKubeconfigSecretName,
@@ -1063,6 +1086,11 @@ func fakeInitHostFactory(apiserverServiceType v1.ServiceType, federationName, na
 						},
 					},
 					NodeSelector: nodeSelector,
+					ImagePullSecrets: []v1.LocalObjectReference{
+						{
+							Name: imagePullSecrets,
+						},
+					},
 					Volumes: []v1.Volume{
 						{
 							Name: cmKubeconfigSecretName,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50718

**Special notes for your reviewer**:
/assign @gyliu513 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
support imagePullSecrets and imagePullPolicy in kubefed init
```
