### PR TITLE
Enable apps/v1beta2 Deployment, ReplicaSet, DaemonSet in federation

### DIFF
--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsapiv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -285,6 +286,12 @@ func defaultResourceConfig() *serverstorage.ResourceConfig {
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("deployments"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("ingresses"),
 		extensionsapiv1beta1.SchemeGroupVersion.WithResource("replicasets"),
+	)
+	// All apps resources except these are disabled by default.
+	rc.EnableResources(
+		appsv1beta2.SchemeGroupVersion.WithResource("daemonsets"),
+		appsv1beta2.SchemeGroupVersion.WithResource("deployments"),
+		appsv1beta2.SchemeGroupVersion.WithResource("replicasets"),
 	)
 	return rc
 }


### PR DESCRIPTION
Fixes #50641
@kubernetes/sig-apps-pr-reviews @kubernetes/sig-federation-pr-reviews 

**Release note**:
```release-note
NONE
```