### PR TITLE
Add v1 API as a default conversion peer

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
@@ -52,9 +52,12 @@ func main() {
 	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
 
 	// Custom args.
+	// TODO: make callers pass this in.  It is too opaque here, and any use of
+	// the flag that DOESN'T include these is broken.
 	customArgs := &generators.CustomArgs{
 		ExtraPeerDirs: []string{
 			"k8s.io/kubernetes/pkg/api",
+			"k8s.io/kubernetes/pkg/api/v1",
 			"k8s.io/api/core/v1",
 			"k8s.io/apimachinery/pkg/apis/meta/v1",
 			"k8s.io/apimachinery/pkg/conversion",


### PR DESCRIPTION
Some of the APIs call do not this out, and a partial build produces
wrong results.