### PR TITLE
Support autoprobing node-security-group for openstack cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/openstack/BUILD
+++ b/pkg/cloudprovider/providers/openstack/BUILD
@@ -56,6 +56,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -87,7 +87,7 @@ type LoadBalancerOpts struct {
 	MonitorTimeout       MyDuration `gcfg:"monitor-timeout"`
 	MonitorMaxRetries    uint       `gcfg:"monitor-max-retries"`
 	ManageSecurityGroups bool       `gcfg:"manage-security-groups"`
-	NodeSecurityGroupID  string     `gcfg:"node-security-group"`
+	NodeSecurityGroupIDs []string   // Do not specify, get it automatically when enable manage-security-groups. TODO(FengyunPan): move it into cache
 }
 
 type BlockStorageOpts struct {
@@ -245,13 +245,6 @@ func checkOpenStackOpts(openstackOpts *OpenStack) error {
 		}
 		if lbOpts.MonitorMaxRetries == uint(0) {
 			return fmt.Errorf("monitor-max-retries not set in cloud provider config")
-		}
-	}
-
-	// if enable ManageSecurityGroups, node-security-group should be set.
-	if lbOpts.ManageSecurityGroups {
-		if len(lbOpts.NodeSecurityGroupID) == 0 {
-			return fmt.Errorf("node-security-group not set in cloud provider config")
 		}
 	}
 

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -174,7 +174,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 					MonitorTimeout:       timeout,
 					MonitorMaxRetries:    uint(3),
 					ManageSecurityGroups: true,
-					NodeSecurityGroupID:  "b41d28c2-d02f-4e1e-8ffb-23b8e4f5c144",
 				},
 				metadataOpts: MetadataOpts{
 					SearchOrder: configDriveID,
@@ -195,7 +194,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 					MonitorTimeout:       timeout,
 					MonitorMaxRetries:    uint(3),
 					ManageSecurityGroups: true,
-					NodeSecurityGroupID:  "b41d28c2-d02f-4e1e-8ffb-23b8e4f5c144",
 				},
 				metadataOpts: MetadataOpts{
 					SearchOrder: configDriveID,
@@ -214,7 +212,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 					LBMethod:             "ROUND_ROBIN",
 					CreateMonitor:        true,
 					ManageSecurityGroups: true,
-					NodeSecurityGroupID:  "b41d28c2-d02f-4e1e-8ffb-23b8e4f5c144",
 				},
 				metadataOpts: MetadataOpts{
 					SearchOrder: configDriveID,
@@ -226,27 +223,6 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			name: "test4",
 			openstackOpts: &OpenStack{
 				provider: nil,
-				lbOpts: LoadBalancerOpts{
-					LBVersion:            "v2",
-					SubnetId:             "6261548e-ffde-4bc7-bd22-59c83578c5ef",
-					FloatingNetworkId:    "38b8b5f9-64dc-4424-bf86-679595714786",
-					LBMethod:             "ROUND_ROBIN",
-					CreateMonitor:        true,
-					MonitorDelay:         delay,
-					MonitorTimeout:       timeout,
-					MonitorMaxRetries:    uint(3),
-					ManageSecurityGroups: true,
-				},
-				metadataOpts: MetadataOpts{
-					SearchOrder: configDriveID,
-				},
-			},
-			expectedError: fmt.Errorf("node-security-group not set in cloud provider config"),
-		},
-		{
-			name: "test5",
-			openstackOpts: &OpenStack{
-				provider: nil,
 				metadataOpts: MetadataOpts{
 					SearchOrder: "",
 				},
@@ -254,7 +230,7 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			expectedError: fmt.Errorf("Invalid value in section [Metadata] with key `search-order`. Value cannot be empty"),
 		},
 		{
-			name: "test6",
+			name: "test5",
 			openstackOpts: &OpenStack{
 				provider: nil,
 				metadataOpts: MetadataOpts{
@@ -264,7 +240,7 @@ func TestCheckOpenStackOpts(t *testing.T) {
 			expectedError: fmt.Errorf("Invalid value in section [Metadata] with key `search-order`. Value cannot contain more than 2 elements"),
 		},
 		{
-			name: "test7",
+			name: "test6",
 			openstackOpts: &OpenStack{
 				provider: nil,
 				metadataOpts: MetadataOpts{


### PR DESCRIPTION
1. Support autoprobing node-security-group
2. Support multiple Security Groups for cluster's nodes
3. Fix recreating Security Group for cluster's nodes

This is a part of #50726

**Special notes for your reviewer**:
/assign @anguslees 
/assign @dims 

**Release note**:
```release-note
Support autoprobing node-security-group for openstack cloud provider, Support multiple Security Groups for cluster's nodes.
```
