### PR TITLE
StatefulSet: Don't try to update immutable hostname/subdomain fields.

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -393,34 +393,6 @@ func TestStatefulPodControlUpdatePodConflictSuccess(t *testing.T) {
 	}
 }
 
-func TestStatefulPodControlUpdatePodConflictFailure(t *testing.T) {
-	recorder := record.NewFakeRecorder(10)
-	set := newStatefulSet(3)
-	pod := newStatefulSetPod(set, 0)
-	fakeClient := &fake.Clientset{}
-	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
-	updatedPod := newStatefulSetPod(set, 0)
-	updatedPod.Spec.Hostname = "wrong"
-	indexer.Add(updatedPod)
-	podLister := corelisters.NewPodLister(indexer)
-	control := NewRealStatefulPodControl(fakeClient, nil, podLister, nil, recorder)
-	fakeClient.AddReactor("update", "pods", func(action core.Action) (bool, runtime.Object, error) {
-		update := action.(core.UpdateAction)
-		return true, update.GetObject(), apierrors.NewConflict(action.GetResource().GroupResource(), pod.Name, errors.New("conflict"))
-
-	})
-	pod.Name = "goo-0"
-	if err := control.UpdateStatefulPod(set, pod); err == nil {
-		t.Error("Failed update did not return an error")
-	}
-	events := collectEvents(recorder.Events)
-	if eventCount := len(events); eventCount != 1 {
-		t.Errorf("Pod update failed: got %d events, but want 1", eventCount)
-	} else if !strings.Contains(events[0], v1.EventTypeWarning) {
-		t.Errorf("Found unexpected non-normal event %s", events[0])
-	}
-}
-
 func TestStatefulPodControlDeletesStatefulPod(t *testing.T) {
 	recorder := record.NewFakeRecorder(10)
 	set := newStatefulSet(3)

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -111,9 +111,7 @@ func identityMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 	return ordinal >= 0 &&
 		set.Name == parent &&
 		pod.Name == getPodName(set, ordinal) &&
-		pod.Namespace == set.Namespace &&
-		pod.Spec.Hostname == pod.Name &&
-		pod.Spec.Subdomain == set.Spec.ServiceName
+		pod.Namespace == set.Namespace
 }
 
 // storageMatches returns true if pod's Volumes cover the set of PersistentVolumeClaims
@@ -181,12 +179,18 @@ func updateStorage(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Spec.Volumes = newVolumes
 }
 
+func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
+	updateIdentity(set, pod)
+	// Set these immutable fields only on initial Pod creation, not updates.
+	pod.Spec.Hostname = pod.Name
+	pod.Spec.Subdomain = set.Spec.ServiceName
+}
+
 // updateIdentity updates pod's name, hostname, and subdomain to conform to set's name and headless service.
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Name = getPodName(set, getOrdinal(pod))
 	pod.Namespace = set.Namespace
-	pod.Spec.Hostname = pod.Name
-	pod.Spec.Subdomain = set.Spec.ServiceName
+
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.
@@ -240,7 +244,7 @@ func getPodRevision(pod *v1.Pod) string {
 func newStatefulSetPod(set *apps.StatefulSet, ordinal int) *v1.Pod {
 	pod, _ := controller.GetPodFromTemplate(&set.Spec.Template, set, metav1.NewControllerRef(set, controllerKind))
 	pod.Name = getPodName(set, ordinal)
-	updateIdentity(set, pod)
+	initIdentity(set, pod)
 	updateStorage(set, pod)
 	return pod
 }

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -78,16 +78,6 @@ func TestIdentityMatches(t *testing.T) {
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with the wrong namespace")
 	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Hostname = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no hostname")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Subdomain = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no subdomain")
-	}
 }
 
 func TestStorageMatches(t *testing.T) {
@@ -136,24 +126,6 @@ func TestUpdateIdentity(t *testing.T) {
 	updateIdentity(set, pod)
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to update the Pods namespace")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Hostname = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no hostname")
-	}
-	updateIdentity(set, pod)
-	if !identityMatches(set, pod) {
-		t.Error("updateIdentity failed to update the Pod's hostname")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Subdomain = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no subdomain")
-	}
-	updateIdentity(set, pod)
-	if !identityMatches(set, pod) {
-		t.Error("updateIdentity failed to update the Pod's subdomain")
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: The StatefulSet controller no longer attempts to mutate "hostname" or "subdomain" fields of the "pod.spec" to enforce the network identity of Pods in a StatefeulSet. Since these fields are set upon creation and immutable thereafter setting the annotations is no longer necessary. 
fixes: #51043
