### PR TITLE
Node which is not present not need update NodeAddress

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -147,6 +147,15 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 		glog.V(5).Infof("This node %s is still tainted. Will not process.", node.Name)
 		return
 	}
+	// Node that isn't present according to the cloud provider shouldn't have its address updated
+	exists, err := ensureNodeExistsByProviderIDOrExternalID(instances, node)
+	if err != nil {
+		// Continue to update node address when not sure the node is not exists
+		glog.Errorf("%v", err)
+	} else if !exists {
+		glog.V(4).Infof("The node %s is no longer present according to the cloud provider, do not process.", node.Name)
+		return
+	}
 
 	nodeAddresses, err := getNodeAddressesByProviderIDOrName(instances, node)
 	if err != nil {

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -925,6 +925,75 @@ func TestNodeAddressesChangeDetected(t *testing.T) {
 	}
 }
 
+// This test checks that a node with the external cloud provider taint is cloudprovider initialized and
+// and node addresses will not be updated when node isn't present according to the cloudprovider
+func TestNodeAddressesNotUpdate(t *testing.T) {
+	fnh := &testutil.FakeNodeHandler{
+		Existing: []*v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "node0",
+					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
+					Labels:            map[string]string{},
+				},
+				Status: v1.NodeStatus{
+					Conditions: []v1.NodeCondition{
+						{
+							Type:               v1.NodeReady,
+							Status:             v1.ConditionUnknown,
+							LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+							LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.UTC),
+						},
+					},
+				},
+				Spec: v1.NodeSpec{
+					Taints: []v1.Taint{
+						{
+							Key:    "ImproveCoverageTaint",
+							Value:  "true",
+							Effect: v1.TaintEffectNoSchedule,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	factory := informers.NewSharedInformerFactory(fnh, controller.NoResyncPeriodFunc())
+
+	fakeCloud := &fakecloud.FakeCloud{
+		InstanceTypes: map[types.NodeName]string{},
+		Addresses: []v1.NodeAddress{
+			{
+				Type:    v1.NodeHostName,
+				Address: "node0.cloud.internal",
+			},
+			{
+				Type:    v1.NodeInternalIP,
+				Address: "10.0.0.1",
+			},
+			{
+				Type:    v1.NodeExternalIP,
+				Address: "132.143.154.163",
+			},
+		},
+		ExistsByProviderID: false,
+		Err:                nil,
+	}
+
+	cloudNodeController := &CloudNodeController{
+		kubeClient:   fnh,
+		nodeInformer: factory.Core().V1().Nodes(),
+		cloud:        fakeCloud,
+	}
+
+	cloudNodeController.updateNodeAddress(fnh.Existing[0], fakeCloud)
+
+	if len(fnh.UpdatedNodes) != 0 {
+		t.Errorf("Node was not correctly updated, the updated len(nodes) got: %v, wanted=0", len(fnh.UpdatedNodes))
+	}
+}
+
 // This test checks that a node is set with the correct providerID
 func TestNodeProviderID(t *testing.T) {
 	fnh := &testutil.FakeNodeHandler{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
when the node is not exist according to cloud provider. there is no need to update node address better. 
finally the node will be delete  in https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/node_controller.go#L240


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
