### PR TITLE
bzl: enable race detection in tests

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -11,3 +11,6 @@ build --sandbox_tmpfs_path=/tmp
 # Ensure that Bazel never runs as root, which can cause unit tests to fail.
 # This flag requires Bazel 0.5.0+
 build --sandbox_fake_username
+
+# Run all tests with race detector
+test --features=race


### PR DESCRIPTION
blocked by the bazel build fix