### PR TITLE
kubeadm: Make the self-hosting with certificates in Secrets mode work again

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -113,6 +113,12 @@ const (
 	// SelfHostingPrefix describes the prefix workloads that are self-hosted by kubeadm has
 	SelfHostingPrefix = "self-hosted-"
 
+	// KubeCertificatesVolumeName specifies the name for the Volume that is used for injecting certificates to control plane components (can be both a hostPath volume or a projected, all-in-one volume)
+	KubeCertificatesVolumeName = "k8s-certs"
+
+	// KubeConfigVolumeName specifies the name for the Volume that is used for injecting the kubeconfig to talk securely to the api server for a control plane component if applicable
+	KubeConfigVolumeName = "kubeconfig"
+
 	// NodeBootstrapTokenAuthGroup specifies which group a Node Bootstrap Token should be authenticated in
 	// TODO: This should be changed in the v1.8 dev cycle to a node-BT-specific group instead of the generic Bootstrap Token group that is used now
 	NodeBootstrapTokenAuthGroup = "system:bootstrappers"

--- a/cmd/kubeadm/app/phases/controlplane/BUILD
+++ b/cmd/kubeadm/app/phases/controlplane/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/staticpod:go_default_library",
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
         "//pkg/util/version:go_default_library",

--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -28,6 +28,7 @@ import (
 	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 	authzmodes "k8s.io/kubernetes/pkg/kubeapiserver/authorizer/modes"
 	"k8s.io/kubernetes/pkg/util/version"
@@ -159,7 +160,7 @@ func getAPIServerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion *versio
 	}
 
 	command := []string{"kube-apiserver"}
-	command = append(command, staticpodutil.GetExtraParameters(cfg.APIServerExtraArgs, defaultArguments)...)
+	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.APIServerExtraArgs)...)
 	command = append(command, getAuthzParameters(cfg.AuthorizationModes)...)
 
 	// Check if the user decided to use an external etcd cluster
@@ -206,7 +207,7 @@ func getControllerManagerCommand(cfg *kubeadmapi.MasterConfiguration, k8sVersion
 	}
 
 	command := []string{"kube-controller-manager"}
-	command = append(command, staticpodutil.GetExtraParameters(cfg.ControllerManagerExtraArgs, defaultArguments)...)
+	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.ControllerManagerExtraArgs)...)
 
 	if cfg.CloudProvider != "" {
 		command = append(command, "--cloud-provider="+cfg.CloudProvider)
@@ -234,7 +235,7 @@ func getSchedulerCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 	}
 
 	command := []string{"kube-scheduler"}
-	command = append(command, staticpodutil.GetExtraParameters(cfg.SchedulerExtraArgs, defaultArguments)...)
+	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.SchedulerExtraArgs)...)
 	return command
 }
 

--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -30,11 +30,9 @@ import (
 )
 
 const (
-	k8sCertsVolumeName   = "k8s-certs"
 	caCertsVolumeName    = "ca-certs"
 	caCertsVolumePath    = "/etc/ssl/certs"
 	caCertsPkiVolumeName = "ca-certs-etc-pki"
-	kubeConfigVolumeName = "kubeconfig"
 )
 
 // caCertsPkiVolumePath specifies the path that can be conditionally mounted into the apiserver and controller-manager containers
@@ -49,7 +47,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	// HostPath volumes for the API Server
 	// Read-only mount for the certificates directory
 	// TODO: Always mount the K8s Certificates directory to a static path inside of the container
-	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, k8sCertsVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
+	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, kubeadmconstants.KubeCertificatesVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
 	// Read-only mount for the ca certs (/etc/ssl/certs) directory
 	mounts.NewHostPathMount(kubeadmconstants.KubeAPIServer, caCertsVolumeName, caCertsVolumePath, caCertsVolumePath, true)
 
@@ -62,17 +60,17 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	// HostPath volumes for the controller manager
 	// Read-only mount for the certificates directory
 	// TODO: Always mount the K8s Certificates directory to a static path inside of the container
-	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, k8sCertsVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
+	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeCertificatesVolumeName, cfg.CertificatesDir, cfg.CertificatesDir, true)
 	// Read-only mount for the ca certs (/etc/ssl/certs) directory
 	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, caCertsVolumeName, caCertsVolumePath, caCertsVolumePath, true)
 	// Read-only mount for the controller manager kubeconfig file
 	controllerManagerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
