### PR TITLE
Mark essential predicates as un-configurable

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -74,17 +74,17 @@ func init() {
 	// Fit is defined based on the absence of port conflicts.
 	// This predicate is actually a default predicate, because it is invoked from
 	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate("PodFitsHostPorts", predicates.PodFitsHostPorts)
+	factory.RegisterMandatoryFitPredicate("PodFitsHostPorts", predicates.PodFitsHostPorts)
 	// Fit is determined by resource availability.
 	// This predicate is actually a default predicate, because it is invoked from
 	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate("PodFitsResources", predicates.PodFitsResources)
+	factory.RegisterMandatoryFitPredicate("PodFitsResources", predicates.PodFitsResources)
 	// Fit is determined by the presence of the Host parameter and a string match
 	// This predicate is actually a default predicate, because it is invoked from
 	// predicates.GeneralPredicates()
-	factory.RegisterFitPredicate("HostName", predicates.PodFitsHost)
+	factory.RegisterMandatoryFitPredicate("HostName", predicates.PodFitsHost)
 	// Fit is determined by node selector query.
-	factory.RegisterFitPredicate("MatchNodeSelector", predicates.PodMatchNodeSelector)
+	factory.RegisterMandatoryFitPredicate("MatchNodeSelector", predicates.PodMatchNodeSelector)
 
 	// Use equivalence class to speed up predicates & priorities
 	factory.RegisterGetEquivalencePodFunction(predicates.GetEquivalencePod)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -140,7 +140,7 @@ func TestSchedulerCreationFromConfigMap(t *testing.T) {
 	schedPredicates := sched.Config().Algorithm.Predicates()
 	schedPrioritizers := sched.Config().Algorithm.Prioritizers()
 	// Includes one mandatory predicates.
-	if len(schedPredicates) != 3 || len(schedPrioritizers) != 2 {
+	if len(schedPredicates) != 7 || len(schedPrioritizers) != 2 {
 		t.Errorf("Unexpected number of predicates or priority functions. Number of predicates: %v, number of prioritizers: %v", len(schedPredicates), len(schedPrioritizers))
 	}
 	// Check a predicate and a priority function.


### PR DESCRIPTION
**What this PR does / why we need it**:
Mark essential predicates as un-configurable

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50516

**Release note**:
```release-note
Mark essential predicates used by kubelet (admit), PodFitsResources, PodFitsHostPorts, HostName, MatchNodeSelector, as un-configurable, after #50362 merged
```