### PR TITLE
Remove redundant err definition

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -97,7 +97,6 @@ func NewCmdTopNode(f cmdutil.Factory, out io.Writer) *cobra.Command {
 }
 
 func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string, out io.Writer) error {
-	var err error
 	if len(args) == 1 {
 		o.ResourceName = args[0]
 	} else if len(args) > 1 {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove redundant err definition，err is defined by using "err :=" at line 107

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->NONE
```release-note
```