-	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, kubeConfigVolumeName, controllerManagerKubeConfigFile, controllerManagerKubeConfigFile, true)
+	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeConfigVolumeName, controllerManagerKubeConfigFile, controllerManagerKubeConfigFile, true)
 
 	// HostPath volumes for the scheduler
 	// Read-only mount for the scheduler kubeconfig file
 	schedulerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.SchedulerKubeConfigFileName)
-	mounts.NewHostPathMount(kubeadmconstants.KubeScheduler, kubeConfigVolumeName, schedulerKubeConfigFile, schedulerKubeConfigFile, true)
+	mounts.NewHostPathMount(kubeadmconstants.KubeScheduler, kubeadmconstants.KubeConfigVolumeName, schedulerKubeConfigFile, schedulerKubeConfigFile, true)
 
 	// On some systems were we host-mount /etc/ssl/certs, it is also required to mount /etc/pki. This is needed
 	// due to symlinks pointing from files in /etc/ssl/certs into /etc/pki/

--- a/cmd/kubeadm/app/phases/etcd/BUILD
+++ b/cmd/kubeadm/app/phases/etcd/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/staticpod:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -21,6 +21,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	staticpodutil "k8s.io/kubernetes/cmd/kubeadm/app/util/staticpod"
 )
 
@@ -60,6 +61,6 @@ func getEtcdCommand(cfg *kubeadmapi.MasterConfiguration) []string {
 	}
 
 	command := []string{"etcd"}
-	command = append(command, staticpodutil.GetExtraParameters(cfg.Etcd.ExtraArgs, defaultArguments)...)
+	command = append(command, kubeadmutil.BuildArgumentListFromMap(defaultArguments, cfg.Etcd.ExtraArgs)...)
 	return command
 }

