### PR TITLE
Clear values for disabled alpha fields

### DIFF
--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -11,7 +11,9 @@ go_library(
     srcs = ["util.go"],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/features:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -18,7 +18,9 @@ package pod
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // Visitor is called with each object name, and returns true if visiting should continue
@@ -224,4 +226,21 @@ func UpdatePodCondition(status *api.PodStatus, condition *api.PodCondition) bool
 	status.Conditions[conditionIndex] = *condition
 	// Return true if one of the fields have changed.
 	return !isEqual
+}
+
+// DropDisabledAlphaFields removes disabled fields from the pod spec.
+// This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a pod spec.
+func DropDisabledAlphaFields(podSpec *api.PodSpec) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.PodPriority) {
+		podSpec.Priority = nil
+		podSpec.PriorityClassName = ""
+	}
+
+	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].EmptyDir != nil {
+				podSpec.Volumes[i].EmptyDir.SizeLimit = nil
+			}
+		}
+	}
 }

--- a/pkg/registry/apps/statefulset/BUILD
+++ b/pkg/registry/apps/statefulset/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/apps/validation"
 )
@@ -55,6 +56,8 @@ func (statefulSetStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 	statefulSet.Status = apps.StatefulSetStatus{}
 
 	statefulSet.Generation = 1
+
+	pod.DropDisabledAlphaFields(&statefulSet.Spec.Template.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -63,6 +66,9 @@ func (statefulSetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, 
 	oldStatefulSet := old.(*apps.StatefulSet)
 	// Update is not allowed to set status
 	newStatefulSet.Status = oldStatefulSet.Status
+
+	pod.DropDisabledAlphaFields(&newStatefulSet.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldStatefulSet.Spec.Template.Spec)
 
 	// Any changes to the spec increment the generation number, any changes to the
 	// status should reflect the generation number of the corresponding object.

--- a/pkg/registry/batch/cronjob/BUILD
+++ b/pkg/registry/batch/cronjob/BUILD
@@ -14,6 +14,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/validation"
 )
@@ -51,6 +52,8 @@ func (cronJobStrategy) NamespaceScoped() bool {
 func (cronJobStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	cronJob := obj.(*batch.CronJob)
 	cronJob.Status = batch.CronJobStatus{}
+
+	pod.DropDisabledAlphaFields(&cronJob.Spec.JobTemplate.Spec.Template.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -58,6 +61,9 @@ func (cronJobStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old 
 	newCronJob := obj.(*batch.CronJob)
 	oldCronJob := old.(*batch.CronJob)
 	newCronJob.Status = oldCronJob.Status
+
+	pod.DropDisabledAlphaFields(&newCronJob.Spec.JobTemplate.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldCronJob.Spec.JobTemplate.Spec.Template.Spec)
 }
 
 // Validate validates a new scheduled job.

--- a/pkg/registry/batch/job/BUILD
+++ b/pkg/registry/batch/job/BUILD
@@ -14,6 +14,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/batch/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/pkg/apis/batch/validation"
 )
@@ -59,6 +60,8 @@ func (jobStrategy) NamespaceScoped() bool {
 func (jobStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	job := obj.(*batch.Job)
 	job.Status = batch.JobStatus{}
+
+	pod.DropDisabledAlphaFields(&job.Spec.Template.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -66,6 +69,9 @@ func (jobStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runt
 	newJob := obj.(*batch.Job)
 	oldJob := old.(*batch.Job)
 	newJob.Status = oldJob.Status
+
+	pod.DropDisabledAlphaFields(&newJob.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldJob.Spec.Template.Spec)
 }
 
 // Validate validates a new job.

--- a/pkg/registry/core/node/BUILD
+++ b/pkg/registry/core/node/BUILD
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/validation:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
@@ -32,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/helper/qos:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/api/validation:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/helper/qos"
+	podutil "k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/kubelet/client"
 )
@@ -65,6 +66,8 @@ func (podStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.O
 		Phase:    api.PodPending,
 		QOSClass: qos.GetPodQOS(pod),
 	}
+
+	podutil.DropDisabledAlphaFields(&pod.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -72,6 +75,9 @@ func (podStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runt
 	newPod := obj.(*api.Pod)
 	oldPod := old.(*api.Pod)
 	newPod.Status = oldPod.Status
+
+	podutil.DropDisabledAlphaFields(&newPod.Spec)
+	podutil.DropDisabledAlphaFields(&oldPod.Spec)
 }
 
 // Validate validates a new pod.

--- a/pkg/registry/core/podtemplate/BUILD
+++ b/pkg/registry/core/podtemplate/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -22,6 +22,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/api/validation"
 )
 
@@ -42,7 +43,9 @@ func (podTemplateStrategy) NamespaceScoped() bool {
 
 // PrepareForCreate clears fields that are not allowed to be set by end users on creation.
 func (podTemplateStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
-	_ = obj.(*api.PodTemplate)
+	template := obj.(*api.PodTemplate)
+
+	pod.DropDisabledAlphaFields(&template.Template.Spec)
 }
 
 // Validate validates a new pod template.
@@ -62,7 +65,11 @@ func (podTemplateStrategy) AllowCreateOnUpdate() bool {
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (podTemplateStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
-	_ = obj.(*api.PodTemplate)
+	newTemplate := obj.(*api.PodTemplate)
+	oldTemplate := old.(*api.PodTemplate)
+
+	pod.DropDisabledAlphaFields(&newTemplate.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldTemplate.Template.Spec)
 }
 
 // ValidateUpdate is the default update validation for an end user.

--- a/pkg/registry/core/replicationcontroller/BUILD
+++ b/pkg/registry/core/replicationcontroller/BUILD
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/helper:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",

--- a/pkg/registry/extensions/daemonset/BUILD
+++ b/pkg/registry/extensions/daemonset/BUILD
@@ -14,6 +14,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/validation:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",

--- a/pkg/registry/extensions/daemonset/strategy.go
+++ b/pkg/registry/extensions/daemonset/strategy.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/validation"
 )
@@ -63,12 +64,17 @@ func (daemonSetStrategy) PrepareForCreate(ctx genericapirequest.Context, obj run
 	if daemonSet.Spec.TemplateGeneration < 1 {
 		daemonSet.Spec.TemplateGeneration = 1
 	}
+
+	pod.DropDisabledAlphaFields(&daemonSet.Spec.Template.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (daemonSetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
 	newDaemonSet := obj.(*extensions.DaemonSet)
 	oldDaemonSet := old.(*extensions.DaemonSet)
+
+	pod.DropDisabledAlphaFields(&newDaemonSet.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldDaemonSet.Spec.Template.Spec)
 
 	// update is not allowed to set status
 	newDaemonSet.Status = oldDaemonSet.Status

--- a/pkg/registry/extensions/deployment/BUILD
+++ b/pkg/registry/extensions/deployment/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/validation:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",

--- a/pkg/registry/extensions/deployment/strategy.go
+++ b/pkg/registry/extensions/deployment/strategy.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/validation"
 )
@@ -61,6 +62,8 @@ func (deploymentStrategy) PrepareForCreate(ctx genericapirequest.Context, obj ru
 	deployment := obj.(*extensions.Deployment)
 	deployment.Status = extensions.DeploymentStatus{}
 	deployment.Generation = 1
+
+	pod.DropDisabledAlphaFields(&deployment.Spec.Template.Spec)
 }
 
 // Validate validates a new deployment.
@@ -83,6 +86,9 @@ func (deploymentStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, o
 	newDeployment := obj.(*extensions.Deployment)
 	oldDeployment := old.(*extensions.Deployment)
 	newDeployment.Status = oldDeployment.Status
+
+	pod.DropDisabledAlphaFields(&newDeployment.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldDeployment.Spec.Template.Spec)
 
 	// Spec updates bump the generation so that we can distinguish between
 	// scaling events and template changes, annotation updates bump the generation

--- a/pkg/registry/extensions/replicaset/BUILD
+++ b/pkg/registry/extensions/replicaset/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/validation:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",

--- a/pkg/registry/extensions/replicaset/strategy.go
+++ b/pkg/registry/extensions/replicaset/strategy.go
@@ -37,6 +37,7 @@ import (
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/apis/extensions/validation"
 )
@@ -67,6 +68,8 @@ func (rsStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Ob
 	rs.Status = extensions.ReplicaSetStatus{}
 
 	rs.Generation = 1
+
+	pod.DropDisabledAlphaFields(&rs.Spec.Template.Spec)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
@@ -75,6 +78,9 @@ func (rsStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runti
 	oldRS := old.(*extensions.ReplicaSet)
 	// update is not allowed to set status
 	newRS.Status = oldRS.Status
+
+	pod.DropDisabledAlphaFields(&newRS.Spec.Template.Spec)
+	pod.DropDisabledAlphaFields(&oldRS.Spec.Template.Spec)
 
 	// Any changes to the spec increment the generation number, any changes to the
 	// status should reflect the generation number of the corresponding object. We push


### PR DESCRIPTION
Fixes #51831

Before persisting new or updated resources, alpha fields that are disabled by feature gate must be removed from the incoming objects.

This adds a helper for clearing these values for pod specs and calls it from the strategies of all in-tree resources containing pod specs.

Addresses https://github.com/kubernetes/community/pull/869