### PR TITLE
Add Humble as GlusterFS approver.

### DIFF
--- a/pkg/volume/glusterfs/OWNERS
+++ b/pkg/volume/glusterfs/OWNERS
@@ -2,6 +2,7 @@ approvers:
 - rootfs
 - saad-ali
 - jingxu97
+- humblec
 reviewers:
 - thockin
 - smarterclayton


### PR DESCRIPTION
@humblec has shown his commitment into GlusterFS by number of commits there
and by support on sig-storage slack channel.

@kubernetes/sig-storage-misc 

```release-note
NONE
```

