### PR TITLE
fix incorrect logic in admission register

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -67,13 +67,15 @@ func (ps *Plugins) Registered() []string {
 func (ps *Plugins) Register(name string, plugin Factory) {
 	ps.lock.Lock()
 	defer ps.lock.Unlock()
-	_, found := ps.registry[name]
-	if found {
-		glog.Fatalf("Admission plugin %q was registered twice", name)
-	}
-	if ps.registry == nil {
+	if ps.registry != nil {
+		_, found := ps.registry[name]
+		if found {
+			glog.Fatalf("Admission plugin %q was registered twice", name)
+		}
+	} else {
 		ps.registry = map[string]Factory{}
 	}
+
 	glog.V(1).Infof("Registered admission plugin %q", name)
 	ps.registry[name] = plugin
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no issue for this PR, just fix incorrect logic in invocation `func (ps *Plugins) Register(name string, plugin Factory) ` after browsing the code accidentally.  And apparently, the logic exits potential panic.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
no issue
**Special notes for your reviewer**:
none
**Release note**:
none
