### PR TITLE
Remove DynamicVolumeProvisioning from feature gate

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -37,10 +37,6 @@ const (
 	// alpha: v1.4
 	ExternalTrafficLocalOnly utilfeature.Feature = "AllowExtTrafficLocalEndpoints"
 
-	// owner: @saad-ali
-	// alpha: v1.3
-	DynamicVolumeProvisioning utilfeature.Feature = "DynamicVolumeProvisioning"
-
 	// owner: @mtaufen
 	// alpha: v1.4
 	DynamicKubeletConfig utilfeature.Feature = "DynamicKubeletConfig"
@@ -157,7 +153,6 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
 	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
 	KubeletConfigFile:                           {Default: false, PreRelease: utilfeature.Alpha},
-	DynamicVolumeProvisioning:                   {Default: true, PreRelease: utilfeature.Alpha},
 	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
 	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
 	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `DynamicVolumeProvisioning` from feature gate.

**Which issue this PR fixes** : fixes #51120 

**Special notes for your reviewer**:
N/A
**Release note**:
No
