### PR TITLE
Fix typo in docs of remote package

### DIFF
--- a/pkg/kubelet/remote/doc.go
+++ b/pkg/kubelet/remote/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package remote containers gRPC implementation of internalapi.RuntimeService
+// Package remote contains gRPC implementation of internalapi.RuntimeService
 // and internalapi.ImageManagerService.
 package remote


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix typo in docs of kubelet/remote package

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