--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -15,8 +15,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
-        "//cmd/kubeadm/app/cmd/features:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
@@ -34,6 +32,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/cmd/features:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -17,43 +17,55 @@ limitations under the License.
 package selfhosting
 
 import (
+	"path/filepath"
+
 	"k8s.io/api/core/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
-// mutatePodSpec makes a Static Pod-hosted PodSpec suitable for self-hosting
-func mutatePodSpec(cfg *kubeadmapi.MasterConfiguration, name string, podSpec *v1.PodSpec) {
-	mutators := map[string][]func(*kubeadmapi.MasterConfiguration, *v1.PodSpec){
+const (
+	// selfHostedKubeConfigDir sets the directory where kubeconfig files for the scheduler and controller-manager should be mounted
+	// Due to how the projected volume mount works (can only be a full directory, not mount individual files), we must change this from
+	// the default as mounts cannot be nested (/etc/kubernetes would override /etc/kubernetes/pki)
+	selfHostedKubeConfigDir = "/etc/kubernetes/kubeconfig"
+)
+
+// PodSpecMutatorFunc is a function capable of mutating a PodSpec
+type PodSpecMutatorFunc func(*v1.PodSpec)
+
+// getDefaultMutators gets the mutator functions that alwasy should be used
+func getDefaultMutators() map[string][]PodSpecMutatorFunc {
+	return map[string][]PodSpecMutatorFunc{
 		kubeadmconstants.KubeAPIServer: {
 			addNodeSelectorToPodSpec,
 			setMasterTolerationOnPodSpec,
 			setRightDNSPolicyOnPodSpec,
-			setVolumesOnKubeAPIServerPodSpec,
 		},
 		kubeadmconstants.KubeControllerManager: {
 			addNodeSelectorToPodSpec,
 			setMasterTolerationOnPodSpec,
 			setRightDNSPolicyOnPodSpec,
-			setVolumesOnKubeControllerManagerPodSpec,
 		},
 		kubeadmconstants.KubeScheduler: {
 			addNodeSelectorToPodSpec,
 			setMasterTolerationOnPodSpec,
 			setRightDNSPolicyOnPodSpec,
-			setVolumesOnKubeSchedulerPodSpec,
 		},
 	}
+}
 
+// mutatePodSpec makes a Static Pod-hosted PodSpec suitable for self-hosting
+func mutatePodSpec(mutators map[string][]PodSpecMutatorFunc, name string, podSpec *v1.PodSpec) {
 	// Get the mutator functions for the component in question, then loop through and execute them
 	mutatorsForComponent := mutators[name]
 	for _, mutateFunc := range mutatorsForComponent {
-		mutateFunc(cfg, podSpec)
+		mutateFunc(podSpec)
 	}
 }
 
 // addNodeSelectorToPodSpec makes Pod require to be scheduled on a node marked with the master label
-func addNodeSelectorToPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
+func addNodeSelectorToPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.NodeSelector == nil {
 		podSpec.NodeSelector = map[string]string{kubeadmconstants.LabelNodeRoleMaster: ""}
 		return
@@ -63,7 +75,7 @@ func addNodeSelectorToPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.P
 }
 
 // setMasterTolerationOnPodSpec makes the Pod tolerate the master taint
-func setMasterTolerationOnPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
+func setMasterTolerationOnPodSpec(podSpec *v1.PodSpec) {
 	if podSpec.Tolerations == nil {
 		podSpec.Tolerations = []v1.Toleration{kubeadmconstants.MasterToleration}
 		return
@@ -73,38 +85,68 @@ func setMasterTolerationOnPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *
 }
 
 // setRightDNSPolicyOnPodSpec makes sure the self-hosted components can look up things via kube-dns if necessary
-func setRightDNSPolicyOnPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
+func setRightDNSPolicyOnPodSpec(podSpec *v1.PodSpec) {
 	podSpec.DNSPolicy = v1.DNSClusterFirstWithHostNet
 }
 
-// setVolumesOnKubeAPIServerPodSpec makes sure the self-hosted api server has the required files
-func setVolumesOnKubeAPIServerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(apiServerVolume, cfg, podSpec)
-	for _, c := range podSpec.Containers {
-		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
-	}
-}
-
-// setVolumesOnKubeControllerManagerPodSpec makes sure the self-hosted controller manager has the required files
-func setVolumesOnKubeControllerManagerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(controllerManagerVolume, cfg, podSpec)
-	for _, c := range podSpec.Containers {
-		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
-	}
-}
-
-// setVolumesOnKubeSchedulerPodSpec makes sure the self-hosted scheduler has the required files
-func setVolumesOnKubeSchedulerPodSpec(cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
-	setK8sVolume(schedulerVolume, cfg, podSpec)
-	for _, c := range podSpec.Containers {
-		c.VolumeMounts = append(c.VolumeMounts, k8sSelfHostedVolumeMount())
-	}
-}
-
-func setK8sVolume(cb func(cfg *kubeadmapi.MasterConfiguration) v1.Volume, cfg *kubeadmapi.MasterConfiguration, podSpec *v1.PodSpec) {
+// setSelfHostedVolumesForAPIServer makes sure the self-hosted api server has the right volume source coming from a self-hosted cluster
+func setSelfHostedVolumesForAPIServer(podSpec *v1.PodSpec) {
 	for i, v := range podSpec.Volumes {
-		if v.Name == "k8s" {
-			podSpec.Volumes[i] = cb(cfg)
+		// If the volume name matches the expected one; switch the volume source from hostPath to cluster-hosted
+		if v.Name == kubeadmconstants.KubeCertificatesVolumeName {
+			podSpec.Volumes[i].VolumeSource = apiServerCertificatesVolumeSource()
 		}
 	}
+}
+
+// setSelfHostedVolumesForControllerManager makes sure the self-hosted controller manager has the right volume source coming from a self-hosted cluster
+func setSelfHostedVolumesForControllerManager(podSpec *v1.PodSpec) {
+	for i, v := range podSpec.Volumes {
+		// If the volume name matches the expected one; switch the volume source from hostPath to cluster-hosted
+		if v.Name == kubeadmconstants.KubeCertificatesVolumeName {
+			podSpec.Volumes[i].VolumeSource = controllerManagerCertificatesVolumeSource()
+		} else if v.Name == kubeadmconstants.KubeConfigVolumeName {
+			podSpec.Volumes[i].VolumeSource = kubeConfigVolumeSource(kubeadmconstants.ControllerManagerKubeConfigFileName)
+		}
+	}
+
+	// Change directory for the kubeconfig directory to selfHostedKubeConfigDir
+	for i, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == kubeadmconstants.KubeConfigVolumeName {
+			podSpec.Containers[0].VolumeMounts[i].MountPath = selfHostedKubeConfigDir
+		}
+	}
+
+	// Rewrite the --kubeconfig path as the volume mount path may not overlap with certs dir, which it does by default (/etc/kubernetes and /etc/kubernetes/pki)
+	// This is not a problem with hostPath mounts as hostPath supports mounting one file only, instead of always a full directory. Secrets and Projected Volumes
+	// don't support that.
+	podSpec.Containers[0].Command = kubeadmutil.ReplaceArgument(podSpec.Containers[0].Command, func(argMap map[string]string) map[string]string {
+		argMap["kubeconfig"] = filepath.Join(selfHostedKubeConfigDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
+		return argMap
+	})
+}
+
+// setSelfHostedVolumesForScheduler makes sure the self-hosted scheduler has the right volume source coming from a self-hosted cluster
+func setSelfHostedVolumesForScheduler(podSpec *v1.PodSpec) {
+	for i, v := range podSpec.Volumes {
+		// If the volume name matches the expected one; switch the volume source from hostPath to cluster-hosted
+		if v.Name == kubeadmconstants.KubeConfigVolumeName {
+			podSpec.Volumes[i].VolumeSource = kubeConfigVolumeSource(kubeadmconstants.SchedulerKubeConfigFileName)
+		}
+	}
+
+	// Change directory for the kubeconfig directory to selfHostedKubeConfigDir
+	for i, vm := range podSpec.Containers[0].VolumeMounts {
+		if vm.Name == kubeadmconstants.KubeConfigVolumeName {
+			podSpec.Containers[0].VolumeMounts[i].MountPath = selfHostedKubeConfigDir
+		}
+	}
+
+	// Rewrite the --kubeconfig path as the volume mount path may not overlap with certs dir, which it does by default (/etc/kubernetes and /etc/kubernetes/pki)
+	// This is not a problem with hostPath mounts as hostPath supports mounting one file only, instead of always a full directory. Secrets and Projected Volumes
+	// don't support that.
+	podSpec.Containers[0].Command = kubeadmutil.ReplaceArgument(podSpec.Containers[0].Command, func(argMap map[string]string) map[string]string {
+		argMap["kubeconfig"] = filepath.Join(selfHostedKubeConfigDir, kubeadmconstants.SchedulerKubeConfigFileName)
+		return argMap
+	})
 }

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -18,10 +18,10 @@ package selfhosting
 
 import (
 	"reflect"
+	"sort"
 	"testing"
 
 	"k8s.io/api/core/v1"
-	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
@@ -72,9 +72,8 @@ func TestMutatePodSpec(t *testing.T) {
 		},
 	}
 
-	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		mutatePodSpec(cfg, rt.component, rt.podSpec)
+		mutatePodSpec(getDefaultMutators(), rt.component, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed mutatePodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -110,9 +109,8 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 		},
 	}
 
-	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		addNodeSelectorToPodSpec(cfg, rt.podSpec)
+		addNodeSelectorToPodSpec(rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed addNodeSelectorToPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -148,9 +146,8 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 		},
 	}
 
-	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		setMasterTolerationOnPodSpec(cfg, rt.podSpec)
+		setMasterTolerationOnPodSpec(rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setMasterTolerationOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -179,12 +176,281 @@ func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 		},
 	}
 
-	cfg := &kubeadmapi.MasterConfiguration{}
 	for _, rt := range tests {
-		setRightDNSPolicyOnPodSpec(cfg, rt.podSpec)
+		setRightDNSPolicyOnPodSpec(rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setRightDNSPolicyOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+		}
+	}
+}
+
+func TestSetSelfHostedVolumesForAPIServer(t *testing.T) {
+	var tests = []struct {
+		podSpec  *v1.PodSpec
+		expected v1.PodSpec
+	}{
+		{
+			podSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "ca-certs",
+								MountPath: "/etc/ssl/certs",
+							},
+							{
+								Name:      "k8s-certs",
+								MountPath: "/etc/kubernetes/pki",
+							},
+						},
+						Command: []string{
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/ssl/certs",
+							},
+						},
+					},
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/kubernetes/pki",
+							},
+						},
+					},
+				},
+			},
+			expected: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "ca-certs",
+								MountPath: "/etc/ssl/certs",
+							},
+							{
+								Name:      "k8s-certs",
+								MountPath: "/etc/kubernetes/pki",
+							},
+						},
+						Command: []string{
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/ssl/certs",
+							},
+						},
+					},
+					{
+						Name:         "k8s-certs",
+						VolumeSource: apiServerCertificatesVolumeSource(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		setSelfHostedVolumesForAPIServer(rt.podSpec)
+		sort.Strings(rt.podSpec.Containers[0].Command)
+		sort.Strings(rt.expected.Containers[0].Command)
+
+		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+			t.Errorf("failed setSelfHostedVolumesForAPIServer:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+		}
+	}
+}
+
+func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
+	var tests = []struct {
+		podSpec  *v1.PodSpec
+		expected v1.PodSpec
+	}{
+		{
+			podSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "ca-certs",
+								MountPath: "/etc/ssl/certs",
+							},
+							{
+								Name:      "k8s-certs",
+								MountPath: "/etc/kubernetes/pki",
+							},
+							{
+								Name:      "kubeconfig",
+								MountPath: "/etc/kubernetes/controller-manager.conf",
+							},
+						},
+						Command: []string{
+							"--kubeconfig=/etc/kubernetes/controller-manager.conf",
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/ssl/certs",
+							},
+						},
+					},
+					{
+						Name: "k8s-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/kubernetes/pki",
+							},
+						},
+					},
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/kubernetes/controller-manager.conf",
+							},
+						},
+					},
+				},
+			},
+			expected: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "ca-certs",
+								MountPath: "/etc/ssl/certs",
+							},
+							{
+								Name:      "k8s-certs",
+								MountPath: "/etc/kubernetes/pki",
+							},
+							{
+								Name:      "kubeconfig",
+								MountPath: "/etc/kubernetes/kubeconfig",
+							},
+						},
+						Command: []string{
+							"--kubeconfig=/etc/kubernetes/kubeconfig/controller-manager.conf",
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "ca-certs",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/ssl/certs",
+							},
+						},
+					},
+					{
+						Name:         "k8s-certs",
+						VolumeSource: controllerManagerCertificatesVolumeSource(),
+					},
+					{
+						Name:         "kubeconfig",
+						VolumeSource: kubeConfigVolumeSource(kubeadmconstants.ControllerManagerKubeConfigFileName),
+					},
+				},
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		setSelfHostedVolumesForControllerManager(rt.podSpec)
+		sort.Strings(rt.podSpec.Containers[0].Command)
+		sort.Strings(rt.expected.Containers[0].Command)
+
+		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+			t.Errorf("failed setSelfHostedVolumesForControllerManager:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
+		}
+	}
+}
+
+func TestSetSelfHostedVolumesForScheduler(t *testing.T) {
+	var tests = []struct {
+		podSpec  *v1.PodSpec
+		expected v1.PodSpec
+	}{
+		{
+			podSpec: &v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "kubeconfig",
+								MountPath: "/etc/kubernetes/scheduler.conf",
+							},
+						},
+						Command: []string{
+							"--kubeconfig=/etc/kubernetes/scheduler.conf",
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "kubeconfig",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/etc/kubernetes/scheduler.conf",
+							},
+						},
+					},
+				},
+			},
+			expected: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "kubeconfig",
+								MountPath: "/etc/kubernetes/kubeconfig",
+							},
+						},
+						Command: []string{
+							"--kubeconfig=/etc/kubernetes/kubeconfig/scheduler.conf",
+							"--foo=bar",
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name:         "kubeconfig",
+						VolumeSource: kubeConfigVolumeSource(kubeadmconstants.SchedulerKubeConfigFileName),
+					},
+				},
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		setSelfHostedVolumesForScheduler(rt.podSpec)
+		sort.Strings(rt.podSpec.Containers[0].Command)
+		sort.Strings(rt.expected.Containers[0].Command)
+
+		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
+			t.Errorf("failed setSelfHostedVolumesForScheduler:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
 		}
 	}
 }

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "arguments.go",
         "endpoint.go",
         "error.go",
         "template.go",
