### PR TITLE
Enable overlay2 on cos-m60 in node e2e tests

### DIFF
--- a/test/e2e_node/jenkins/cos-init-live-restore.yaml
+++ b/test/e2e_node/jenkins/cos-init-live-restore.yaml
@@ -1,6 +1,9 @@
 #cloud-config
 
 runcmd:
+  - cp /usr/lib/systemd/system/docker.service /etc/systemd/system/
+  - sed -i -e 's/-s overlay/-s overlay2/g' /etc/systemd/system/docker.service
+  - systemctl daemon-reload
   - echo '{"live-restore":true}' > /etc/docker/daemon.json
   - systemctl restart docker
   - mount /tmp /tmp -o remount,exec,suid

--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -12,7 +12,7 @@ images:
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images
-  cos-stable:
+  cos-stable2:
     image_regex: cos-stable-59-9460-64-0 # docker 1.11.2
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/gci-init-gpu.yaml,gci-update-strategy=update_disabled"
@@ -20,7 +20,7 @@ images:
       accelerators:
         - type: nvidia-tesla-k80
           count: 2
-  cos-beta:
-    image_regex: cos-beta-60-9592-70-0 # docker 1.13.1
+  cos-stable1:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
     project: cos-cloud
-    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -12,11 +12,11 @@ images:
   containervm:
     image: e2e-node-containervm-v20161208-image # docker 1.11.2
     project: kubernetes-node-e2e-images
-  cos-stable:
+  cos-stable2:
     image_regex: cos-stable-59-9460-64-0 # docker 1.11.2
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
-  cos-beta:
-    image_regex: cos-beta-60-9592-70-0 # docker 1.13.1
+  cos-stable1:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/issues/42926

- Restart docker with `-s overlay2` in cloud-init before running all node e2e tests. I have to copy the systemd unit file to `/etc/systemd/system` because the `/usr/lib/systemd/system/` is read only.
- Updated node e2e tests to use the new cos-m60 image.
- The name of the cloud init file (`cos-init-live-restore.yaml`) does not indicate overlay2 will be enabled, but I can't just change the name in this PR, since it's referenced in test-infra.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
None
```

/assign @Random-Liu 