### PR TITLE
[WIP] Provide the whole aggregation chain to aggregator server

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -84,8 +84,12 @@ func createAggregatorConfig(kubeAPIServerConfig genericapiserver.Config, command
 	return aggregatorConfig, nil
 }
 
-func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delegateAPIServer genericapiserver.DelegationTarget, apiExtensionInformers apiextensionsinformers.SharedInformerFactory) (*aggregatorapiserver.APIAggregator, error) {
-	aggregatorServer, err := aggregatorConfig.Complete().NewWithDelegate(delegateAPIServer)
+func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delegateAPIServerChain []genericapiserver.DelegationTarget, apiExtensionInformers apiextensionsinformers.SharedInformerFactory) (*aggregatorapiserver.APIAggregator, error) {
+	if len(delegateAPIServerChain) < 1 {
+		return nil, fmt.Errorf("There should be at least one delegateAPIServer in the chain.")
+	}
+	delegateAPIServer := delegateAPIServerChain[0]
+	aggregatorServer, err := aggregatorConfig.Complete().NewWithDelegate(delegateAPIServerChain)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -172,7 +172,9 @@ func CreateServerChain(runOptions *options.ServerRunOptions, stopCh <-chan struc
 	}
 	aggregatorConfig.ProxyTransport = proxyTransport
 	aggregatorConfig.ServiceResolver = serviceResolver
-	aggregatorServer, err := createAggregatorServer(aggregatorConfig, kubeAPIServer.GenericAPIServer, apiExtensionsServer.Informers)
+	aggregatorServer, err := createAggregatorServer(aggregatorConfig,
+		[]genericapiserver.DelegationTarget{kubeAPIServer.GenericAPIServer, apiExtensionsServer.GenericAPIServer},
+		apiExtensionsServer.Informers)
 	if err != nil {
 		// we don't need special handling for innerStopCh because the aggregator server doesn't create any go routines
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -185,6 +185,8 @@ var EmptyDelegate = emptyDelegate{
 	requestContextMapper: apirequest.NewRequestContextMapper(),
 }
 
+var EmptyDelegateChain = []DelegationTarget{EmptyDelegate}
+
 type emptyDelegate struct {
 	requestContextMapper apirequest.RequestContextMapper
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -165,7 +165,7 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	server, err := config.Complete().NewWithDelegate(genericapiserver.EmptyDelegate)
+	server, err := config.Complete().NewWithDelegate(genericapiserver.EmptyDelegateChain)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes #50011 

I like the approach here though I contemplated about passing the whole chain and assume the first in the chain is `kubeApiServer`/`delegateTarget` vs. passing `delegateTarget` separately. Tests may not pass yet as I prefer us to agree on the solution before doing cleanups/tests on this. 

Also the first commit is from the other PR and does not need review (at least not here :)