### PR TITLE
Fix zsh completion for kubeadm

### DIFF
--- a/cmd/kubeadm/app/cmd/completion.go
+++ b/cmd/kubeadm/app/cmd/completion.go
@@ -186,14 +186,6 @@ __kubeadm_compopt() {
 	true # don't do anything. Not supported by bashcompinit in zsh
 }
 
-__kubeadm_declare() {
-	if [ "$1" == "-F" ]; then
-		whence -w "$@"
-	else
-		builtin declare "$@"
-	fi
-}
-
 __kubeadm_ltrim_colon_completions()
 {
 	if [[ "$1" == *:* && "$COMP_WORDBREAKS" == *:* ]]; then
@@ -280,7 +272,7 @@ __kubeadm_convert_bash_to_zsh() {
 	-e "s/${LWORD}__ltrim_colon_completions${RWORD}/__kubeadm_ltrim_colon_completions/g" \
 	-e "s/${LWORD}compgen${RWORD}/__kubeadm_compgen/g" \
 	-e "s/${LWORD}compopt${RWORD}/__kubeadm_compopt/g" \
-	-e "s/${LWORD}declare${RWORD}/__kubeadm_declare/g" \
+	-e "s/${LWORD}declare${RWORD}/builtin declare/g" \
 	-e "s/\\\$(type${RWORD}/\$(__kubeadm_type/g" \
 	<<'BASH_COMPLETION_EOF'
 `


### PR DESCRIPTION
**What this PR does / why we need it**:

kubeadm zsh completion will report an error when using after '--flag':
```
kubeadm join --token=1 __handle_flag:25: bad math expression: operand expected at end of string
```

There is a similar bug in kubectl which has been fixed by #48553. It is due to `__kubeadm_declare` gets 'declare -A' into function scope, and `__kubeadm_declare` could be removed now.

This is to port that fix here. 

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
