### PR TITLE
Fix prefixing bug in import verifier

### DIFF
--- a/cmd/importverifier/OWNERS
+++ b/cmd/importverifier/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - stevekuznetsov 
+  - deads2k
+  - sttts 
+approvers:
+  - stevekuznetsov 
+  - deads2k
+  - sttts 

--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -152,7 +152,9 @@ func (i *ImportRestriction) isForbidden(imp string) bool {
 	importsBelowBase := strings.HasPrefix(imp, i.BaseDir)
 	importsAllowed := false
 	for _, allowed := range i.AllowedImports {
-		importsAllowed = importsAllowed || strings.HasPrefix(imp, allowed)
+		exactlyImportsAllowed := imp == allowed
+		importsBelowAllowed := strings.HasPrefix(imp, fmt.Sprintf("%s/", allowed))
+		importsAllowed = importsAllowed || (importsBelowAllowed || exactlyImportsAllowed)
 	}
 
 	return importsBelowRoot && !importsBelowBase && !importsAllowed


### PR DESCRIPTION
In order to check if an import is of an allowed tree, we need to check
that the import is either literally to the base of the tree or that the
import is below the tree (the import, suffixed with `/`, should be a
prefix) instead of checking simply that the import is a prefix of the
allowed tree, as that causes issues with packages that are prefixes of
each other, like `k8s.io/api` and `k8s.io/apimachinery`.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```release-note
NONE
```

Fixes https://github.com/kubernetes/kubernetes/issues/51212
/assign @sttts @deads2k 

This will be broken right now hopefully you'll be able to build on top to fix it @sttts 
