### PR TITLE
Disable test to fix kubectl skew tests

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -206,6 +206,17 @@ var _ = framework.KubeDescribe("Kubectl alpha client", func() {
 
 		It("should create a ScheduledJob", func() {
 			framework.SkipIfMissingResource(f.ClientPool, ScheduledJobGroupVersionResource, f.Namespace.Name)
+			serverVersion, err := c.Discovery().ServerVersion()
+			if err != nil {
+				framework.Failf("Failed to get server version: %v", err)
+			}
+			sv, err := utilversion.ParseSemantic(serverVersion.GitVersion)
+			if err != nil {
+				framework.Failf("Failed to parse server version: %v", err)
+			}
+			if !sv.LessThan(utilversion.MustParseSemantic("v1.8.0")) {
+				framework.Skipf("scheduledjob/v2alpha1 generator not supported on cluster starting in 1.8")
+			}
 
 			schedule := "*/5 * * * ?"
 			framework.RunKubectlOrDie("run", sjName, "--restart=OnFailure", "--generator=scheduledjob/v2alpha1",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Removes a `kubectl` test in the **release-1.7** branch that always fails skew tests against a 1.8 cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/51048

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
