### PR TITLE
Kubectl help CMD examples

### DIFF
--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -45,8 +45,7 @@ var (
 		# Get output from ruby-container from pod 123456-7890
 		kubectl attach 123456-7890 -c ruby-container
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
-		# and sends stdout/stderr from 'bash' back to the client
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890 and sends stdout/stderr from 'bash' back to the client
 		kubectl attach 123456-7890 -c ruby-container -i -t
 
 		# Get output from the first pod of a ReplicaSet named nginx

--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -73,8 +73,7 @@ var (
 		Bearer token and basic auth are mutually exclusive.`), clientcmd.FlagCertFile, clientcmd.FlagKeyFile, clientcmd.FlagBearerToken, clientcmd.FlagUsername, clientcmd.FlagPassword)
 
 	create_authinfo_example = templates.Examples(`
-		# Set only the "client-key" field on the "cluster-admin"
-		# entry, without touching other values:
+		# Set only the "client-key" field on the "cluster-admin" entry, without touching other values:
 		kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
 
 		# Set basic auth for the "cluster-admin" entry

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -49,8 +49,7 @@ var (
 		# Convert 'pod.yaml' to latest version and print to stdout.
 		kubectl convert -f pod.yaml
 
-		# Convert the live state of the resource specified by 'pod.yaml' to the latest version
-		# and print to stdout in json format.
+		# Convert the live state of the resource specified by 'pod.yaml' to the latest version and print to stdout in json format.
 		kubectl convert -f pod.yaml --local -o json
 
 		# Convert all files under current directory to latest version and create them all.

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -36,9 +36,8 @@ import (
 var (
 	cpExample = templates.Examples(i18n.T(`
 		# !!!Important Note!!!
-		# Requires that the 'tar' binary is present in your container
-		# image.  If 'tar' is not present, 'kubectl cp' will fail.
-
+		# Requires that the 'tar' binary is present in your container image.
+		# If 'tar' is not present, 'kubectl cp' will fail.
 		# Copy /tmp/foo_dir local directory to /tmp/bar_dir in a remote pod in the default namespace
 		kubectl cp /tmp/foo_dir <some-pod>:/tmp/bar_dir
 

--- a/pkg/kubectl/cmd/create_pdb.go
+++ b/pkg/kubectl/cmd/create_pdb.go
@@ -32,12 +32,10 @@ var (
 		Create a pod disruption budget with the specified name, selector, and desired minimum available pods`))
 
 	pdbExample = templates.Examples(i18n.T(`
-		# Create a pod disruption budget named my-pdb that will select all pods with the app=rails label
-		# and require at least one of them being available at any point in time.
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=rails label and require at least one of them being available at any point in time.
 		kubectl create poddisruptionbudget my-pdb --selector=app=rails --min-available=1
 
-		# Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label
-		# and require at least half of the pods selected to be available at any point in time.
+		# Create a pod disruption budget named my-pdb that will select all pods with the app=nginx label and require at least half of the pods selected to be available at any point in time.
 		kubectl create pdb my-pdb --selector=app=nginx --min-available=50%`))
 )
 

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -65,8 +65,7 @@ var (
 		# Describe pods by label name=myLabel
 		kubectl describe po -l name=myLabel
 
-		# Describe all pods managed by the 'frontend' replication controller (rc-created pods
-		# get the name of the rc as a prefix in the pod the name).
+		# Describe all pods managed by the 'frontend' replication controller (rc-created pods get the name of the rc as a prefix in the pod the name).
 		kubectl describe pods frontend`))
 )
 

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -20,10 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"k8s.io/apimachinery/pkg/util/json"
 	"math"
 	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/json"
 
 	"github.com/jonboulle/clockwork"
 	"github.com/spf13/cobra"
@@ -119,7 +120,7 @@ var (
 
 	uncordon_example = templates.Examples(i18n.T(`
 		# Mark node "foo" as schedulable.
-		$ kubectl uncordon foo`))
+		kubectl uncordon foo`))
 )
 
 func NewCmdUncordon(f cmdutil.Factory, out io.Writer) *cobra.Command {
@@ -166,10 +167,10 @@ var (
 
 	drain_example = templates.Examples(i18n.T(`
 		# Drain node "foo", even if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet on it.
-		$ kubectl drain foo --force
+		kubectl drain foo --force
 
 		# As above, but abort if there are pods not managed by a ReplicationController, ReplicaSet, Job, DaemonSet or StatefulSet, and use a grace period of 15 minutes.
-		$ kubectl drain foo --grace-period=900`))
+		kubectl drain foo --grace-period=900`))
 )
 
 func NewCmdDrain(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {

--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -44,15 +44,12 @@ var (
 		# Get output from running 'date' in ruby-container from pod 123456-7890
 		kubectl exec 123456-7890 -c ruby-container date
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
-		# and sends stdout/stderr from 'bash' back to the client
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890 and sends stdout/stderr from 'bash' back to the client
 		kubectl exec 123456-7890 -c ruby-container -i -t -- bash -il
 
 		# List contents of /usr from the first container of pod 123456-7890 and sort by modification time.
-		# If the command you want to execute in the pod has any flags in common (e.g. -i),
-		# you must use two dashes (--) to separate your command's flags/arguments.
-		# Also note, do not surround your command and its flags/arguments with quotes
-		# unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
+		# If the command you want to execute in the pod has any flags in common (e.g. -i), you must use two dashes (--) to separate your command's flags/arguments.
+		# Also note, do not surround your command and its flags/arguments with quotes unless that is how you would execute it normally (i.e., do ls -t /usr, not "ls -t /usr").
 		kubectl exec 123456-7890 -i -t -- ls -t /usr
 		`))
 )

--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -41,21 +41,16 @@ var (
 		the remote kubernetes API Server port, except for the path matching the static content path.`))
 
 	proxyExample = templates.Examples(i18n.T(`
-		# To proxy all of the kubernetes api and nothing else, use:
+		# To proxy all of the kubernetes api and nothing else
+		kubectl proxy --api-prefix=/
 
-		    $ kubectl proxy --api-prefix=/
-
-		# To proxy only part of the kubernetes api and also some static files:
-
-		    $ kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
-
-		# The above lets you 'curl localhost:8001/api/v1/pods'.
+		# To proxy only part of the kubernetes api and also some static files
+		# This lets you 'curl localhost:8001/api/v1/pods'.
+		kubectl proxy --www=/my/files --www-prefix=/static/ --api-prefix=/api/
 
 		# To proxy the entire kubernetes api at a different root, use:
-
-		    $ kubectl proxy --api-prefix=/custom/
-
-		# The above lets you 'curl localhost:8001/custom/api/v1/pods'
+		# This lets you 'curl localhost:8001/custom/api/v1/pods'
+		kubectl proxy --api-prefix=/custom/
 
 		# Run a proxy to kubernetes apiserver on port 8011, serving static content from ./local/www/
 		kubectl proxy --port=8011 --www=./local/www/

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -57,8 +57,7 @@ var (
 		# Update pods of frontend-v1 using JSON data passed into stdin.
 		cat frontend-v2.json | kubectl rolling-update frontend-v1 -f -
 
-		# Update the pods of frontend-v1 to frontend-v2 by just changing the image, and switching the
-		# name of the replication controller.
+		# Update the pods of frontend-v1 to frontend-v2 by just changing the image, and switching the name of the replication controller.
 		kubectl rolling-update frontend-v1 frontend-v2 --image=image:v2
 
 		# Update the pods of frontend by just changing the image, and keeping the old name.

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -57,9 +57,8 @@ var (
 		Currently only deployments support being paused.`)
 
 	pause_example = templates.Examples(`
-		# Mark the nginx deployment as paused. Any current state of
-		# the deployment will continue its function, new updates to the deployment will not
-		# have an effect as long as the deployment is paused.
+		# Mark the nginx deployment as paused.
+		# Any current state of the deployment will continue its function, new updates to the deployment will not have an effect as long as the deployment is paused.
 		kubectl rollout pause deployment/nginx`)
 )
 

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -66,7 +66,7 @@ var (
 		If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
         Note: currently selectors can only be set on Service objects.`)
 	selectorExample = templates.Examples(`
-        # set the labels and selector before creating a deployment/service pair.
+        # Set the labels and selector before creating a deployment/service pair.
         kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
         kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds sanity checks to the `kubectl help` output for command examples. This PR also fixes all current examples to pass the new verification.

This PR builds on a PR to community repository amending the conventions [929](https://github.com/kubernetes/community/pull/929)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Previous closed PR's that attempted to fix this are (all authored and closed by tcharding) #50349 and #50228.

**Release note**:
```release-note
Update kubectl CMD --help output to be more uniform
```

sig /cli
kind /cleanup
kind /documentation