@@ -24,6 +25,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "arguments_test.go",
         "endpoint_test.go",
         "error_test.go",
         "template_test.go",

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -43,6 +43,20 @@ func CreateOrUpdateConfigMap(client clientset.Interface, cm *v1.ConfigMap) error
 	return nil
 }
 
+// CreateOrUpdateSecret creates a Secret if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
+func CreateOrUpdateSecret(client clientset.Interface, secret *v1.Secret) error {
+	if _, err := client.CoreV1().Secrets(secret.ObjectMeta.Namespace).Create(secret); err != nil {
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("unable to create secret: %v", err)
+		}
+
+		if _, err := client.CoreV1().Secrets(secret.ObjectMeta.Namespace).Update(secret); err != nil {
+			return fmt.Errorf("unable to update secret: %v", err)
+		}
+	}
+	return nil
+}
+
 // CreateOrUpdateServiceAccount creates a ServiceAccount if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
 func CreateOrUpdateServiceAccount(client clientset.Interface, sa *v1.ServiceAccount) error {
 	if _, err := client.CoreV1().ServiceAccounts(sa.ObjectMeta.Namespace).Create(sa); err != nil {

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -88,3 +88,22 @@ func WaitForStaticPodToDisappear(client clientset.Interface, timeout time.Durati
 		return false, nil
 	})
 }
