### PR TITLE
Fix swallowed error in registrytest

### DIFF
--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -222,6 +222,9 @@ func (t *Tester) emitObject(obj runtime.Object, action string) error {
 			return err
 		}
 		_, _, err = t.storage.Delete(ctx, accessor.GetName(), nil)
+		if err != nil {
+			return err
+		}
 	default:
 		err = fmt.Errorf("unexpected action: %v", action)
 	}

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -217,14 +217,12 @@ func (t *Tester) emitObject(obj runtime.Object, action string) error {
 	case etcdstorage.EtcdCreate:
 		err = t.createObject(ctx, obj)
 	case etcdstorage.EtcdDelete:
-		accessor, err := meta.Accessor(obj)
+		var accessor metav1.Object
+		accessor, err = meta.Accessor(obj)
 		if err != nil {
 			return err
 		}
 		_, _, err = t.storage.Delete(ctx, accessor.GetName(), nil)
-		if err != nil {
-			return err
-		}
 	default:
 		err = fmt.Errorf("unexpected action: %v", action)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a swallowed error in the registrytest package.

```release-note NONE
```
