### PR TITLE
Fix swallowed error in attachdetach tests

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -99,6 +99,10 @@ func Test_AttachDetachControllerStateOfWolrdPopulators_Positive(t *testing.T) {
 
 	// Test the ActualStateOfWorld contains all the node volumes
 	nodes, err := adc.nodeLister.List(labels.Everything())
+	if err != nil {
+		t.Fatalf("Failed to list nodes in indexer. Expected: <no error> Actual: %v", err)
+	}
+
 	for _, node := range nodes {
 		nodeName := types.NodeName(node.Name)
 		for _, attachedVolume := range node.Status.VolumesAttached {


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes swallowed error in attachdetach tests.

```release-note NONE
```
