### PR TITLE
add diff details to pod validation error

### DIFF
--- a/pkg/api/validation/BUILD
+++ b/pkg/api/validation/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",


### PR DESCRIPTION
This adds a basic (large) diff to the `ValidatePodUpdate` method, but we've been waiting on the "perfect" diff for a long time and it hasn't appeared.