### PR TITLE
FlexVolume: Add ability to control 'SupportsSELinux' during driver's init phase

### DIFF
--- a/pkg/volume/flexvolume/mounter-defaults.go
+++ b/pkg/volume/flexvolume/mounter-defaults.go
@@ -47,7 +47,7 @@ func (f *mounterDefaults) GetAttributes() volume.Attributes {
 	return volume.Attributes{
 		ReadOnly:        f.readOnly,
 		Managed:         !f.readOnly,
-		SupportsSELinux: true,
+		SupportsSELinux: f.flexVolume.plugin.capabilities.selinuxRelabel,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the ability to disable FlexVolume SELinux relabeling for filesystems that don't support it, e.g. fuse

**Which issue this PR fixes**:
This was reported in: https://github.com/lizardfs/lizardfs/issues/581

This is a reworked solution as per feedback from #50548 
https://github.com/kubernetes/kubernetes/pull/50548#issuecomment-322328679

**Special notes for your reviewer**:
/assign @thockin 
/cc @chakri-nelluri @verult @saad-ali 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
