### PR TITLE
GCE: Add projectID parameter to waitForXOp funcs

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -136,7 +136,7 @@ type ServiceManager interface {
 	DeleteDisk(project string, zone string, disk string) (*compute.Operation, error)
 
 	// Waits until GCE reports the given operation in the given zone as done.
-	WaitForZoneOp(op *compute.Operation, zone string, mc *metricContext) error
+	WaitForZoneOp(op *compute.Operation, projectID string, zone string, mc *metricContext) error
 }
 
 type GCEServiceManager struct {
@@ -626,6 +626,6 @@ func (manager *GCEServiceManager) DeleteDisk(
 	return manager.gce.service.Disks.Delete(project, zone, diskName).Do()
 }
 
-func (manager *GCEServiceManager) WaitForZoneOp(op *compute.Operation, zone string, mc *metricContext) error {
-	return manager.gce.waitForZoneOp(op, zone, mc)
+func (manager *GCEServiceManager) WaitForZoneOp(op *compute.Operation, projectID string, zone string, mc *metricContext) error {
+	return manager.gce.waitForZoneOp(op, projectID, zone, mc)
 }

--- a/pkg/cloudprovider/providers/gce/gce_addresses.go
+++ b/pkg/cloudprovider/providers/gce/gce_addresses.go
@@ -42,7 +42,7 @@ func (gce *GCECloud) ReserveGlobalAddress(addr *compute.Address) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteGlobalAddress deletes a global address by name.
@@ -52,7 +52,7 @@ func (gce *GCECloud) DeleteGlobalAddress(name string) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // GetGlobalAddress returns the global address by name.
@@ -69,7 +69,7 @@ func (gce *GCECloud) ReserveRegionAddress(addr *compute.Address, region string) 
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // ReserveAlphaRegionAddress creates an Alpha, regional address.
@@ -79,7 +79,7 @@ func (gce *GCECloud) ReserveAlphaRegionAddress(addr *computealpha.Address, regio
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // DeleteRegionAddress deletes a region address by name.
@@ -89,7 +89,7 @@ func (gce *GCECloud) DeleteRegionAddress(name, region string) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // GetRegionAddress returns the region address by name

--- a/pkg/cloudprovider/providers/gce/gce_backendservice.go
+++ b/pkg/cloudprovider/providers/gce/gce_backendservice.go
@@ -41,7 +41,7 @@ func (gce *GCECloud) UpdateGlobalBackendService(bg *compute.BackendService) erro
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteGlobalBackendService deletes the given BackendService by name.
@@ -55,7 +55,7 @@ func (gce *GCECloud) DeleteGlobalBackendService(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // CreateGlobalBackendService creates the given BackendService.
@@ -66,7 +66,7 @@ func (gce *GCECloud) CreateGlobalBackendService(bg *compute.BackendService) erro
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListGlobalBackendServices lists all backend services in the project.
@@ -102,7 +102,7 @@ func (gce *GCECloud) UpdateRegionBackendService(bg *compute.BackendService, regi
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // DeleteRegionBackendService deletes the given BackendService by name.
@@ -116,7 +116,7 @@ func (gce *GCECloud) DeleteRegionBackendService(name, region string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // CreateRegionBackendService creates the given BackendService.
@@ -127,7 +127,7 @@ func (gce *GCECloud) CreateRegionBackendService(bg *compute.BackendService, regi
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // ListRegionBackendServices lists all backend services in the project.

--- a/pkg/cloudprovider/providers/gce/gce_cert.go
+++ b/pkg/cloudprovider/providers/gce/gce_cert.go
@@ -42,7 +42,7 @@ func (gce *GCECloud) CreateSslCertificate(sslCerts *compute.SslCertificate) (*co
 		return nil, mc.Observe(err)
 	}
 
-	if err = gce.waitForGlobalOp(op, mc); err != nil {
+	if err = gce.waitForGlobalOp(op, gce.projectID, mc); err != nil {
 		return nil, mc.Observe(err)
 	}
 
@@ -62,7 +62,7 @@ func (gce *GCECloud) DeleteSslCertificate(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListSslCertificates lists all SslCertificates in the project.

--- a/pkg/cloudprovider/providers/gce/gce_disks.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks.go
@@ -111,7 +111,7 @@ func (gce *GCECloud) AttachDisk(diskName string, nodeName types.NodeName, readOn
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(attachOp, disk.Zone, mc)
+	return gce.waitForZoneOp(attachOp, gce.projectID, disk.Zone, mc)
 }
 
 func (gce *GCECloud) DetachDisk(devicePath string, nodeName types.NodeName) error {
@@ -136,7 +136,7 @@ func (gce *GCECloud) DetachDisk(devicePath string, nodeName types.NodeName) erro
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(detachOp, inst.Zone, mc)
+	return gce.waitForZoneOp(detachOp, gce.projectID, inst.Zone, mc)
 }
 
 func (gce *GCECloud) DiskIsAttached(diskName string, nodeName types.NodeName) (bool, error) {
@@ -252,7 +252,7 @@ func (gce *GCECloud) CreateDisk(
 		return mc.Observe(err)
 	}
 
-	err = gce.manager.WaitForZoneOp(createOp, zone, mc)
+	err = gce.manager.WaitForZoneOp(createOp, gce.projectID, zone, mc)
 	if isGCEError(err, "alreadyExists") {
 		glog.Warningf("GCE PD %q already exists, reusing", name)
 		return nil
@@ -415,7 +415,7 @@ func (gce *GCECloud) doDeleteDisk(diskToDelete string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.manager.WaitForZoneOp(deleteOp, disk.Zone, mc)
+	return gce.manager.WaitForZoneOp(deleteOp, gce.projectID, disk.Zone, mc)
 }
 
 // Converts a Disk resource to an AttachedDisk resource.

--- a/pkg/cloudprovider/providers/gce/gce_disks_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_disks_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"fmt"
+
 	compute "google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
 	"k8s.io/kubernetes/pkg/cloudprovider"
@@ -493,6 +494,7 @@ func (manager *FakeServiceManager) DeleteDisk(
 
 func (manager *FakeServiceManager) WaitForZoneOp(
 	op *compute.Operation,
+	projectID string,
 	zone string,
 	mc *metricContext) error {
 	if op == manager.op {

--- a/pkg/cloudprovider/providers/gce/gce_firewall.go
+++ b/pkg/cloudprovider/providers/gce/gce_firewall.go
@@ -39,7 +39,7 @@ func (gce *GCECloud) CreateFirewall(f *compute.Firewall) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteFirewall deletes the given firewall rule.
@@ -49,7 +49,7 @@ func (gce *GCECloud) DeleteFirewall(name string) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // UpdateFirewall applies the given firewall as an update to an existing service.
@@ -60,5 +60,5 @@ func (gce *GCECloud) UpdateFirewall(f *compute.Firewall) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }

--- a/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
+++ b/pkg/cloudprovider/providers/gce/gce_forwardingrule.go
@@ -35,7 +35,7 @@ func (gce *GCECloud) CreateGlobalForwardingRule(rule *compute.ForwardingRule) er
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // SetProxyForGlobalForwardingRule links the given TargetHttp(s)Proxy with the given GlobalForwardingRule.
@@ -48,7 +48,7 @@ func (gce *GCECloud) SetProxyForGlobalForwardingRule(forwardingRuleName, targetP
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteGlobalForwardingRule deletes the GlobalForwardingRule by name.
@@ -59,7 +59,7 @@ func (gce *GCECloud) DeleteGlobalForwardingRule(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // GetGlobalForwardingRule returns the GlobalForwardingRule by name.
@@ -108,7 +108,7 @@ func (gce *GCECloud) CreateRegionForwardingRule(rule *compute.ForwardingRule, re
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // CreateAlphaRegionForwardingRule creates and returns an Alpha
@@ -120,7 +120,7 @@ func (gce *GCECloud) CreateAlphaRegionForwardingRule(rule *computealpha.Forwardi
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // DeleteRegionForwardingRule deletes the RegionalForwardingRule by name & region.
@@ -131,5 +131,5 @@ func (gce *GCECloud) DeleteRegionForwardingRule(name, region string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }

--- a/pkg/cloudprovider/providers/gce/gce_healthchecks.go
+++ b/pkg/cloudprovider/providers/gce/gce_healthchecks.go
@@ -61,7 +61,7 @@ func (gce *GCECloud) UpdateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteHttpHealthCheck deletes the given HttpHealthCheck by name.
@@ -72,7 +72,7 @@ func (gce *GCECloud) DeleteHttpHealthCheck(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // CreateHttpHealthCheck creates the given HttpHealthCheck.
@@ -83,7 +83,7 @@ func (gce *GCECloud) CreateHttpHealthCheck(hc *compute.HttpHealthCheck) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListHttpHealthChecks lists all HttpHealthChecks in the project.
@@ -113,7 +113,7 @@ func (gce *GCECloud) UpdateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error 
 		return err
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteHttpsHealthCheck deletes the given HttpsHealthCheck by name.
@@ -124,7 +124,7 @@ func (gce *GCECloud) DeleteHttpsHealthCheck(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // CreateHttpsHealthCheck creates the given HttpsHealthCheck.
@@ -135,7 +135,7 @@ func (gce *GCECloud) CreateHttpsHealthCheck(hc *compute.HttpsHealthCheck) error 
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListHttpsHealthChecks lists all HttpsHealthChecks in the project.
@@ -163,7 +163,7 @@ func (gce *GCECloud) UpdateHealthCheck(hc *compute.HealthCheck) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteHealthCheck deletes the given HealthCheck by name.
@@ -174,7 +174,7 @@ func (gce *GCECloud) DeleteHealthCheck(name string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // CreateHealthCheck creates the given HealthCheck.
@@ -185,7 +185,7 @@ func (gce *GCECloud) CreateHealthCheck(hc *compute.HealthCheck) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListHealthChecks lists all HealthCheck in the project.

--- a/pkg/cloudprovider/providers/gce/gce_instancegroup.go
+++ b/pkg/cloudprovider/providers/gce/gce_instancegroup.go
@@ -31,7 +31,7 @@ func (gce *GCECloud) CreateInstanceGroup(ig *compute.InstanceGroup, zone string)
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(op, zone, mc)
+	return gce.waitForZoneOp(op, gce.projectID, zone, mc)
 }
 
 // DeleteInstanceGroup deletes an instance group.
@@ -43,7 +43,7 @@ func (gce *GCECloud) DeleteInstanceGroup(name string, zone string) error {
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(op, zone, mc)
+	return gce.waitForZoneOp(op, gce.projectID, zone, mc)
 }
 
 // ListInstanceGroups lists all InstanceGroups in the project and
@@ -83,7 +83,7 @@ func (gce *GCECloud) AddInstancesToInstanceGroup(name string, zone string, insta
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(op, zone, mc)
+	return gce.waitForZoneOp(op, gce.projectID, zone, mc)
 }
 
 // RemoveInstancesFromInstanceGroup removes the given instances from
@@ -103,7 +103,7 @@ func (gce *GCECloud) RemoveInstancesFromInstanceGroup(name string, zone string, 
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(op, zone, mc)
+	return gce.waitForZoneOp(op, gce.projectID, zone, mc)
 }
 
 // SetNamedPortsOfInstanceGroup sets the list of named ports on a given instance group
@@ -116,7 +116,7 @@ func (gce *GCECloud) SetNamedPortsOfInstanceGroup(igName, zone string, namedPort
 		return mc.Observe(err)
 	}
 
-	return gce.waitForZoneOp(op, zone, mc)
+	return gce.waitForZoneOp(op, gce.projectID, zone, mc)
 }
 
 // GetInstanceGroup returns an instance group by name.

--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -231,7 +231,7 @@ func (gce *GCECloud) AddSSHKeyToAllInstances(user string, keyData []byte) error 
 			return false, nil
 		}
 
-		if err := gce.waitForGlobalOp(op, mc); err != nil {
+		if err := gce.waitForGlobalOp(op, gce.projectID, mc); err != nil {
 			glog.Errorf("Could not Set Metadata: %v", err)
 			return false, nil
 		}

--- a/pkg/cloudprovider/providers/gce/gce_op.go
+++ b/pkg/cloudprovider/providers/gce/gce_op.go
@@ -92,63 +92,63 @@ func getErrorFromOp(op *computev1.Operation) error {
 	return nil
 }
 
-func (gce *GCECloud) waitForGlobalOp(op gceObject, mc *metricContext) error {
+func (gce *GCECloud) waitForGlobalOp(op gceObject, projectID string, mc *metricContext) error {
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceAlpha.GlobalOperations.Get(gce.projectID, operationName).Do()
+			op, err := gce.serviceAlpha.GlobalOperations.Get(projectID, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceBeta.GlobalOperations.Get(gce.projectID, operationName).Do()
+			op, err := gce.serviceBeta.GlobalOperations.Get(projectID, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.GlobalOperations.Get(gce.projectID, operationName).Do()
+			return gce.service.GlobalOperations.Get(projectID, operationName).Do()
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)
 	}
 }
 
-func (gce *GCECloud) waitForRegionOp(op gceObject, region string, mc *metricContext) error {
+func (gce *GCECloud) waitForRegionOp(op gceObject, projectID string, region string, mc *metricContext) error {
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceAlpha.RegionOperations.Get(gce.projectID, region, operationName).Do()
+			op, err := gce.serviceAlpha.RegionOperations.Get(projectID, region, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceBeta.RegionOperations.Get(gce.projectID, region, operationName).Do()
+			op, err := gce.serviceBeta.RegionOperations.Get(projectID, region, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.RegionOperations.Get(gce.projectID, region, operationName).Do()
+			return gce.service.RegionOperations.Get(projectID, region, operationName).Do()
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)
 	}
 }
 
-func (gce *GCECloud) waitForZoneOp(op gceObject, zone string, mc *metricContext) error {
+func (gce *GCECloud) waitForZoneOp(op gceObject, projectID string, zone string, mc *metricContext) error {
 	switch v := op.(type) {
 	case *computealpha.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceAlpha.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+			op, err := gce.serviceAlpha.ZoneOperations.Get(projectID, zone, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computebeta.Operation:
 		return gce.waitForOp(convertToV1Operation(op), func(operationName string) (*computev1.Operation, error) {
-			op, err := gce.serviceBeta.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+			op, err := gce.serviceBeta.ZoneOperations.Get(projectID, zone, operationName).Do()
 			return convertToV1Operation(op), err
 		}, mc)
 	case *computev1.Operation:
 		return gce.waitForOp(op.(*computev1.Operation), func(operationName string) (*computev1.Operation, error) {
-			return gce.service.ZoneOperations.Get(gce.projectID, zone, operationName).Do()
+			return gce.service.ZoneOperations.Get(projectID, zone, operationName).Do()
 		}, mc)
 	default:
 		return fmt.Errorf("unexpected type: %T", v)

--- a/pkg/cloudprovider/providers/gce/gce_routes.go
+++ b/pkg/cloudprovider/providers/gce/gce_routes.go
@@ -96,7 +96,7 @@ func (gce *GCECloud) CreateRoute(clusterName string, nameHint string, route *clo
 			return mc.Observe(err)
 		}
 	}
-	return gce.waitForGlobalOp(insertOp, mc)
+	return gce.waitForGlobalOp(insertOp, gce.projectID, mc)
 }
 
 func (gce *GCECloud) DeleteRoute(clusterName string, route *cloudprovider.Route) error {
@@ -105,7 +105,7 @@ func (gce *GCECloud) DeleteRoute(clusterName string, route *cloudprovider.Route)
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(deleteOp, mc)
+	return gce.waitForGlobalOp(deleteOp, gce.projectID, mc)
 }
 
 func truncateClusterName(clusterName string) string {

--- a/pkg/cloudprovider/providers/gce/gce_targetpool.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetpool.go
@@ -37,7 +37,7 @@ func (gce *GCECloud) CreateTargetPool(tp *compute.TargetPool, region string) err
 		return mc.Observe(err)
 	}
 
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // DeleteTargetPool deletes TargetPool by name.
@@ -47,7 +47,7 @@ func (gce *GCECloud) DeleteTargetPool(name, region string) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // AddInstancesToTargetPool adds instances by link to the TargetPool
@@ -58,7 +58,7 @@ func (gce *GCECloud) AddInstancesToTargetPool(name, region string, instanceRefs 
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }
 
 // RemoveInstancesToTargetPool removes instances by link to the TargetPool
@@ -69,5 +69,5 @@ func (gce *GCECloud) RemoveInstancesFromTargetPool(name, region string, instance
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForRegionOp(op, region, mc)
+	return gce.waitForRegionOp(op, gce.projectID, region, mc)
 }

--- a/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -40,7 +40,7 @@ func (gce *GCECloud) CreateTargetHttpProxy(proxy *compute.TargetHttpProxy) error
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // SetUrlMapForTargetHttpProxy sets the given UrlMap for the given TargetHttpProxy.
@@ -51,7 +51,7 @@ func (gce *GCECloud) SetUrlMapForTargetHttpProxy(proxy *compute.TargetHttpProxy,
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteTargetHttpProxy deletes the TargetHttpProxy by name.
@@ -64,7 +64,7 @@ func (gce *GCECloud) DeleteTargetHttpProxy(name string) error {
 		}
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListTargetHttpProxies lists all TargetHttpProxies in the project.
@@ -91,7 +91,7 @@ func (gce *GCECloud) CreateTargetHttpsProxy(proxy *compute.TargetHttpsProxy) err
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // SetUrlMapForTargetHttpsProxy sets the given UrlMap for the given TargetHttpsProxy.
@@ -102,7 +102,7 @@ func (gce *GCECloud) SetUrlMapForTargetHttpsProxy(proxy *compute.TargetHttpsProx
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // SetSslCertificateForTargetHttpsProxy sets the given SslCertificate for the given TargetHttpsProxy.
@@ -113,7 +113,7 @@ func (gce *GCECloud) SetSslCertificateForTargetHttpsProxy(proxy *compute.TargetH
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteTargetHttpsProxy deletes the TargetHttpsProxy by name.
@@ -126,7 +126,7 @@ func (gce *GCECloud) DeleteTargetHttpsProxy(name string) error {
 		}
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListTargetHttpsProxies lists all TargetHttpsProxies in the project.

--- a/pkg/cloudprovider/providers/gce/gce_urlmap.go
+++ b/pkg/cloudprovider/providers/gce/gce_urlmap.go
@@ -40,7 +40,7 @@ func (gce *GCECloud) CreateUrlMap(urlMap *compute.UrlMap) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // UpdateUrlMap applies the given UrlMap as an update
@@ -50,7 +50,7 @@ func (gce *GCECloud) UpdateUrlMap(urlMap *compute.UrlMap) error {
 	if err != nil {
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // DeleteUrlMap deletes a url map by name.
@@ -63,7 +63,7 @@ func (gce *GCECloud) DeleteUrlMap(name string) error {
 		}
 		return mc.Observe(err)
 	}
-	return gce.waitForGlobalOp(op, mc)
+	return gce.waitForGlobalOp(op, gce.projectID, mc)
 }
 
 // ListUrlMaps lists all UrlMaps in the project.


### PR DESCRIPTION
**What this PR does / why we need it**:
Soon there will be a difference between project ID and network project ID.  For resources like routes and firewall rules, the API needs to make the calls using the network project ID. This includes the `waitFor(Global|Region|Zone)Op` calls.

This PR passes through the project parameter so it'll be easy to change when network project ID exists.

**Special notes for your reviewer**:
/assign @bowei 

**Release note**:
```release-note
NONE
```

**this will likely need to be rebased several times as other PRs get merged**
