### PR TITLE
Add AddAliasToInstance() to gce cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -18,6 +18,7 @@ package gce
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	"github.com/golang/glog"
+	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
 	compute "google.golang.org/api/compute/v1"
 
@@ -316,6 +318,43 @@ func (gce *GCECloud) AliasRanges(nodeName types.NodeName) (cidrs []string, err e
 		}
 	}
 	return
+}
+
+// AddAliasToInstance adds an alias to the given instance from the named
+// secondary range.
+func (gce *GCECloud) AddAliasToInstance(nodeName types.NodeName, alias *net.IPNet) error {
+
+	v1instance, err := gce.getInstanceByName(mapNodeNameToInstanceName(nodeName))
+	if err != nil {
+		return err
+	}
+	instance, err := gce.serviceAlpha.Instances.Get(gce.projectID, v1instance.Zone, v1instance.Name).Do()
+	if err != nil {
+		return err
+	}
+
+	switch len(instance.NetworkInterfaces) {
+	case 0:
+		return fmt.Errorf("Instance %q has no network interfaces", nodeName)
+	case 1:
+	default:
+		glog.Warningf("Instance %q has more than one network interface, using only the first (%v)",
+			nodeName, instance.NetworkInterfaces)
+	}
+
+	iface := instance.NetworkInterfaces[0]
+	iface.AliasIpRanges = append(iface.AliasIpRanges, &computealpha.AliasIpRange{
+		IpCidrRange:         alias.String(),
+		SubnetworkRangeName: gce.secondaryRangeName,
+	})
+
+	mc := newInstancesMetricContext("addalias", v1instance.Zone)
+	op, err := gce.serviceAlpha.Instances.UpdateNetworkInterface(
+		gce.projectID, instance.Zone, instance.Name, iface.Name, iface).Do()
+	if err != nil {
+		return mc.Observe(err)
+	}
+	return gce.waitForZoneOp(op, v1instance.Zone, mc)
 }
 
 // Gets the named instances, returning cloudprovider.InstanceNotFound if any instance is not found

--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -18,10 +18,11 @@ package gce
 
 import (
 	"encoding/json"
-	"golang.org/x/oauth2/google"
 	"reflect"
 	"strings"
 	"testing"
+
+	"golang.org/x/oauth2/google"
 
 	computealpha "google.golang.org/api/compute/v0.alpha"
 	computebeta "google.golang.org/api/compute/v0.beta"
@@ -268,6 +269,7 @@ type generateConfigParams struct {
 	ProjectID          string
 	NetworkName        string
 	SubnetworkName     string
+	SecondaryRangeName string
 	NodeTags           []string
 	NodeInstancePrefix string
 	Multizone          bool
@@ -283,6 +285,7 @@ func newGenerateConfigDefaults() *generateConfigParams {
 		ProjectID:          "project-id",
 		NetworkName:        "network-name",
 		SubnetworkName:     "",
+		SecondaryRangeName: "",
 		NodeTags:           []string{"node-tag"},
 		NodeInstancePrefix: "node-prefix",
 		Multizone:          false,
@@ -452,6 +455,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 				ProjectID          string   `gcfg:"project-id"`
 				NetworkName        string   `gcfg:"network-name"`
 				SubnetworkName     string   `gcfg:"subnetwork-name"`
+				SecondaryRangeName string   `gcfg:"secondary-range-name"`
 				NodeTags           []string `gcfg:"node-tags"`
 				NodeInstancePrefix string   `gcfg:"node-instance-prefix"`
 				Multizone          bool     `gcfg:"multizone"`
@@ -464,6 +468,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 				ProjectID:          config.ProjectID,
 				NetworkName:        config.NetworkName,
 				SubnetworkName:     config.SubnetworkName,
+				SecondaryRangeName: config.SecondaryRangeName,
 				NodeTags:           config.NodeTags,
 				NodeInstancePrefix: config.NodeInstancePrefix,
 				Multizone:          config.Multizone,
@@ -477,7 +482,7 @@ func TestGenerateCloudConfigs(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(cloudConfig, tc.cloudConfig) {
-			t.Errorf("Expecting cloud config: %v, but got %v", tc.cloudConfig, cloudConfig)
+			t.Errorf("Got %v, want %v", cloudConfig, tc.cloudConfig)
 		}
 	}
 }


### PR DESCRIPTION
- Adds AddAliasToInstance() to the GCE cloud provider.
- Adds field "secondary-range-name" to the gce.conf configuration file.

```release-note
NONE
```