### PR TITLE
Update kubectl help output format for options

### DIFF
--- a/pkg/kubectl/cmd/templates/templater.go
+++ b/pkg/kubectl/cmd/templates/templater.go
@@ -211,10 +211,10 @@ func flagsUsages(f *flag.FlagSet) string {
 		if flag.Hidden {
 			return
 		}
-		format := "--%s=%s: %s\n"
+		format := "--%s=%s:\n\t\t%s\n\n"
 
 		if flag.Value.Type() == "string" {
-			format = "--%s='%s': %s\n"
+			format = "--%s='%s':\n\t\t%s\n\n"
 		}
 
 		if len(flag.Shorthand) > 0 {


### PR DESCRIPTION
**What this PR does / why we need it**:

`kubectl help CMD` output for section `Options:` is overly cluttered. This PR attempts to increase the readability of the output.

**Which issue this PR fixes** 
fixes #51015

**Special notes for your reviewer**:

**Release note**:
```release-note
Improve layout of kubectl help command
```
