### PR TITLE
add nil check for TableConvertor in response.go

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -114,6 +114,11 @@ func transformResponseObject(ctx request.Context, scope RequestScope, req *http.
 				return
 			}
 
+			if scope.TableConvertor == nil {
+				err = newNotAcceptableError("scope.TableConvertor is nil")
+				scope.err(err, w, req)
+				return
+			}
 			table, err := scope.TableConvertor.ConvertToTable(ctx, result, opts)
 			if err != nil {
 				scope.err(err, w, req)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response.go
@@ -115,7 +115,7 @@ func transformResponseObject(ctx request.Context, scope RequestScope, req *http.
 			}
 
 			if scope.TableConvertor == nil {
-				err = newNotAcceptableError("scope.TableConvertor is nil")
+				err = errors.NewInternalError(fmt.Errorf("RequestScope.TableConvertor is nil"))
 				scope.err(err, w, req)
 				return
 			}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -537,7 +537,6 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		Typer:           a.group.Typer,
 		UnsafeConvertor: a.group.UnsafeConvertor,
 
-		// TODO: Check for the interface on storage
 		TableConvertor: tableProvider,
 
 		// TODO: This seems wrong for cross-group subresources. It makes an assumption that a subresource and its parent are in the same group version. Revisit this.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
check if scope.TableConvertor is nil,  else call scope.TableConvertor.ConvertToTable(ctx, result, opts) directly may panic
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
