### PR TITLE
Reject unknown container resource names in the default `*kubernetes.io/` namespace.

### DIFF
--- a/pkg/api/helper/helpers.go
+++ b/pkg/api/helper/helpers.go
@@ -107,10 +107,13 @@ func IsResourceQuotaScopeValidForResource(scope api.ResourceQuotaScope, resource
 var standardContainerResources = sets.NewString(
 	string(api.ResourceCPU),
 	string(api.ResourceMemory),
+	string(api.ResourceStorageOverlay),
+	string(api.ResourceStorageScratch),
+	string(api.ResourceNvidiaGPU),
 )
 
-// IsStandardContainerResourceName returns true if the container can make a resource request
-// for the specified resource
+// IsStandardContainerResourceName returns true if a container can make a
+// resource request for the specified resource.
 func IsStandardContainerResourceName(str string) bool {
 	return standardContainerResources.Has(str)
 }
@@ -199,12 +202,14 @@ var standardResources = sets.NewString(
 	string(api.ResourceLimitsCPU),
 	string(api.ResourceLimitsMemory),
 	string(api.ResourcePods),
-	string(api.ResourceQuotas),
 	string(api.ResourceServices),
 	string(api.ResourceReplicationControllers),
+	string(api.ResourceQuotas),
 	string(api.ResourceSecrets),
 	string(api.ResourceConfigMaps),
 	string(api.ResourcePersistentVolumeClaims),
+	string(api.ResourceServicesNodePorts),
+	string(api.ResourceServicesLoadBalancers),
 	string(api.ResourceStorage),
 	string(api.ResourceRequestsStorage),
 )

--- a/pkg/api/helper/helpers_test.go
+++ b/pkg/api/helper/helpers_test.go
@@ -48,13 +48,38 @@ func TestSemantic(t *testing.T) {
 	}
 }
 
+func TestIsStandardContainerResourceName(t *testing.T) {
+	testCases := []struct {
+		input  string
+		output bool
+	}{
+		{"cpu", true},
+		{"kubernetes.io/cpu", false},
+		{"memory", true},
+		{"kubernetes.io/memory", false},
+		{"storage.kubernetes.io/overlay", true},
+		{"storage.kubernetes.io/scratch", true},
+		{"alpha.kubernetes.io/nvidia-gpu", true},
+		{"foo", false},
+		{"example.com/foo", false},
+		{"kubernetes.io/foo", false},
+	}
+	for _, tc := range testCases {
+		if IsStandardContainerResourceName(tc.input) != tc.output {
+			t.Errorf("case[%s], expected: %t, got: %t", tc.input, tc.output, !tc.output)
+		}
+	}
+}
+
 func TestIsStandardResource(t *testing.T) {
 	testCases := []struct {
 		input  string
 		output bool
 	}{
 		{"cpu", true},
+		{"kubernetes.io/cpu", false},
 		{"memory", true},
+		{"kubernetes.io/memory", false},
 		{"disk", false},
 		{"blah", false},
 		{"x.y.z", false},

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -8280,43 +8280,39 @@ func TestValidateResourceNames(t *testing.T) {
 	table := []struct {
 		input   string
 		success bool
-		expect  string
 	}{
-		{"memory", true, ""},
-		{"cpu", true, ""},
-		{"storage", true, ""},
-		{"requests.cpu", true, ""},
-		{"requests.memory", true, ""},
-		{"requests.storage", true, ""},
-		{"limits.cpu", true, ""},
-		{"limits.memory", true, ""},
-		{"network", false, ""},
-		{"disk", false, ""},
-		{"", false, ""},
-		{".", false, ""},
-		{"..", false, ""},
-		{"my.favorite.app.co/12345", true, ""},
-		{"my.favorite.app.co/_12345", false, ""},
-		{"my.favorite.app.co/12345_", false, ""},
-		{"kubernetes.io/..", false, ""},
-		{"kubernetes.io/" + strings.Repeat("a", 63), true, ""},
-		{"kubernetes.io/" + strings.Repeat("a", 64), false, ""},
-		{"kubernetes.io//", false, ""},
-		{"kubernetes.io", false, ""},
-		{"kubernetes.io/will/not/work/", false, ""},
+		{"memory", true},
+		{"cpu", true},
+		{"storage.kubernetes.io/scratch", true},
+		{"storage.kubernetes.io/overlay", true},
+		{"storage", true},
+		{"requests.cpu", true},
+		{"requests.memory", true},
+		{"limits.cpu", true},
+		{"limits.memory", true},
+		{"alpha.kubernetes.io/nvidia-gpu", true},
+		{"network", false},
+		{"disk", false},
+		{"", false},
+		{".", false},
+		{"..", false},
+		{"example.com/foo", true},
+		{"my.favorite.app.co/12345", true},
+		{"my.favorite.app.co/_12345", false},
+		{"my.favorite.app.co/12345_", false},
+		{"kubernetes.io/..", false},
+		{"kubernetes.io/" + strings.Repeat("a", 63), true},
+		{"kubernetes.io/" + strings.Repeat("a", 64), false},
+		{"kubernetes.io//", false},
+		{"kubernetes.io", false},
+		{"kubernetes.io/will/not/work/", false},
 	}
-	for k, item := range table {
+	for _, item := range table {
 		err := validateResourceName(item.input, field.NewPath("field"))
 		if len(err) != 0 && item.success {
 			t.Errorf("expected no failure for input %q", item.input)
 		} else if len(err) == 0 && !item.success {
 			t.Errorf("expected failure for input %q", item.input)
-			for i := range err {
-				detail := err[i].Detail
-				if detail != "" && !strings.Contains(detail, item.expect) {
-					t.Errorf("%d: expected error detail either empty or %s, got %s", k, item.expect, detail)
-				}
-			}
 		}
 	}
 }


### PR DESCRIPTION
- Requires resource names in container requests and limits to be known to the system if in the *kubernetes.io/ namespace, or no namespace is specified.
- Fixes #50658.

**Example**:

_Contents of `fc1.yaml`_

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: fc1
spec:
  containers:
    - image: nginx
      name: fc1
      resources:
        requests:
          kubernetes.io/foo: 1
          cpu: "100m"
          memory: "128M"
```

```
$ kubectl create -f fc1.yaml
The Pod "fc1" is invalid: spec.containers[0].resources.requests[kubernetes.io/foo]:
Invalid value: "kubernetes.io/foo": must be a standard resource for containers or
fully qualified
```

**Release note**:
```release-note
Reject unknown container resource names in the default `*kubernetes.io/` namespace.
```

@kubernetes/sig-scheduling-api-reviews 
@kubernetes/api-reviewers 

cc @vishh @davidopp @xiangpengzhao @balajismaniam 