### PR TITLE
set --audit-log-format default to json

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -133,7 +133,7 @@ func TestAddFlagsFlag(t *testing.T) {
 				MaxAge:     11,
 				MaxBackups: 12,
 				MaxSize:    13,
-				Format:     "legacy",
+				Format:     "json",
 			},
 			WebhookOptions: apiserveroptions.AuditWebhookOptions{
 				Mode:       "blocking",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -81,7 +81,7 @@ type AuditWebhookOptions struct {
 func NewAuditOptions() *AuditOptions {
 	return &AuditOptions{
 		WebhookOptions: AuditWebhookOptions{Mode: pluginwebhook.ModeBatch},
-		LogOptions:     AuditLogOptions{Format: pluginlog.FormatLegacy},
+		LogOptions:     AuditLogOptions{Format: pluginlog.FormatJson},
 	}
 }
 


### PR DESCRIPTION
Updates: https://github.com/kubernetes/kubernetes/issues/48561

**Release note**:
```
set --audit-log-format default to json for kube-apiserver
```
