### PR TITLE
[Federation] Unit test fix for discovery error handling changes for 1.7

### DIFF
--- a/federation/pkg/federation-controller/namespace/BUILD
+++ b/federation/pkg/federation-controller/namespace/BUILD
@@ -56,6 +56,8 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
+        "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",


### PR DESCRIPTION
The federated unit tests for namespaces, the way are done have been updated in master and are
no longer the preferred way of doing this test. They however are still invoked on 1.7. 
This PR is to enable the cherry pick of https://github.com/kubernetes/kubernetes/pull/49495 on 1.7.


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Enables merge of https://github.com/kubernetes/kubernetes/pull/49767

**Special notes for your reviewer**:
@wojtek-t, @foxish 
cc @nikhiljindal 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```None
```
