### PR TITLE
Bump repo-infra/kazel dependency

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -7,9 +7,9 @@ http_archive(
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "5ba54d17d582ec099ba65d4e409e318e209216b15be819c922a5baae3f4d4283",
-    strip_prefix = "repo-infra-e9d1a126ef355ff5d38e20612c889b07728225a4",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/e9d1a126ef355ff5d38e20612c889b07728225a4.tar.gz"],
+    sha256 = "2b2cb64b2fd7734c5eb2b79b79fa35d064fcf53b92cb3aaec5b90fc10fc94135",
+    strip_prefix = "repo-infra-9ba3a24eeffafa3a794b9e7312103424e7da26e9",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/9ba3a24eeffafa3a794b9e7312103424e7da26e9.tar.gz"],
 )
 
 ETCD_VERSION = "3.0.17"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -25,7 +25,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel e9d1a126ef355ff5d38e20612c889b07728225a4
+kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 9ba3a24eeffafa3a794b9e7312103424e7da26e9
 kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
 
 gazelle fix -build_file_name=BUILD,BUILD.bazel -external=vendored -mode=fix -repo_root="$(kube::realpath ${KUBE_ROOT})"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -25,7 +25,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel e9d1a126ef355ff5d38e20612c889b07728225a4
+kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 9ba3a24eeffafa3a794b9e7312103424e7da26e9
 kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
 
 gazelle_diff=$(gazelle fix -build_file_name=BUILD,BUILD.bazel -external=vendored -mode=diff -repo_root="$(kube::realpath ${KUBE_ROOT})")


### PR DESCRIPTION
**What this PR does / why we need it**: `kazel` shouldn't be looking under skipped paths (like `_output`) for openapi files. This was fixed in https://github.com/kubernetes/repo-infra/pull/32 and now should be included here.

I've tested locally that this now ignores everything under `_output`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @mikedanese @spxtr 
