### PR TITLE
Add EventCorrelatorOptions for event rate limiting

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -416,7 +416,7 @@ func TestWriteEventError(t *testing.T) {
 	}
 
 	clock := clock.IntervalClock{Time: time.Now(), Duration: time.Second}
-	eventCorrelator := NewEventCorrelator(&clock)
+	eventCorrelator := NewEventCorrelator(&clock, NewDefaultEventCorrelatorOptions())
 	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for caseName, ent := range table {
@@ -440,7 +440,7 @@ func TestWriteEventError(t *testing.T) {
 
 func TestUpdateExpiredEvent(t *testing.T) {
 	clock := clock.IntervalClock{Time: time.Now(), Duration: time.Second}
-	eventCorrelator := NewEventCorrelator(&clock)
+	eventCorrelator := NewEventCorrelator(&clock, NewDefaultEventCorrelatorOptions())
 	randGen := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	var createdEvent *v1.Event


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
With the client side rate limiting from #47367 we also need to be able to create event sinks with non-default cache, aggregation, and spam settings.

**Which issue this PR fixes**:

**Special notes for your reviewer**:
depends on #47367

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
@derekwaynecarr 