### PR TITLE
[advanced audit api] fuzz Event with random value

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/fuzzer/fuzzer.go
@@ -28,6 +28,7 @@ import (
 func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		func(e *audit.Event, c fuzz.Continue) {
+			c.FuzzNoCustom(e)
 			switch c.RandBool() {
 			case true:
 				e.RequestObject = nil


### PR DESCRIPTION
This is an error import by me:
https://github.com/kubernetes/kubernetes/pull/49115

We need to fuzz other parts of Event with random value, otherwise
this round trip test will not make too much sense.
@sttts 
@ericchiang is also researching this.

**Release note**:
```
NONE
```
