### PR TITLE
kubeadm: Fix self-hosting race condition

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"strconv"
 	"text/template"
+	"time"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -261,8 +262,9 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	fmt.Printf("[init] Waiting for the kubelet to boot up the control plane as Static Pods from directory %q\n", kubeadmconstants.GetStaticPodDirectory())
-	// TODO: Don't wait forever here
-	apiclient.WaitForAPI(client)
+	if err := apiclient.WaitForAPI(client, 30*time.Minute); err != nil {
+		return err
+	}
 
 	// PHASE 4: Mark the master with the right label/taint
 	if err := markmasterphase.MarkMaster(client, i.cfg.NodeName); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Splitted out from: https://github.com/kubernetes/kubernetes/pull/50766

Waits for the Static Pod to be deleted before proceeding with checking the API health.
Otherwise there is a race condition where we're checking the health on the static pod API server; not the self-hosted one that we expect.
Also improves the logging output and adds reasonable timeouts for the process

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Dependency for
 - https://github.com/kubernetes/kubernetes/pull/50766
 - https://github.com/kubernetes/kubernetes/pull/50631
 - https://github.com/kubernetes/kubernetes/pull/48899

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 