### PR TITLE
Allow kube-proxy to use service account if neither --kubeconfig nor --master was specified

### DIFF
--- a/cmd/kube-proxy/app/BUILD
+++ b/cmd/kube-proxy/app/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -43,6 +43,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientgoclientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/record"
@@ -384,17 +385,26 @@ type ProxyServer struct {
 // createClients creates a kube client and an event client from the given config and masterOverride.
 // TODO remove masterOverride when CLI flags are removed.
 func createClients(config componentconfig.ClientConnectionConfiguration, masterOverride string) (clientset.Interface, v1core.EventsGetter, error) {
-	if len(config.KubeConfigFile) == 0 && len(masterOverride) == 0 {
-		glog.Warningf("Neither --kubeconfig nor --master was specified. Using default API client. This might not work.")
-	}
+	var kubeConfig *rest.Config
+	var err error
 
-	// This creates a client, first loading any specified kubeconfig
-	// file, and then overriding the Master flag, if non-empty.
-	kubeConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.KubeConfigFile},
-		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterOverride}}).ClientConfig()
-	if err != nil {
-		return nil, nil, err
+	// If both kubeconfig and master URL are empty, use service account.
+	if len(config.KubeConfigFile) == 0 && len(masterOverride) == 0 {
+		glog.Info("Neither --kubeconfig nor --master was specified. Using service account.")
+		kubeConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		// This creates a client, first loading any specified kubeconfig
+		// file, and then overriding the Master flag, if non-empty.
+		kubeConfig, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+			&clientcmd.ClientConfigLoadingRules{ExplicitPath: config.KubeConfigFile},
+			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterOverride}}).ClientConfig()
+		if err != nil {
+			return nil, nil, err
+		}
+
 	}
 
 	kubeConfig.AcceptContentTypes = config.AcceptContentTypes


### PR DESCRIPTION
**What this PR does / why we need it**:
From https://github.com/kubernetes/kubernetes/issues/23225#issuecomment-322560790, we plan to use service account for kube-proxy daemonset.

This is basically the same logic as in kube-dns: https://github.com/kubernetes/dns/blob/1.14.4/cmd/kube-dns/app/server.go#L92-L98

**Special notes for your reviewer**:
/assign @bowei @thockin 
cc @luxas 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kube-proxy now uses service account if neither --kubeconfig nor --master was specified.
```
