### PR TITLE
Use `--oom-score-adj` flag for kube-proxy

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -46,7 +46,7 @@ spec:
         command:
         - /bin/sh
         - -c
-        - echo -998 > /proc/$$$/oom_score_adj && kube-proxy {{kubeconfig}} {{cluster_cidr}} --resource-container="" {{params}} 1>>/var/log/kube-proxy.log 2>&1
+        - kube-proxy {{kubeconfig}} {{cluster_cidr}} --resource-container="" --oom-score-adj=-998 {{params}} 1>>/var/log/kube-proxy.log 2>&1
         {{container_env}}
         {{kube_cache_mutation_detector_env_name}}
           {{kube_cache_mutation_detector_env_value}}

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -78,7 +78,7 @@ spec:
     command:
     - /bin/sh
     - -c
-    - echo -998 > /proc/$$$/oom_score_adj && kube-proxy {{api_servers_with_port}} {{kubeconfig}} {{cluster_cidr}} --resource-container="" {{params}} 1>>/var/log/kube-proxy.log 2>&1
+    - kube-proxy {{api_servers_with_port}} {{kubeconfig}} {{cluster_cidr}} --resource-container="" --oom-score-adj=-998 {{params}} 1>>/var/log/kube-proxy.log 2>&1
     {{container_env}}
     {{kube_cache_mutation_detector_env_name}}
       {{kube_cache_mutation_detector_env_value}}

--- a/pkg/util/oom/oom_linux.go
+++ b/pkg/util/oom/oom_linux.go
@@ -1,4 +1,4 @@
-// +build cgo,linux
+// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/util/oom/oom_linux_test.go
+++ b/pkg/util/oom/oom_linux_test.go
@@ -1,4 +1,4 @@
-// +build cgo,linux
+// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/util/oom/oom_unsupported.go
+++ b/pkg/util/oom/oom_unsupported.go
@@ -1,4 +1,4 @@
-// +build !cgo !linux
+// +build !linux
 
 /*
 Copyright 2015 The Kubernetes Authors.


### PR DESCRIPTION
**What this PR does / why we need it**:
Replace `echo -998 > /proc/$$$/oom_score_adj` with `--oom-score-adj` flag for kube-proxy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51083

**Special notes for your reviewer**:
/assign @justinsb @vishh 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
