### PR TITLE
Skip non-update endpoint updates

### DIFF
--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -50,6 +50,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

On large clusters, a large percentage of endpoint updates are actually non-updates that occur as a result of a change in an associated pod. This results in endpoint updates where the only field that has changed is the `TargetRef.ResourceVersion` in the endpoint address associated with the changed pod. Given enough of these non-updates, the endpoint controller's queue rate limit can be overwhelmed and legitimate updates can be delayed, resulting in (temporarily) broken services. We have clusters where we've seen endpoint updates take 9 minutes.

**Which issue this PR fixes** : fixes #50936 

**Special notes for your reviewer**:
N/A

**Release note**:
```release-note
Prevent unneeded endpoint updates
```