### PR TITLE
Allow rsync to sync generated files

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -687,7 +687,6 @@ function kube::build::sync_to_container() {
     --filter='- /_tmp/' \
     --filter='- /_output/' \
     --filter='- /' \
-    --filter='- zz_generated.*' \
     --filter='- generated.proto' \
     "${KUBE_ROOT}/" "rsync://k8s@${KUBE_RSYNC_ADDR}/k8s/"
 


### PR DESCRIPTION
This manifested as local codegen files being newer than data container, but the older files got synced out, causing needless rebuilds.