### PR TITLE
add kernel version to node label

### DIFF
--- a/pkg/kubelet/apis/well_known_labels.go
+++ b/pkg/kubelet/apis/well_known_labels.go
@@ -23,8 +23,9 @@ const (
 
 	LabelInstanceType = "beta.kubernetes.io/instance-type"
 
-	LabelOS   = "beta.kubernetes.io/os"
-	LabelArch = "beta.kubernetes.io/arch"
+	LabelOS            = "beta.kubernetes.io/os"
+	LabelArch          = "beta.kubernetes.io/arch"
+	LabelKernelVersion = "kubernetes.io/kernel-version"
 )
 
 // When the --failure-domains scheduler flag is not specified,

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -687,6 +687,12 @@ func TestRegisterWithApiServer(t *testing.T) {
 			Spec: v1.NodeSpec{ExternalID: testKubeletHostname},
 		}, nil
 	})
+	kubeClient.AddReactor("patch", "nodes", func(action core.Action) (bool, runtime.Object, error) {
+		if action.GetSubresource() == "status" {
+			return true, nil, nil
+		}
+		return true, nil, fmt.Errorf("no reaction implemented for %s", action)
+	})
 	kubeClient.AddReactor("*", "*", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, fmt.Errorf("no reaction implemented for %s", action)
 	})
@@ -737,13 +743,14 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 		ErrStatus: metav1.Status{Reason: metav1.StatusReasonConflict},
 	}
 
-	newNode := func(cmad bool, externalID string) *v1.Node {
+	newNode := func(cmad bool, externalID string, kernelVersion string) *v1.Node {
 		node := &v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					kubeletapis.LabelHostname: testKubeletHostname,
-					kubeletapis.LabelOS:       goruntime.GOOS,
-					kubeletapis.LabelArch:     goruntime.GOARCH,
+					kubeletapis.LabelHostname:      testKubeletHostname,
+					kubeletapis.LabelOS:            goruntime.GOOS,
+					kubeletapis.LabelArch:          goruntime.GOARCH,
+					kubeletapis.LabelKernelVersion: kernelVersion,
 				},
 			},
 			Spec: v1.NodeSpec{
@@ -760,18 +767,19 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 	}
 
 	cases := []struct {
-		name            string
-		newNode         *v1.Node
-		existingNode    *v1.Node
-		createError     error
-		getError        error
-		patchError      error
-		deleteError     error
-		expectedResult  bool
-		expectedActions int
-		testSavedNode   bool
-		savedNodeIndex  int
-		savedNodeCMAD   bool
+		name               string
+		newNode            *v1.Node
+		existingNode       *v1.Node
+		createError        error
+		getError           error
+		patchError         error
+		deleteError        error
+		expectedResult     bool
+		expectedActions    int
+		testSavedNode      bool
+		savedNodeIndex     int
+		savedNodeCMAD      bool
+		savedKernelVersion string
 	}{
 		{
 			name:            "success case - new node",
@@ -781,17 +789,17 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 		},
 		{
 			name:            "success case - existing node - no change in CMAD",
-			newNode:         newNode(true, "a"),
+			newNode:         newNode(true, "a", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(true, "a"),
+			existingNode:    newNode(true, "a", ""),
 			expectedResult:  true,
 			expectedActions: 2,
 		},
 		{
 			name:            "success case - existing node - CMAD disabled",
-			newNode:         newNode(false, "a"),
+			newNode:         newNode(false, "a", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(true, "a"),
+			existingNode:    newNode(true, "a", ""),
 			expectedResult:  true,
 			expectedActions: 3,
 			testSavedNode:   true,
@@ -800,9 +808,9 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 		},
 		{
 			name:            "success case - existing node - CMAD enabled",
-			newNode:         newNode(true, "a"),
+			newNode:         newNode(true, "a", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(false, "a"),
+			existingNode:    newNode(false, "a", ""),
 			expectedResult:  true,
 			expectedActions: 3,
 			testSavedNode:   true,
@@ -810,23 +818,32 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 			savedNodeCMAD:   true,
 		},
 		{
+			name:               "success case - kernel version changed",
+			newNode:            newNode(false, "b", "4.12.0"),
+			createError:        alreadyExists,
+			existingNode:       newNode(false, "b", "4.4.0-92-generic"),
+			expectedResult:     true,
+			expectedActions:    3,
+			savedKernelVersion: "4.12.0",
+		},
+		{
 			name:            "success case - external ID changed",
-			newNode:         newNode(false, "b"),
+			newNode:         newNode(false, "b", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(false, "a"),
+			existingNode:    newNode(false, "a", ""),
 			expectedResult:  false,
 			expectedActions: 3,
 		},
 		{
 			name:            "create failed",
-			newNode:         newNode(false, "b"),
+			newNode:         newNode(false, "b", ""),
 			createError:     conflict,
 			expectedResult:  false,
 			expectedActions: 1,
 		},
 		{
 			name:            "get existing node failed",
-			newNode:         newNode(false, "a"),
+			newNode:         newNode(false, "a", ""),
 			createError:     alreadyExists,
 			getError:        conflict,
 			expectedResult:  false,
@@ -834,18 +851,18 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 		},
 		{
 			name:            "update existing node failed",
-			newNode:         newNode(false, "a"),
+			newNode:         newNode(false, "a", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(true, "a"),
+			existingNode:    newNode(true, "a", ""),
 			patchError:      conflict,
 			expectedResult:  false,
 			expectedActions: 3,
 		},
 		{
 			name:            "delete existing node failed",
-			newNode:         newNode(false, "b"),
+			newNode:         newNode(false, "b", ""),
 			createError:     alreadyExists,
-			existingNode:    newNode(false, "a"),
+			existingNode:    newNode(false, "a", ""),
 			deleteError:     conflict,
 			expectedResult:  false,
 			expectedActions: 3,
@@ -907,6 +924,9 @@ func TestTryRegisterWithApiServer(t *testing.T) {
 
 			actualCMAD, _ := strconv.ParseBool(savedNode.Annotations[volumehelper.ControllerManagedAttachAnnotation])
 			assert.Equal(t, tc.savedNodeCMAD, actualCMAD, "test [%s]", tc.name)
+
+			actualKernelVersion, _ := savedNode.Labels[kubeletapis.LabelKernelVersion]
+			assert.Equal(t, tc.savedKernelVersion, actualKernelVersion, "test [%s]", tc.name)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Some pods may need a higher kernel version. so we doesn't need to upgrade the kernel for all node.
The label will be updated at the same time when the node start up.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51234

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add kernel version to node label
```
