### PR TITLE
oidc auth: make the OIDC claims prefix configurable

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -60,11 +60,13 @@ type KeystoneAuthenticationOptions struct {
 }
 
 type OIDCAuthenticationOptions struct {
-	CAFile        string
-	ClientID      string
-	IssuerURL     string
-	UsernameClaim string
-	GroupsClaim   string
+	CAFile         string
+	ClientID       string
+	IssuerURL      string
+	UsernameClaim  string
+	UsernamePrefix string
+	GroupsClaim    string
+	GroupsPrefix   string
 }
 
 type PasswordFileAuthenticationOptions struct {
@@ -213,10 +215,20 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 			"is not guaranteed to be unique and immutable. This flag is experimental, please see "+
 			"the authentication documentation for further details.")
 
+		fs.StringVar(&s.OIDC.UsernamePrefix, "oidc-username-prefix", "", ""+
+			"If provided, all usernames will be prefixed with this value. If not provided, "+
+			"username claims other than 'email' are prefixed by the issuer URL to avoid "+
+			"clashes. To skip any prefixing, provide the value '-'.")
+
 		fs.StringVar(&s.OIDC.GroupsClaim, "oidc-groups-claim", "", ""+
 			"If provided, the name of a custom OpenID Connect claim for specifying user groups. "+
 			"The claim value is expected to be a string or array of strings. This flag is experimental, "+
 			"please see the authentication documentation for further details.")
+
+		fs.StringVar(&s.OIDC.GroupsPrefix, "oidc-groups-prefix", "", ""+
+			"If provided, all groups will be prefixed with this value to prevent conflicts with "+
+			"other authentication strategies.")
+
 	}
 
 	if s.PasswordFile != nil {


### PR DESCRIPTION
Add the following flags to control the prefixing of usernames and
groups authenticated using OpenID Connect tokens.

	--oidc-username-prefix
	--oidc-groups-prefix

```release-note
The OpenID Connect authenticator can now use a custom prefix, or omit the default prefix, for username and groups claims through the --oidc-username-prefix and --oidc-groups-prefix flags. For example, the authenticator can map a user with the username "jane" to "google:jane" by supplying the "google:" username prefix.
```

Closes https://github.com/kubernetes/kubernetes/issues/50408
Ref https://github.com/kubernetes/kubernetes/issues/31380

cc @grillz @kubernetes/sig-auth-pr-reviews @thomastaylor312 @gtaylor