### PR TITLE
Revert default service-cidr config on kubernetes-master charm

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -9,7 +9,7 @@ options:
     description: The local domain for cluster dns
   service-cidr:
     type: string
-    default: 10.152.0.0/16
+    default: 10.152.183.0/24
     description: CIDR to user for Kubernetes services. Cannot be changed after deployment.
   allow-privileged:
     type: string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This reverts the default service-cidr config in the kubernetes-master charm.

A while back, we changed the default service-cidr in the kubernetes-master charm from `10.152.183.0/24` to `10.152.0.0/16`. In testing, we have found that the charms don't handle this change well, so we are reverting it until we can make the change more safely.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
