### PR TITLE
cAdvisor should not care about the kubelet root path at startup

### DIFF
--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -108,9 +108,9 @@ func New(address string, port uint, runtime string, rootPath string) (Interface,
 
 	if _, err := os.Stat(rootPath); err != nil {
 		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("rootDirectory %q does not exist", rootPath)
+			glog.Warningf("rootDirectory %q does not exist", rootPath)
 		} else {
-			return nil, fmt.Errorf("failed to Stat %q: %v", rootPath, err)
+			glog.Warningf("failed to Stat %q: %v", rootPath, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The default kubelet root directory(/var/lib/kubelet) will not be created until calling function [`RunKubelet`](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L458.)  Exactly at function [`func (kl *Kubelet) setupDataDirs() `  ](https://github.com/kubernetes/kubernetes/blob/0ade03bc0f477f10132de3a1b90d935186082bcc/pkg/kubelet/kubelet.go#L1135).So the invocation `cadvisor.New()` should not check the directory whether exist or not. We should only give some warning info other than return error directly. IMO, that is enough. Otherwise kubelet will start failed.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fix https://github.com/kubernetes/kubernetes/issues/50917

**Special notes for your reviewer**:
Releated PR https://github.com/kubernetes/kubernetes/pull/48487

**Release note**:
none
