### PR TITLE
Improve commentary around an API panic.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
@@ -222,6 +222,8 @@ func (m *APIRegistrationManager) GroupOrDie(group string) *apimachinery.GroupMet
 	groupMeta, found := m.groupMetaMap[group]
 	if !found {
 		if group == "" {
+			// If a test triggers this panic, assure that the test's package
+			// imports "k8s.io/kubernetes/pkg/api/testapi" to run its init.
 			panic("The legacy v1 API is not registered.")
 		} else {
 			panic(fmt.Sprintf("Group %s is not registered.", group))


### PR DESCRIPTION
The panic can be triggered by tests that don't import a magic init
New comment suggests the appropriate import.

```release-note
NONE
```
