### PR TITLE
Attempt to Attach Volume fails for very first time on vSphere in 1.6 release

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -801,7 +801,7 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, nodeName k8stypes.NodeName) (di
 		}
 
 		scsiControllersOfRequiredType := getSCSIControllersOfType(vmDevices, diskControllerType)
-		scsiController := getAvailableSCSIController(scsiControllersOfRequiredType)
+		scsiController = getAvailableSCSIController(scsiControllersOfRequiredType)
 		if scsiController == nil {
 			glog.Errorf("cannot find SCSI controller in VM")
 			// attempt clean up of scsi controller


### PR DESCRIPTION
Before every attach, vSphere cloud provider checks if the SCSI controller is present on the VM. If not present, it will try to create one and attach the disk to that SCSI controller on VM. If already present, if will use the SCSI controller.

For the very first time when SCSI controller is not present on the VM, we try to create one and retrieve the SCSI controller for the disk to created on that SCSI controller. But in release 1.6, after successful creation of SCSI controller, we are not assigning back the SCSI controller to the existing "scsicontroller" variable. Because of this the very first time, attach of the disk will fail.

This problem is not observed on master, as we have taken care of this in vSphere cloud provider refactoring - https://github.com/kubernetes/kubernetes/pull/49164

@luomiao @divyenpatel @rohitjogvmw 

```release-note
vSphere: Fix attach volume failing on the first try.
```