### PR TITLE
Delete security-group not need first delete the security-group rules,

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -1221,27 +1221,8 @@ func (lbaas *LbaasV2) EnsureLoadBalancerDeleted(clusterName string, service *v1.
 		if lbSecGroup.Err != nil && !isNotFound(lbSecGroup.Err) {
 			return lbSecGroup.Err
 		}
-
-		// Delete the rules in the Node Security Group
-		opts := rules.ListOpts{
-			SecGroupID:    lbaas.opts.NodeSecurityGroupID,
-			RemoteGroupID: lbSecGroupID,
-		}
-		secGroupRules, err := getSecurityGroupRules(lbaas.network, opts)
-
-		if err != nil && !isNotFound(err) {
-			glog.Errorf("Error finding rules for remote group id %s in security group id %s", lbSecGroupID, lbaas.opts.NodeSecurityGroupID)
-			return err
-		}
-
-		for _, rule := range secGroupRules {
-			res := rules.Delete(lbaas.network, rule.ID)
-			if res.Err != nil && !isNotFound(res.Err) {
-				glog.V(1).Infof("Error occurred deleting security group rule: %s: %v", rule.ID, res.Err)
-			}
-		}
 	}
-
+	
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go#L1220, deleteRules after delete security_groups.  But In openstack, delete security_groups will auto delete the  rules.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
