### PR TITLE
[1.6] StatefulSet: Set Pod hostname/subdomain fields.

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -402,6 +402,7 @@ func TestStatefulPodControlUpdatePodConflictFailure(t *testing.T) {
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	updatedPod := newStatefulSetPod(set, 0)
 	updatedPod.Annotations[podapi.PodHostnameAnnotation] = "wrong"
+	updatedPod.Spec.Hostname = "wrong"
 	indexer.Add(updatedPod)
 	podLister := corelisters.NewPodLister(indexer)
 	control := NewRealStatefulPodControl(fakeClient, nil, podLister, nil, recorder)

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -80,11 +80,13 @@ func TestIdentityMatches(t *testing.T) {
 	}
 	pod = newStatefulSetPod(set, 1)
 	delete(pod.Annotations, podapi.PodHostnameAnnotation)
+	pod.Spec.Hostname = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no hostname")
 	}
 	pod = newStatefulSetPod(set, 1)
 	delete(pod.Annotations, podapi.PodSubdomainAnnotation)
+	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no subdomain")
 	}
@@ -139,6 +141,7 @@ func TestUpdateIdentity(t *testing.T) {
 	}
 	pod = newStatefulSetPod(set, 1)
 	delete(pod.Annotations, podapi.PodHostnameAnnotation)
+	pod.Spec.Hostname = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no hostname")
 	}
@@ -148,6 +151,7 @@ func TestUpdateIdentity(t *testing.T) {
 	}
 	pod = newStatefulSetPod(set, 1)
 	delete(pod.Annotations, podapi.PodSubdomainAnnotation)
+	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with no subdomain")
 	}
@@ -157,6 +161,8 @@ func TestUpdateIdentity(t *testing.T) {
 	}
 	pod = newStatefulSetPod(set, 1)
 	pod.Annotations = nil
+	pod.Spec.Hostname = ""
+	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod no annotations")
 	}


### PR DESCRIPTION
This is a partial, manual cherrypick of #44137 to provide a path to mitigate #48327.

To prepare for upgrading to 1.7+ in which the hostname/subdomain annotations are removed, we should have started setting the corresponding fields in a prior version. Pods that are freshly created by StatefulSet after updating to v1.6.9 will continue to function after upgrading to Kubernetes v1.7.x.

```release-note
StatefulSet: Set hostname/subdomain fields on new Pods in addition to the deprecated annotations, to allow mitigation of Pod DNS issues upon upgrading to Kubernetes v1.7.x.
```
