### PR TITLE
Update core controller manifests for test-cmd to apps/v1beta2

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -9,6 +9,7 @@ reviewers:
   - zmerlynn
   - sttts
   - gmarek
+  - janetkuo
 approvers:
   - cblecker
   - deads2k
@@ -25,3 +26,4 @@ approvers:
   - zmerlynn
   - sttts
   - gmarek
+  - janetkuo

--- a/hack/testdata/deployment-multicontainer-resources.yaml
+++ b/hack/testdata/deployment-multicontainer-resources.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nginx-deployment-resources

--- a/hack/testdata/deployment-multicontainer.yaml
+++ b/hack/testdata/deployment-multicontainer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nginx-deployment

--- a/hack/testdata/deployment-revision1.yaml
+++ b/hack/testdata/deployment-revision1.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nginx

--- a/hack/testdata/deployment-revision2.yaml
+++ b/hack/testdata/deployment-revision2.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: nginx

--- a/hack/testdata/deployment-with-UnixUserID.yaml
+++ b/hack/testdata/deployment-with-UnixUserID.yaml
@@ -1,9 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: deployment-with-unixuserid
 spec:
-  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
   template:
     metadata:
       labels:

--- a/hack/testdata/frontend-replicaset.yaml
+++ b/hack/testdata/frontend-replicaset.yaml
@@ -1,22 +1,16 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-    # app: guestbook
-    # tier: frontend
+  labels:
+    app: guestbook
+    tier: frontend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   template:
     metadata:
       labels:

--- a/hack/testdata/list.yaml
+++ b/hack/testdata/list.yaml
@@ -11,14 +11,16 @@ items:
       port: 80
     selector:
       app: list-deployment-test
-- apiVersion: extensions/v1beta1
+- apiVersion: apps/v1beta2
   kind: Deployment
   metadata:
     name: list-deployment-test
     labels:
       app: list-deployment-test
   spec:
-    replicas: 1
+    selector:
+      matchLabels:
+        app: list-deployment-test
     template:
       metadata:
         labels:

--- a/hack/testdata/redis-slave-replicaset.yaml
+++ b/hack/testdata/redis-slave-replicaset.yaml
@@ -1,23 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
+  labels:
+    app: redis
+    role: slave
+    tier: backend
 spec:
-  # this replicas value is default
-  # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: slave
-  #   tier: backend
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:

--- a/hack/testdata/rollingupdate-daemonset-rv2.yaml
+++ b/hack/testdata/rollingupdate-daemonset-rv2.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: bind
@@ -7,6 +7,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 10%
+  selector:
+    matchLabels:
+      service: bind
   template:
     metadata:
       labels:

--- a/hack/testdata/rollingupdate-daemonset.yaml
+++ b/hack/testdata/rollingupdate-daemonset.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
   name: bind
@@ -7,6 +7,9 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 10%
+  selector:
+    matchLabels:
+      service: bind
   template:
     metadata:
       labels:

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -565,7 +565,8 @@ func (f *ring0Factory) Generators(cmdName string) map[string]kubectl.Generator {
 func (f *ring0Factory) CanBeExposed(kind schema.GroupKind) error {
 	switch kind {
 	case api.Kind("ReplicationController"), api.Kind("Service"), api.Kind("Pod"),
-		extensions.Kind("Deployment"), apps.Kind("Deployment"), extensions.Kind("ReplicaSet"):
+		extensions.Kind("Deployment"), apps.Kind("Deployment"),
+		extensions.Kind("ReplicaSet"), apps.Kind("ReplicaSet"):
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot expose a %s", kind)
@@ -575,8 +576,9 @@ func (f *ring0Factory) CanBeExposed(kind schema.GroupKind) error {
 
 func (f *ring0Factory) CanBeAutoscaled(kind schema.GroupKind) error {
 	switch kind {
-	case api.Kind("ReplicationController"), extensions.Kind("ReplicaSet"),
-		extensions.Kind("Deployment"), apps.Kind("Deployment"):
+	case api.Kind("ReplicationController"),
+		extensions.Kind("Deployment"), apps.Kind("Deployment"),
+		extensions.Kind("ReplicaSet"), apps.Kind("ReplicaSet"):
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot autoscale a %v", kind)


### PR DESCRIPTION
So that apps/v1beta2 core controllers are tested. 

@kubernetes/sig-apps-pr-reviews

/approve no-issue 
/release-note-none