### PR TITLE
Fix StatefulSet update validation

### DIFF
--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -158,8 +158,6 @@ func ValidateStatefulSetUpdate(statefulSet, oldStatefulSet *apps.StatefulSet) fi
 	statefulSet.Spec.UpdateStrategy = restoreStrategy
 
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(statefulSet.Spec.Replicas), field.NewPath("spec", "replicas"))...)
-	containerErrs, _ := apivalidation.ValidateContainerUpdates(statefulSet.Spec.Template.Spec.Containers, oldStatefulSet.Spec.Template.Spec.Containers, field.NewPath("spec").Child("template").Child("containers"))
-	allErrs = append(allErrs, containerErrs...)
 	return allErrs
 }
 


### PR DESCRIPTION
StatefulSet update validation did not allow change to number of containers in pod template. Fix this bug so that it's possible to make this kind of change. 

Found it when suggesting test-cmd changes in https://github.com/kubernetes/kubernetes/pull/49674.

@kubernetes/sig-apps-pr-reviews @smarterclayton 

/approve no-issue 