+
+// TryRunCommand runs a function a maximum of failureThreshold times, and retries on error. If failureThreshold is hit; the last error is returned
+func TryRunCommand(f func() error, failureThreshold uint8) error {
+	var numFailures uint8
+	return wait.PollImmediate(5*time.Second, 20*time.Minute, func() (bool, error) {
+		err := f()
+		if err != nil {
+			numFailures++
+			// If we've reached the maximum amount of failures, error out
+			if numFailures == failureThreshold {
+				return false, err
+			}
+			// Retry
+			return false, nil
+		}
+		// The last f() call was a success!
+		return true, nil
+	})
+}

--- a/cmd/kubeadm/app/util/arguments.go
+++ b/cmd/kubeadm/app/util/arguments.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// BuildArgumentListFromMap takes two string-string maps, one with the base arguments and one with optional override arguments
+func BuildArgumentListFromMap(baseArguments map[string]string, overrideArguments map[string]string) []string {
+	var command []string
+	for k, v := range overrideArguments {
+		// values of "" are allowed as well
+		command = append(command, fmt.Sprintf("--%s=%s", k, v))
+	}
+	for k, v := range baseArguments {
+		if _, overrideExists := overrideArguments[k]; !overrideExists {
+			command = append(command, fmt.Sprintf("--%s=%s", k, v))
+		}
+	}
+	return command
+}
+
+// ParseArgumentListToMap parses a CLI argument list in the form "--foo=bar" to a string-string map
+func ParseArgumentListToMap(arguments []string) map[string]string {
+	resultingMap := map[string]string{}
+	for i, arg := range arguments {
+		key, val, err := parseArgument(arg)
+
+		// Ignore if the first argument doesn't satisfy the criteria, it's most often the binary name
+		// Warn in all other cases, but don't error out. This can happen only if the user has edited the argument list by hand, so they might know what they are doing
+		if err != nil {
+			if i != 0 {
+				fmt.Printf("[kubeadm] WARNING: The component argument %q could not be parsed correctly. The argument must be of the form %q. Skipping...", arg, "--")
+			}
+			continue
+		}
+
+		resultingMap[key] = val
+	}
+	return resultingMap
+}
+
+// ReplaceArgument gets a command list; converts it to a map for easier modification, runs the provided function that
+// returns a new modified map, and then converts the map back to a command string slice
+func ReplaceArgument(command []string, argMutateFunc func(map[string]string) map[string]string) []string {
+	argMap := ParseArgumentListToMap(command)
+
+	// Save the first command (the executable) if we're sure it's not an argument (i.e. no --)
+	var newCommand []string
+	if len(command) > 0 && !strings.HasPrefix(command[0], "--") {
+		newCommand = append(newCommand, command[0])
+	}
+	newArgMap := argMutateFunc(argMap)
+	newCommand = append(newCommand, BuildArgumentListFromMap(newArgMap, map[string]string{})...)
+	return newCommand
+}
+
+// parseArgument parses the argument "--foo=bar" to "foo" and "bar"
+func parseArgument(arg string) (string, string, error) {
+	if !strings.HasPrefix(arg, "--") {
+		return "", "", fmt.Errorf("the argument should start with '--'")
+	}
+	if !strings.Contains(arg, "=") {
+		return "", "", fmt.Errorf("the argument should have a '=' between the flag and the value")
+	}
+	// Remove the starting --
+	arg = strings.TrimPrefix(arg, "--")
+	// Split the string on =. Return only two substrings, since we want only key/value, but the value can include '=' as well
+	keyvalSlice := strings.SplitN(arg, "=", 2)
+
+	// Make sure both a key and value is present
+	if len(keyvalSlice) != 2 {
+		return "", "", fmt.Errorf("the argument must have both a key and a value")
+	}
+	if len(keyvalSlice[0]) == 0 {
+		return "", "", fmt.Errorf("the argument must have a key")
+	}
+
+	return keyvalSlice[0], keyvalSlice[1], nil
+}

