### PR TITLE
fibre channel: Remove unused exe interface

### DIFF
--- a/pkg/volume/fc/BUILD
+++ b/pkg/volume/fc/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -29,13 +29,11 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
-	"k8s.io/utils/exec"
 )
 
 type fcAttacher struct {
 	host    volume.VolumeHost
 	manager diskManager
-	exe     exec.Interface
 }
 
 var _ volume.Attacher = &fcAttacher{}
@@ -46,7 +44,6 @@ func (plugin *fcPlugin) NewAttacher() (volume.Attacher, error) {
 	return &fcAttacher{
 		host:    plugin.host,
 		manager: &FCUtil{},
-		exe:     exec.New(),
 	}, nil
 }
 
@@ -126,7 +123,6 @@ func (attacher *fcAttacher) MountDevice(spec *volume.Spec, devicePath string, de
 type fcDetacher struct {
 	mounter mount.Interface
 	manager diskManager
-	exe     exec.Interface
 }
 
 var _ volume.Detacher = &fcDetacher{}
@@ -135,7 +131,6 @@ func (plugin *fcPlugin) NewDetacher() (volume.Detacher, error) {
 	return &fcDetacher{
 		mounter: plugin.host.GetMounter(plugin.GetPluginName()),
 		manager: &FCUtil{},
-		exe:     exec.New(),
 	}, nil
 }
 

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -28,17 +28,15 @@ import (
 	utilstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
-	"k8s.io/utils/exec"
 )
 
 // This is the primary entrypoint for volume plugins.
 func ProbeVolumePlugins() []volume.VolumePlugin {
-	return []volume.VolumePlugin{&fcPlugin{nil, exec.New()}}
+	return []volume.VolumePlugin{&fcPlugin{nil}}
 }
 
 type fcPlugin struct {
 	host volume.VolumeHost
-	exe  exec.Interface
 }
 
 var _ volume.VolumePlugin = &fcPlugin{}
@@ -158,11 +156,6 @@ func (plugin *fcPlugin) newUnmounterInternal(volName string, podUID types.UID, m
 		},
 		mounter: mounter,
 	}, nil
-}
-
-func (plugin *fcPlugin) execCommand(command string, args []string) ([]byte, error) {
-	cmd := plugin.exe.Command(command, args...)
-	return cmd.CombinedOutput()
 }
 
 func (plugin *fcPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`execCommand` is not used anywhere, let's remove it and associated `exe` field from several structs.

@kubernetes/sig-storage-pr-reviews 

**Release note**:
```release-note
NONE
```
