### PR TITLE
kubeadm: Add back labels for the Static Pod control plane (attempt 2)

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/BUILD
+++ b/cmd/kubeadm/app/util/staticpod/BUILD
@@ -15,6 +15,7 @@ go_test(
     tags = ["automanaged"],
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -42,6 +42,9 @@ func ComponentPod(container v1.Container, volumes []v1.Volume) v1.Pod {
 			Name:        container.Name,
 			Namespace:   metav1.NamespaceSystem,
 			Annotations: map[string]string{kubetypes.CriticalPodAnnotationKey: ""},
+			// The component and tier labels are useful for quickly identifying the control plane Pods when doing a .List()
+			// against Pods in the kube-system namespace. Can for example be used together with the WaitForPodsWithLabel function
+			Labels: map[string]string{"component": container.Name, "tier": "control-plane"},
 		},
 		Spec: v1.PodSpec{
 			Containers:  []v1.Container{container},

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -79,22 +80,43 @@ func TestComponentProbe(t *testing.T) {
 
 func TestComponentPod(t *testing.T) {
 	var tests = []struct {
-		n string
+		name     string
+		expected v1.Pod
 	}{
 		{
-			n: "foo",
+			name: "foo",
+			expected: v1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "foo",
+					Namespace:   "kube-system",
+					Annotations: map[string]string{"scheduler.alpha.kubernetes.io/critical-pod": ""},
+					Labels:      map[string]string{"component": "foo", "tier": "control-plane"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "foo",
+						},
+					},
+					HostNetwork: true,
+					Volumes:     []v1.Volume{},
+				},
+			},
 		},
 	}
 
 	for _, rt := range tests {
-		c := v1.Container{Name: rt.n}
-		v := []v1.Volume{}
-		actual := ComponentPod(c, v)
-		if actual.ObjectMeta.Name != rt.n {
+		c := v1.Container{Name: rt.name}
+		actual := ComponentPod(c, []v1.Volume{})
+		if !reflect.DeepEqual(rt.expected, actual) {
 			t.Errorf(
-				"failed componentPod:\n\texpected: %s\n\t  actual: %s",
-				rt.n,
-				actual.ObjectMeta.Name,
+				"failed componentPod:\n\texpected: %v\n\t  actual: %v",
+				rt.expected,
+				actual,
 			)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Exactly the same PR as https://github.com/kubernetes/kubernetes/pull/50174, but that PR was appearently lost in a rebase/mis-merge or something, so resending this one.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 