### PR TITLE
kubeadm: Get kube-dns based on the kubernetes version

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -308,7 +308,7 @@ func (i *Init) Run(out io.Writer) error {
 		return err
 	}
 
-	if err := dnsaddonphase.EnsureDNSAddon(i.cfg, client); err != nil {
+	if err := dnsaddonphase.EnsureDNSAddon(i.cfg, client, k8sVersion); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -10,12 +10,16 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["dns_test.go"],
+    srcs = [
+        "dns_test.go",
+        "versions_test.go",
+    ],
     library = ":go_default_library",
     tags = ["automanaged"],
     deps = [
         "//cmd/kubeadm/app/util:go_default_library",
         "//pkg/api:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
@@ -28,6 +32,7 @@ go_library(
     srcs = [
         "dns.go",
         "manifests.go",
+        "versions.go",
     ],
     tags = ["automanaged"],
     deps = [
@@ -36,6 +41,7 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -32,6 +32,7 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/util/version"
 )
 
 const (
@@ -40,17 +41,20 @@ const (
 )
 
 // EnsureDNSAddon creates the kube-dns addon
-func EnsureDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
+func EnsureDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface, k8sVersion *version.Version) error {
 	if err := CreateServiceAccount(client); err != nil {
 		return err
 	}
 
-	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(KubeDNSDeployment, struct{ ImageRepository, Arch, Version, DNSDomain, MasterTaintKey string }{
+	// Get the YAML manifest conditionally based on the k8s version
+	kubeDNSDeploymentBytes := GetKubeDNSManifest(k8sVersion)
+	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(kubeDNSDeploymentBytes, struct{ ImageRepository, Arch, Version, DNSDomain, MasterTaintKey string }{
 		ImageRepository: cfg.ImageRepository,
 		Arch:            runtime.GOARCH,
-		Version:         KubeDNSVersion,
-		DNSDomain:       cfg.Networking.DNSDomain,
-		MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
+		// Get the kube-dns version conditionally based on the k8s version
+		Version:        GetKubeDNSVersion(k8sVersion),
+		DNSDomain:      cfg.Networking.DNSDomain,
+		MasterTaintKey: kubeadmconstants.LabelNodeRoleMaster,
 	})
 	if err != nil {
 		return fmt.Errorf("error when parsing kube-dns deployment template: %v", err)

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -90,7 +90,7 @@ func TestCompileManifests(t *testing.T) {
 		expected bool
 	}{
 		{
-			manifest: KubeDNSDeployment,
+			manifest: v170AndAboveKubeDNSDeployment,
 			data: struct{ ImageRepository, Arch, Version, DNSDomain, MasterTaintKey string }{
 				ImageRepository: "foo",
 				Arch:            "foo",

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -17,11 +17,8 @@ limitations under the License.
 package dns
 
 const (
-	// KubeDNSVersion is the version of kube-dns to run
-	KubeDNSVersion = "1.14.4"
-
-	// KubeDNSDeployment is the kube-dns Deployemnt manifest
-	KubeDNSDeployment = `
+	// v170AndAboveKubeDNSDeployment is the kube-dns Deployment manifest for the kube-dns manifest for v1.7+
+	v170AndAboveKubeDNSDeployment = `
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/cmd/kubeadm/app/phases/addons/dns/versions.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"k8s.io/kubernetes/pkg/util/version"
+)
+
+const (
+	kubeDNSv170AndAboveVersion = "1.14.4"
+)
+
+// GetKubeDNSVersion returns the right kube-dns version for a specific k8s version
+func GetKubeDNSVersion(kubeVersion *version.Version) string {
+	// v1.7.0+ uses 1.14.4, just return that here
+	// In the future when the kube-dns version is bumped at HEAD; add conditional logic to return the right versions
+	// Also, the version might be bumped for different k8s releases on the same branch
+	return kubeDNSv170AndAboveVersion
+}
+
+// GetKubeDNSManifest returns the right kube-dns YAML manifest for a specific k8s version
+func GetKubeDNSManifest(kubeVersion *version.Version) string {
+	// v1.7.0+ has only one known YAML manifest spec, just return that here
+	// In the future when the kube-dns version is bumped at HEAD; add conditional logic to return the right manifest
+	return v170AndAboveKubeDNSDeployment
+}

--- a/cmd/kubeadm/app/phases/addons/dns/versions_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dns
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/pkg/util/version"
+)
+
+func TestGetKubeDNSVersion(t *testing.T) {
+	var tests = []struct {
+		k8sVersion, expected string
+	}{
+		{
+			k8sVersion: "v1.7.0",
+			expected:   "1.14.4",
+		},
+		{
+			k8sVersion: "v1.7.1",
+			expected:   "1.14.4",
+		},
+		{
+			k8sVersion: "v1.7.2",
+			expected:   "1.14.4",
+		},
+		{
+			k8sVersion: "v1.7.3",
+			expected:   "1.14.4",
+		},
+		{
+			k8sVersion: "v1.8.0-alpha.2",
+			expected:   "1.14.4",
+		},
+		{
+			k8sVersion: "v1.8.0",
+			expected:   "1.14.4",
+		},
+	}
+	for _, rt := range tests {
+
+		k8sVersion, err := version.ParseSemantic(rt.k8sVersion)
+		if err != nil {
+			t.Fatalf("couldn't parse kubernetes version %q: %v", rt.k8sVersion, err)
+		}
+
+		actualDNSVersion := GetKubeDNSVersion(k8sVersion)
+		if actualDNSVersion != rt.expected {
+			t.Errorf(
+				"failed GetKubeDNSVersion:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actualDNSVersion,
+			)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Makes the kube-dns version used dependent on the kubernetes version. This is required for upgrades as we have to be able to handle one kube-dns version per branch for instance...

Currently a no-op though, as both v1.7 and v1.8 seem to use 1.14.4

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Dependency for https://github.com/kubernetes/kubernetes/pull/48899 (kubeadm upgrades)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 

@kubernetes/dns-maintainers FYI; next time you bump DNS version, please update this func instead of the constant there...