### PR TITLE
daemon_controller: fix typo.

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -854,7 +854,7 @@ func (dsc *DaemonSetsController) manage(ds *extensions.DaemonSet, hash string) e
 			if len(daemonPodsRunning) > 1 {
 				sort.Sort(podByCreationTimestamp(daemonPodsRunning))
 				for i := 1; i < len(daemonPodsRunning); i++ {
-					podsToDelete = append(podsToDelete, daemonPods[i].Name)
+					podsToDelete = append(podsToDelete, daemonPodsRunning[i].Name)
 				}
 			}
 		case !shouldContinueRunning && exists:


### PR DESCRIPTION
**What this PR does / why we need it**:

I found a small typo while implementing #48841.

With the existing code, some edge cases might lead to the wrong pods
being deleted.

**Release note**:
```release-note
NONE
```
