### PR TITLE
Update Registry interface for deployment and endpoints

### DIFF
--- a/pkg/registry/core/endpoint/registry.go
+++ b/pkg/registry/core/endpoint/registry.go
@@ -29,6 +29,7 @@ import (
 type Registry interface {
 	ListEndpoints(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (*api.EndpointsList, error)
 	GetEndpoints(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (*api.Endpoints, error)
+	CreateEndpoints(ctx genericapirequest.Context, e *api.Endpoints) (*api.Endpoints, error)
 	WatchEndpoints(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (watch.Interface, error)
 	UpdateEndpoints(ctx genericapirequest.Context, e *api.Endpoints) error
 	DeleteEndpoints(ctx genericapirequest.Context, name string) error
@@ -59,6 +60,14 @@ func (s *storage) WatchEndpoints(ctx genericapirequest.Context, options *metaint
 
 func (s *storage) GetEndpoints(ctx genericapirequest.Context, name string, options *metav1.GetOptions) (*api.Endpoints, error) {
 	obj, err := s.Get(ctx, name, options)
+	if err != nil {
+		return nil, err
+	}
+	return obj.(*api.Endpoints), nil
+}
+
+func (s *storage) CreateEndpoints(ctx genericapirequest.Context, endpoints *api.Endpoints) (*api.Endpoints, error) {
+	obj, err := s.Create(ctx, endpoints, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registry/extensions/deployment/BUILD
+++ b/pkg/registry/extensions/deployment/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",

--- a/pkg/registry/extensions/deployment/registry.go
+++ b/pkg/registry/extensions/deployment/registry.go
@@ -21,6 +21,7 @@ import (
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
@@ -30,6 +31,7 @@ import (
 // Registry is an interface for things that know how to store Deployments.
 type Registry interface {
 	ListDeployments(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (*extensions.DeploymentList, error)
+	WatchDeployments(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (watch.Interface, error)
 	GetDeployment(ctx genericapirequest.Context, deploymentID string, options *metav1.GetOptions) (*extensions.Deployment, error)
 	CreateDeployment(ctx genericapirequest.Context, deployment *extensions.Deployment) (*extensions.Deployment, error)
 	UpdateDeployment(ctx genericapirequest.Context, deployment *extensions.Deployment) (*extensions.Deployment, error)
@@ -55,6 +57,10 @@ func (s *storage) ListDeployments(ctx genericapirequest.Context, options *metain
 		return nil, err
 	}
 	return obj.(*extensions.DeploymentList), err
+}
+
+func (s *storage) WatchDeployments(ctx genericapirequest.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	return s.Watch(ctx, options)
 }
 
 func (s *storage) GetDeployment(ctx genericapirequest.Context, deploymentID string, options *metav1.GetOptions) (*extensions.Deployment, error) {


### PR DESCRIPTION
All Registry interfaces implement Create and Watch methods.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @sttts 
