### PR TITLE
Add instance metadata from flag even when using image config.

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -208,11 +208,15 @@ func main() {
 				images = []string{imageConfig.Image}
 			}
 			for _, image := range images {
+				metadata := imageConfig.Metadata
+				if len(strings.TrimSpace(*instanceMetadata)) > 0 {
+					metadata += "," + *instanceMetadata
+				}
 				gceImage := internalGCEImage{
 					image:     image,
 					imageDesc: imageConfig.ImageDesc,
 					project:   imageConfig.Project,
-					metadata:  getImageMetadata(imageConfig.Metadata),
+					metadata:  getImageMetadata(metadata),
 					machine:   imageConfig.Machine,
 					tests:     imageConfig.Tests,
 					resources: imageConfig.Resources,


### PR DESCRIPTION
Also add instance metadata from flag even when we are using image config.

* Sometimes we need to dynamically generate instance metadata, it's troublesome to put them into image config.
* Sometimes we want to apply instance metadata to all images, it's duplicated to add them to each image in the image config.

/assign @yguo0905 Could you help me review this?