### PR TITLE
Update vendored package heredoc

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -98,7 +98,7 @@
 		},
 		{
 			"ImportPath": "github.com/MakeNowJust/heredoc",
-			"Rev": "1d91351acdc1cb2f2c995864674b754134b86ca7"
+			"Rev": "bb23615498cded5e105af4ce27de75b089cbe851"
 		},
 		{
 			"ImportPath": "github.com/Microsoft/go-winio",

--- a/vendor/github.com/MakeNowJust/heredoc/LICENSE
+++ b/vendor/github.com/MakeNowJust/heredoc/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 TSUYUSATO Kitsune
+Copyright (c) 2014-2017 TSUYUSATO Kitsune
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/vendor/github.com/MakeNowJust/heredoc/README.md
+++ b/vendor/github.com/MakeNowJust/heredoc/README.md
@@ -1,16 +1,16 @@
-#heredoc [![Build Status](https://drone.io/github.com/MakeNowJust/heredoc/status.png)](https://drone.io/github.com/MakeNowJust/heredoc/latest) [![Go Walker](http://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/MakeNowJust/heredoc)
+# heredoc [![CircleCI](https://circleci.com/gh/MakeNowJust/heredoc.svg?style=svg)](https://circleci.com/gh/MakeNowJust/heredoc) [![Go Walker](http://gowalker.org/api/v1/badge)](https://gowalker.org/github.com/MakeNowJust/heredoc)
 
-##About
+## About
 
 Package heredoc provides the here-document with keeping indent.
 
-##Install
+## Install
 
 ```console
 $ go get github.com/MakeNowJust/heredoc
 ```
 
-##Import
+## Import
 
 ```go
 // usual
@@ -19,7 +19,7 @@ import "github.com/MakeNowJust/heredoc"
 import . "github.com/MakeNowJust/heredoc/dot"
 ```
 
-##Example
+## Example
 
 ```go
 package main
@@ -43,11 +43,11 @@ func main() {
 }
 ```
 
-##API Document
+## API Document
 
  - [Go Walker - github.com/MakeNowJust/heredoc](https://gowalker.org/github.com/MakeNowJust/heredoc)
  - [Go Walker - github.com/MakeNowJust/heredoc/dot](https://gowalker.org/github.com/MakeNowJust/heredoc/dot)
 
-##License
+## License
 
 This software is released under the MIT License, see LICENSE.

--- a/vendor/github.com/MakeNowJust/heredoc/heredoc.go
+++ b/vendor/github.com/MakeNowJust/heredoc/heredoc.go
@@ -1,15 +1,15 @@
-// Copyright (c) 2014 TSUYUSATO Kitsune
+// Copyright (c) 2014-2017 TSUYUSATO Kitsune
 // This software is released under the MIT License.
 // http://opensource.org/licenses/mit-license.php
 
-// Package heredoc provides the here-document with keeping indent.
+// Package heredoc provides creation of here-documents from raw strings.
 //
 // Golang supports raw-string syntax.
 //     doc := `
 //     	Foo
 //     	Bar
 //     `
-// But raw-string cannot recognize indent. Thus such content is indented string, equivalent to
+// But raw-string cannot recognize indentation. Thus such content is an indented string, equivalent to
 //     "\n\tFoo\n\tBar\n"
 // I dont't want this!
 //
@@ -18,7 +18,7 @@
 //     	Foo
 //     	Bar
 //     `)
-// It is equivalent to
+// Is equivalent to
 //     "Foo\nBar\n"
 package heredoc
 
@@ -28,11 +28,9 @@ import (
 	"unicode"
 )
 
-// heredoc.Doc retutns unindented string as here-document.
-//
-// Process of making here-document:
-//     1. Find most little indent size. (Skip empty lines)
-//     2. Remove this indents of lines.
+const maxInt = int(^uint(0) >> 1)
+
+// Doc returns un-indented string as here-document.
 func Doc(raw string) string {
 	skipFirstLine := false
 	if raw[0] == '\n' {
@@ -41,10 +39,18 @@ func Doc(raw string) string {
 		skipFirstLine = true
 	}
 
-	minIndentSize := int(^uint(0) >> 1) // Max value of type int
 	lines := strings.Split(raw, "\n")
 
-	// 1.
+	minIndentSize := getMinIndent(lines, skipFirstLine)
+	lines = removeIndentation(lines, minIndentSize, skipFirstLine)
+
+	return strings.Join(lines, "\n")
+}
+
+// getMinIndent calculates the minimum indentation in lines, excluding empty lines.
+func getMinIndent(lines []string, skipFirstLine bool) int {
+	minIndentSize := maxInt
+
 	for i, line := range lines {
 		if i == 0 && skipFirstLine {
 			continue
@@ -67,23 +73,26 @@ func Doc(raw string) string {
 			minIndentSize = indentSize
 		}
 	}
+	return minIndentSize
+}
 
-	// 2.
+// removeIndentation removes n characters from the front of each line in lines.
+// Skips first line if skipFirstLine is true, skips empty lines.
+func removeIndentation(lines []string, n int, skipFirstLine bool) []string {
 	for i, line := range lines {
 		if i == 0 && skipFirstLine {
 			continue
 		}
 
-		if len(lines[i]) >= minIndentSize {
-			lines[i] = line[minIndentSize:]
+		if len(lines[i]) >= n {
+			lines[i] = line[n:]
 		}
 	}
-
-	return strings.Join(lines, "\n")
+	return lines
 }
 
-// heredoc.Docf returns unindented and formatted string as here-document.
-// This format is same with package fmt's format.
+// Docf returns unindented and formatted string as here-document.
+// Formatting is done as for fmt.Printf().
 func Docf(raw string, args ...interface{}) string {
 	return fmt.Sprintf(Doc(raw), args...)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates vendored package `github.com/MakeNowJust/heredoc`. This package is used by `kubectl`. The upstream updates do not effect program logic. Upstream changes consist of some refactoring commits and updates to README and LICENSE. The refactoring was carried out while bug hunting in `kubectl` and is the primary reason for merging the upstream changes. No bugs were found, this PR aims to save the next developer some time if/when they go bug hunting again in `heredoc`.

**Special notes for your reviewer**:

First effort at updating `vendor/`. I used `godep update` even though the [community docs](https://github.com/kubernetes/community/blob/master/contributors/devel/godep.md) state that no one has this working, the command appears to work.
```release-note
NONE
```

sig /cli
kind /cleanup