### PR TITLE
Run multiarch/qemu-user-static:register before building cross-arch images

### DIFF
--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -51,6 +51,8 @@ endif
 	mkdir -p ${TEMP_DIR}/cni-bin
 	tar -xz -C ${TEMP_DIR}/cni-bin -f "cni-tars/${CNI_TARBALL}"
 
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -38,6 +38,8 @@ endif
 
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 


### PR DESCRIPTION
**What this PR does / why we need it**: #48365 inadvertently broke building non-x86 hyperkube images for developers who'd not built non-x86 images before and thus hadn't yet run `multiarch/qemu-user-static:register`. This PR restores that step.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @david-mcmahon @mbohlool @luxas 
