### PR TITLE
Manual cherrypick of #51043

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -79,16 +79,6 @@ func TestIdentityMatches(t *testing.T) {
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with the wrong namespace")
 	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Hostname = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no hostname")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Subdomain = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no subdomain")
-	}
 }
 
 func TestStorageMatches(t *testing.T) {
@@ -137,24 +127,6 @@ func TestUpdateIdentity(t *testing.T) {
 	updateIdentity(set, pod)
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to update the Pods namespace")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Hostname = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no hostname")
-	}
-	updateIdentity(set, pod)
-	if !identityMatches(set, pod) {
-		t.Error("updateIdentity failed to update the Pod's hostname")
-	}
-	pod = newStatefulSetPod(set, 1)
-	pod.Spec.Subdomain = ""
-	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no subdomain")
-	}
-	updateIdentity(set, pod)
-	if !identityMatches(set, pod) {
-		t.Error("updateIdentity failed to update the Pod's subdomain")
 	}
 }
 


### PR DESCRIPTION
StatefulSet controller no longer attempts to mutate v1.PodSpec.Hostname or v1.PodSpec.Subdomain
fixes: #51043 
Partial fix for #48327 

Manual cherrypick of #51044

```release-note
StatefulSet: Fix "forbidden pod updates" error on Pods created prior to upgrading to 1.7. (#48327)
```
