### PR TITLE
Add liggitt as an API approver. 

### DIFF
--- a/api/OWNERS
+++ b/api/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - lavalamp
 - smarterclayton
 - thockin
+- liggitt
+# - bgrant0607 # manual	escalations only
 reviewers:
 - thockin
 - lavalamp

--- a/pkg/api/OWNERS
+++ b/pkg/api/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - lavalamp
 - smarterclayton
 - thockin
+- liggitt
+# - bgrant0607 # manual escalations only
 reviewers:
 - thockin
 - lavalamp

--- a/pkg/apis/OWNERS
+++ b/pkg/apis/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - lavalamp
 - smarterclayton
 - thockin
+- liggitt
+# - bgrant0607 # manual escalations only
 reviewers:
 - lavalamp
 - smarterclayton

--- a/staging/src/k8s.io/api/OWNERS
+++ b/staging/src/k8s.io/api/OWNERS
@@ -3,6 +3,8 @@ approvers:
 - lavalamp
 - smarterclayton
 - thockin
+- liggitt
+# - bgrant0607 # manual escalations only
 reviewers:
 - brendandburns
 - caesarxuchao


### PR DESCRIPTION
@liggitt has been on the project since 2014, was a key participant of the evolution of the v1beta3 and v1 APIs, has performed many API reviews, has helped to develop the API conventions (most recently with the added guidance regarding alpha fields), and has demonstrated attention to detail and good taste. His efforts have helped keep the API sane and consistent.

Also note that bgrant0607 is an approver, but shouldn't be auto-assigned.

cc @kubernetes/api-approvers 

**Release note**:
```release-note
NONE
```
