### PR TITLE
output junit report dir in cmd test

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -173,6 +173,9 @@ function cleanup()
   kube::etcd::cleanup
   rm -rf "${KUBE_TEMP}"
 
+  local junit_dir="${KUBE_JUNIT_REPORT_DIR:-/tmp/junit-results}"
+  echo "junit report dir:" ${junit_dir}
+
   kube::log::status "Clean up complete"
 }
 


### PR DESCRIPTION
Output junit report dir for easier debug locally, otherwise people need to dive into the code to find the junit report dir. This will save people's time.

```release-note
None
```
