### PR TITLE
Bump repo-infra dependency to fix go_genrule without sandboxing

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -7,9 +7,9 @@ http_archive(
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "2b2cb64b2fd7734c5eb2b79b79fa35d064fcf53b92cb3aaec5b90fc10fc94135",
-    strip_prefix = "repo-infra-9ba3a24eeffafa3a794b9e7312103424e7da26e9",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/9ba3a24eeffafa3a794b9e7312103424e7da26e9.tar.gz"],
+    sha256 = "5da78568ffb9a323410c701618c23da8c93f4bf4aea76eee41ac244dbd8c8f95",
+    strip_prefix = "repo-infra-4eaf9e671bbb549fb4ec292cf251f921d7ef80ac",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/4eaf9e671bbb549fb4ec292cf251f921d7ef80ac.tar.gz"],
 )
 
 ETCD_VERSION = "3.0.17"

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -25,7 +25,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 9ba3a24eeffafa3a794b9e7312103424e7da26e9
+kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
 kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
 
 gazelle fix -build_file_name=BUILD,BUILD.bazel -external=vendored -mode=fix -repo_root="$(kube::realpath ${KUBE_ROOT})"

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -25,7 +25,7 @@ source "${KUBE_ROOT}/hack/lib/init.sh"
 rm -f "${KUBE_ROOT}/pkg/generated/openapi/zz_generated.openapi.go"
 
 # The git commit sha1s here should match the values in $KUBE_ROOT/WORKSPACE.
-kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 9ba3a24eeffafa3a794b9e7312103424e7da26e9
+kube::util::go_install_from_commit github.com/kubernetes/repo-infra/kazel 4eaf9e671bbb549fb4ec292cf251f921d7ef80ac
 kube::util::go_install_from_commit github.com/bazelbuild/rules_go/go/tools/gazelle/gazelle 82483596ec203eb9c1849937636f4cbed83733eb
 
 gazelle_diff=$(gazelle fix -build_file_name=BUILD,BUILD.bazel -external=vendored -mode=diff -repo_root="$(kube::realpath ${KUBE_ROOT})")


### PR DESCRIPTION
**What this PR does / why we need it**: pulls in https://github.com/kubernetes/repo-infra/pull/35, which fixes the bazel build when sandboxing is not available.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49569 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @spxtr @mikedanese @BenTheElder