### PR TITLE
Add support to modify precomputed predicate metadata upon adding/removal of a pod

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/BUILD
+++ b/plugin/pkg/scheduler/algorithm/predicates/BUILD
@@ -40,6 +40,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "metadata_test.go",
         "predicates_test.go",
         "utils_test.go",
     ],

--- a/plugin/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/metadata.go
@@ -17,15 +17,51 @@ limitations under the License.
 package predicates
 
 import (
+	"fmt"
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 	schedutil "k8s.io/kubernetes/plugin/pkg/scheduler/util"
+	"sync"
 )
 
 type PredicateMetadataFactory struct {
 	podLister algorithm.PodLister
+}
+
+//  Note that predicateMetadata and matchingPodAntiAffinityTerm need to be declared in the same file
+//  due to the way declarations are processed in predicate declaration unit tests.
+type matchingPodAntiAffinityTerm struct {
+	term *v1.PodAffinityTerm
+	node *v1.Node
+}
+
+// NOTE: When new fields are added/removed or logic is changed, please make sure
+// that RemovePod and AddPod functions are updated to work with the new changes.
+type predicateMetadata struct {
+	pod           *v1.Pod
+	podBestEffort bool
+	podRequest    *schedulercache.Resource
+	podPorts      map[int]bool
+	//key is a pod full name with the anti-affinity rules.
+	matchingAntiAffinityTerms          map[string][]matchingPodAntiAffinityTerm
+	serviceAffinityInUse               bool
+	serviceAffinityMatchingPodList     []*v1.Pod
+	serviceAffinityMatchingPodServices []*v1.Service
+}
+
+// PredicateMetadataProducer: Helper types/variables...
+type PredicateMetadataProducer func(pm *predicateMetadata)
+
+var predicateMetaProducerRegisterLock sync.Mutex
+var predicateMetadataProducers map[string]PredicateMetadataProducer = make(map[string]PredicateMetadataProducer)
+
+func RegisterPredicateMetadataProducer(predicateName string, precomp PredicateMetadataProducer) {
+	predicateMetaProducerRegisterLock.Lock()
+	defer predicateMetaProducerRegisterLock.Unlock()
+	predicateMetadataProducers[predicateName] = precomp
 }
 
 func NewPredicateMetadataFactory(podLister algorithm.PodLister) algorithm.MetadataProducer {
@@ -52,9 +88,72 @@ func (pfactory *PredicateMetadataFactory) GetMetadata(pod *v1.Pod, nodeNameToInf
 		podPorts:                  schedutil.GetUsedPorts(pod),
 		matchingAntiAffinityTerms: matchingTerms,
 	}
-	for predicateName, precomputeFunc := range predicatePrecomputations {
+	for predicateName, precomputeFunc := range predicateMetadataProducers {
 		glog.V(10).Infof("Precompute: %v", predicateName)
 		precomputeFunc(predicateMetadata)
 	}
 	return predicateMetadata
+}
+
+// RemovePod changes predicateMetadata assuming that the given `deletedPod` is
+// deleted from the system.
+func (meta *predicateMetadata) RemovePod(deletedPod *v1.Pod) error {
+	deletedPodFullName := schedutil.GetPodFullName(deletedPod)
+	if deletedPodFullName == schedutil.GetPodFullName(meta.pod) {
+		return fmt.Errorf("deletedPod and meta.pod must not be the same.")
+	}
+	// Delete any anti-affinity rule from the deletedPod.
+	delete(meta.matchingAntiAffinityTerms, deletedPodFullName)
+	// All pods in the serviceAffinityMatchingPodList are in the same namespace.
+	// So, if the namespace of the first one is not the same as the namespace of the
+	// deletedPod, we don't need to check the list, as deletedPod isn't in the list.
+	if meta.serviceAffinityInUse &&
+		len(meta.serviceAffinityMatchingPodList) > 0 &&
+		deletedPod.Namespace == meta.serviceAffinityMatchingPodList[0].Namespace {
+		for i, pod := range meta.serviceAffinityMatchingPodList {
+			if schedutil.GetPodFullName(pod) == deletedPodFullName {
+				meta.serviceAffinityMatchingPodList = append(
+					meta.serviceAffinityMatchingPodList[:i],
+					meta.serviceAffinityMatchingPodList[i+1:]...)
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// AddPod changes predicateMetadata assuming that `newPod` is added to the
+// system.
+func (meta *predicateMetadata) AddPod(addedPod *v1.Pod, nodeInfo *schedulercache.NodeInfo) error {
+	addedPodFullName := schedutil.GetPodFullName(addedPod)
+	if addedPodFullName == schedutil.GetPodFullName(meta.pod) {
+		return fmt.Errorf("addedPod and meta.pod must not be the same.")
+	}
+	if nodeInfo.Node() == nil {
+		return fmt.Errorf("Invalid node in nodeInfo.")
+	}
+	// Add matching anti-affinity terms of the addedPod to the map.
+	podMatchingTerms, err := getMatchingAntiAffinityTermsOfExistingPod(meta.pod, addedPod, nodeInfo.Node())
+	if err != nil {
+		return err
+	}
+	if len(podMatchingTerms) > 0 {
+		existingTerms, found := meta.matchingAntiAffinityTerms[addedPodFullName]
+		if found {
+			meta.matchingAntiAffinityTerms[addedPodFullName] = append(existingTerms,
+				podMatchingTerms...)
+		} else {
+			meta.matchingAntiAffinityTerms[addedPodFullName] = podMatchingTerms
+		}
+	}
+	// If addedPod is in the same namespace as the meta.pod, update the list
+	// of matching pods if applicable.
+	if meta.serviceAffinityInUse && addedPod.Namespace == meta.pod.Namespace {
+		selector := CreateSelectorFromLabels(meta.pod.Labels)
+		if selector.Matches(labels.Set(addedPod.Labels)) {
+			meta.serviceAffinityMatchingPodList = append(meta.serviceAffinityMatchingPodList,
+				addedPod)
+		}
+	}
+	return nil
 }

--- a/plugin/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -1,0 +1,357 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package predicates
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
+	schedulertesting "k8s.io/kubernetes/plugin/pkg/scheduler/testing"
+)
+
+// sortableAntiAffinityTerms lets us to sort anti-affinity terms.
+type sortableAntiAffinityTerms []matchingPodAntiAffinityTerm
+
+// Less establishes some ordering between two matchingPodAntiAffinityTerms for
+// sorting.
+func (s sortableAntiAffinityTerms) Less(i, j int) bool {
+	t1, t2 := s[i], s[j]
+	if t1.node.Name != t2.node.Name {
+		return t1.node.Name < t2.node.Name
+	}
+	if len(t1.term.Namespaces) != len(t2.term.Namespaces) {
+		return len(t1.term.Namespaces) < len(t2.term.Namespaces)
+	}
+	if t1.term.TopologyKey != t2.term.TopologyKey {
+		return t1.term.TopologyKey < t2.term.TopologyKey
+	}
+	if len(t1.term.LabelSelector.MatchLabels) != len(t2.term.LabelSelector.MatchLabels) {
+		return len(t1.term.LabelSelector.MatchLabels) < len(t2.term.LabelSelector.MatchLabels)
+	}
+	return false
+}
+func (s sortableAntiAffinityTerms) Len() int { return len(s) }
+func (s sortableAntiAffinityTerms) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+var _ = sort.Interface(sortableAntiAffinityTerms{})
+
+func sortAntiAffinityTerms(terms map[string][]matchingPodAntiAffinityTerm) {
+	for k, v := range terms {
+		sortableTerms := sortableAntiAffinityTerms(v)
+		sort.Sort(sortableTerms)
+		terms[k] = sortableTerms
+	}
+}
+
+// sortablePods lets us to sort pods.
+type sortablePods []*v1.Pod
+
+func (s sortablePods) Less(i, j int) bool {
+	return s[i].Namespace < s[j].Namespace ||
+		(s[i].Namespace == s[j].Namespace && s[i].Name < s[j].Name)
+}
+func (s sortablePods) Len() int      { return len(s) }
+func (s sortablePods) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+var _ = sort.Interface(&sortablePods{})
+
+// sortableServices allows us to sort services.
+type sortableServices []*v1.Service
+
+func (s sortableServices) Less(i, j int) bool {
+	return s[i].Namespace < s[j].Namespace ||
+		(s[i].Namespace == s[j].Namespace && s[i].Name < s[j].Name)
+}
+func (s sortableServices) Len() int      { return len(s) }
+func (s sortableServices) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
+
+var _ = sort.Interface(&sortableServices{})
+
+// predicateMetadataEquivalent returns true if the two metadata are equivalent.
+// Note: this function does not compare podRequest.
+func predicateMetadataEquivalent(meta1, meta2 *predicateMetadata) error {
+	if !reflect.DeepEqual(meta1.pod, meta2.pod) {
+		return fmt.Errorf("pods are not the same.")
+	}
+	if meta1.podBestEffort != meta2.podBestEffort {
+		return fmt.Errorf("podBestEfforts are not equal.")
+	}
+	if meta1.serviceAffinityInUse != meta1.serviceAffinityInUse {
+		return fmt.Errorf("serviceAffinityInUses are not equal.")
+	}
+	if len(meta1.podPorts) != len(meta2.podPorts) {
+		return fmt.Errorf("podPorts are not equal.")
+	}
+	for !reflect.DeepEqual(meta1.podPorts, meta2.podPorts) {
+		return fmt.Errorf("podPorts are not equal.")
+	}
+	sortAntiAffinityTerms(meta1.matchingAntiAffinityTerms)
+	sortAntiAffinityTerms(meta2.matchingAntiAffinityTerms)
+	if !reflect.DeepEqual(meta1.matchingAntiAffinityTerms, meta2.matchingAntiAffinityTerms) {
+		return fmt.Errorf("matchingAntiAffinityTerms are not euqal.")
+	}
+	if meta1.serviceAffinityInUse {
+		sortablePods1 := sortablePods(meta1.serviceAffinityMatchingPodList)
+		sort.Sort(sortablePods1)
+		sortablePods2 := sortablePods(meta2.serviceAffinityMatchingPodList)
+		sort.Sort(sortablePods2)
+		if !reflect.DeepEqual(sortablePods1, sortablePods2) {
+			return fmt.Errorf("serviceAffinityMatchingPodLists are not euqal.")
+		}
+
+		sortableServices1 := sortableServices(meta1.serviceAffinityMatchingPodServices)
+		sort.Sort(sortableServices1)
+		sortableServices2 := sortableServices(meta2.serviceAffinityMatchingPodServices)
+		sort.Sort(sortableServices2)
+		if !reflect.DeepEqual(sortableServices1, sortableServices2) {
+			return fmt.Errorf("serviceAffinityMatchingPodServices are not euqal.")
+		}
+	}
+	return nil
+}
+
+func TestPredicateMetadata_AddRemovePod(t *testing.T) {
+	var label1 = map[string]string{
+		"region": "r1",
+		"zone":   "z11",
+	}
+	var label2 = map[string]string{
+		"region": "r1",
+		"zone":   "z12",
+	}
+	var label3 = map[string]string{
+		"region": "r2",
+		"zone":   "z21",
+	}
+	selector1 := map[string]string{"foo": "bar"}
+	antiAffinityFooBar := &v1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "foo",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"bar"},
+						},
+					},
+				},
+				TopologyKey: "region",
+			},
+		},
+	}
+	antiAffinityComplex := &v1.PodAntiAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: []v1.PodAffinityTerm{
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "foo",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"bar", "buzz"},
+						},
+					},
+				},
+				TopologyKey: "region",
+			},
+			{
+				LabelSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "service",
+							Operator: metav1.LabelSelectorOpNotIn,
+							Values:   []string{"bar", "security", "test"},
+						},
+					},
+				},
+				TopologyKey: "zone",
+			},
+		},
+	}
+
+	tests := []struct {
+		description  string
+		pendingPod   *v1.Pod
+		addedPod     *v1.Pod
+		existingPods []*v1.Pod
+		nodes        []*v1.Node
+		services     []*v1.Service
+	}{
+		{
+			description: "no anti-affinity or service affinity exist",
+			pendingPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
+			},
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p1", Labels: selector1},
+					Spec: v1.PodSpec{NodeName: "nodeA"},
+				},
+				{ObjectMeta: metav1.ObjectMeta{Name: "p2"},
+					Spec: v1.PodSpec{NodeName: "nodeC"},
+				},
+			},
+			addedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "addedPod", Labels: selector1},
+				Spec:       v1.PodSpec{NodeName: "nodeB"},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: label3}},
+			},
+		},
+		{
+			description: "metadata anti-affinity terms are updated correctly after adding and removing a pod",
+			pendingPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
+			},
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p1", Labels: selector1},
+					Spec: v1.PodSpec{NodeName: "nodeA"},
+				},
+				{ObjectMeta: metav1.ObjectMeta{Name: "p2"},
+					Spec: v1.PodSpec{
+						NodeName: "nodeC",
+						Affinity: &v1.Affinity{
+							PodAntiAffinity: antiAffinityFooBar,
+						},
+					},
+				},
+			},
+			addedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "addedPod", Labels: selector1},
+				Spec: v1.PodSpec{
+					NodeName: "nodeB",
+					Affinity: &v1.Affinity{
+						PodAntiAffinity: antiAffinityFooBar,
+					},
+				},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: label3}},
+			},
+		},
+		{
+			description: "metadata service-affinity data are updated correctly after adding and removing a pod",
+			pendingPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
+			},
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p1", Labels: selector1},
+					Spec: v1.PodSpec{NodeName: "nodeA"},
+				},
+				{ObjectMeta: metav1.ObjectMeta{Name: "p2"},
+					Spec: v1.PodSpec{NodeName: "nodeC"},
+				},
+			},
+			addedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "addedPod", Labels: selector1},
+				Spec:       v1.PodSpec{NodeName: "nodeB"},
+			},
+			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector1}}},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: label3}},
+			},
+		},
+		{
+			description: "metadata anti-affinity terms and service affinity data are updated correctly after adding and removing a pod",
+			pendingPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "pending", Labels: selector1},
+			},
+			existingPods: []*v1.Pod{
+				{ObjectMeta: metav1.ObjectMeta{Name: "p1", Labels: selector1},
+					Spec: v1.PodSpec{NodeName: "nodeA"},
+				},
+				{ObjectMeta: metav1.ObjectMeta{Name: "p2"},
+					Spec: v1.PodSpec{
+						NodeName: "nodeC",
+						Affinity: &v1.Affinity{
+							PodAntiAffinity: antiAffinityFooBar,
+						},
+					},
+				},
+			},
+			addedPod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "addedPod", Labels: selector1},
+				Spec: v1.PodSpec{
+					NodeName: "nodeA",
+					Affinity: &v1.Affinity{
+						PodAntiAffinity: antiAffinityComplex,
+					},
+				},
+			},
+			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: selector1}}},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeA", Labels: label1}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeB", Labels: label2}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "nodeC", Labels: label3}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		allPodLister := schedulertesting.FakePodLister(append(test.existingPods, test.addedPod))
+		// getMeta creates predicate meta data given the list of pods.
+		getMeta := func(lister schedulertesting.FakePodLister) (*predicateMetadata, map[string]*schedulercache.NodeInfo) {
+			nodeInfoMap := schedulercache.CreateNodeNameToInfoMap(lister, test.nodes)
+			// nodeList is a list of non-pointer nodes to feed to FakeNodeListInfo.
+			nodeList := []v1.Node{}
+			for _, n := range test.nodes {
+				nodeList = append(nodeList, *n)
+			}
+			_, precompute := NewServiceAffinityPredicate(lister, schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodeList), nil)
+			RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", precompute)
+			pmf := PredicateMetadataFactory{lister}
+			meta := pmf.GetMetadata(test.pendingPod, nodeInfoMap)
+			return meta.(*predicateMetadata), nodeInfoMap
+		}
+
+		// allPodsMeta is meta data produced when all pods, including test.addedPod
+		// are given to the metadata producer.
+		allPodsMeta, _ := getMeta(allPodLister)
+		// existingPodsMeta1 is meta data produced for test.existingPods (without test.addedPod).
+		existingPodsMeta1, nodeInfoMap := getMeta(schedulertesting.FakePodLister(test.existingPods))
+		// Add test.addedPod to existingPodsMeta1 and make sure meta is equal to allPodsMeta
+		nodeInfo := nodeInfoMap[test.addedPod.Spec.NodeName]
+		if err := existingPodsMeta1.AddPod(test.addedPod, nodeInfo); err != nil {
+			t.Errorf("test [%v]: error adding pod to meta: %v", test.description, err)
+		}
+		if err := predicateMetadataEquivalent(allPodsMeta, existingPodsMeta1); err != nil {
+			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
+		}
+		// Remove the added pod and from existingPodsMeta1 an make sure it is equal
+		// to meta generated for existing pods.
+		existingPodsMeta2, _ := getMeta(schedulertesting.FakePodLister(test.existingPods))
+		if err := existingPodsMeta1.RemovePod(test.addedPod); err != nil {
+			t.Errorf("test [%v]: error removing pod from meta: %v", test.description, err)
+		}
+		if err := predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2); err != nil {
+			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
+		}
+	}
+}

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -1590,7 +1590,7 @@ func TestServiceAffinity(t *testing.T) {
 			// Reimplementing the logic that the scheduler implements: Any time it makes a predicate, it registers any precomputations.
 			predicate, precompute := NewServiceAffinityPredicate(schedulertesting.FakePodLister(test.pods), schedulertesting.FakeServiceLister(test.services), FakeNodeListInfo(nodes), test.labels)
 			// Register a precomputation or Rewrite the precomputation to a no-op, depending on the state we want to test.
-			RegisterPredicatePrecomputation("checkServiceAffinity-unitTestPredicate", func(pm *predicateMetadata) {
+			RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", func(pm *predicateMetadata) {
 				if !skipPrecompute {
 					precompute(pm)
 				}

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -80,6 +80,9 @@ type PodLister interface {
 	// We explicitly return []*v1.Pod, instead of v1.PodList, to avoid
 	// performing expensive copies that are unneeded.
 	List(labels.Selector) ([]*v1.Pod, error)
+	// This is similar to "List()", but the returned slice does not
+	// contain pods that don't pass `podFilter`.
+	FilteredList(podFilter schedulercache.PodFilter, selector labels.Selector) ([]*v1.Pod, error)
 }
 
 // ServiceLister interface represents anything that can produce a list of services; the list is consumed by a scheduler.

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -129,7 +129,7 @@ func RegisterCustomFitPredicate(policy schedulerapi.PredicatePolicy) string {
 				)
 
 				// Once we generate the predicate we should also Register the Precomputation
-				predicates.RegisterPredicatePrecomputation(policy.Name, precomputationFunction)
+				predicates.RegisterPredicateMetadataProducer(policy.Name, precomputationFunction)
 				return predicate
 			}
 		} else if policy.Argument.LabelsPresence != nil {

--- a/plugin/pkg/scheduler/schedulercache/BUILD
+++ b/plugin/pkg/scheduler/schedulercache/BUILD
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//pkg/api/v1/helper:go_default_library",
         "//plugin/pkg/scheduler/algorithm/priorities/util:go_default_library",
+        "//plugin/pkg/scheduler/util:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/plugin/pkg/scheduler/schedulercache/cache.go
+++ b/plugin/pkg/scheduler/schedulercache/cache.go
@@ -93,12 +93,17 @@ func (cache *schedulerCache) UpdateNodeNameToInfoMap(nodeNameToInfo map[string]*
 }
 
 func (cache *schedulerCache) List(selector labels.Selector) ([]*v1.Pod, error) {
+	alwaysTrue := func(p *v1.Pod) bool { return true }
+	return cache.FilteredList(alwaysTrue, selector)
+}
+
+func (cache *schedulerCache) FilteredList(podFilter PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
 	cache.mu.Lock()
 	defer cache.mu.Unlock()
 	var pods []*v1.Pod
 	for _, info := range cache.nodes {
 		for _, pod := range info.pods {
-			if selector.Matches(labels.Set(pod.Labels)) {
+			if podFilter(pod) && selector.Matches(labels.Set(pod.Labels)) {
 				pods = append(pods, pod)
 			}
 		}

--- a/plugin/pkg/scheduler/schedulercache/interface.go
+++ b/plugin/pkg/scheduler/schedulercache/interface.go
@@ -21,6 +21,8 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
+type PodFilter func(*v1.Pod) bool
+
 // Cache collects pods' information and provides node-level aggregated information.
 // It's intended for generic scheduler to do efficient lookup.
 // Cache's operations are pod centric. It does incremental updates based on pod events.
@@ -93,4 +95,7 @@ type Cache interface {
 
 	// List lists all cached pods (including assumed ones).
 	List(labels.Selector) ([]*v1.Pod, error)
+
+	// FilteredList returns all cached pods that pass the filter.
+	FilteredList(filter PodFilter, selector labels.Selector) ([]*v1.Pod, error)
 }

--- a/plugin/pkg/scheduler/testing/fake_cache.go
+++ b/plugin/pkg/scheduler/testing/fake_cache.go
@@ -57,3 +57,7 @@ func (f *FakeCache) UpdateNodeNameToInfoMap(infoMap map[string]*schedulercache.N
 }
 
 func (f *FakeCache) List(s labels.Selector) ([]*v1.Pod, error) { return nil, nil }
+
+func (f *FakeCache) FilteredList(filter schedulercache.PodFilter, selector labels.Selector) ([]*v1.Pod, error) {
+	return nil, nil
+}

--- a/plugin/pkg/scheduler/testing/fake_lister.go
+++ b/plugin/pkg/scheduler/testing/fake_lister.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	. "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
 var _ NodeLister = &FakeNodeLister{}
@@ -46,6 +47,15 @@ type FakePodLister []*v1.Pod
 func (f FakePodLister) List(s labels.Selector) (selected []*v1.Pod, err error) {
 	for _, pod := range f {
 		if s.Matches(labels.Set(pod.Labels)) {
+			selected = append(selected, pod)
+		}
+	}
+	return selected, nil
+}
+
+func (f FakePodLister) FilteredList(podFilter schedulercache.PodFilter, s labels.Selector) (selected []*v1.Pod, err error) {
+	for _, pod := range f {
+		if podFilter(pod) && s.Matches(labels.Set(pod.Labels)) {
 			selected = append(selected, pod)
 		}
 	}

--- a/plugin/pkg/scheduler/util/utils.go
+++ b/plugin/pkg/scheduler/util/utils.go
@@ -39,3 +39,10 @@ func GetUsedPorts(pods ...*v1.Pod) map[int]bool {
 	}
 	return ports
 }
+
+// GetPodFullName returns a name that uniquely identifies a pod.
+func GetPodFullName(pod *v1.Pod) string {
+	// Use underscore as the delimiter because it is not allowed in pod name
+	// (DNS subdomain format).
+	return pod.Name + "_" + pod.Namespace
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This PR adds capability to change precomputed predicate metadata and let's us add/remove pods to the precomputed metadata efficiently without the need ot recomputing everything upon addition/removal of pods. This PR is needed as a part of adding preemption logic to the scheduler.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
To make the review process a bit easier, there are three commits. The cleanup commit is only moving code and renaming some functions, without logic changes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
ref/ #47604
ref/ #48646

/assign @wojtek-t 

@kubernetes/sig-scheduling-pr-reviews @davidopp