### PR TITLE
Cherry Pick on 1.6 - Fix initial exec terminal dimensions (#47991)

### DIFF
--- a/pkg/kubelet/dockertools/kube_docker_client.go
+++ b/pkg/kubelet/dockertools/kube_docker_client.go
@@ -458,6 +458,15 @@ func (d *kubeDockerClient) StartExec(startExec string, opts dockertypes.ExecStar
 		return err
 	}
 	defer resp.Close()
+
+	if sopts.ExecStarted != nil {
+		// Send a message to the channel indicating that the exec has started. This is needed so
+		// interactive execs can handle resizing correctly - the request to resize the TTY has to happen
+		// after the call to d.client.ContainerExecAttach, and because d.holdHijackedConnection below
+		// blocks, we use sopts.ExecStarted to signal the caller that it's ok to resize.
+		sopts.ExecStarted <- struct{}{}
+	}
+
 	return d.holdHijackedConnection(sopts.RawTerminal || opts.Tty, sopts.InputStream, sopts.OutputStream, sopts.ErrorStream, resp)
 }
 
@@ -594,6 +603,7 @@ type StreamOptions struct {
 	InputStream  io.Reader
 	OutputStream io.Writer
 	ErrorStream  io.Writer
+	ExecStarted  chan struct{}
 }
 
 // operationTimeout is the error returned when the docker operations are timeout.


### PR DESCRIPTION
Cherry-picking #47991 on release-1.6

--

From @ncdc's original PR:

**What this PR does / why we need it**: Delay attempting to send a terminal resize request to docker until after the exec has started; otherwise, the initial resize request will fail.

**Which issue this PR fixes** : fixes #47990

**Release note**:
```release-note
Fix initial exec terminal dimensions.
```
