### PR TITLE
kubeapiserver: rename `--experimental-bootstrap-token-auth` to `--enable-bootstrap-token-auth`.

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -51,7 +51,7 @@ type AnonymousAuthenticationOptions struct {
 }
 
 type BootstrapTokenAuthenticationOptions struct {
-	Allow bool
+	Enable bool
 }
 
 type KeystoneAuthenticationOptions struct {
@@ -178,7 +178,11 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	if s.BootstrapToken != nil {
-		fs.BoolVar(&s.BootstrapToken.Allow, "experimental-bootstrap-token-auth", s.BootstrapToken.Allow, ""+
+		fs.BoolVar(&s.BootstrapToken.Enable, "experimental-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
+			"Deprecated (use --enable-bootstrap-token-auth).")
+		fs.MarkDeprecated("experimental-bootstrap-token-auth", "use --enable-bootstrap-token-auth instead.")
+
+		fs.BoolVar(&s.BootstrapToken.Enable, "enable-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
 			"Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' "+
 			"namespace to be used for TLS bootstrapping authentication.")
 	}
@@ -266,7 +270,7 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.Au
 	}
 
 	if s.BootstrapToken != nil {
-		ret.BootstrapToken = s.BootstrapToken.Allow
+		ret.BootstrapToken = s.BootstrapToken.Enable
 	}
 
 	if s.ClientCert != nil {


### PR DESCRIPTION
#**What this PR does / why we need it**:
This change renames the API server `--experimental-bootstrap-token-auth` flag to `--enable-bootstrap-token-auth`. The old flag is accepted but generates a warning.

In 1.9, we will drop support for `--experimental-bootstrap-token-auth` entirely.

#### Example of the warning log:
```
$ kube-apiserver --experimental-bootstrap-token-auth --etcd-servers https://127.0.0.1:1234 --service-cluster-ip-range 10.0.1.0/24
Flag --experimental-bootstrap-token-auth has been deprecated, use --enable-bootstrap-token-auth instead.
[...]
```

**Which issue this PR fixes** fixes https://github.com/kubernetes/kubernetes/issues/50613

**Release note**:
```release-note
Renamed the API server flag `--experimental-bootstrap-token-auth` to `--enable-bootstrap-token-auth`. The old value is accepted with a warning in 1.8 and will be removed in 1.9.
```

/sig cli
/sig cluster-lifecycle

cc @luxas 