### PR TITLE
issue(#51078) add statefulset info into kubectl cluster-info dump

### DIFF
--- a/pkg/kubectl/cmd/clusterinfo_dump.go
+++ b/pkg/kubectl/cmd/clusterinfo_dump.go
@@ -167,6 +167,14 @@ func dumpClusterInfo(f cmdutil.Factory, cmd *cobra.Command, out io.Writer) error
 			return err
 		}
 
+		statefulSets, err := clientset.Apps().StatefulSets(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
+		if err := printer.PrintObj(statefulSets, setupOutputWriter(cmd, out, path.Join(namespace, "statefulsets.json"))); err != nil {
+			return err
+		}
+
 		deps, err := clientset.Extensions().Deployments(namespace).List(metav1.ListOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
#51078

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
