### PR TITLE
Remove unused command waitfordetach from flex volume driver

### DIFF
--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -19,7 +19,6 @@ package flexvolume
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,18 +42,6 @@ func (d *flexVolumeDetacher) Detach(pvOrVolumeName string, hostName types.NodeNa
 	_, err := call.Run()
 	if isCmdNotSupportedErr(err) {
 		return (*detacherDefaults)(d).Detach(pvOrVolumeName, hostName)
-	}
-	return err
-}
-
-// WaitForDetach is part of the volume.Detacher interface.
-func (d *flexVolumeDetacher) WaitForDetach(devicePath string, timeout time.Duration) error {
-	call := d.plugin.NewDriverCallWithTimeout(waitForDetachCmd, timeout)
-	call.Append(devicePath)
-
-	_, err := call.Run()
-	if isCmdNotSupportedErr(err) {
-		return (*detacherDefaults)(d).WaitForDetach(devicePath, timeout)
 	}
 	return err
 }

--- a/pkg/volume/flexvolume/driver-call.go
+++ b/pkg/volume/flexvolume/driver-call.go
@@ -39,7 +39,6 @@ const (
 	mountDeviceCmd   = "mountdevice"
 
 	detachCmd        = "detach"
-	waitForDetachCmd = "waitfordetach"
 	unmountDeviceCmd = "unmountdevice"
 
 	mountCmd   = "mount"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Clean unused code.

**Special notes for your reviewer**:
See https://github.com/kubernetes/kubernetes/pull/35629

**Release note**:
```release-note
NONE
```
