### PR TITLE
Add a unit test for kubeadm configuration defaults

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -37,4 +38,11 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    library = ":go_default_library",
+    deps = ["//pkg/api:go_default_library"],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// Register API defaulters functions
+func registerAPIDefFunctions(t *testing.T) {
+	if err := addDefaultingFuncs(api.Scheme); err != nil {
+		t.Errorf("Error registering defaulters functions: '%v'", err)
+	}
+}
+
+func TestMasterConfigDefaults(t *testing.T) {
+	registerAPIDefFunctions(t)
+
+	// Create a master configuration and set defaults
+	cfg := &MasterConfiguration{}
+	api.Scheme.Default(cfg)
+
+	// Check default string fields
+	stringFields := []struct {
+		name       string
+		valPtr     *string
+		expDefault string
+	}{
+		{
+			name:       "DNSDomain",
+			valPtr:     &cfg.Networking.DNSDomain,
+			expDefault: DefaultServiceDNSDomain,
+		}, {
+			name:       "ServiceSubnet",
+			valPtr:     &cfg.Networking.ServiceSubnet,
+			expDefault: DefaultServicesSubnet,
+		}, {
+			name:       "KubernetesVersion",
+			valPtr:     &cfg.KubernetesVersion,
+			expDefault: DefaultKubernetesVersion,
+		}, {
+			name:       "CertificatesDir",
+			valPtr:     &cfg.CertificatesDir,
+			expDefault: DefaultCertificatesDir,
+		}, {
+			name:       "EtcdDataDir",
+			valPtr:     &cfg.Etcd.DataDir,
+			expDefault: DefaultEtcdDataDir,
+		}, {
+			name:       "ImageRepository",
+			valPtr:     &cfg.ImageRepository,
+			expDefault: DefaultImageRepository,
+		},
+	}
+	for _, field := range stringFields {
+		val := *field.valPtr
+		if *field.valPtr != field.expDefault {
+			t.Errorf("Wrong default for %s, got: '%s', expected: '%s'", field.name, val, field.expDefault)
+		}
+	}
+
+	// Check default API bind port
+	if cfg.API.BindPort != DefaultAPIBindPort {
+		t.Errorf("Wrong default for APIBindPort, got: '%d', expected: '%d'", cfg.API.BindPort, DefaultAPIBindPort)
+	}
+
+	// Check default AuthorizationModes
+	expModes := strings.Split(DefaultAuthorizationModes, ",")
+	if !reflect.DeepEqual(cfg.AuthorizationModes, expModes) {
+		t.Errorf("Wrong default for AuthorizationModes, got: %v, expected: %v", cfg.AuthorizationModes, expModes)
+	}
+}
+
+func TestNodeConfigDefaults(t *testing.T) {
+	registerAPIDefFunctions(t)
+
+	discoveryFiles := []string{
+		"",
+		"http://example.com/foobar",
+		"file:/temp/foobar",
+	}
+
+	for _, discoveryFile := range discoveryFiles {
+		// Create a node configuration and set token and discovery file
+		cfg := &NodeConfiguration{}
+		token := "testToken"
+		cfg.Token = token
+		cfg.DiscoveryFile = discoveryFile
+
+		// Set defaults
+		api.Scheme.Default(cfg)
+
+		// Check default values
+		if cfg.CACertPath != DefaultCACertPath {
+			t.Errorf("Wrong default for CACertPath, got: '%s', expected: '%s'", cfg.CACertPath, DefaultCACertPath)
+		}
+		if cfg.TLSBootstrapToken != token {
+			t.Errorf("Wrong default for TLSBootstrapToken, got: '%s', expected: '%s'", cfg.TLSBootstrapToken, token)
+		}
+		if discoveryFile == "" {
+			if cfg.DiscoveryToken != token {
+				t.Errorf("Wrong default for DiscoveryToken, got: '%s', expected: '%s'", cfg.DiscoveryToken, token)
+			}
+		} else {
+			// Strip "file:" prefix from discovery file if necessary
+			if strings.HasPrefix(discoveryFile, "file:") {
+				discoveryFile = discoveryFile[len("file:"):]
+				if cfg.DiscoveryFile != discoveryFile {
+					t.Errorf("Wrong default for DiscoveryFile, got: '%s', expected: '%s'", cfg.DiscoveryFile, discoveryFile)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
This change adds a unit test for checking that the kubeadm
MasterConfiguration defaults are set correctly.

fixes #50959

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This change adds a unit test for checking that the kubeadm
MasterConfiguration defaults are set correctly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50959

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
