### PR TITLE
cni: print better error when a CNI .configlist is put into a .config

### DIFF
--- a/pkg/kubelet/network/cni/cni.go
+++ b/pkg/kubelet/network/cni/cni.go
@@ -119,6 +119,13 @@ func getDefaultCNINetwork(pluginDir, binDir, vendorCNIDirPrefix string) (*cniNet
 				glog.Warningf("Error loading CNI config file %s: %v", confFile, err)
 				continue
 			}
+			// Ensure the config has a "type" so we know what plugin to run.
+			// Also catches the case where somebody put a conflist into a conf file.
+			if conf.Network.Type == "" {
+				glog.Warningf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
+				continue
+			}
+
 			confList, err = libcni.ConfListFromConf(conf)
 			if err != nil {
 				glog.Warningf("Error converting CNI config file %s to list: %v", confFile, err)


### PR DESCRIPTION
If the admin mistakenly puts a CNI configlist into a "conf" file, that's not correct, but kubelet will still read the config file and then fail to start the pod because "type=".  Be a bit smarter about that.  Should also be fixed in CNI, which I'm doing a PR for as well.

@squeed @thockin @freehan 