--- a/cmd/kubeadm/app/util/arguments_test.go
+++ b/cmd/kubeadm/app/util/arguments_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestBuildArgumentListFromMap(t *testing.T) {
+	var tests = []struct {
+		base      map[string]string
+		overrides map[string]string
+		expected  []string
+	}{
+		{ // override an argument from the base
+			base: map[string]string{
+				"admission-control":     "NamespaceLifecycle",
+				"insecure-bind-address": "127.0.0.1",
+				"allow-privileged":      "true",
+			},
+			overrides: map[string]string{
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+			},
+			expected: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+		},
+		{ // add an argument that is not in base
+			base: map[string]string{
+				"insecure-bind-address": "127.0.0.1",
+				"allow-privileged":      "true",
+			},
+			overrides: map[string]string{
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+			},
+			expected: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+		},
+		{ // allow empty strings in base
+			base: map[string]string{
+				"insecure-bind-address":              "127.0.0.1",
+				"allow-privileged":                   "true",
+				"something-that-allows-empty-string": "",
+			},
+			overrides: map[string]string{
+				"admission-control": "NamespaceLifecycle,LimitRanger",
+			},
+			expected: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--something-that-allows-empty-string=",
+			},
+		},
+		{ // allow empty strings in overrides
+			base: map[string]string{
+				"insecure-bind-address":              "127.0.0.1",
+				"allow-privileged":                   "true",
+				"something-that-allows-empty-string": "foo",
+			},
+			overrides: map[string]string{
+				"admission-control":                  "NamespaceLifecycle,LimitRanger",
+				"something-that-allows-empty-string": "",
+			},
+			expected: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--something-that-allows-empty-string=",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actual := BuildArgumentListFromMap(rt.base, rt.overrides)
+		sort.Strings(actual)
+		sort.Strings(rt.expected)
+		if !reflect.DeepEqual(actual, rt.expected) {
+			t.Errorf("failed BuildArgumentListFromMap:\nexpected:\n%v\nsaw:\n%v", rt.expected, actual)
+		}
+	}
+}
+
+func TestParseArgumentListToMap(t *testing.T) {
+	var tests = []struct {
+		args        []string
+		expectedMap map[string]string
+	}{
+		{
+			// normal case
+			args: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+			expectedMap: map[string]string{
+				"admission-control":     "NamespaceLifecycle,LimitRanger",
+				"insecure-bind-address": "127.0.0.1",
+				"allow-privileged":      "true",
+			},
+		},
+		{
+			// test that feature-gates is working
+			args: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--feature-gates=EnableFoo=true,EnableBar=false",
+			},
+			expectedMap: map[string]string{
+				"admission-control":     "NamespaceLifecycle,LimitRanger",
+				"insecure-bind-address": "127.0.0.1",
+				"allow-privileged":      "true",
+				"feature-gates":         "EnableFoo=true,EnableBar=false",
+			},
+		},
+		{
+			// test that a binary can be the first arg
+			args: []string{
+				"kube-apiserver",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--feature-gates=EnableFoo=true,EnableBar=false",
+			},
+			expectedMap: map[string]string{
+				"admission-control":     "NamespaceLifecycle,LimitRanger",
+				"insecure-bind-address": "127.0.0.1",
+				"allow-privileged":      "true",
+				"feature-gates":         "EnableFoo=true,EnableBar=false",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actualMap := ParseArgumentListToMap(rt.args)
+		if !reflect.DeepEqual(actualMap, rt.expectedMap) {
+			t.Errorf("failed ParseArgumentListToMap:\nexpected:\n%v\nsaw:\n%v", rt.expectedMap, actualMap)
+		}
+	}
+}
+
+func TestReplaceArgument(t *testing.T) {
+	var tests = []struct {
+		args         []string
+		mutateFunc   func(map[string]string) map[string]string
+		expectedArgs []string
+	}{
+		{
+			// normal case
+			args: []string{
+				"kube-apiserver",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+			mutateFunc: func(argMap map[string]string) map[string]string {
+				argMap["admission-control"] = "NamespaceLifecycle,LimitRanger,ResourceQuota"
+				return argMap
+			},
+			expectedArgs: []string{
+				"kube-apiserver",
+				"--admission-control=NamespaceLifecycle,LimitRanger,ResourceQuota",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+		},
+		{
+			// normal case
+			args: []string{
+				"kube-apiserver",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+			mutateFunc: func(argMap map[string]string) map[string]string {
+				argMap["new-arg-here"] = "foo"
+				return argMap
+			},
+			expectedArgs: []string{
+				"kube-apiserver",
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--new-arg-here=foo",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		actualArgs := ReplaceArgument(rt.args, rt.mutateFunc)
+		sort.Strings(actualArgs)
+		sort.Strings(rt.expectedArgs)
+		if !reflect.DeepEqual(actualArgs, rt.expectedArgs) {
+			t.Errorf("failed ReplaceArgument:\nexpected:\n%v\nsaw:\n%v", rt.expectedArgs, actualArgs)
+		}
+	}
+}
+
+func TestRoundtrip(t *testing.T) {
+	var tests = []struct {
+		args []string
+	}{
+		{
+			// normal case
+			args: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+			},
+		},
+		{
+			// test that feature-gates is working
+			args: []string{
+				"--admission-control=NamespaceLifecycle,LimitRanger",
+				"--insecure-bind-address=127.0.0.1",
+				"--allow-privileged=true",
+				"--feature-gates=EnableFoo=true,EnableBar=false",
+			},
+		},
+	}
+
+	for _, rt := range tests {
+		// These two methods should be each other's opposite functions, test that by chaining the methods and see if you get the same result back
+		actual := BuildArgumentListFromMap(ParseArgumentListToMap(rt.args), map[string]string{})
+		sort.Strings(actual)
+		sort.Strings(rt.args)
+
+		if !reflect.DeepEqual(actual, rt.args) {
+			t.Errorf("failed TestRoundtrip:\nexpected:\n%v\nsaw:\n%v", rt.args, actual)
+		}
+	}
+}
+
+func TestParseArgument(t *testing.T) {
+	var tests = []struct {
+		arg         string
+		expectedKey string
+		expectedVal string
+		expectedErr bool
+	}{
+		{
+			// cannot be empty
+			arg:         "",
+			expectedErr: true,
+		},
+		{
+			// must contain -- and =
+			arg:         "a",
+			expectedErr: true,
+		},
+		{
+			// must contain -- and =
+			arg:         "a-z",
+			expectedErr: true,
+		},
+		{
+			// must contain --
+			arg:         "a=b",
+			expectedErr: true,
+		},
+		{
+			// must contain a key
+			arg:         "--=b",
+			expectedErr: true,
+		},
+		{
+			// can contain key but no value
+			arg:         "--a=",
+			expectedKey: "a",
+			expectedVal: "",
+			expectedErr: false,
+		},
+		{
+			// simple case
+			arg:         "--a=b",
+			expectedKey: "a",
+			expectedVal: "b",
+			expectedErr: false,
+		},
+		{
+			// keys/values with '-' should be supported
+			arg:         "--very-long-flag-name=some-value",
+			expectedKey: "very-long-flag-name",
+			expectedVal: "some-value",
+			expectedErr: false,
+		},
+		{
+			// numbers should be handled correctly
+			arg:         "--some-number=0.2",
+			expectedKey: "some-number",
+			expectedVal: "0.2",
+			expectedErr: false,
+		},
+		{
+			// lists should be handled correctly
+			arg:         "--admission-control=foo,bar,baz",
+			expectedKey: "admission-control",
+			expectedVal: "foo,bar,baz",
+			expectedErr: false,
+		},
+		{
+			// more than one '=' should be allowed
+			arg:         "--feature-gates=EnableFoo=true,EnableBar=false",
+			expectedKey: "feature-gates",
+			expectedVal: "EnableFoo=true,EnableBar=false",
+			expectedErr: false,
+		},
+	}
+
+	for _, rt := range tests {
+		key, val, actual := parseArgument(rt.arg)
+		if (actual != nil) != rt.expectedErr {
+			t.Errorf("failed parseArgument:\nexpected error:\n%t\nsaw error:\n%v", rt.expectedErr, actual)
+		}
+		if (key != rt.expectedKey) || (val != rt.expectedVal) {
+			t.Errorf("failed parseArgument:\nexpected key: %s\nsaw key: %s\nexpected value: %s\nsaw value: %s", rt.expectedKey, key, rt.expectedVal, val)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR:
 - makes the self-hosting with certificates in Secrets mode work
 - makes the wait functions timeoutable
 - fixes a race condition where the kubelet may be slow to remove the Static Pod
 - cleans up some of the self-hosting logic
 - makes self-hosting-with-secrets respect the feature flag

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes: https://github.com/kubernetes/kubeadm/issues/405

**Special notes for your reviewer**:

This is work in progress. I'll add unit tests, rebase upon https://github.com/kubernetes/kubernetes/pull/50762 and maybe split out some of the functionatlity here into a separate PR

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 