### PR TITLE
Disable Docker's health check until we officially support it

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -131,6 +131,11 @@ func (ds *dockerService) CreateContainer(podSandboxID string, config *runtimeapi
 			OpenStdin: config.Stdin,
 			StdinOnce: config.StdinOnce,
 			Tty:       config.Tty,
+			// Disable Docker's health check until we officially support it
+			// (https://github.com/kubernetes/kubernetes/issues/25829).
+			Healthcheck: &dockercontainer.HealthConfig{
+				Test: []string{"NONE"},
+			},
 		},
 		HostConfig: &dockercontainer.HostConfig{
 			Binds: generateMountBindings(config.GetMounts()),


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/50703

Tested locally.

Without this PR:

```
CONTAINER ID        IMAGE                                                  COMMAND                  CREATED             STATUS                     PORTS               NAMES
afdd796ddddc        gcr.io/ygg-gke-dev/nginx-healthcheck                   "nginx -g 'daemon ..."   5 minutes ago       Up 5 minutes (healthy)                       k8s_test-container_test-pod_default_8a1ad225-82bf-11e7-becb-480fcf514648_0
```

With this PR:
```
e3fb2437555f        gcr.io/ygg-gke-dev/nginx-healthcheck                   "nginx -g 'daemon ..."   10 seconds ago      Up 9 seconds                            k8s_test-container_test-pod_default_de82e83c-82c0-11e7-b3fc-480fcf514648_0
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Disable Docker's health check until we officially support it.
```

/assign @yujuhong 
/assign @dchen1107 