### PR TITLE
[sig-network-e2e] Remove redundant sig prefix from tests

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -64,7 +64,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 	//
 	// Slow by design ~10m for each "It" block dominated by loadbalancer setup time
 	// TODO: write similar tests for nginx, haproxy and AWS Ingress.
-	SIGDescribe("GCE [Slow] [Feature:Ingress]", func() {
+	Describe("GCE [Slow] [Feature:Ingress]", func() {
 		var gceController *framework.GCEIngressController
 
 		// Platform specific setup
@@ -151,7 +151,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 	})
 
 	// Time: borderline 5m, slow by design
-	SIGDescribe("[Slow] Nginx", func() {
+	Describe("[Slow] Nginx", func() {
 		var nginxController *framework.NginxIngressController
 
 		BeforeEach(func() {

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -92,7 +92,7 @@ var _ = SIGDescribe("Networking", func() {
 	})
 
 	// TODO: Remove [Slow] when this has had enough bake time to prove presubmit worthiness.
-	SIGDescribe("Granular Checks: Services [Slow]", func() {
+	Describe("Granular Checks: Services [Slow]", func() {
 
 		It("should function for pod-Service: http", func() {
 			config := framework.NewNetworkingTestConfig(f)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove redundant sig prefix from:
```
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for endpoint-Service: http
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for endpoint-Service: udp
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for node-Service: http
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for node-Service: udp
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for pod-Service: http
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should function for pod-Service: udp
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should update endpoints: http
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should update endpoints: udp
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should update nodePort: http [Slow]
[sig-network] Networking [sig-network] Granular Checks: Services [Slow] should update nodePort: udp [Slow]
[sig-network] Loadbalancing: L7 [sig-network] GCE [Slow] [Feature:Ingress] should conform to Ingress spec
[sig-network] Loadbalancing: L7 [sig-network] GCE [Slow] [Feature:Ingress] should create ingress with given static-ip
```

Umbrella issue #49161

**Special notes for your reviewer**:
cc @xiangpengzhao 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
