### PR TITLE
Add upgrades tests for kube-proxy daemonset migration path

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -42,7 +42,7 @@ func EtcdUpgrade(target_storage, target_version string) error {
 func MasterUpgrade(v string) error {
 	switch TestContext.Provider {
 	case "gce":
-		return masterUpgradeGCE(v)
+		return masterUpgradeGCE(v, false)
 	case "gke":
 		return masterUpgradeGKE(v)
 	default:
@@ -61,8 +61,14 @@ func etcdUpgradeGCE(target_storage, target_version string) error {
 	return err
 }
 
-func masterUpgradeGCE(rawV string) error {
-	env := os.Environ()
+// TODO(mrhohn): Remove this function when kube-proxy is run as a DaemonSet by default.
+func MasterUpgradeGCEWithKubeProxyDaemonSet(v string, enableKubeProxyDaemonSet bool) error {
+	return masterUpgradeGCE(v, enableKubeProxyDaemonSet)
+}
+
+// TODO(mrhohn): Remove 'enableKubeProxyDaemonSet' when kube-proxy is run as a DaemonSet by default.
+func masterUpgradeGCE(rawV string, enableKubeProxyDaemonSet bool) error {
+	env := append(os.Environ(), fmt.Sprintf("KUBE_PROXY_DAEMONSET=%v", enableKubeProxyDaemonSet))
 	// TODO: Remove these variables when they're no longer needed for downgrades.
 	if TestContext.EtcdUpgradeVersion != "" && TestContext.EtcdUpgradeStorage != "" {
 		env = append(env,
@@ -101,7 +107,7 @@ func NodeUpgrade(f *Framework, v string, img string) error {
 	var err error
 	switch TestContext.Provider {
 	case "gce":
-		err = nodeUpgradeGCE(v, img)
+		err = nodeUpgradeGCE(v, img, false)
 	case "gke":
 		err = nodeUpgradeGKE(v, img)
 	default:
@@ -122,14 +128,30 @@ func NodeUpgrade(f *Framework, v string, img string) error {
 	return nil
 }
 
-func nodeUpgradeGCE(rawV, img string) error {
+// TODO(mrhohn): Remove this function when kube-proxy is run as a DaemonSet by default.
+func NodeUpgradeGCEWithKubeProxyDaemonSet(f *Framework, v string, enableKubeProxyDaemonSet bool) error {
+	// Perform the upgrade.
+	if err := nodeUpgradeGCE(v, "", enableKubeProxyDaemonSet); err != nil {
+		return err
+	}
+	// Wait for it to complete and validate nodes are healthy.
+	Logf("Waiting up to %v for all nodes to be ready after the upgrade", RestartNodeReadyAgainTimeout)
+	if _, err := CheckNodesReady(f.ClientSet, RestartNodeReadyAgainTimeout, TestContext.CloudConfig.NumNodes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// TODO(mrhohn): Remove 'enableKubeProxyDaemonSet' when kube-proxy is run as a DaemonSet by default.
+func nodeUpgradeGCE(rawV, img string, enableKubeProxyDaemonSet bool) error {
 	v := "v" + rawV
+	env := append(os.Environ(), fmt.Sprintf("KUBE_PROXY_DAEMONSET=%v", enableKubeProxyDaemonSet))
 	if img != "" {
-		env := append(os.Environ(), "KUBE_NODE_OS_DISTRIBUTION="+img)
+		env = append(env, "KUBE_NODE_OS_DISTRIBUTION="+img)
 		_, _, err := RunCmdEnv(env, gceUpgradeScript(), "-N", "-o", v)
 		return err
 	}
-	_, _, err := RunCmd(gceUpgradeScript(), "-N", v)
+	_, _, err := RunCmdEnv(env, gceUpgradeScript(), "-N", v)
 	return err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
From #23225, this is a part of setting up CIs to validate the kube-proxy migration path (static pods -> daemonset and reverse).
The other part of the works (adding real CIs that run these tests) will be in a separate PR against [kubernetes/test-infra](https://github.com/kubernetes/test-infra).

Though this is currently blocked by #50705.

**Special notes for your reviewer**:
cc @roberthbailey  @pwittrock 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
