### PR TITLE
azure: Use VolumeHost.GetExec() to execute stuff in volume plugins

### DIFF
--- a/pkg/volume/azure_dd/BUILD
+++ b/pkg/volume/azure_dd/BUILD
@@ -34,7 +34,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 
@@ -63,7 +62,5 @@ go_test(
         "//pkg/volume/testing:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/util/testing:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
-        "//vendor/k8s.io/utils/exec/testing:go_default_library",
     ],
 )

--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"regexp"
 	"strconv"
 	libstrings "strings"
 
@@ -158,6 +157,7 @@ type ioHandler interface {
 	ReadDir(dirname string) ([]os.FileInfo, error)
 	WriteFile(filename string, data []byte, perm os.FileMode) error
 	Readlink(name string) (string, error)
+	ReadFile(filename string) ([]byte, error)
 }
 
 //TODO: check if priming the iscsi interface is actually needed
@@ -174,6 +174,10 @@ func (handler *osIOHandler) WriteFile(filename string, data []byte, perm os.File
 
 func (handler *osIOHandler) Readlink(name string) (string, error) {
 	return os.Readlink(name)
+}
+
+func (handler *osIOHandler) ReadFile(filename string) ([]byte, error) {
+	return ioutil.ReadFile(filename)
 }
 
 // exclude those used by azure as resource and OS root in /dev/disk/azure
@@ -237,18 +241,30 @@ func findDiskByLunWithConstraint(lun int, io ioHandler, exe exec.Interface, azur
 			if lun == l {
 				// find the matching LUN
 				// read vendor and model to ensure it is a VHD disk
-				vendor := path.Join(sys_path, name, "vendor")
-				model := path.Join(sys_path, name, "model")
-				out, err := exe.Command("cat", vendor, model).CombinedOutput()
+				vendorPath := path.Join(sys_path, name, "vendor")
+				vendorBytes, err := io.ReadFile(vendorPath)
 				if err != nil {
-					glog.V(4).Infof("azure disk - failed to cat device vendor and model, err: %v", err)
+					glog.Errorf("failed to read device vendor, err: %v", err)
 					continue
 				}
-				matched, err := regexp.MatchString("^MSFT[ ]{0,}\nVIRTUAL DISK[ ]{0,}\n$", libstrings.ToUpper(string(out)))
-				if err != nil || !matched {
-					glog.V(4).Infof("azure disk - doesn't match VHD, output %v, error %v", string(out), err)
+				vendor := libstrings.TrimSpace(string(vendorBytes))
+				if libstrings.ToUpper(vendor) != "MSFT" {
+					glog.V(4).Infof("vendor doesn't match VHD, got %s", vendor)
 					continue
 				}
+
+				modelPath := path.Join(sys_path, name, "model")
+				modelBytes, err := io.ReadFile(modelPath)
+				if err != nil {
+					glog.Errorf("failed to read device model, err: %v", err)
+					continue
+				}
+				model := libstrings.TrimSpace(string(modelBytes))
+				if libstrings.ToUpper(model) != "VIRTUAL DISK" {
+					glog.V(4).Infof("model doesn't match VHD, got %s", model)
+					continue
+				}
+
 				// find a disk, validate name
 				dir := path.Join(sys_path, name, "block")
 				if dev, err := io.ReadDir(dir); err == nil {

--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -19,6 +19,7 @@ package azure_dd
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -105,6 +106,16 @@ func (handler *fakeIOHandler) WriteFile(filename string, data []byte, perm os.Fi
 
 func (handler *fakeIOHandler) Readlink(name string) (string, error) {
 	return "/dev/azure/disk/sda", nil
+}
+
+func (handler *fakeIOHandler) ReadFile(filename string) ([]byte, error) {
+	if strings.HasSuffix(filename, "vendor") {
+		return []byte("Msft    \n"), nil
+	}
+	if strings.HasSuffix(filename, "model") {
+		return []byte("Virtual Disk \n"), nil
+	}
+	return nil, fmt.Errorf("unknown file")
 }
 
 func TestIoHandler(t *testing.T) {

--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -22,9 +22,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-	"k8s.io/utils/exec"
-	fakeexec "k8s.io/utils/exec/testing"
 )
 
 type fakeFileInfo struct {
@@ -119,26 +116,7 @@ func (handler *fakeIOHandler) ReadFile(filename string) ([]byte, error) {
 }
 
 func TestIoHandler(t *testing.T) {
-	var fcmd fakeexec.FakeCmd
-	fcmd = fakeexec.FakeCmd{
-		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
-			// cat
-			func() ([]byte, error) {
-				return []byte("Msft    \nVirtual Disk \n"), nil
-			},
-			// cat
-			func() ([]byte, error) {
-				return []byte("Msft    \nVirtual Disk \n"), nil
-			},
-		},
-	}
-	fake := fakeexec.FakeExec{
-		CommandScript: []fakeexec.FakeCommandAction{
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-		},
-	}
-	disk, err := findDiskByLun(lun, &fakeIOHandler{}, &fake)
+	disk, err := findDiskByLun(lun, &fakeIOHandler{})
 	// if no disk matches lun, exit
 	if disk != "/dev/"+devName || err != nil {
 		t.Errorf("no data disk found: disk %v err %v", disk, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates Azure volume plugin to use `VolumeHost.GetExec()` to execute utilities like mkfs and lsblk instead of simple `os/exec`. This prepares the volume plugin to run these utilities in containers instead of running them on the host + makes the volume plugin more independent and less hardcoded.

See proposal in https://github.com/kubernetes/community/pull/589.

Note that this PR does **not** change place where utilities are executed - `VolumeHost.GetExec()` still leads directly to `os/exec`. It will be changed when the aforementioned proposal is merged and implemented.

To simplify testing, `/sys/bus/scsi/devices/*/model` and `.../vendor` are read using `ioutil.ReadFile` instead of `/bin/cat` in the first commit.

```release-note
NONE
```

@kubernetes/sig-storage-pr-reviews @kubernetes/sig-azure-misc 
