### PR TITLE
Automated cherry pick of #49834 upstream release 1.7

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1138,7 +1138,7 @@ func mergePatchIntoOriginal(original, patch map[string]interface{}, t reflect.Ty
 				return err
 			}
 		case !foundOriginal && !foundPatch:
-			return nil
+			continue
 		}
 
 		// Split all items into patch items and server-only items and then enforce the order.

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch_test.go
@@ -5969,6 +5969,75 @@ retainKeysMergingList:
 `),
 		},
 	},
+	{
+		Description: "delete and reorder in one list, reorder in another",
+		StrategicMergePatchRawTestCaseData: StrategicMergePatchRawTestCaseData{
+			Original: []byte(`
+mergingList:
+- name: a
+  value: a
+- name: b
+  value: b
+mergeItemPtr:
+- name: c
+  value: c
+- name: d
+  value: d
+`),
+			Current: []byte(`
+mergingList:
+- name: a
+  value: a
+- name: b
+  value: b
+mergeItemPtr:
+- name: c
+  value: c
+- name: d
+  value: d
+`),
+			Modified: []byte(`
+mergingList:
+- name: b
+  value: b
+mergeItemPtr:
+- name: d
+  value: d
+- name: c
+  value: c
+`),
+			TwoWay: []byte(`
+$setElementOrder/mergingList:
+- name: b
+$setElementOrder/mergeItemPtr:
+- name: d
+- name: c
+mergingList:
+- $patch: delete
+  name: a
+`),
+			ThreeWay: []byte(`
+$setElementOrder/mergingList:
+- name: b
+$setElementOrder/mergeItemPtr:
+- name: d
+- name: c
+mergingList:
+- $patch: delete
+  name: a
+`),
+			Result: []byte(`
+mergingList:
+- name: b
+  value: b
+mergeItemPtr:
+- name: d
+  value: d
+- name: c
+  value: c
+`),
+		},
+	},
 }
 
 func TestStrategicMergePatch(t *testing.T) {
@@ -5993,9 +6062,12 @@ func TestStrategicMergePatch(t *testing.T) {
 		testThreeWayPatch(t, c)
 	}
 
-	for _, c := range strategicMergePatchRawTestCases {
-		testTwoWayPatchForRawTestCase(t, c)
-		testThreeWayPatchForRawTestCase(t, c)
+	// run multiple times to exercise different map traversal orders
+	for i := 0; i < 10; i++ {
+		for _, c := range strategicMergePatchRawTestCases {
+			testTwoWayPatchForRawTestCase(t, c)
+			testThreeWayPatchForRawTestCase(t, c)
+		}
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #49834  on release-1.7.

#49834: Fix premature return