### PR TITLE
Change eviction manager to manage one single local storage resource

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -745,7 +745,7 @@ func parseResourceList(m kubeletconfiginternal.ConfigurationMap) (v1.ResourceLis
 	for k, v := range m {
 		switch v1.ResourceName(k) {
 		// CPU, memory and local storage resources are supported.
-		case v1.ResourceCPU, v1.ResourceMemory, v1.ResourceStorage:
+		case v1.ResourceCPU, v1.ResourceMemory, v1.ResourceEphemeralStorage:
 			q, err := resource.ParseQuantity(v)
 			if err != nil {
 				return nil, err
@@ -753,12 +753,7 @@ func parseResourceList(m kubeletconfiginternal.ConfigurationMap) (v1.ResourceLis
 			if q.Sign() == -1 {
 				return nil, fmt.Errorf("resource quantity for %q cannot be negative: %v", k, v)
 			}
-			// storage specified in configuration map is mapped to ResourceStorageScratch API
-			if v1.ResourceName(k) == v1.ResourceStorage {
-				rl[v1.ResourceStorageScratch] = q
-			} else {
-				rl[v1.ResourceName(k)] = q
-			}
+			rl[v1.ResourceName(k)] = q
 		default:
 			return nil, fmt.Errorf("cannot reserve %q resource", k)
 		}

--- a/pkg/api/helper/helpers.go
+++ b/pkg/api/helper/helpers.go
@@ -107,6 +107,7 @@ func IsResourceQuotaScopeValidForResource(scope api.ResourceQuotaScope, resource
 var standardContainerResources = sets.NewString(
 	string(api.ResourceCPU),
 	string(api.ResourceMemory),
+	string(api.ResourceEphemeralStorage),
 )
 
 // IsStandardContainerResourceName returns true if the container can make a resource request
@@ -194,10 +195,13 @@ func IsStandardQuotaResourceName(str string) bool {
 var standardResources = sets.NewString(
 	string(api.ResourceCPU),
 	string(api.ResourceMemory),
+	string(api.ResourceEphemeralStorage),
 	string(api.ResourceRequestsCPU),
 	string(api.ResourceRequestsMemory),
+	string(api.ResourceRequestsEphemeralStorage),
 	string(api.ResourceLimitsCPU),
 	string(api.ResourceLimitsMemory),
+	string(api.ResourceLimitsEphemeralStorage),
 	string(api.ResourcePods),
 	string(api.ResourceQuotas),
 	string(api.ResourceServices),

--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3783,8 +3783,8 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 		// Validate resource quantity.
 		allErrs = append(allErrs, ValidateResourceQuantityValue(string(resourceName), quantity, fldPath)...)
 
-		if resourceName == api.ResourceStorageOverlay && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
-			allErrs = append(allErrs, field.Forbidden(limPath, "ResourceStorageOverlay field disabled by feature-gate for ResourceRequirements"))
+		if resourceName == api.ResourceEphemeralStorage && !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+			allErrs = append(allErrs, field.Forbidden(limPath, "ResourceEphemeralStorage field disabled by feature-gate for ResourceRequirements"))
 		}
 	}
 	for resourceName, quantity := range requirements.Requests {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -2683,7 +2683,7 @@ func TestAlphaLocalStorageCapacityIsolation(t *testing.T) {
 
 	containerLimitCase := api.ResourceRequirements{
 		Limits: api.ResourceList{
-			api.ResourceStorageOverlay: *resource.NewMilliQuantity(
+			api.ResourceEphemeralStorage: *resource.NewMilliQuantity(
 				int64(40000),
 				resource.BinarySI),
 		},

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -35,18 +35,9 @@ func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 	return c
 }
 
-func StorageScratchCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceList {
+func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceList {
 	c := v1.ResourceList{
-		v1.ResourceStorageScratch: *resource.NewQuantity(
-			int64(info.Capacity),
-			resource.BinarySI),
-	}
-	return c
-}
-
-func StorageOverlayCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceList {
-	c := v1.ResourceList{
-		v1.ResourceStorageOverlay: *resource.NewQuantity(
+		v1.ResourceEphemeralStorage: *resource.NewQuantity(
 			int64(info.Capacity),
 			resource.BinarySI),
 	}

--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -55,7 +55,6 @@ go_library(
             "//pkg/util/procfs:go_default_library",
             "//pkg/util/sysctl:go_default_library",
             "//pkg/util/version:go_default_library",
-            "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/systemd:go_default_library",

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	cadvisorapiv2 "github.com/google/cadvisor/info/v2"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -552,23 +551,10 @@ func (cm *containerManagerImpl) setFsCapacity() error {
 	if err != nil {
 		return fmt.Errorf("Fail to get rootfs information %v", err)
 	}
-	hasDedicatedImageFs, _ := cm.cadvisorInterface.HasDedicatedImageFs()
-	var imagesfs cadvisorapiv2.FsInfo
-	if hasDedicatedImageFs {
-		imagesfs, err = cm.cadvisorInterface.ImagesFsInfo()
-		if err != nil {
-			return fmt.Errorf("Fail to get imagefs information %v", err)
-		}
-	}
 
 	cm.Lock()
-	for rName, rCap := range cadvisor.StorageScratchCapacityFromFsInfo(rootfs) {
+	for rName, rCap := range cadvisor.EphemeralStorageCapacityFromFsInfo(rootfs) {
 		cm.capacity[rName] = rCap
-	}
-	if hasDedicatedImageFs {
-		for rName, rCap := range cadvisor.StorageOverlayCapacityFromFsInfo(imagesfs) {
-			cm.capacity[rName] = rCap
-		}
 	}
 	cm.Unlock()
 	return nil

--- a/pkg/kubelet/cm/node_container_manager.go
+++ b/pkg/kubelet/cm/node_container_manager.go
@@ -218,9 +218,9 @@ func hardEvictionReservation(thresholds []evictionapi.Threshold, capacity v1.Res
 			value := evictionapi.GetThresholdQuantity(threshold.Value, &memoryCapacity)
 			ret[v1.ResourceMemory] = *value
 		case evictionapi.SignalNodeFsAvailable:
-			storageCapacity := capacity[v1.ResourceStorageScratch]
+			storageCapacity := capacity[v1.ResourceEphemeralStorage]
 			value := evictionapi.GetThresholdQuantity(threshold.Value, &storageCapacity)
-			ret[v1.ResourceStorageScratch] = *value
+			ret[v1.ResourceEphemeralStorage] = *value
 		}
 	}
 	return ret

--- a/pkg/kubelet/cm/node_container_manager_test.go
+++ b/pkg/kubelet/cm/node_container_manager_test.go
@@ -316,17 +316,17 @@ func TestNodeAllocatableInputValidation(t *testing.T) {
 		invalidConfiguration bool
 	}{
 		{
-			kubeReserved:   getScratchResourceList("100Mi"),
-			systemReserved: getScratchResourceList("50Mi"),
-			capacity:       getScratchResourceList("500Mi"),
+			kubeReserved:   getEphemeralStorageResourceList("100Mi"),
+			systemReserved: getEphemeralStorageResourceList("50Mi"),
+			capacity:       getEphemeralStorageResourceList("500Mi"),
 		},
 		{
-			kubeReserved:   getScratchResourceList("10Gi"),
-			systemReserved: getScratchResourceList("10Gi"),
+			kubeReserved:   getEphemeralStorageResourceList("10Gi"),
+			systemReserved: getEphemeralStorageResourceList("10Gi"),
 			hardThreshold: evictionapi.ThresholdValue{
 				Quantity: &storageEvictionThreshold,
 			},
-			capacity:             getScratchResourceList("20Gi"),
+			capacity:             getEphemeralStorageResourceList("20Gi"),
 			invalidConfiguration: true,
 		},
 	}
@@ -359,12 +359,12 @@ func TestNodeAllocatableInputValidation(t *testing.T) {
 	}
 }
 
-// getScratchResourceList returns a ResourceList with the
-// specified scratch storage resource values
-func getScratchResourceList(storage string) v1.ResourceList {
+// getEphemeralStorageResourceList returns a ResourceList with the
+// specified ephemeral storage resource values
+func getEphemeralStorageResourceList(storage string) v1.ResourceList {
 	res := v1.ResourceList{}
 	if storage != "" {
-		res[v1.ResourceStorageScratch] = resource.MustParse(storage)
+		res[v1.ResourceEphemeralStorage] = resource.MustParse(storage)
 	}
 	return res
 }

--- a/pkg/kubelet/eviction/BUILD
+++ b/pkg/kubelet/eviction/BUILD
@@ -48,6 +48,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/v1/helper/qos:go_default_library",
+        "//pkg/api/v1/resource:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/cm:go_default_library",

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -31,6 +31,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/record"
 	v1qos "k8s.io/kubernetes/pkg/api/v1/helper/qos"
+	apiv1resource "k8s.io/kubernetes/pkg/api/v1/resource"
 	"k8s.io/kubernetes/pkg/features"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
@@ -472,7 +473,12 @@ func (m *managerImpl) localStorageEviction(pods []*v1.Pod) []*v1.Pod {
 			continue
 		}
 
-		if m.containerOverlayLimitEviction(podStats, pod) {
+		if m.podEphemeralStorageLimitEviction(podStats, pod) {
+			evicted = append(evicted, pod)
+			continue
+		}
+
+		if m.containerEphemeralStorageLimitEviction(podStats, pod) {
 			evicted = append(evicted, pod)
 		}
 	}
@@ -496,23 +502,56 @@ func (m *managerImpl) emptyDirLimitEviction(podStats statsapi.PodStats, pod *v1.
 			}
 		}
 	}
+
 	return false
 }
 
-func (m *managerImpl) containerOverlayLimitEviction(podStats statsapi.PodStats, pod *v1.Pod) bool {
+func (m *managerImpl) podEphemeralStorageLimitEviction(podStats statsapi.PodStats, pod *v1.Pod) bool {
+	_, podLimits := apiv1resource.PodRequestsAndLimits(pod)
+	_, found := podLimits[v1.ResourceEphemeralStorage]
+	if !found {
+		return false
+	}
+
+	podEphemeralStorageTotalUsage := &resource.Quantity{}
+	fsStatsSet := []fsStatsType{}
+	if *m.dedicatedImageFs {
+		fsStatsSet = []fsStatsType{fsStatsLogs, fsStatsLocalVolumeSource}
+	} else {
+		fsStatsSet = []fsStatsType{fsStatsRoot, fsStatsLogs, fsStatsLocalVolumeSource}
+	}
+	podUsage, err := podDiskUsage(podStats, pod, fsStatsSet)
+	if err != nil {
+		glog.Errorf("eviction manager: error getting pod disk usage %v", err)
+		return false
+	}
+
+	podEphemeralStorageTotalUsage.Add(podUsage[resourceDisk])
+	if podEphemeralStorageTotalUsage.Cmp(podLimits[v1.ResourceEphemeralStorage]) > 0 {
+		// the total usage of pod exceeds the total size limit of containers, evict the pod
+		return m.evictPod(pod, v1.ResourceEphemeralStorage, fmt.Sprintf("pod ephemeral local storage usage exceeds the total limit of containers %v", podLimits[v1.ResourceEphemeralStorage]))
+	}
+	return false
+}
+
+func (m *managerImpl) containerEphemeralStorageLimitEviction(podStats statsapi.PodStats, pod *v1.Pod) bool {
 	thresholdsMap := make(map[string]*resource.Quantity)
 	for _, container := range pod.Spec.Containers {
-		overlayLimit := container.Resources.Limits.StorageOverlay()
-		if overlayLimit != nil && overlayLimit.Value() != 0 {
-			thresholdsMap[container.Name] = overlayLimit
+		ephemeralLimit := container.Resources.Limits.StorageEphemeral()
+		if ephemeralLimit != nil && ephemeralLimit.Value() != 0 {
+			thresholdsMap[container.Name] = ephemeralLimit
 		}
 	}
 
 	for _, containerStat := range podStats.Containers {
-		rootfs := diskUsage(containerStat.Rootfs)
-		if overlayThreshold, ok := thresholdsMap[containerStat.Name]; ok {
-			if overlayThreshold.Cmp(*rootfs) < 0 {
-				return m.evictPod(pod, v1.ResourceName("containerOverlay"), fmt.Sprintf("container's overlay usage exceeds the limit %q", overlayThreshold.String()))
+		containerUsed := diskUsage(containerStat.Logs)
+		if !*m.dedicatedImageFs {
+			containerUsed.Add(*diskUsage(containerStat.Rootfs))
+		}
+
+		if ephemeralStorageThreshold, ok := thresholdsMap[containerStat.Name]; ok {
+			if ephemeralStorageThreshold.Cmp(*containerUsed) < 0 {
+				return m.evictPod(pod, v1.ResourceEphemeralStorage, fmt.Sprintf("container's ephemeral local storage usage exceeds the limit %q", ephemeralStorageThreshold.String()))
 
 			}
 		}

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -564,11 +564,7 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 			// capacity for every node status request
 			initialCapacity := kl.containerManager.GetCapacity()
 			if initialCapacity != nil {
-				node.Status.Capacity[v1.ResourceStorageScratch] = initialCapacity[v1.ResourceStorageScratch]
-				imageCapacity, ok := initialCapacity[v1.ResourceStorageOverlay]
-				if ok {
-					node.Status.Capacity[v1.ResourceStorageOverlay] = imageCapacity
-				}
+				node.Status.Capacity[v1.ResourceEphemeralStorage] = initialCapacity[v1.ResourceEphemeralStorage]
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We decided to manage one single resource name, eviction policy should be modified too.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:  part of #50818

**Special notes for your reviewer**:

**Release note**:
```release-note
Change eviction manager to manage one single local ephemeral storage resource
```

/assign @jingxu97 
