### PR TITLE
Fix duplicate field in kubeconfig

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -653,7 +653,6 @@ clusters:
   cluster:
     server: https://${apiserver_address}
     certificate-authority: ${CA_CERT_BUNDLE_PATH}
-    server: https://${KUBERNETES_MASTER_NAME}
 contexts:
 - context:
     cluster: local


### PR DESCRIPTION
The server field was accidentally duplicated during a rebase of #40050.

```release-note
NONE
```
