### PR TITLE
quobyte: Use VolumeHost.GetExec() to execute stuff in volume plugins

### DIFF
--- a/pkg/volume/quobyte/BUILD
+++ b/pkg/volume/quobyte/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
-	"k8s.io/utils/exec"
 )
 
 // ProbeVolumePlugins is the primary entrypoint for volume plugins.
@@ -103,7 +102,8 @@ func (plugin *quobytePlugin) CanSupport(spec *volume.Spec) bool {
 		glog.V(4).Infof("quobyte: Error: %v", err)
 	}
 
-	if out, err := exec.New().Command("ls", "/sbin/mount.quobyte").CombinedOutput(); err == nil {
+	exec := plugin.host.GetExec(plugin.GetPluginName())
+	if out, err := exec.Run("ls", "/sbin/mount.quobyte"); err == nil {
 		glog.V(4).Infof("quobyte: can support: %s", string(out))
 		return true
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates ~~nfs~~ quobyte volume plugin to use `VolumeHost.GetExec()` to execute utilities like mkfs and lsblk instead of simple `os/exec`. This prepares the volume plugin to run these utilities in containers instead of running them on the host + makes the volume plugin more independent and less hardcoded.

See proposal in https://github.com/kubernetes/community/pull/589.

Note that this PR does **not** change place where the utilities are executed - `VolumeHost.GetExec()` still leads directly to `os/exec`. It will be changed when the aforementioned proposal is merged and implemented.

@kubernetes/sig-storage-pr-reviews 

**Release note**:
```release-note
NONE
```