### PR TITLE
Feature-gate self-hosted secrets

### DIFF
--- a/cmd/kubeadm/app/cmd/features/features.go
+++ b/cmd/kubeadm/app/cmd/features/features.go
@@ -33,8 +33,7 @@ type FeatureList map[utilfeature.Feature]utilfeature.FeatureSpec
 
 // Enabled indicates whether a feature name has been enabled
 func Enabled(featureList map[string]bool, featureName utilfeature.Feature) bool {
-	_, ok := featureList[string(featureName)]
-	return ok
+	return featureList[string(featureName)]
 }
 
 // Supports indicates whether a feature name is supported on the given

--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -16,6 +16,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/cmd/features:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -31,6 +32,7 @@ go_library(
     ],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/cmd/features:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -79,7 +79,7 @@ func setRightDNSPolicyOnPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1
 
 // setVolumesOnKubeAPIServerPodSpec makes sure the self-hosted api server has the required files
 func setVolumesOnKubeAPIServerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(apiServerProjectedVolume, cfg, podSpec)
+	setK8sVolume(apiServerVolume, cfg, podSpec)
 	for _, c := range podSpec.Containers {
 		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
 	}
@@ -87,7 +87,7 @@ func setVolumesOnKubeAPIServerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSp
 
 // setVolumesOnKubeControllerManagerPodSpec makes sure the self-hosted controller manager has the required files
 func setVolumesOnKubeControllerManagerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(controllerManagerProjectedVolume, cfg, podSpec)
+	setK8sVolume(controllerManagerVolume, cfg, podSpec)
 	for _, c := range podSpec.Containers {
 		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
 	}
@@ -95,7 +95,7 @@ func setVolumesOnKubeControllerManagerPodSpec(cfg *kubeadmapi.MasterConfiguratio
 
 // setVolumesOnKubeSchedulerPodSpec makes sure the self-hosted scheduler has the required files
 func setVolumesOnKubeSchedulerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(schedulerProjectedVolume, cfg, podSpec)
+	setK8sVolume(schedulerVolume, cfg, podSpec)
 	for _, c := range podSpec.Containers {
 		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
 	}

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -28,6 +28,7 @@ import (
 	kuberuntime "k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/features"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	"k8s.io/kubernetes/pkg/api"
@@ -46,12 +47,13 @@ import (
 // 9. Do that for the kube-apiserver, kube-controller-manager and kube-scheduler in a loop
 func CreateSelfHostedControlPlane(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
 
-	if err := createTLSSecrets(cfg, client); err != nil {
-		return err
-	}
-
-	if err := createOpaqueSecrets(cfg, client); err != nil {
-		return err
+	if features.Enabled(cfg.FeatureFlags, features.StoreCertsInSecrets) {
+		if err := createTLSSecrets(cfg, client); err != nil {
+			return err
+		}
+		if err := createOpaqueSecrets(cfg, client); err != nil {
+			return err
+		}
 	}
 
 	for _, componentName := range kubeadmconstants.MasterComponents {

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_volumes.go
@@ -25,7 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/features"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+const (
+	volumeName      = "k8s"
+	volumeMountName = "k8s"
 )
 
 type tlsKeyPair struct {
@@ -36,16 +42,16 @@ type tlsKeyPair struct {
 
 func k8sSelfHostedVolumeMount() v1.VolumeMount {
 	return v1.VolumeMount{
-		Name:      "k8s",
+		Name:      volumeMountName,
 		MountPath: kubeadmconstants.KubernetesDir,
 		ReadOnly:  true,
 	}
 }
 
-func apiServerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
-	return v1.Volume{
-		Name: "k8s",
-		VolumeSource: v1.VolumeSource{
+func apiServerVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	var volumeSource v1.VolumeSource
+	if features.Enabled(cfg.FeatureFlags, features.StoreCertsInSecrets) {
+		volumeSource = v1.VolumeSource{
 			Projected: &v1.ProjectedVolumeSource{
 				Sources: []v1.VolumeProjection{
 					{
@@ -148,14 +154,24 @@ func apiServerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
 					},
 				},
 			},
-		},
+		}
+	} else {
+		volumeSource = v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: kubeadmconstants.KubernetesDir,
+			},
+		}
+	}
+	return v1.Volume{
+		Name:         volumeName,
+		VolumeSource: volumeSource,
 	}
 }
 
-func schedulerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
-	return v1.Volume{
-		Name: "k8s",
-		VolumeSource: v1.VolumeSource{
+func schedulerVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	var volumeSource v1.VolumeSource
+	if features.Enabled(cfg.FeatureFlags, features.StoreCertsInSecrets) {
+		volumeSource = v1.VolumeSource{
 			Projected: &v1.ProjectedVolumeSource{
 				Sources: []v1.VolumeProjection{
 					{
@@ -167,14 +183,24 @@ func schedulerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
 					},
 				},
 			},
-		},
+		}
+	} else {
+		volumeSource = v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: kubeadmconstants.KubernetesDir,
+			},
+		}
+	}
+	return v1.Volume{
+		Name:         volumeName,
+		VolumeSource: volumeSource,
 	}
 }
 
-func controllerManagerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
-	return v1.Volume{
-		Name: "k8s",
-		VolumeSource: v1.VolumeSource{
+func controllerManagerVolume(cfg *kubeadmapi.MasterConfiguration) v1.Volume {
+	var volumeSource v1.VolumeSource
+	if features.Enabled(cfg.FeatureFlags, features.StoreCertsInSecrets) {
+		volumeSource = v1.VolumeSource{
 			Projected: &v1.ProjectedVolumeSource{
 				Sources: []v1.VolumeProjection{
 					{
@@ -216,7 +242,17 @@ func controllerManagerProjectedVolume(cfg *kubeadmapi.MasterConfiguration) v1.Vo
 					},
 				},
 			},
-		},
+		}
+	} else {
+		volumeSource = v1.VolumeSource{
+			HostPath: &v1.HostPathVolumeSource{
+				Path: kubeadmconstants.KubernetesDir,
+			},
+		}
+	}
+	return v1.Volume{
+		Name:         volumeName,
+		VolumeSource: volumeSource,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Feature gates now select whether secrets are used for TLS cert storage in self-hosted clusters.

**Release note**:
```release-note
TLS cert storage for self-hosted clusters is now configurable. You can store them as secrets (alpha) or as usual host mounts.
```

/cc @luxas 
