### PR TITLE
Modify the version message, replace the "Kubernets" to "Version", which is more general.

### DIFF
--- a/pkg/version/verflag/verflag.go
+++ b/pkg/version/verflag/verflag.go
@@ -96,7 +96,7 @@ func PrintAndExitIfRequested() {
 		fmt.Printf("%#v\n", version.Get())
 		os.Exit(0)
 	} else if *versionFlag == VersionTrue {
-		fmt.Printf("Kubernetes %s\n", version.Get())
+		fmt.Printf("Version %s\n", version.Get())
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
What this PR does / why we need it:
We find that multiple modules add an message to print the verson for debugging, it used "Version: " of the begin.

Such as:
kubernetes\cmd\cloud-controller-manager\app\controllermanager.go:109:
glog.Infof("Version: %+v", version.Get())

But in the PrintAndExitIfRequested function, it used "kubernets: " of the begin.

We think the two places of printing version to be an same begin message is more better.So we replace the "Kubernets" to "Version" in the PrintAndExitIfRequested function.

Another two reason is that "Version" is more general than "Kubernets" and the --version=raw print like
“version.Info{Major:"", Minor:"", GitVersion:"v0.0.0-master+$Format:%h$", GitCommit:"$Format:%H$", GitTreeState:"not a git tree", BuildDate:"1970-01-01T00:00:00Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}” the first word is also "version".

Special notes for your reviewer:
None