### PR TITLE
adding grace period seconds valiadation

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/BUILD
@@ -10,7 +10,11 @@ go_test(
     name = "go_default_test",
     srcs = ["validation_test.go"],
     library = ":go_default_library",
-    deps = ["//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+    ],
 )
 
 go_library(

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go
@@ -77,6 +77,9 @@ func ValidateLabels(labels map[string]string, fldPath *field.Path) field.ErrorLi
 
 func ValidateDeleteOptions(options *metav1.DeleteOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if options.GracePeriodSeconds != nil && *options.GracePeriodSeconds < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath(""), options, "GracePeriodSeconds must be non-negative integer"))
+	}
 	if options.OrphanDependents != nil && options.PropagationPolicy != nil {
 		allErrs = append(allErrs, field.Invalid(field.NewPath(""), options, "OrphanDependents and DeletionPropagation cannot be both set"))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The field `GracePeriodSeconds` in `staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go` must be a non-negative number. However, this has not been checked in `staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation/validation.go`. I have added this validation along with an unit test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`
