### PR TITLE
Automated cherry pick of #47991 upstream release 1.7

### DIFF
--- a/pkg/kubelet/dockershim/exec.go
+++ b/pkg/kubelet/dockershim/exec.go
@@ -135,6 +135,9 @@ func (*NsenterExecHandler) ExecInContainer(client libdocker.Interface, container
 type NativeExecHandler struct{}
 
 func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container *dockertypes.ContainerJSON, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize, timeout time.Duration) error {
+	done := make(chan struct{})
+	defer close(done)
+
 	createOpts := dockertypes.ExecConfig{
 		Cmd:          cmd,
 		AttachStdin:  stdin != nil,
@@ -149,9 +152,23 @@ func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container 
 
 	// Have to start this before the call to client.StartExec because client.StartExec is a blocking
 	// call :-( Otherwise, resize events don't get processed and the terminal never resizes.
-	kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
-		client.ResizeExecTTY(execObj.ID, int(size.Height), int(size.Width))
-	})
+	//
+	// We also have to delay attempting to send a terminal resize request to docker until after the
+	// exec has started; otherwise, the initial resize request will fail.
+	execStarted := make(chan struct{})
+	go func() {
+		select {
+		case <-execStarted:
+			// client.StartExec has started the exec, so we can start resizing
+		case <-done:
+			// ExecInContainer has returned, so short-circuit
+			return
+		}
+
+		kubecontainer.HandleResizing(resize, func(size remotecommand.TerminalSize) {
+			client.ResizeExecTTY(execObj.ID, int(size.Height), int(size.Width))
+		})
+	}()
 
 	startOpts := dockertypes.ExecStartCheck{Detach: false, Tty: tty}
 	streamOpts := libdocker.StreamOptions{
@@ -159,6 +176,7 @@ func (*NativeExecHandler) ExecInContainer(client libdocker.Interface, container 
 		OutputStream: stdout,
 		ErrorStream:  stderr,
 		RawTerminal:  tty,
+		ExecStarted:  execStarted,
 	}
 	err = client.StartExec(execObj.ID, startOpts, streamOpts)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #47991 on release-1.7.

#47991: Fix initial exec terminal dimensions