### PR TITLE
Add options to sharedinformers to include uninitialized objects

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -121,6 +121,7 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/leaderelection:go_default_library",
         "//vendor/k8s.io/client-go/tools/leaderelection/resourcelock:go_default_library",

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/record"
 	certutil "k8s.io/client-go/util/cert"
@@ -397,7 +398,11 @@ func GetAvailableResources(clientBuilder controller.ControllerClientBuilder) (ma
 
 func CreateControllerContext(s *options.CMServer, rootClientBuilder, clientBuilder controller.ControllerClientBuilder, stop <-chan struct{}) (ControllerContext, error) {
 	versionedClient := rootClientBuilder.ClientOrDie("shared-informers")
-	sharedInformers := informers.NewSharedInformerFactory(versionedClient, ResyncPeriod(s)())
+	options := cache.SharedInformerOptions{
+		IncludeUninitialized: true,
+		ResyncPeriod:         ResyncPeriod(s)(),
+	}
+	sharedInformers := informers.NewSharedInformerFactoryWithOptions(versionedClient, options)
 
 	availableResources, err := GetAvailableResources(rootClientBuilder)
 	if err != nil {

--- a/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -60,8 +60,27 @@ func NewExternalAdmissionHookConfigurationInformer(client internalclientset.Inte
 	)
 }
 
-func defaultExternalAdmissionHookConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewExternalAdmissionHookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewExternalAdmissionHookConfigurationInformerWithOptions constructs a new informer for ExternalAdmissionHookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewExternalAdmissionHookConfigurationInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Admissionregistration().ExternalAdmissionHookConfigurations().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Admissionregistration().ExternalAdmissionHookConfigurations().Watch(options)
+			},
+		},
+		options,
+		&admissionregistration.ExternalAdmissionHookConfiguration{},
+		indexers,
+	)
+}
+
+func defaultExternalAdmissionHookConfigurationInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewExternalAdmissionHookConfigurationInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/informers/informers_generated/internalversion/admissionregistration/internalversion/initializerconfiguration.go
@@ -60,8 +60,27 @@ func NewInitializerConfigurationInformer(client internalclientset.Interface, res
 	)
 }
 
-func defaultInitializerConfigurationInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewInitializerConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewInitializerConfigurationInformerWithOptions constructs a new informer for InitializerConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewInitializerConfigurationInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Admissionregistration().InitializerConfigurations().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Admissionregistration().InitializerConfigurations().Watch(options)
+			},
+		},
+		options,
+		&admissionregistration.InitializerConfiguration{},
+		indexers,
+	)
+}
+
+func defaultInitializerConfigurationInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewInitializerConfigurationInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *initializerConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/batch/internalversion/cronjob.go
+++ b/pkg/client/informers/informers_generated/internalversion/batch/internalversion/cronjob.go
@@ -60,8 +60,27 @@ func NewCronJobInformer(client internalclientset.Interface, namespace string, re
 	)
 }
 
-func defaultCronJobInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCronJobInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewCronJobInformerWithOptions constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCronJobInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Batch().CronJobs(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Batch().CronJobs(namespace).Watch(options)
+			},
+		},
+		options,
+		&batch.CronJob{},
+		indexers,
+	)
+}
+
+func defaultCronJobInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewCronJobInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/informers/informers_generated/internalversion/certificates/internalversion/certificatesigningrequest.go
@@ -60,8 +60,27 @@ func NewCertificateSigningRequestInformer(client internalclientset.Interface, re
 	)
 }
 
-func defaultCertificateSigningRequestInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCertificateSigningRequestInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewCertificateSigningRequestInformerWithOptions constructs a new informer for CertificateSigningRequest type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCertificateSigningRequestInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Certificates().CertificateSigningRequests().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Certificates().CertificateSigningRequests().Watch(options)
+			},
+		},
+		options,
+		&certificates.CertificateSigningRequest{},
+		indexers,
+	)
+}
+
+func defaultCertificateSigningRequestInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewCertificateSigningRequestInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *certificateSigningRequestInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/endpoints.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/endpoints.go
@@ -60,8 +60,27 @@ func NewEndpointsInformer(client internalclientset.Interface, namespace string, 
 	)
 }
 
-func defaultEndpointsInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEndpointsInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewEndpointsInformerWithOptions constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEndpointsInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().Endpoints(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().Endpoints(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.Endpoints{},
+		indexers,
+	)
+}
+
+func defaultEndpointsInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewEndpointsInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *endpointsInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/limitrange.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/limitrange.go
@@ -60,8 +60,27 @@ func NewLimitRangeInformer(client internalclientset.Interface, namespace string,
 	)
 }
 
-func defaultLimitRangeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLimitRangeInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewLimitRangeInformerWithOptions constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewLimitRangeInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().LimitRanges(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().LimitRanges(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.LimitRange{},
+		indexers,
+	)
+}
+
+func defaultLimitRangeInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewLimitRangeInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/namespace.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/namespace.go
@@ -60,8 +60,27 @@ func NewNamespaceInformer(client internalclientset.Interface, resyncPeriod time.
 	)
 }
 
-func defaultNamespaceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNamespaceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewNamespaceInformerWithOptions constructs a new informer for Namespace type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNamespaceInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().Namespaces().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().Namespaces().Watch(options)
+			},
+		},
+		options,
+		&api.Namespace{},
+		indexers,
+	)
+}
+
+func defaultNamespaceInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewNamespaceInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *namespaceInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/node.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/node.go
@@ -60,8 +60,27 @@ func NewNodeInformer(client internalclientset.Interface, resyncPeriod time.Durat
 	)
 }
 
-func defaultNodeInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewNodeInformerWithOptions constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNodeInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().Nodes().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().Nodes().Watch(options)
+			},
+		},
+		options,
+		&api.Node{},
+		indexers,
+	)
+}
+
+func defaultNodeInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewNodeInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/persistentvolumeclaim.go
@@ -60,8 +60,27 @@ func NewPersistentVolumeClaimInformer(client internalclientset.Interface, namesp
 	)
 }
 
-func defaultPersistentVolumeClaimInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPersistentVolumeClaimInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPersistentVolumeClaimInformerWithOptions constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeClaimInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().PersistentVolumeClaims(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().PersistentVolumeClaims(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.PersistentVolumeClaim{},
+		indexers,
+	)
+}
+
+func defaultPersistentVolumeClaimInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPersistentVolumeClaimInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/podtemplate.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/podtemplate.go
@@ -60,8 +60,27 @@ func NewPodTemplateInformer(client internalclientset.Interface, namespace string
 	)
 }
 
-func defaultPodTemplateInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodTemplateInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodTemplateInformerWithOptions constructs a new informer for PodTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodTemplateInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().PodTemplates(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().PodTemplates(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.PodTemplate{},
+		indexers,
+	)
+}
+
+func defaultPodTemplateInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodTemplateInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/replicationcontroller.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/replicationcontroller.go
@@ -60,8 +60,27 @@ func NewReplicationControllerInformer(client internalclientset.Interface, namesp
 	)
 }
 
-func defaultReplicationControllerInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicationControllerInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewReplicationControllerInformerWithOptions constructs a new informer for ReplicationController type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewReplicationControllerInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().ReplicationControllers(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().ReplicationControllers(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.ReplicationController{},
+		indexers,
+	)
+}
+
+func defaultReplicationControllerInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewReplicationControllerInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *replicationControllerInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/service.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/service.go
@@ -60,8 +60,27 @@ func NewServiceInformer(client internalclientset.Interface, namespace string, re
 	)
 }
 
-func defaultServiceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewServiceInformerWithOptions constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().Services(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().Services(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.Service{},
+		indexers,
+	)
+}
+
+func defaultServiceInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewServiceInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/core/internalversion/serviceaccount.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/internalversion/serviceaccount.go
@@ -60,8 +60,27 @@ func NewServiceAccountInformer(client internalclientset.Interface, namespace str
 	)
 }
 
-func defaultServiceAccountInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceAccountInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewServiceAccountInformerWithOptions constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceAccountInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Core().ServiceAccounts(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Core().ServiceAccounts(namespace).Watch(options)
+			},
+		},
+		options,
+		&api.ServiceAccount{},
+		indexers,
+	)
+}
+
+func defaultServiceAccountInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewServiceAccountInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceAccountInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/daemonset.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/daemonset.go
@@ -60,8 +60,27 @@ func NewDaemonSetInformer(client internalclientset.Interface, namespace string, 
 	)
 }
 
-func defaultDaemonSetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDaemonSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDaemonSetInformerWithOptions constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDaemonSetInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Extensions().DaemonSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Extensions().DaemonSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&extensions.DaemonSet{},
+		indexers,
+	)
+}
+
+func defaultDaemonSetInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDaemonSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/deployment.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/deployment.go
@@ -60,8 +60,27 @@ func NewDeploymentInformer(client internalclientset.Interface, namespace string,
 	)
 }
 
-func defaultDeploymentInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDeploymentInformerWithOptions constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Extensions().Deployments(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Extensions().Deployments(namespace).Watch(options)
+			},
+		},
+		options,
+		&extensions.Deployment{},
+		indexers,
+	)
+}
+
+func defaultDeploymentInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDeploymentInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/ingress.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/ingress.go
@@ -60,8 +60,27 @@ func NewIngressInformer(client internalclientset.Interface, namespace string, re
 	)
 }
 
-func defaultIngressInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewIngressInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewIngressInformerWithOptions constructs a new informer for Ingress type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewIngressInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Extensions().Ingresses(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Extensions().Ingresses(namespace).Watch(options)
+			},
+		},
+		options,
+		&extensions.Ingress{},
+		indexers,
+	)
+}
+
+func defaultIngressInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewIngressInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *ingressInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/internalversion/thirdpartyresource.go
@@ -60,8 +60,27 @@ func NewThirdPartyResourceInformer(client internalclientset.Interface, resyncPer
 	)
 }
 
-func defaultThirdPartyResourceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewThirdPartyResourceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewThirdPartyResourceInformerWithOptions constructs a new informer for ThirdPartyResource type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewThirdPartyResourceInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Extensions().ThirdPartyResources().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Extensions().ThirdPartyResources().Watch(options)
+			},
+		},
+		options,
+		&extensions.ThirdPartyResource{},
+		indexers,
+	)
+}
+
+func defaultThirdPartyResourceInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewThirdPartyResourceInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *thirdPartyResourceInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/factory.go
+++ b/pkg/client/informers/informers_generated/internalversion/factory.go
@@ -43,9 +43,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        internalclientset.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  internalclientset.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -57,7 +57,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client internalclientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -109,7 +120,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/pkg/client/informers/informers_generated/internalversion/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/informers_generated/internalversion/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	internalclientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	time "time"
 )
 
-type NewInformerFunc func(internalclientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(internalclientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/pkg/client/informers/informers_generated/internalversion/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/informers/informers_generated/internalversion/policy/internalversion/poddisruptionbudget.go
@@ -60,8 +60,27 @@ func NewPodDisruptionBudgetInformer(client internalclientset.Interface, namespac
 	)
 }
 
-func defaultPodDisruptionBudgetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodDisruptionBudgetInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Policy().PodDisruptionBudgets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Policy().PodDisruptionBudgets(namespace).Watch(options)
+			},
+		},
+		options,
+		&policy.PodDisruptionBudget{},
+		indexers,
+	)
+}
+
+func defaultPodDisruptionBudgetInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodDisruptionBudgetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrole.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrole.go
@@ -60,8 +60,27 @@ func NewClusterRoleInformer(client internalclientset.Interface, resyncPeriod tim
 	)
 }
 
-func defaultClusterRoleInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Rbac().ClusterRoles().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Rbac().ClusterRoles().Watch(options)
+			},
+		},
+		options,
+		&rbac.ClusterRole{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/clusterrolebinding.go
@@ -60,8 +60,27 @@ func NewClusterRoleBindingInformer(client internalclientset.Interface, resyncPer
 	)
 }
 
-func defaultClusterRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleBindingInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Rbac().ClusterRoleBindings().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Rbac().ClusterRoleBindings().Watch(options)
+			},
+		},
+		options,
+		&rbac.ClusterRoleBinding{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleBindingInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleBindingInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/rolebinding.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/internalversion/rolebinding.go
@@ -60,8 +60,27 @@ func NewRoleBindingInformer(client internalclientset.Interface, namespace string
 	)
 }
 
-func defaultRoleBindingInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleBindingInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Rbac().RoleBindings(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Rbac().RoleBindings(namespace).Watch(options)
+			},
+		},
+		options,
+		&rbac.RoleBinding{},
+		indexers,
+	)
+}
+
+func defaultRoleBindingInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewRoleBindingInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/scheduling/internalversion/priorityclass.go
+++ b/pkg/client/informers/informers_generated/internalversion/scheduling/internalversion/priorityclass.go
@@ -60,8 +60,27 @@ func NewPriorityClassInformer(client internalclientset.Interface, resyncPeriod t
 	)
 }
 
-func defaultPriorityClassInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPriorityClassInformerWithOptions constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPriorityClassInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Scheduling().PriorityClasses().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Scheduling().PriorityClasses().Watch(options)
+			},
+		},
+		options,
+		&scheduling.PriorityClass{},
+		indexers,
+	)
+}
+
+func defaultPriorityClassInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPriorityClassInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/informers/informers_generated/internalversion/settings/internalversion/podpreset.go
+++ b/pkg/client/informers/informers_generated/internalversion/settings/internalversion/podpreset.go
@@ -60,8 +60,27 @@ func NewPodPresetInformer(client internalclientset.Interface, namespace string, 
 	)
 }
 
-func defaultPodPresetInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodPresetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodPresetInformerWithOptions constructs a new informer for PodPreset type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodPresetInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Settings().PodPresets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Settings().PodPresets(namespace).Watch(options)
+			},
+		},
+		options,
+		&settings.PodPreset{},
+		indexers,
+	)
+}
+
+func defaultPodPresetInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodPresetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podPresetInformer) Informer() cache.SharedIndexInformer {

--- a/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ExternalAdmissionHookConfigurationLister interface {
 	// List lists all ExternalAdmissionHookConfigurations in the indexer.
 	List(selector labels.Selector) (ret []*admissionregistration.ExternalAdmissionHookConfiguration, err error)
+	// ListWithOptions lists all ExternalAdmissionHookConfigurations in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*admissionregistration.ExternalAdmissionHookConfiguration, err error)
 	// Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 	Get(name string) (*admissionregistration.ExternalAdmissionHookConfiguration, error)
 	ExternalAdmissionHookConfigurationListerExpansion
@@ -48,6 +52,15 @@ func NewExternalAdmissionHookConfigurationLister(indexer cache.Indexer) External
 // List lists all ExternalAdmissionHookConfigurations in the indexer.
 func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector) (ret []*admissionregistration.ExternalAdmissionHookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*admissionregistration.ExternalAdmissionHookConfiguration))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ExternalAdmissionHookConfigurations in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *externalAdmissionHookConfigurationLister) ListWithOptions(options metav1.ListOptions) (ret []*admissionregistration.ExternalAdmissionHookConfiguration, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*admissionregistration.ExternalAdmissionHookConfiguration))
 	})
 	return ret, err

--- a/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type InitializerConfigurationLister interface {
 	// List lists all InitializerConfigurations in the indexer.
 	List(selector labels.Selector) (ret []*admissionregistration.InitializerConfiguration, err error)
+	// ListWithOptions lists all InitializerConfigurations in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*admissionregistration.InitializerConfiguration, err error)
 	// Get retrieves the InitializerConfiguration from the index for a given name.
 	Get(name string) (*admissionregistration.InitializerConfiguration, error)
 	InitializerConfigurationListerExpansion
@@ -48,6 +52,15 @@ func NewInitializerConfigurationLister(indexer cache.Indexer) InitializerConfigu
 // List lists all InitializerConfigurations in the indexer.
 func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*admissionregistration.InitializerConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*admissionregistration.InitializerConfiguration))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all InitializerConfigurations in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *initializerConfigurationLister) ListWithOptions(options metav1.ListOptions) (ret []*admissionregistration.InitializerConfiguration, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*admissionregistration.InitializerConfiguration))
 	})
 	return ret, err

--- a/pkg/client/listers/authentication/internalversion/tokenreview.go
+++ b/pkg/client/listers/authentication/internalversion/tokenreview.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type TokenReviewLister interface {
 	// List lists all TokenReviews in the indexer.
 	List(selector labels.Selector) (ret []*authentication.TokenReview, err error)
+	// ListWithOptions lists all TokenReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*authentication.TokenReview, err error)
 	// Get retrieves the TokenReview from the index for a given name.
 	Get(name string) (*authentication.TokenReview, error)
 	TokenReviewListerExpansion
@@ -48,6 +52,15 @@ func NewTokenReviewLister(indexer cache.Indexer) TokenReviewLister {
 // List lists all TokenReviews in the indexer.
 func (s *tokenReviewLister) List(selector labels.Selector) (ret []*authentication.TokenReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*authentication.TokenReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all TokenReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *tokenReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*authentication.TokenReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*authentication.TokenReview))
 	})
 	return ret, err

--- a/pkg/client/listers/authorization/internalversion/localsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/localsubjectaccessreview.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -29,6 +30,9 @@ import (
 type LocalSubjectAccessReviewLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*authorization.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*authorization.LocalSubjectAccessReview, err error)
 	// LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister
 	LocalSubjectAccessReviewListerExpansion
@@ -52,6 +56,15 @@ func (s *localSubjectAccessReviewLister) List(selector labels.Selector) (ret []*
 	return ret, err
 }
 
+// ListWithOptions lists all LocalSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *localSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*authorization.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*authorization.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
 // LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister {
 	return localSubjectAccessReviewNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace str
 type LocalSubjectAccessReviewNamespaceLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*authorization.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*authorization.LocalSubjectAccessReview, err error)
 	// Get retrieves the LocalSubjectAccessReview from the indexer for a given namespace and name.
 	Get(name string) (*authorization.LocalSubjectAccessReview, error)
 	LocalSubjectAccessReviewNamespaceListerExpansion
@@ -76,6 +93,15 @@ type localSubjectAccessReviewNamespaceLister struct {
 // List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 func (s localSubjectAccessReviewNamespaceLister) List(selector labels.Selector) (ret []*authorization.LocalSubjectAccessReview, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*authorization.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+// in the indexer for a given namespace.
+func (s localSubjectAccessReviewNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*authorization.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*authorization.LocalSubjectAccessReview))
 	})
 	return ret, err

--- a/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type SelfSubjectAccessReviewLister interface {
 	// List lists all SelfSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*authorization.SelfSubjectAccessReview, err error)
+	// ListWithOptions lists all SelfSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*authorization.SelfSubjectAccessReview, err error)
 	// Get retrieves the SelfSubjectAccessReview from the index for a given name.
 	Get(name string) (*authorization.SelfSubjectAccessReview, error)
 	SelfSubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSelfSubjectAccessReviewLister(indexer cache.Indexer) SelfSubjectAccessRe
 // List lists all SelfSubjectAccessReviews in the indexer.
 func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*authorization.SelfSubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*authorization.SelfSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SelfSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *selfSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*authorization.SelfSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*authorization.SelfSubjectAccessReview))
 	})
 	return ret, err

--- a/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type SubjectAccessReviewLister interface {
 	// List lists all SubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*authorization.SubjectAccessReview, err error)
+	// ListWithOptions lists all SubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*authorization.SubjectAccessReview, err error)
 	// Get retrieves the SubjectAccessReview from the index for a given name.
 	Get(name string) (*authorization.SubjectAccessReview, error)
 	SubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSubjectAccessReviewLister(indexer cache.Indexer) SubjectAccessReviewList
 // List lists all SubjectAccessReviews in the indexer.
 func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*authorization.SubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*authorization.SubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *subjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*authorization.SubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*authorization.SubjectAccessReview))
 	})
 	return ret, err

--- a/pkg/client/listers/autoscaling/internalversion/BUILD
+++ b/pkg/client/listers/autoscaling/internalversion/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apis/autoscaling:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/autoscaling/internalversion/horizontalpodautoscaler.go
+++ b/pkg/client/listers/autoscaling/internalversion/horizontalpodautoscaler.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
@@ -29,6 +30,9 @@ import (
 type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	List(selector labels.Selector) (ret []*autoscaling.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*autoscaling.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -52,6 +56,15 @@ func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*a
 	return ret, err
 }
 
+// ListWithOptions lists all HorizontalPodAutoscalers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *horizontalPodAutoscalerLister) ListWithOptions(options metav1.ListOptions) (ret []*autoscaling.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*autoscaling.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
 // HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister {
 	return horizontalPodAutoscalerNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace strin
 type HorizontalPodAutoscalerNamespaceLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*autoscaling.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*autoscaling.HorizontalPodAutoscaler, err error)
 	// Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 	Get(name string) (*autoscaling.HorizontalPodAutoscaler, error)
 	HorizontalPodAutoscalerNamespaceListerExpansion
@@ -76,6 +93,15 @@ type horizontalPodAutoscalerNamespaceLister struct {
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*autoscaling.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*autoscaling.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+// in the indexer for a given namespace.
+func (s horizontalPodAutoscalerNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*autoscaling.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*autoscaling.HorizontalPodAutoscaler))
 	})
 	return ret, err

--- a/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type CertificateSigningRequestLister interface {
 	// List lists all CertificateSigningRequests in the indexer.
 	List(selector labels.Selector) (ret []*certificates.CertificateSigningRequest, err error)
+	// ListWithOptions lists all CertificateSigningRequests in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*certificates.CertificateSigningRequest, err error)
 	// Get retrieves the CertificateSigningRequest from the index for a given name.
 	Get(name string) (*certificates.CertificateSigningRequest, error)
 	CertificateSigningRequestListerExpansion
@@ -48,6 +52,15 @@ func NewCertificateSigningRequestLister(indexer cache.Indexer) CertificateSignin
 // List lists all CertificateSigningRequests in the indexer.
 func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []*certificates.CertificateSigningRequest, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*certificates.CertificateSigningRequest))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CertificateSigningRequests in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *certificateSigningRequestLister) ListWithOptions(options metav1.ListOptions) (ret []*certificates.CertificateSigningRequest, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*certificates.CertificateSigningRequest))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/componentstatus.go
+++ b/pkg/client/listers/core/internalversion/componentstatus.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ComponentStatusLister interface {
 	// List lists all ComponentStatuses in the indexer.
 	List(selector labels.Selector) (ret []*api.ComponentStatus, err error)
+	// ListWithOptions lists all ComponentStatuses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ComponentStatus, err error)
 	// Get retrieves the ComponentStatus from the index for a given name.
 	Get(name string) (*api.ComponentStatus, error)
 	ComponentStatusListerExpansion
@@ -48,6 +52,15 @@ func NewComponentStatusLister(indexer cache.Indexer) ComponentStatusLister {
 // List lists all ComponentStatuses in the indexer.
 func (s *componentStatusLister) List(selector labels.Selector) (ret []*api.ComponentStatus, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.ComponentStatus))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ComponentStatuses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *componentStatusLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ComponentStatus, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*api.ComponentStatus))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/configmap.go
+++ b/pkg/client/listers/core/internalversion/configmap.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type ConfigMapLister interface {
 	// List lists all ConfigMaps in the indexer.
 	List(selector labels.Selector) (ret []*api.ConfigMap, err error)
+	// ListWithOptions lists all ConfigMaps in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ConfigMap, err error)
 	// ConfigMaps returns an object that can list and get ConfigMaps.
 	ConfigMaps(namespace string) ConfigMapNamespaceLister
 	ConfigMapListerExpansion
@@ -52,6 +56,15 @@ func (s *configMapLister) List(selector labels.Selector) (ret []*api.ConfigMap, 
 	return ret, err
 }
 
+// ListWithOptions lists all ConfigMaps in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *configMapLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ConfigMap, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.ConfigMap))
+	})
+	return ret, err
+}
+
 // ConfigMaps returns an object that can list and get ConfigMaps.
 func (s *configMapLister) ConfigMaps(namespace string) ConfigMapNamespaceLister {
 	return configMapNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *configMapLister) ConfigMaps(namespace string) ConfigMapNamespaceLister 
 type ConfigMapNamespaceLister interface {
 	// List lists all ConfigMaps in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.ConfigMap, err error)
+	// ListWithOptions lists all ConfigMaps that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ConfigMap, err error)
 	// Get retrieves the ConfigMap from the indexer for a given namespace and name.
 	Get(name string) (*api.ConfigMap, error)
 	ConfigMapNamespaceListerExpansion
@@ -76,6 +93,15 @@ type configMapNamespaceLister struct {
 // List lists all ConfigMaps in the indexer for a given namespace.
 func (s configMapNamespaceLister) List(selector labels.Selector) (ret []*api.ConfigMap, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.ConfigMap))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ConfigMaps that matches the options
+// in the indexer for a given namespace.
+func (s configMapNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ConfigMap, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.ConfigMap))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/event.go
+++ b/pkg/client/listers/core/internalversion/event.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type EventLister interface {
 	// List lists all Events in the indexer.
 	List(selector labels.Selector) (ret []*api.Event, err error)
+	// ListWithOptions lists all Events in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Event, err error)
 	// Events returns an object that can list and get Events.
 	Events(namespace string) EventNamespaceLister
 	EventListerExpansion
@@ -52,6 +56,15 @@ func (s *eventLister) List(selector labels.Selector) (ret []*api.Event, err erro
 	return ret, err
 }
 
+// ListWithOptions lists all Events in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *eventLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Event, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.Event))
+	})
+	return ret, err
+}
+
 // Events returns an object that can list and get Events.
 func (s *eventLister) Events(namespace string) EventNamespaceLister {
 	return eventNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *eventLister) Events(namespace string) EventNamespaceLister {
 type EventNamespaceLister interface {
 	// List lists all Events in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.Event, err error)
+	// ListWithOptions lists all Events that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Event, err error)
 	// Get retrieves the Event from the indexer for a given namespace and name.
 	Get(name string) (*api.Event, error)
 	EventNamespaceListerExpansion
@@ -76,6 +93,15 @@ type eventNamespaceLister struct {
 // List lists all Events in the indexer for a given namespace.
 func (s eventNamespaceLister) List(selector labels.Selector) (ret []*api.Event, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.Event))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Events that matches the options
+// in the indexer for a given namespace.
+func (s eventNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Event, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.Event))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/limitrange.go
+++ b/pkg/client/listers/core/internalversion/limitrange.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type LimitRangeLister interface {
 	// List lists all LimitRanges in the indexer.
 	List(selector labels.Selector) (ret []*api.LimitRange, err error)
+	// ListWithOptions lists all LimitRanges in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.LimitRange, err error)
 	// LimitRanges returns an object that can list and get LimitRanges.
 	LimitRanges(namespace string) LimitRangeNamespaceLister
 	LimitRangeListerExpansion
@@ -52,6 +56,15 @@ func (s *limitRangeLister) List(selector labels.Selector) (ret []*api.LimitRange
 	return ret, err
 }
 
+// ListWithOptions lists all LimitRanges in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *limitRangeLister) ListWithOptions(options metav1.ListOptions) (ret []*api.LimitRange, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.LimitRange))
+	})
+	return ret, err
+}
+
 // LimitRanges returns an object that can list and get LimitRanges.
 func (s *limitRangeLister) LimitRanges(namespace string) LimitRangeNamespaceLister {
 	return limitRangeNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *limitRangeLister) LimitRanges(namespace string) LimitRangeNamespaceList
 type LimitRangeNamespaceLister interface {
 	// List lists all LimitRanges in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.LimitRange, err error)
+	// ListWithOptions lists all LimitRanges that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.LimitRange, err error)
 	// Get retrieves the LimitRange from the indexer for a given namespace and name.
 	Get(name string) (*api.LimitRange, error)
 	LimitRangeNamespaceListerExpansion
@@ -76,6 +93,15 @@ type limitRangeNamespaceLister struct {
 // List lists all LimitRanges in the indexer for a given namespace.
 func (s limitRangeNamespaceLister) List(selector labels.Selector) (ret []*api.LimitRange, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.LimitRange))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all LimitRanges that matches the options
+// in the indexer for a given namespace.
+func (s limitRangeNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.LimitRange, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.LimitRange))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/namespace.go
+++ b/pkg/client/listers/core/internalversion/namespace.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type NamespaceLister interface {
 	// List lists all Namespaces in the indexer.
 	List(selector labels.Selector) (ret []*api.Namespace, err error)
+	// ListWithOptions lists all Namespaces in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Namespace, err error)
 	// Get retrieves the Namespace from the index for a given name.
 	Get(name string) (*api.Namespace, error)
 	NamespaceListerExpansion
@@ -48,6 +52,15 @@ func NewNamespaceLister(indexer cache.Indexer) NamespaceLister {
 // List lists all Namespaces in the indexer.
 func (s *namespaceLister) List(selector labels.Selector) (ret []*api.Namespace, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.Namespace))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Namespaces in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *namespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Namespace, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*api.Namespace))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/node.go
+++ b/pkg/client/listers/core/internalversion/node.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type NodeLister interface {
 	// List lists all Nodes in the indexer.
 	List(selector labels.Selector) (ret []*api.Node, err error)
+	// ListWithOptions lists all Nodes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Node, err error)
 	// Get retrieves the Node from the index for a given name.
 	Get(name string) (*api.Node, error)
 	NodeListerExpansion
@@ -48,6 +52,15 @@ func NewNodeLister(indexer cache.Indexer) NodeLister {
 // List lists all Nodes in the indexer.
 func (s *nodeLister) List(selector labels.Selector) (ret []*api.Node, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.Node))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Nodes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *nodeLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Node, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*api.Node))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/persistentvolume.go
+++ b/pkg/client/listers/core/internalversion/persistentvolume.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type PersistentVolumeLister interface {
 	// List lists all PersistentVolumes in the indexer.
 	List(selector labels.Selector) (ret []*api.PersistentVolume, err error)
+	// ListWithOptions lists all PersistentVolumes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolume, err error)
 	// Get retrieves the PersistentVolume from the index for a given name.
 	Get(name string) (*api.PersistentVolume, error)
 	PersistentVolumeListerExpansion
@@ -48,6 +52,15 @@ func NewPersistentVolumeLister(indexer cache.Indexer) PersistentVolumeLister {
 // List lists all PersistentVolumes in the indexer.
 func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*api.PersistentVolume, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.PersistentVolume))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PersistentVolumes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *persistentVolumeLister) ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolume, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*api.PersistentVolume))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/persistentvolumeclaim.go
+++ b/pkg/client/listers/core/internalversion/persistentvolumeclaim.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type PersistentVolumeClaimLister interface {
 	// List lists all PersistentVolumeClaims in the indexer.
 	List(selector labels.Selector) (ret []*api.PersistentVolumeClaim, err error)
+	// ListWithOptions lists all PersistentVolumeClaims in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolumeClaim, err error)
 	// PersistentVolumeClaims returns an object that can list and get PersistentVolumeClaims.
 	PersistentVolumeClaims(namespace string) PersistentVolumeClaimNamespaceLister
 	PersistentVolumeClaimListerExpansion
@@ -52,6 +56,15 @@ func (s *persistentVolumeClaimLister) List(selector labels.Selector) (ret []*api
 	return ret, err
 }
 
+// ListWithOptions lists all PersistentVolumeClaims in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *persistentVolumeClaimLister) ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolumeClaim, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.PersistentVolumeClaim))
+	})
+	return ret, err
+}
+
 // PersistentVolumeClaims returns an object that can list and get PersistentVolumeClaims.
 func (s *persistentVolumeClaimLister) PersistentVolumeClaims(namespace string) PersistentVolumeClaimNamespaceLister {
 	return persistentVolumeClaimNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *persistentVolumeClaimLister) PersistentVolumeClaims(namespace string) P
 type PersistentVolumeClaimNamespaceLister interface {
 	// List lists all PersistentVolumeClaims in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.PersistentVolumeClaim, err error)
+	// ListWithOptions lists all PersistentVolumeClaims that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolumeClaim, err error)
 	// Get retrieves the PersistentVolumeClaim from the indexer for a given namespace and name.
 	Get(name string) (*api.PersistentVolumeClaim, error)
 	PersistentVolumeClaimNamespaceListerExpansion
@@ -76,6 +93,15 @@ type persistentVolumeClaimNamespaceLister struct {
 // List lists all PersistentVolumeClaims in the indexer for a given namespace.
 func (s persistentVolumeClaimNamespaceLister) List(selector labels.Selector) (ret []*api.PersistentVolumeClaim, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.PersistentVolumeClaim))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PersistentVolumeClaims that matches the options
+// in the indexer for a given namespace.
+func (s persistentVolumeClaimNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.PersistentVolumeClaim, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.PersistentVolumeClaim))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/pod.go
+++ b/pkg/client/listers/core/internalversion/pod.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type PodLister interface {
 	// List lists all Pods in the indexer.
 	List(selector labels.Selector) (ret []*api.Pod, err error)
+	// ListWithOptions lists all Pods in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Pod, err error)
 	// Pods returns an object that can list and get Pods.
 	Pods(namespace string) PodNamespaceLister
 	PodListerExpansion
@@ -52,6 +56,15 @@ func (s *podLister) List(selector labels.Selector) (ret []*api.Pod, err error) {
 	return ret, err
 }
 
+// ListWithOptions lists all Pods in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Pod, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.Pod))
+	})
+	return ret, err
+}
+
 // Pods returns an object that can list and get Pods.
 func (s *podLister) Pods(namespace string) PodNamespaceLister {
 	return podNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podLister) Pods(namespace string) PodNamespaceLister {
 type PodNamespaceLister interface {
 	// List lists all Pods in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.Pod, err error)
+	// ListWithOptions lists all Pods that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.Pod, err error)
 	// Get retrieves the Pod from the indexer for a given namespace and name.
 	Get(name string) (*api.Pod, error)
 	PodNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podNamespaceLister struct {
 // List lists all Pods in the indexer for a given namespace.
 func (s podNamespaceLister) List(selector labels.Selector) (ret []*api.Pod, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.Pod))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Pods that matches the options
+// in the indexer for a given namespace.
+func (s podNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.Pod, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.Pod))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/podtemplate.go
+++ b/pkg/client/listers/core/internalversion/podtemplate.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type PodTemplateLister interface {
 	// List lists all PodTemplates in the indexer.
 	List(selector labels.Selector) (ret []*api.PodTemplate, err error)
+	// ListWithOptions lists all PodTemplates in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.PodTemplate, err error)
 	// PodTemplates returns an object that can list and get PodTemplates.
 	PodTemplates(namespace string) PodTemplateNamespaceLister
 	PodTemplateListerExpansion
@@ -52,6 +56,15 @@ func (s *podTemplateLister) List(selector labels.Selector) (ret []*api.PodTempla
 	return ret, err
 }
 
+// ListWithOptions lists all PodTemplates in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podTemplateLister) ListWithOptions(options metav1.ListOptions) (ret []*api.PodTemplate, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.PodTemplate))
+	})
+	return ret, err
+}
+
 // PodTemplates returns an object that can list and get PodTemplates.
 func (s *podTemplateLister) PodTemplates(namespace string) PodTemplateNamespaceLister {
 	return podTemplateNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podTemplateLister) PodTemplates(namespace string) PodTemplateNamespaceL
 type PodTemplateNamespaceLister interface {
 	// List lists all PodTemplates in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.PodTemplate, err error)
+	// ListWithOptions lists all PodTemplates that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.PodTemplate, err error)
 	// Get retrieves the PodTemplate from the indexer for a given namespace and name.
 	Get(name string) (*api.PodTemplate, error)
 	PodTemplateNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podTemplateNamespaceLister struct {
 // List lists all PodTemplates in the indexer for a given namespace.
 func (s podTemplateNamespaceLister) List(selector labels.Selector) (ret []*api.PodTemplate, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.PodTemplate))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodTemplates that matches the options
+// in the indexer for a given namespace.
+func (s podTemplateNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.PodTemplate, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.PodTemplate))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/replicationcontroller.go
+++ b/pkg/client/listers/core/internalversion/replicationcontroller.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type ReplicationControllerLister interface {
 	// List lists all ReplicationControllers in the indexer.
 	List(selector labels.Selector) (ret []*api.ReplicationController, err error)
+	// ListWithOptions lists all ReplicationControllers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ReplicationController, err error)
 	// ReplicationControllers returns an object that can list and get ReplicationControllers.
 	ReplicationControllers(namespace string) ReplicationControllerNamespaceLister
 	ReplicationControllerListerExpansion
@@ -52,6 +56,15 @@ func (s *replicationControllerLister) List(selector labels.Selector) (ret []*api
 	return ret, err
 }
 
+// ListWithOptions lists all ReplicationControllers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *replicationControllerLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ReplicationController, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.ReplicationController))
+	})
+	return ret, err
+}
+
 // ReplicationControllers returns an object that can list and get ReplicationControllers.
 func (s *replicationControllerLister) ReplicationControllers(namespace string) ReplicationControllerNamespaceLister {
 	return replicationControllerNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *replicationControllerLister) ReplicationControllers(namespace string) R
 type ReplicationControllerNamespaceLister interface {
 	// List lists all ReplicationControllers in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.ReplicationController, err error)
+	// ListWithOptions lists all ReplicationControllers that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ReplicationController, err error)
 	// Get retrieves the ReplicationController from the indexer for a given namespace and name.
 	Get(name string) (*api.ReplicationController, error)
 	ReplicationControllerNamespaceListerExpansion
@@ -76,6 +93,15 @@ type replicationControllerNamespaceLister struct {
 // List lists all ReplicationControllers in the indexer for a given namespace.
 func (s replicationControllerNamespaceLister) List(selector labels.Selector) (ret []*api.ReplicationController, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.ReplicationController))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ReplicationControllers that matches the options
+// in the indexer for a given namespace.
+func (s replicationControllerNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ReplicationController, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.ReplicationController))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/resourcequota.go
+++ b/pkg/client/listers/core/internalversion/resourcequota.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type ResourceQuotaLister interface {
 	// List lists all ResourceQuotas in the indexer.
 	List(selector labels.Selector) (ret []*api.ResourceQuota, err error)
+	// ListWithOptions lists all ResourceQuotas in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ResourceQuota, err error)
 	// ResourceQuotas returns an object that can list and get ResourceQuotas.
 	ResourceQuotas(namespace string) ResourceQuotaNamespaceLister
 	ResourceQuotaListerExpansion
@@ -52,6 +56,15 @@ func (s *resourceQuotaLister) List(selector labels.Selector) (ret []*api.Resourc
 	return ret, err
 }
 
+// ListWithOptions lists all ResourceQuotas in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *resourceQuotaLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ResourceQuota, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.ResourceQuota))
+	})
+	return ret, err
+}
+
 // ResourceQuotas returns an object that can list and get ResourceQuotas.
 func (s *resourceQuotaLister) ResourceQuotas(namespace string) ResourceQuotaNamespaceLister {
 	return resourceQuotaNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *resourceQuotaLister) ResourceQuotas(namespace string) ResourceQuotaName
 type ResourceQuotaNamespaceLister interface {
 	// List lists all ResourceQuotas in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.ResourceQuota, err error)
+	// ListWithOptions lists all ResourceQuotas that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ResourceQuota, err error)
 	// Get retrieves the ResourceQuota from the indexer for a given namespace and name.
 	Get(name string) (*api.ResourceQuota, error)
 	ResourceQuotaNamespaceListerExpansion
@@ -76,6 +93,15 @@ type resourceQuotaNamespaceLister struct {
 // List lists all ResourceQuotas in the indexer for a given namespace.
 func (s resourceQuotaNamespaceLister) List(selector labels.Selector) (ret []*api.ResourceQuota, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.ResourceQuota))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ResourceQuotas that matches the options
+// in the indexer for a given namespace.
+func (s resourceQuotaNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ResourceQuota, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.ResourceQuota))
 	})
 	return ret, err

--- a/pkg/client/listers/core/internalversion/serviceaccount.go
+++ b/pkg/client/listers/core/internalversion/serviceaccount.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -29,6 +30,9 @@ import (
 type ServiceAccountLister interface {
 	// List lists all ServiceAccounts in the indexer.
 	List(selector labels.Selector) (ret []*api.ServiceAccount, err error)
+	// ListWithOptions lists all ServiceAccounts in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ServiceAccount, err error)
 	// ServiceAccounts returns an object that can list and get ServiceAccounts.
 	ServiceAccounts(namespace string) ServiceAccountNamespaceLister
 	ServiceAccountListerExpansion
@@ -52,6 +56,15 @@ func (s *serviceAccountLister) List(selector labels.Selector) (ret []*api.Servic
 	return ret, err
 }
 
+// ListWithOptions lists all ServiceAccounts in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *serviceAccountLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ServiceAccount, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*api.ServiceAccount))
+	})
+	return ret, err
+}
+
 // ServiceAccounts returns an object that can list and get ServiceAccounts.
 func (s *serviceAccountLister) ServiceAccounts(namespace string) ServiceAccountNamespaceLister {
 	return serviceAccountNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *serviceAccountLister) ServiceAccounts(namespace string) ServiceAccountN
 type ServiceAccountNamespaceLister interface {
 	// List lists all ServiceAccounts in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*api.ServiceAccount, err error)
+	// ListWithOptions lists all ServiceAccounts that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*api.ServiceAccount, err error)
 	// Get retrieves the ServiceAccount from the indexer for a given namespace and name.
 	Get(name string) (*api.ServiceAccount, error)
 	ServiceAccountNamespaceListerExpansion
@@ -76,6 +93,15 @@ type serviceAccountNamespaceLister struct {
 // List lists all ServiceAccounts in the indexer for a given namespace.
 func (s serviceAccountNamespaceLister) List(selector labels.Selector) (ret []*api.ServiceAccount, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*api.ServiceAccount))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ServiceAccounts that matches the options
+// in the indexer for a given namespace.
+func (s serviceAccountNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*api.ServiceAccount, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*api.ServiceAccount))
 	})
 	return ret, err

--- a/pkg/client/listers/extensions/internalversion/daemonset.go
+++ b/pkg/client/listers/extensions/internalversion/daemonset.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -29,6 +30,9 @@ import (
 type DaemonSetLister interface {
 	// List lists all DaemonSets in the indexer.
 	List(selector labels.Selector) (ret []*extensions.DaemonSet, err error)
+	// ListWithOptions lists all DaemonSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.DaemonSet, err error)
 	// DaemonSets returns an object that can list and get DaemonSets.
 	DaemonSets(namespace string) DaemonSetNamespaceLister
 	DaemonSetListerExpansion
@@ -52,6 +56,15 @@ func (s *daemonSetLister) List(selector labels.Selector) (ret []*extensions.Daem
 	return ret, err
 }
 
+// ListWithOptions lists all DaemonSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *daemonSetLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.DaemonSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*extensions.DaemonSet))
+	})
+	return ret, err
+}
+
 // DaemonSets returns an object that can list and get DaemonSets.
 func (s *daemonSetLister) DaemonSets(namespace string) DaemonSetNamespaceLister {
 	return daemonSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *daemonSetLister) DaemonSets(namespace string) DaemonSetNamespaceLister 
 type DaemonSetNamespaceLister interface {
 	// List lists all DaemonSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*extensions.DaemonSet, err error)
+	// ListWithOptions lists all DaemonSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.DaemonSet, err error)
 	// Get retrieves the DaemonSet from the indexer for a given namespace and name.
 	Get(name string) (*extensions.DaemonSet, error)
 	DaemonSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type daemonSetNamespaceLister struct {
 // List lists all DaemonSets in the indexer for a given namespace.
 func (s daemonSetNamespaceLister) List(selector labels.Selector) (ret []*extensions.DaemonSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*extensions.DaemonSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all DaemonSets that matches the options
+// in the indexer for a given namespace.
+func (s daemonSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.DaemonSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*extensions.DaemonSet))
 	})
 	return ret, err

--- a/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type PodSecurityPolicyLister interface {
 	// List lists all PodSecurityPolicies in the indexer.
 	List(selector labels.Selector) (ret []*extensions.PodSecurityPolicy, err error)
+	// ListWithOptions lists all PodSecurityPolicies in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.PodSecurityPolicy, err error)
 	// Get retrieves the PodSecurityPolicy from the index for a given name.
 	Get(name string) (*extensions.PodSecurityPolicy, error)
 	PodSecurityPolicyListerExpansion
@@ -48,6 +52,15 @@ func NewPodSecurityPolicyLister(indexer cache.Indexer) PodSecurityPolicyLister {
 // List lists all PodSecurityPolicies in the indexer.
 func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*extensions.PodSecurityPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*extensions.PodSecurityPolicy))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodSecurityPolicies in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podSecurityPolicyLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.PodSecurityPolicy, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*extensions.PodSecurityPolicy))
 	})
 	return ret, err

--- a/pkg/client/listers/extensions/internalversion/replicaset.go
+++ b/pkg/client/listers/extensions/internalversion/replicaset.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -29,6 +30,9 @@ import (
 type ReplicaSetLister interface {
 	// List lists all ReplicaSets in the indexer.
 	List(selector labels.Selector) (ret []*extensions.ReplicaSet, err error)
+	// ListWithOptions lists all ReplicaSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.ReplicaSet, err error)
 	// ReplicaSets returns an object that can list and get ReplicaSets.
 	ReplicaSets(namespace string) ReplicaSetNamespaceLister
 	ReplicaSetListerExpansion
@@ -52,6 +56,15 @@ func (s *replicaSetLister) List(selector labels.Selector) (ret []*extensions.Rep
 	return ret, err
 }
 
+// ListWithOptions lists all ReplicaSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *replicaSetLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.ReplicaSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*extensions.ReplicaSet))
+	})
+	return ret, err
+}
+
 // ReplicaSets returns an object that can list and get ReplicaSets.
 func (s *replicaSetLister) ReplicaSets(namespace string) ReplicaSetNamespaceLister {
 	return replicaSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *replicaSetLister) ReplicaSets(namespace string) ReplicaSetNamespaceList
 type ReplicaSetNamespaceLister interface {
 	// List lists all ReplicaSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*extensions.ReplicaSet, err error)
+	// ListWithOptions lists all ReplicaSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.ReplicaSet, err error)
 	// Get retrieves the ReplicaSet from the indexer for a given namespace and name.
 	Get(name string) (*extensions.ReplicaSet, error)
 	ReplicaSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type replicaSetNamespaceLister struct {
 // List lists all ReplicaSets in the indexer for a given namespace.
 func (s replicaSetNamespaceLister) List(selector labels.Selector) (ret []*extensions.ReplicaSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*extensions.ReplicaSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ReplicaSets that matches the options
+// in the indexer for a given namespace.
+func (s replicaSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.ReplicaSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*extensions.ReplicaSet))
 	})
 	return ret, err

--- a/pkg/client/listers/extensions/internalversion/scale.go
+++ b/pkg/client/listers/extensions/internalversion/scale.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -29,6 +30,9 @@ import (
 type ScaleLister interface {
 	// List lists all Scales in the indexer.
 	List(selector labels.Selector) (ret []*extensions.Scale, err error)
+	// ListWithOptions lists all Scales in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.Scale, err error)
 	// Scales returns an object that can list and get Scales.
 	Scales(namespace string) ScaleNamespaceLister
 	ScaleListerExpansion
@@ -52,6 +56,15 @@ func (s *scaleLister) List(selector labels.Selector) (ret []*extensions.Scale, e
 	return ret, err
 }
 
+// ListWithOptions lists all Scales in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *scaleLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.Scale, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*extensions.Scale))
+	})
+	return ret, err
+}
+
 // Scales returns an object that can list and get Scales.
 func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 	return scaleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 type ScaleNamespaceLister interface {
 	// List lists all Scales in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*extensions.Scale, err error)
+	// ListWithOptions lists all Scales that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.Scale, err error)
 	// Get retrieves the Scale from the indexer for a given namespace and name.
 	Get(name string) (*extensions.Scale, error)
 	ScaleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type scaleNamespaceLister struct {
 // List lists all Scales in the indexer for a given namespace.
 func (s scaleNamespaceLister) List(selector labels.Selector) (ret []*extensions.Scale, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*extensions.Scale))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Scales that matches the options
+// in the indexer for a given namespace.
+func (s scaleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.Scale, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*extensions.Scale))
 	})
 	return ret, err

--- a/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ThirdPartyResourceLister interface {
 	// List lists all ThirdPartyResources in the indexer.
 	List(selector labels.Selector) (ret []*extensions.ThirdPartyResource, err error)
+	// ListWithOptions lists all ThirdPartyResources in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*extensions.ThirdPartyResource, err error)
 	// Get retrieves the ThirdPartyResource from the index for a given name.
 	Get(name string) (*extensions.ThirdPartyResource, error)
 	ThirdPartyResourceListerExpansion
@@ -48,6 +52,15 @@ func NewThirdPartyResourceLister(indexer cache.Indexer) ThirdPartyResourceLister
 // List lists all ThirdPartyResources in the indexer.
 func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*extensions.ThirdPartyResource, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*extensions.ThirdPartyResource))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ThirdPartyResources in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *thirdPartyResourceLister) ListWithOptions(options metav1.ListOptions) (ret []*extensions.ThirdPartyResource, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*extensions.ThirdPartyResource))
 	})
 	return ret, err

--- a/pkg/client/listers/imagepolicy/internalversion/imagereview.go
+++ b/pkg/client/listers/imagepolicy/internalversion/imagereview.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ImageReviewLister interface {
 	// List lists all ImageReviews in the indexer.
 	List(selector labels.Selector) (ret []*imagepolicy.ImageReview, err error)
+	// ListWithOptions lists all ImageReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*imagepolicy.ImageReview, err error)
 	// Get retrieves the ImageReview from the index for a given name.
 	Get(name string) (*imagepolicy.ImageReview, error)
 	ImageReviewListerExpansion
@@ -48,6 +52,15 @@ func NewImageReviewLister(indexer cache.Indexer) ImageReviewLister {
 // List lists all ImageReviews in the indexer.
 func (s *imageReviewLister) List(selector labels.Selector) (ret []*imagepolicy.ImageReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*imagepolicy.ImageReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ImageReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *imageReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*imagepolicy.ImageReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*imagepolicy.ImageReview))
 	})
 	return ret, err

--- a/pkg/client/listers/networking/internalversion/BUILD
+++ b/pkg/client/listers/networking/internalversion/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apis/networking:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/networking/internalversion/networkpolicy.go
+++ b/pkg/client/listers/networking/internalversion/networkpolicy.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	networking "k8s.io/kubernetes/pkg/apis/networking"
@@ -29,6 +30,9 @@ import (
 type NetworkPolicyLister interface {
 	// List lists all NetworkPolicies in the indexer.
 	List(selector labels.Selector) (ret []*networking.NetworkPolicy, err error)
+	// ListWithOptions lists all NetworkPolicies in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*networking.NetworkPolicy, err error)
 	// NetworkPolicies returns an object that can list and get NetworkPolicies.
 	NetworkPolicies(namespace string) NetworkPolicyNamespaceLister
 	NetworkPolicyListerExpansion
@@ -52,6 +56,15 @@ func (s *networkPolicyLister) List(selector labels.Selector) (ret []*networking.
 	return ret, err
 }
 
+// ListWithOptions lists all NetworkPolicies in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *networkPolicyLister) ListWithOptions(options metav1.ListOptions) (ret []*networking.NetworkPolicy, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*networking.NetworkPolicy))
+	})
+	return ret, err
+}
+
 // NetworkPolicies returns an object that can list and get NetworkPolicies.
 func (s *networkPolicyLister) NetworkPolicies(namespace string) NetworkPolicyNamespaceLister {
 	return networkPolicyNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *networkPolicyLister) NetworkPolicies(namespace string) NetworkPolicyNam
 type NetworkPolicyNamespaceLister interface {
 	// List lists all NetworkPolicies in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*networking.NetworkPolicy, err error)
+	// ListWithOptions lists all NetworkPolicies that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*networking.NetworkPolicy, err error)
 	// Get retrieves the NetworkPolicy from the indexer for a given namespace and name.
 	Get(name string) (*networking.NetworkPolicy, error)
 	NetworkPolicyNamespaceListerExpansion
@@ -76,6 +93,15 @@ type networkPolicyNamespaceLister struct {
 // List lists all NetworkPolicies in the indexer for a given namespace.
 func (s networkPolicyNamespaceLister) List(selector labels.Selector) (ret []*networking.NetworkPolicy, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*networking.NetworkPolicy))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all NetworkPolicies that matches the options
+// in the indexer for a given namespace.
+func (s networkPolicyNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*networking.NetworkPolicy, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*networking.NetworkPolicy))
 	})
 	return ret, err

--- a/pkg/client/listers/policy/internalversion/eviction.go
+++ b/pkg/client/listers/policy/internalversion/eviction.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
@@ -29,6 +30,9 @@ import (
 type EvictionLister interface {
 	// List lists all Evictions in the indexer.
 	List(selector labels.Selector) (ret []*policy.Eviction, err error)
+	// ListWithOptions lists all Evictions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*policy.Eviction, err error)
 	// Evictions returns an object that can list and get Evictions.
 	Evictions(namespace string) EvictionNamespaceLister
 	EvictionListerExpansion
@@ -52,6 +56,15 @@ func (s *evictionLister) List(selector labels.Selector) (ret []*policy.Eviction,
 	return ret, err
 }
 
+// ListWithOptions lists all Evictions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *evictionLister) ListWithOptions(options metav1.ListOptions) (ret []*policy.Eviction, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*policy.Eviction))
+	})
+	return ret, err
+}
+
 // Evictions returns an object that can list and get Evictions.
 func (s *evictionLister) Evictions(namespace string) EvictionNamespaceLister {
 	return evictionNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *evictionLister) Evictions(namespace string) EvictionNamespaceLister {
 type EvictionNamespaceLister interface {
 	// List lists all Evictions in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*policy.Eviction, err error)
+	// ListWithOptions lists all Evictions that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*policy.Eviction, err error)
 	// Get retrieves the Eviction from the indexer for a given namespace and name.
 	Get(name string) (*policy.Eviction, error)
 	EvictionNamespaceListerExpansion
@@ -76,6 +93,15 @@ type evictionNamespaceLister struct {
 // List lists all Evictions in the indexer for a given namespace.
 func (s evictionNamespaceLister) List(selector labels.Selector) (ret []*policy.Eviction, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*policy.Eviction))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Evictions that matches the options
+// in the indexer for a given namespace.
+func (s evictionNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*policy.Eviction, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*policy.Eviction))
 	})
 	return ret, err

--- a/pkg/client/listers/policy/internalversion/poddisruptionbudget.go
+++ b/pkg/client/listers/policy/internalversion/poddisruptionbudget.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	policy "k8s.io/kubernetes/pkg/apis/policy"
@@ -29,6 +30,9 @@ import (
 type PodDisruptionBudgetLister interface {
 	// List lists all PodDisruptionBudgets in the indexer.
 	List(selector labels.Selector) (ret []*policy.PodDisruptionBudget, err error)
+	// ListWithOptions lists all PodDisruptionBudgets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*policy.PodDisruptionBudget, err error)
 	// PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 	PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister
 	PodDisruptionBudgetListerExpansion
@@ -52,6 +56,15 @@ func (s *podDisruptionBudgetLister) List(selector labels.Selector) (ret []*polic
 	return ret, err
 }
 
+// ListWithOptions lists all PodDisruptionBudgets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podDisruptionBudgetLister) ListWithOptions(options metav1.ListOptions) (ret []*policy.PodDisruptionBudget, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*policy.PodDisruptionBudget))
+	})
+	return ret, err
+}
+
 // PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 func (s *podDisruptionBudgetLister) PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister {
 	return podDisruptionBudgetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podDisruptionBudgetLister) PodDisruptionBudgets(namespace string) PodDi
 type PodDisruptionBudgetNamespaceLister interface {
 	// List lists all PodDisruptionBudgets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*policy.PodDisruptionBudget, err error)
+	// ListWithOptions lists all PodDisruptionBudgets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*policy.PodDisruptionBudget, err error)
 	// Get retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
 	Get(name string) (*policy.PodDisruptionBudget, error)
 	PodDisruptionBudgetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podDisruptionBudgetNamespaceLister struct {
 // List lists all PodDisruptionBudgets in the indexer for a given namespace.
 func (s podDisruptionBudgetNamespaceLister) List(selector labels.Selector) (ret []*policy.PodDisruptionBudget, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*policy.PodDisruptionBudget))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodDisruptionBudgets that matches the options
+// in the indexer for a given namespace.
+func (s podDisruptionBudgetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*policy.PodDisruptionBudget, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*policy.PodDisruptionBudget))
 	})
 	return ret, err

--- a/pkg/client/listers/rbac/internalversion/clusterrole.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrole.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	List(selector labels.Selector) (ret []*rbac.ClusterRole, err error)
+	// ListWithOptions lists all ClusterRoles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*rbac.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	Get(name string) (*rbac.ClusterRole, error)
 	ClusterRoleListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*rbac.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*rbac.ClusterRole))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleLister) ListWithOptions(options metav1.ListOptions) (ret []*rbac.ClusterRole, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*rbac.ClusterRole))
 	})
 	return ret, err

--- a/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*rbac.ClusterRoleBinding, err error)
+	// ListWithOptions lists all ClusterRoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*rbac.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	Get(name string) (*rbac.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*rbac.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*rbac.ClusterRoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*rbac.ClusterRoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*rbac.ClusterRoleBinding))
 	})
 	return ret, err

--- a/pkg/client/listers/rbac/internalversion/rolebinding.go
+++ b/pkg/client/listers/rbac/internalversion/rolebinding.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -29,6 +30,9 @@ import (
 type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*rbac.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*rbac.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -52,6 +56,15 @@ func (s *roleBindingLister) List(selector labels.Selector) (ret []*rbac.RoleBind
 	return ret, err
 }
 
+// ListWithOptions lists all RoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*rbac.RoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*rbac.RoleBinding))
+	})
+	return ret, err
+}
+
 // RoleBindings returns an object that can list and get RoleBindings.
 func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceLister {
 	return roleBindingNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceL
 type RoleBindingNamespaceLister interface {
 	// List lists all RoleBindings in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*rbac.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*rbac.RoleBinding, err error)
 	// Get retrieves the RoleBinding from the indexer for a given namespace and name.
 	Get(name string) (*rbac.RoleBinding, error)
 	RoleBindingNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleBindingNamespaceLister struct {
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*rbac.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*rbac.RoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all RoleBindings that matches the options
+// in the indexer for a given namespace.
+func (s roleBindingNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*rbac.RoleBinding, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*rbac.RoleBinding))
 	})
 	return ret, err

--- a/pkg/client/listers/scheduling/internalversion/priorityclass.go
+++ b/pkg/client/listers/scheduling/internalversion/priorityclass.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type PriorityClassLister interface {
 	// List lists all PriorityClasses in the indexer.
 	List(selector labels.Selector) (ret []*scheduling.PriorityClass, err error)
+	// ListWithOptions lists all PriorityClasses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*scheduling.PriorityClass, err error)
 	// Get retrieves the PriorityClass from the index for a given name.
 	Get(name string) (*scheduling.PriorityClass, error)
 	PriorityClassListerExpansion
@@ -48,6 +52,15 @@ func NewPriorityClassLister(indexer cache.Indexer) PriorityClassLister {
 // List lists all PriorityClasses in the indexer.
 func (s *priorityClassLister) List(selector labels.Selector) (ret []*scheduling.PriorityClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*scheduling.PriorityClass))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PriorityClasses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *priorityClassLister) ListWithOptions(options metav1.ListOptions) (ret []*scheduling.PriorityClass, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*scheduling.PriorityClass))
 	})
 	return ret, err

--- a/pkg/client/listers/settings/internalversion/BUILD
+++ b/pkg/client/listers/settings/internalversion/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/apis/settings:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/settings/internalversion/podpreset.go
+++ b/pkg/client/listers/settings/internalversion/podpreset.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	settings "k8s.io/kubernetes/pkg/apis/settings"
@@ -29,6 +30,9 @@ import (
 type PodPresetLister interface {
 	// List lists all PodPresets in the indexer.
 	List(selector labels.Selector) (ret []*settings.PodPreset, err error)
+	// ListWithOptions lists all PodPresets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*settings.PodPreset, err error)
 	// PodPresets returns an object that can list and get PodPresets.
 	PodPresets(namespace string) PodPresetNamespaceLister
 	PodPresetListerExpansion
@@ -52,6 +56,15 @@ func (s *podPresetLister) List(selector labels.Selector) (ret []*settings.PodPre
 	return ret, err
 }
 
+// ListWithOptions lists all PodPresets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podPresetLister) ListWithOptions(options metav1.ListOptions) (ret []*settings.PodPreset, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*settings.PodPreset))
+	})
+	return ret, err
+}
+
 // PodPresets returns an object that can list and get PodPresets.
 func (s *podPresetLister) PodPresets(namespace string) PodPresetNamespaceLister {
 	return podPresetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podPresetLister) PodPresets(namespace string) PodPresetNamespaceLister 
 type PodPresetNamespaceLister interface {
 	// List lists all PodPresets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*settings.PodPreset, err error)
+	// ListWithOptions lists all PodPresets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*settings.PodPreset, err error)
 	// Get retrieves the PodPreset from the indexer for a given namespace and name.
 	Get(name string) (*settings.PodPreset, error)
 	PodPresetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podPresetNamespaceLister struct {
 // List lists all PodPresets in the indexer for a given namespace.
 func (s podPresetNamespaceLister) List(selector labels.Selector) (ret []*settings.PodPreset, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*settings.PodPreset))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodPresets that matches the options
+// in the indexer for a given namespace.
+func (s podPresetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*settings.PodPreset, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*settings.PodPreset))
 	})
 	return ret, err

--- a/pkg/client/listers/storage/internalversion/storageclass.go
+++ b/pkg/client/listers/storage/internalversion/storageclass.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	List(selector labels.Selector) (ret []*storage.StorageClass, err error)
+	// ListWithOptions lists all StorageClasses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*storage.StorageClass, err error)
 	// Get retrieves the StorageClass from the index for a given name.
 	Get(name string) (*storage.StorageClass, error)
 	StorageClassListerExpansion
@@ -48,6 +52,15 @@ func NewStorageClassLister(indexer cache.Indexer) StorageClassLister {
 // List lists all StorageClasses in the indexer.
 func (s *storageClassLister) List(selector labels.Selector) (ret []*storage.StorageClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*storage.StorageClass))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all StorageClasses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *storageClassLister) ListWithOptions(options metav1.ListOptions) (ret []*storage.StorageClass, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*storage.StorageClass))
 	})
 	return ret, err

--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -108,6 +108,7 @@ func (jm *CronJobController) syncAll() {
 	// This guarantees that if we see any Job that got orphaned by the GC orphan finalizer,
 	// we must also see that the parent CronJob has non-nil DeletionTimestamp (see #42639).
 	// Note that this only works because we are NOT using any caches here.
+	// TODO: this should List uninitialized jobs as well, to avoid recreating jobs.
 	jl, err := jm.kubeClient.BatchV1().Jobs(metav1.NamespaceAll).List(metav1.ListOptions{})
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("can't list Jobs: %v", err))
@@ -320,6 +321,7 @@ func syncOne(sj *batchv2alpha1.CronJob, js []batchv1.Job, now time.Time, jc jobC
 		return
 	}
 	jobResp, err := jc.CreateJob(sj.Namespace, jobReq)
+	// TODO: need to handle timeout due to slow initialization
 	if err != nil {
 		recorder.Eventf(sj, v1.EventTypeWarning, "FailedCreate", "Error creating job: %v", err)
 		return

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -181,11 +181,11 @@ func NewDaemonSetsController(daemonSetInformer extensionsinformers.DaemonSetInfo
 
 	// Watch for creation/deletion of pods. The reason we watch is that we don't want a daemon set to create/delete
 	// more pods until all the effects (expectations) of a daemon set's create/delete have been observed.
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	podInformer.Informer().AddEventHandlerWithOptions(cache.ResourceEventHandlerFuncs{
 		AddFunc:    dsc.addPod,
 		UpdateFunc: dsc.updatePod,
 		DeleteFunc: dsc.deletePod,
-	})
+	}, cache.HandlerOptions{IncludeUninitialized: true})
 	dsc.podLister = podInformer.Lister()
 	dsc.podStoreSynced = podInformer.Informer().HasSynced
 
@@ -737,7 +737,7 @@ func (dsc *DaemonSetsController) getDaemonPods(ds *extensions.DaemonSet) ([]*v1.
 
 	// List all pods to include those that don't match the selector anymore but
 	// have a ControllerRef pointing to this controller.
-	pods, err := dsc.podLister.Pods(ds.Namespace).List(labels.Everything())
+	pods, err := dsc.podLister.Pods(ds.Namespace).ListWithOptions(metav1.ListOptions{IncludeUninitialized: true})
 	if err != nil {
 		return nil, err
 	}
@@ -1172,7 +1172,7 @@ func (dsc *DaemonSetsController) simulate(newPod *v1.Pod, node *v1.Node, ds *ext
 
 	pods := []*v1.Pod{}
 
-	podList, err := dsc.podLister.List(labels.Everything())
+	podList, err := dsc.podLister.ListWithOptions(metav1.ListOptions{IncludeUninitialized: true})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -422,10 +422,10 @@ func TestGCListWatcher(t *testing.T) {
 	if e, a := 2, len(testHandler.actions); e != a {
 		t.Errorf("expect %d requests, got %d", e, a)
 	}
-	if e, a := "resourceVersion=1&watch=true", testHandler.actions[0].query; e != a {
+	if e, a := "includeUninitialized=true&resourceVersion=1&watch=true", testHandler.actions[0].query; e != a {
 		t.Errorf("expect %s, got %s", e, a)
 	}
-	if e, a := "resourceVersion=1", testHandler.actions[1].query; e != a {
+	if e, a := "includeUninitialized=true&resourceVersion=1", testHandler.actions[1].query; e != a {
 		t.Errorf("expect %s, got %s", e, a)
 	}
 }

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -132,6 +132,7 @@ func listWatcher(client dynamic.Interface, resource schema.GroupVersionResource)
 			// namespaces if it's namespace scoped, so leave
 			// APIResource.Namespaced as false is all right.
 			apiResource := metav1.APIResource{Name: resource.Resource}
+			options.IncludeUninitialized = true
 			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
 				Resource(&apiResource, metav1.NamespaceAll).
 				List(options)
@@ -142,6 +143,7 @@ func listWatcher(client dynamic.Interface, resource schema.GroupVersionResource)
 			// namespaces if it's namespace scoped, so leave
 			// APIResource.Namespaced as false is all right.
 			apiResource := metav1.APIResource{Name: resource.Resource}
+			options.IncludeUninitialized = true
 			return client.ParameterCodec(dynamic.VersionedParameterEncoderWithV1Fallback).
 				Resource(&apiResource, metav1.NamespaceAll).
 				Watch(options)
@@ -188,7 +190,7 @@ func (gb *GraphBuilder) controllerFor(resource schema.GroupVersionResource, kind
 	if err == nil {
 		glog.V(4).Infof("using a shared informer for resource %q, kind %q", resource.String(), kind.String())
 		// need to clone because it's from a shared cache
-		shared.Informer().AddEventHandlerWithResyncPeriod(handlers, ResourceResyncTime)
+		shared.Informer().AddEventHandlerWithOptions(handlers, cache.HandlerOptions{IncludeUninitialized: true})
 		return shared.Informer().GetController(), nil
 	} else {
 		glog.V(4).Infof("unable to use a shared informer for resource %q, kind %q: %v", resource.String(), kind.String(), err)

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -389,6 +389,7 @@ func (fh *fakeHistory) CreateControllerRevision(parent metav1.Object, revision *
 		clone.Name = ControllerRevisionName(parent.GetName(), hash)
 		created, err := fh.addRevision(clone)
 		if errors.IsAlreadyExists(err) {
+			// TODO: only increment the collisionCount if the controllerRevision spec is different
 			*collisionCount++
 			continue
 		}

--- a/pkg/controller/job/BUILD
+++ b/pkg/controller/job/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers/batch/v1:go_default_library",

--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -394,12 +394,12 @@ func (kubemarkCluster *kubemarkCluster) markNodeForDeletion(name string) {
 	kubemarkCluster.nodesToDelete[name] = true
 }
 
-func newReplicationControllerInformer(kubeClient kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func newReplicationControllerInformer(kubeClient kubeclient.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
 	rcListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "replicationcontrollers", namespaceKubemark, fields.Everything())
-	return cache.NewSharedIndexInformer(rcListWatch, &apiv1.ReplicationController{}, resyncPeriod, nil)
+	return cache.NewSharedIndexInformer(rcListWatch, &apiv1.ReplicationController{}, options.ResyncPeriod, nil)
 }
 
-func newPodInformer(kubeClient kubeclient.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
+func newPodInformer(kubeClient kubeclient.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
 	podListWatch := cache.NewListWatchFromClient(kubeClient.CoreV1().RESTClient(), "pods", namespaceKubemark, fields.Everything())
-	return cache.NewSharedIndexInformer(podListWatch, &apiv1.Pod{}, resyncPeriod, nil)
+	return cache.NewSharedIndexInformer(podListWatch, &apiv1.Pod{}, options.ResyncPeriod, nil)
 }

--- a/pkg/quota/generic/evaluator.go
+++ b/pkg/quota/generic/evaluator.go
@@ -33,15 +33,11 @@ import (
 // ListResourceUsingInformerFunc returns a listing function based on the shared informer factory for the specified resource.
 func ListResourceUsingInformerFunc(f informers.SharedInformerFactory, resource schema.GroupVersionResource) ListFuncByNamespace {
 	return func(namespace string, options metav1.ListOptions) ([]runtime.Object, error) {
-		labelSelector, err := labels.Parse(options.LabelSelector)
-		if err != nil {
-			return nil, err
-		}
 		informer, err := f.ForResource(resource)
 		if err != nil {
 			return nil, err
 		}
-		return informer.Lister().ByNamespace(namespace).List(labelSelector)
+		return informer.Lister().ByNamespace(namespace).ListWithOptions(options)
 	}
 }
 
@@ -92,7 +88,8 @@ func CalculateUsageStats(options quota.UsageStatsOptions,
 		result.Used[resourceName] = resource.Quantity{Format: resource.DecimalSI}
 	}
 	items, err := listFunc(options.Namespace, metav1.ListOptions{
-		LabelSelector: labels.Everything().String(),
+		LabelSelector:        labels.Everything().String(),
+		IncludeUninitialized: true,
 	})
 	if err != nil {
 		return result, fmt.Errorf("failed to list content: %v", err)

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
@@ -37,6 +37,10 @@ func (l *lister) List(selector labels.Selector) (ret []*api.Secret, err error) {
 	return l.secrets, nil
 }
 
+func (l *lister) ListWithOptions(options metav1.ListOptions) (ret []*api.Secret, err error) {
+	return l.secrets, nil
+}
+
 func (l *lister) Get(name string) (*api.Secret, error) {
 	for _, s := range l.secrets {
 		if s.Name == name {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -31,9 +31,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        clientset.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  clientset.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,7 +45,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client clientset.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -97,7 +108,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-	time "time"
 )
 
-type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(clientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	internalclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
-	time "time"
 )
 
-type NewInformerFunc func(internalclientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(internalclientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -21,6 +21,7 @@ package internalversion
 import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	List(selector labels.Selector) (ret []*apiextensions.CustomResourceDefinition, err error)
+	// ListWithOptions lists all CustomResourceDefinitions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*apiextensions.CustomResourceDefinition, err error)
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	Get(name string) (*apiextensions.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
@@ -48,6 +52,15 @@ func NewCustomResourceDefinitionLister(indexer cache.Indexer) CustomResourceDefi
 // List lists all CustomResourceDefinitions in the indexer.
 func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*apiextensions.CustomResourceDefinition, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*apiextensions.CustomResourceDefinition))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CustomResourceDefinitions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *customResourceDefinitionLister) ListWithOptions(options metav1.ListOptions) (ret []*apiextensions.CustomResourceDefinition, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*apiextensions.CustomResourceDefinition))
 	})
 	return ret, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type CustomResourceDefinitionLister interface {
 	// List lists all CustomResourceDefinitions in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error)
+	// ListWithOptions lists all CustomResourceDefinitions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CustomResourceDefinition, err error)
 	// Get retrieves the CustomResourceDefinition from the index for a given name.
 	Get(name string) (*v1beta1.CustomResourceDefinition, error)
 	CustomResourceDefinitionListerExpansion
@@ -48,6 +52,15 @@ func NewCustomResourceDefinitionLister(indexer cache.Indexer) CustomResourceDefi
 // List lists all CustomResourceDefinitions in the indexer.
 func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*v1beta1.CustomResourceDefinition, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.CustomResourceDefinition))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CustomResourceDefinitions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *customResourceDefinitionLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CustomResourceDefinition, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CustomResourceDefinition))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/informers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -60,8 +60,27 @@ func NewExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, 
 	)
 }
 
-func defaultExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewExternalAdmissionHookConfigurationInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewExternalAdmissionHookConfigurationInformerWithOptions constructs a new informer for ExternalAdmissionHookConfiguration type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewExternalAdmissionHookConfigurationInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AdmissionregistrationV1alpha1().ExternalAdmissionHookConfigurations().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AdmissionregistrationV1alpha1().ExternalAdmissionHookConfigurations().Watch(options)
+			},
+		},
+		options,
+		&admissionregistration_v1alpha1.ExternalAdmissionHookConfiguration{},
+		indexers,
+	)
+}
+
+func defaultExternalAdmissionHookConfigurationInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewExternalAdmissionHookConfigurationInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *externalAdmissionHookConfigurationInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/controllerrevision.go
@@ -60,8 +60,27 @@ func NewControllerRevisionInformer(client kubernetes.Interface, namespace string
 	)
 }
 
-func defaultControllerRevisionInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewControllerRevisionInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta1().ControllerRevisions(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta1().ControllerRevisions(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta1.ControllerRevision{},
+		indexers,
+	)
+}
+
+func defaultControllerRevisionInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewControllerRevisionInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/deployment.go
@@ -60,8 +60,27 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDeploymentInformerWithOptions constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta1().Deployments(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta1().Deployments(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta1.Deployment{},
+		indexers,
+	)
+}
+
+func defaultDeploymentInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDeploymentInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta1/statefulset.go
@@ -60,8 +60,27 @@ func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyn
 	)
 }
 
-func defaultStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStatefulSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewStatefulSetInformerWithOptions constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta1().StatefulSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta1().StatefulSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta1.StatefulSet{},
+		indexers,
+	)
+}
+
+func defaultStatefulSetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewStatefulSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/controllerrevision.go
@@ -60,8 +60,27 @@ func NewControllerRevisionInformer(client kubernetes.Interface, namespace string
 	)
 }
 
-func defaultControllerRevisionInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewControllerRevisionInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewControllerRevisionInformerWithOptions constructs a new informer for ControllerRevision type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewControllerRevisionInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta2().ControllerRevisions(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta2().ControllerRevisions(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta2.ControllerRevision{},
+		indexers,
+	)
+}
+
+func defaultControllerRevisionInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewControllerRevisionInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *controllerRevisionInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/daemonset.go
@@ -60,8 +60,27 @@ func NewDaemonSetInformer(client kubernetes.Interface, namespace string, resyncP
 	)
 }
 
-func defaultDaemonSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDaemonSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDaemonSetInformerWithOptions constructs a new informer for DaemonSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDaemonSetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta2().DaemonSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta2().DaemonSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta2.DaemonSet{},
+		indexers,
+	)
+}
+
+func defaultDaemonSetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDaemonSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *daemonSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/deployment.go
@@ -60,8 +60,27 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDeploymentInformerWithOptions constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta2().Deployments(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta2().Deployments(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta2.Deployment{},
+		indexers,
+	)
+}
+
+func defaultDeploymentInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDeploymentInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/replicaset.go
@@ -60,8 +60,27 @@ func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultReplicaSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicaSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta2().ReplicaSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta2().ReplicaSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta2.ReplicaSet{},
+		indexers,
+	)
+}
+
+func defaultReplicaSetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewReplicaSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/informers/apps/v1beta2/statefulset.go
@@ -60,8 +60,27 @@ func NewStatefulSetInformer(client kubernetes.Interface, namespace string, resyn
 	)
 }
 
-func defaultStatefulSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStatefulSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewStatefulSetInformerWithOptions constructs a new informer for StatefulSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStatefulSetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AppsV1beta2().StatefulSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AppsV1beta2().StatefulSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&apps_v1beta2.StatefulSet{},
+		indexers,
+	)
+}
+
+func defaultStatefulSetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewStatefulSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *statefulSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/informers/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -60,8 +60,27 @@ func NewHorizontalPodAutoscalerInformer(client kubernetes.Interface, namespace s
 	)
 }
 
-func defaultHorizontalPodAutoscalerInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewHorizontalPodAutoscalerInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewHorizontalPodAutoscalerInformerWithOptions constructs a new informer for HorizontalPodAutoscaler type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewHorizontalPodAutoscalerInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.AutoscalingV2alpha1().HorizontalPodAutoscalers(namespace).Watch(options)
+			},
+		},
+		options,
+		&autoscaling_v2alpha1.HorizontalPodAutoscaler{},
+		indexers,
+	)
+}
+
+func defaultHorizontalPodAutoscalerInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewHorizontalPodAutoscalerInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *horizontalPodAutoscalerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v1beta1/cronjob.go
@@ -60,8 +60,27 @@ func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPer
 	)
 }
 
-func defaultCronJobInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCronJobInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewCronJobInformerWithOptions constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.BatchV1beta1().CronJobs(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.BatchV1beta1().CronJobs(namespace).Watch(options)
+			},
+		},
+		options,
+		&batch_v1beta1.CronJob{},
+		indexers,
+	)
+}
+
+func defaultCronJobInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewCronJobInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/informers/batch/v2alpha1/cronjob.go
@@ -60,8 +60,27 @@ func NewCronJobInformer(client kubernetes.Interface, namespace string, resyncPer
 	)
 }
 
-func defaultCronJobInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewCronJobInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewCronJobInformerWithOptions constructs a new informer for CronJob type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewCronJobInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.BatchV2alpha1().CronJobs(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.BatchV2alpha1().CronJobs(namespace).Watch(options)
+			},
+		},
+		options,
+		&batch_v2alpha1.CronJob{},
+		indexers,
+	)
+}
+
+func defaultCronJobInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewCronJobInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *cronJobInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -60,8 +60,27 @@ func NewComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.D
 	)
 }
 
-func defaultComponentStatusInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewComponentStatusInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewComponentStatusInformerWithOptions constructs a new informer for ComponentStatus type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewComponentStatusInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().ComponentStatuses().List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().ComponentStatuses().Watch(options)
+			},
+		},
+		options,
+		&core_v1.ComponentStatus{},
+		indexers,
+	)
+}
+
+func defaultComponentStatusInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewComponentStatusInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *componentStatusInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/configmap.go
@@ -60,8 +60,27 @@ func NewConfigMapInformer(client kubernetes.Interface, namespace string, resyncP
 	)
 }
 
-func defaultConfigMapInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewConfigMapInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewConfigMapInformerWithOptions constructs a new informer for ConfigMap type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewConfigMapInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().ConfigMaps(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().ConfigMaps(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.ConfigMap{},
+		indexers,
+	)
+}
+
+func defaultConfigMapInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewConfigMapInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *configMapInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -60,8 +60,27 @@ func NewEndpointsInformer(client kubernetes.Interface, namespace string, resyncP
 	)
 }
 
-func defaultEndpointsInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewEndpointsInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewEndpointsInformerWithOptions constructs a new informer for Endpoints type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewEndpointsInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Endpoints(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Endpoints(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.Endpoints{},
+		indexers,
+	)
+}
+
+func defaultEndpointsInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewEndpointsInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *endpointsInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -60,8 +60,27 @@ func NewLimitRangeInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultLimitRangeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewLimitRangeInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewLimitRangeInformerWithOptions constructs a new informer for LimitRange type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewLimitRangeInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().LimitRanges(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().LimitRanges(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.LimitRange{},
+		indexers,
+	)
+}
+
+func defaultLimitRangeInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewLimitRangeInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *limitRangeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/node.go
@@ -60,8 +60,27 @@ func NewNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration, in
 	)
 }
 
-func defaultNodeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNodeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewNodeInformerWithOptions constructs a new informer for Node type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNodeInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Nodes().List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Nodes().Watch(options)
+			},
+		},
+		options,
+		&core_v1.Node{},
+		indexers,
+	)
+}
+
+func defaultNodeInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewNodeInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *nodeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -60,8 +60,27 @@ func NewPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.
 	)
 }
 
-func defaultPersistentVolumeInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPersistentVolumeInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPersistentVolumeInformerWithOptions constructs a new informer for PersistentVolume type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().PersistentVolumes().List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().PersistentVolumes().Watch(options)
+			},
+		},
+		options,
+		&core_v1.PersistentVolume{},
+		indexers,
+	)
+}
+
+func defaultPersistentVolumeInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPersistentVolumeInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -60,8 +60,27 @@ func NewPersistentVolumeClaimInformer(client kubernetes.Interface, namespace str
 	)
 }
 
-func defaultPersistentVolumeClaimInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPersistentVolumeClaimInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPersistentVolumeClaimInformerWithOptions constructs a new informer for PersistentVolumeClaim type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPersistentVolumeClaimInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().PersistentVolumeClaims(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().PersistentVolumeClaims(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.PersistentVolumeClaim{},
+		indexers,
+	)
+}
+
+func defaultPersistentVolumeClaimInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPersistentVolumeClaimInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *persistentVolumeClaimInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/pod.go
@@ -60,8 +60,27 @@ func NewPodInformer(client kubernetes.Interface, namespace string, resyncPeriod 
 	)
 }
 
-func defaultPodInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodInformerWithOptions constructs a new informer for Pod type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Pods(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Pods(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.Pod{},
+		indexers,
+	)
+}
+
+func defaultPodInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -60,8 +60,27 @@ func NewPodTemplateInformer(client kubernetes.Interface, namespace string, resyn
 	)
 }
 
-func defaultPodTemplateInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodTemplateInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodTemplateInformerWithOptions constructs a new informer for PodTemplate type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodTemplateInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().PodTemplates(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().PodTemplates(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.PodTemplate{},
+		indexers,
+	)
+}
+
+func defaultPodTemplateInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodTemplateInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podTemplateInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -60,8 +60,27 @@ func NewReplicationControllerInformer(client kubernetes.Interface, namespace str
 	)
 }
 
-func defaultReplicationControllerInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicationControllerInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewReplicationControllerInformerWithOptions constructs a new informer for ReplicationController type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewReplicationControllerInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().ReplicationControllers(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().ReplicationControllers(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.ReplicationController{},
+		indexers,
+	)
+}
+
+func defaultReplicationControllerInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewReplicationControllerInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *replicationControllerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -60,8 +60,27 @@ func NewResourceQuotaInformer(client kubernetes.Interface, namespace string, res
 	)
 }
 
-func defaultResourceQuotaInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewResourceQuotaInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewResourceQuotaInformerWithOptions constructs a new informer for ResourceQuota type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewResourceQuotaInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().ResourceQuotas(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().ResourceQuotas(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.ResourceQuota{},
+		indexers,
+	)
+}
+
+func defaultResourceQuotaInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewResourceQuotaInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *resourceQuotaInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/service.go
@@ -60,8 +60,27 @@ func NewServiceInformer(client kubernetes.Interface, namespace string, resyncPer
 	)
 }
 
-func defaultServiceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewServiceInformerWithOptions constructs a new informer for Service type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().Services(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().Services(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.Service{},
+		indexers,
+	)
+}
+
+func defaultServiceInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewServiceInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -60,8 +60,27 @@ func NewServiceAccountInformer(client kubernetes.Interface, namespace string, re
 	)
 }
 
-func defaultServiceAccountInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewServiceAccountInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewServiceAccountInformerWithOptions constructs a new informer for ServiceAccount type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewServiceAccountInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.CoreV1().ServiceAccounts(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.CoreV1().ServiceAccounts(namespace).Watch(options)
+			},
+		},
+		options,
+		&core_v1.ServiceAccount{},
+		indexers,
+	)
+}
+
+func defaultServiceAccountInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewServiceAccountInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *serviceAccountInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -60,8 +60,27 @@ func NewDeploymentInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultDeploymentInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewDeploymentInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewDeploymentInformerWithOptions constructs a new informer for Deployment type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewDeploymentInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.ExtensionsV1beta1().Deployments(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.ExtensionsV1beta1().Deployments(namespace).Watch(options)
+			},
+		},
+		options,
+		&extensions_v1beta1.Deployment{},
+		indexers,
+	)
+}
+
+func defaultDeploymentInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewDeploymentInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *deploymentInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
@@ -60,8 +60,27 @@ func NewPodSecurityPolicyInformer(client kubernetes.Interface, resyncPeriod time
 	)
 }
 
-func defaultPodSecurityPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodSecurityPolicyInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodSecurityPolicyInformerWithOptions constructs a new informer for PodSecurityPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodSecurityPolicyInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.ExtensionsV1beta1().PodSecurityPolicies().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.ExtensionsV1beta1().PodSecurityPolicies().Watch(options)
+			},
+		},
+		options,
+		&extensions_v1beta1.PodSecurityPolicy{},
+		indexers,
+	)
+}
+
+func defaultPodSecurityPolicyInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodSecurityPolicyInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podSecurityPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -60,8 +60,27 @@ func NewReplicaSetInformer(client kubernetes.Interface, namespace string, resync
 	)
 }
 
-func defaultReplicaSetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewReplicaSetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewReplicaSetInformerWithOptions constructs a new informer for ReplicaSet type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewReplicaSetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.ExtensionsV1beta1().ReplicaSets(namespace).Watch(options)
+			},
+		},
+		options,
+		&extensions_v1beta1.ReplicaSet{},
+		indexers,
+	)
+}
+
+func defaultReplicaSetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewReplicaSetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *replicaSetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
@@ -60,8 +60,27 @@ func NewThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod tim
 	)
 }
 
-func defaultThirdPartyResourceInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewThirdPartyResourceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewThirdPartyResourceInformerWithOptions constructs a new informer for ThirdPartyResource type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewThirdPartyResourceInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.ExtensionsV1beta1().ThirdPartyResources().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.ExtensionsV1beta1().ThirdPartyResources().Watch(options)
+			},
+		},
+		options,
+		&extensions_v1beta1.ThirdPartyResource{},
+		indexers,
+	)
+}
+
+func defaultThirdPartyResourceInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewThirdPartyResourceInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *thirdPartyResourceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/factory.go
+++ b/staging/src/k8s.io/client-go/informers/factory.go
@@ -43,9 +43,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        kubernetes.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  kubernetes.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -57,7 +57,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client kubernetes.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -109,7 +120,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/client-go/informers/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kubernetes "k8s.io/client-go/kubernetes"
 	cache "k8s.io/client-go/tools/cache"
-	time "time"
 )
 
-type NewInformerFunc func(kubernetes.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(kubernetes.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/informers/networking/v1/networkpolicy.go
@@ -60,8 +60,27 @@ func NewNetworkPolicyInformer(client kubernetes.Interface, namespace string, res
 	)
 }
 
-func defaultNetworkPolicyInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewNetworkPolicyInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewNetworkPolicyInformerWithOptions constructs a new informer for NetworkPolicy type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewNetworkPolicyInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.NetworkingV1().NetworkPolicies(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.NetworkingV1().NetworkPolicies(namespace).Watch(options)
+			},
+		},
+		options,
+		&networking_v1.NetworkPolicy{},
+		indexers,
+	)
+}
+
+func defaultNetworkPolicyInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewNetworkPolicyInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *networkPolicyInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/informers/policy/v1beta1/poddisruptionbudget.go
@@ -60,8 +60,27 @@ func NewPodDisruptionBudgetInformer(client kubernetes.Interface, namespace strin
 	)
 }
 
-func defaultPodDisruptionBudgetInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPodDisruptionBudgetInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPodDisruptionBudgetInformerWithOptions constructs a new informer for PodDisruptionBudget type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPodDisruptionBudgetInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.PolicyV1beta1().PodDisruptionBudgets(namespace).Watch(options)
+			},
+		},
+		options,
+		&policy_v1beta1.PodDisruptionBudget{},
+		indexers,
+	)
+}
+
+func defaultPodDisruptionBudgetInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPodDisruptionBudgetInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *podDisruptionBudgetInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrole.go
@@ -60,8 +60,27 @@ func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 	)
 }
 
-func defaultClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1().ClusterRoles().List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1().ClusterRoles().Watch(options)
+			},
+		},
+		options,
+		&rbac_v1.ClusterRole{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/clusterrolebinding.go
@@ -60,8 +60,27 @@ func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 	)
 }
 
-func defaultClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1().ClusterRoleBindings().List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1().ClusterRoleBindings().Watch(options)
+			},
+		},
+		options,
+		&rbac_v1.ClusterRoleBinding{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleBindingInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleBindingInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1/rolebinding.go
@@ -60,8 +60,27 @@ func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyn
 	)
 }
 
-func defaultRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1().RoleBindings(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1().RoleBindings(namespace).Watch(options)
+			},
+		},
+		options,
+		&rbac_v1.RoleBinding{},
+		indexers,
+	)
+}
+
+func defaultRoleBindingInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewRoleBindingInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrole.go
@@ -60,8 +60,27 @@ func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 	)
 }
 
-func defaultClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1alpha1().ClusterRoles().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1alpha1().ClusterRoles().Watch(options)
+			},
+		},
+		options,
+		&rbac_v1alpha1.ClusterRole{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/clusterrolebinding.go
@@ -60,8 +60,27 @@ func NewClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod tim
 	)
 }
 
-func defaultClusterRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleBindingInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleBindingInformerWithOptions constructs a new informer for ClusterRoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleBindingInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1alpha1().ClusterRoleBindings().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1alpha1().ClusterRoleBindings().Watch(options)
+			},
+		},
+		options,
+		&rbac_v1alpha1.ClusterRoleBinding{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleBindingInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleBindingInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1alpha1/role.go
@@ -60,8 +60,27 @@ func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod
 	)
 }
 
-func defaultRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewRoleInformerWithOptions constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1alpha1().Roles(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1alpha1().Roles(namespace).Watch(options)
+			},
+		},
+		options,
+		&rbac_v1alpha1.Role{},
+		indexers,
+	)
+}
+
+func defaultRoleInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewRoleInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/clusterrole.go
@@ -60,8 +60,27 @@ func NewClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Durat
 	)
 }
 
-func defaultClusterRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewClusterRoleInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewClusterRoleInformerWithOptions constructs a new informer for ClusterRole type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewClusterRoleInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1beta1().ClusterRoles().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1beta1().ClusterRoles().Watch(options)
+			},
+		},
+		options,
+		&rbac_v1beta1.ClusterRole{},
+		indexers,
+	)
+}
+
+func defaultClusterRoleInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewClusterRoleInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *clusterRoleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/role.go
@@ -60,8 +60,27 @@ func NewRoleInformer(client kubernetes.Interface, namespace string, resyncPeriod
 	)
 }
 
-func defaultRoleInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewRoleInformerWithOptions constructs a new informer for Role type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1beta1().Roles(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1beta1().Roles(namespace).Watch(options)
+			},
+		},
+		options,
+		&rbac_v1beta1.Role{},
+		indexers,
+	)
+}
+
+func defaultRoleInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewRoleInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/informers/rbac/v1beta1/rolebinding.go
@@ -60,8 +60,27 @@ func NewRoleBindingInformer(client kubernetes.Interface, namespace string, resyn
 	)
 }
 
-func defaultRoleBindingInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewRoleBindingInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewRoleBindingInformerWithOptions constructs a new informer for RoleBinding type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewRoleBindingInformerWithOptions(client kubernetes.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.RbacV1beta1().RoleBindings(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.RbacV1beta1().RoleBindings(namespace).Watch(options)
+			},
+		},
+		options,
+		&rbac_v1beta1.RoleBinding{},
+		indexers,
+	)
+}
+
+func defaultRoleBindingInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewRoleBindingInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *roleBindingInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/informers/scheduling/v1alpha1/priorityclass.go
@@ -60,8 +60,27 @@ func NewPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Dur
 	)
 }
 
-func defaultPriorityClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewPriorityClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewPriorityClassInformerWithOptions constructs a new informer for PriorityClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewPriorityClassInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.SchedulingV1alpha1().PriorityClasses().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.SchedulingV1alpha1().PriorityClasses().Watch(options)
+			},
+		},
+		options,
+		&scheduling_v1alpha1.PriorityClass{},
+		indexers,
+	)
+}
+
+func defaultPriorityClassInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewPriorityClassInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *priorityClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/informers/storage/v1beta1/storageclass.go
@@ -60,8 +60,27 @@ func NewStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Dura
 	)
 }
 
-func defaultStorageClassInformer(client kubernetes.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewStorageClassInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewStorageClassInformerWithOptions constructs a new informer for StorageClass type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewStorageClassInformerWithOptions(client kubernetes.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.StorageV1beta1().StorageClasses().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.StorageV1beta1().StorageClasses().Watch(options)
+			},
+		},
+		options,
+		&storage_v1beta1.StorageClass{},
+		indexers,
+	)
+}
+
+func defaultStorageClassInformer(client kubernetes.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewStorageClassInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *storageClassInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ExternalAdmissionHookConfigurationLister interface {
 	// List lists all ExternalAdmissionHookConfigurations in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.ExternalAdmissionHookConfiguration, err error)
+	// ListWithOptions lists all ExternalAdmissionHookConfigurations in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ExternalAdmissionHookConfiguration, err error)
 	// Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 	Get(name string) (*v1alpha1.ExternalAdmissionHookConfiguration, error)
 	ExternalAdmissionHookConfigurationListerExpansion
@@ -48,6 +52,15 @@ func NewExternalAdmissionHookConfigurationLister(indexer cache.Indexer) External
 // List lists all ExternalAdmissionHookConfigurations in the indexer.
 func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector) (ret []*v1alpha1.ExternalAdmissionHookConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.ExternalAdmissionHookConfiguration))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ExternalAdmissionHookConfigurations in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *externalAdmissionHookConfigurationLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ExternalAdmissionHookConfiguration, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ExternalAdmissionHookConfiguration))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type InitializerConfigurationLister interface {
 	// List lists all InitializerConfigurations in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.InitializerConfiguration, err error)
+	// ListWithOptions lists all InitializerConfigurations in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.InitializerConfiguration, err error)
 	// Get retrieves the InitializerConfiguration from the index for a given name.
 	Get(name string) (*v1alpha1.InitializerConfiguration, error)
 	InitializerConfigurationListerExpansion
@@ -48,6 +52,15 @@ func NewInitializerConfigurationLister(indexer cache.Indexer) InitializerConfigu
 // List lists all InitializerConfigurations in the indexer.
 func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*v1alpha1.InitializerConfiguration, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.InitializerConfiguration))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all InitializerConfigurations in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *initializerConfigurationLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.InitializerConfiguration, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.InitializerConfiguration))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/controllerrevision.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ControllerRevisionLister interface {
 	// List lists all ControllerRevisions in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error)
+	// ListWithOptions lists all ControllerRevisions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ControllerRevision, err error)
 	// ControllerRevisions returns an object that can list and get ControllerRevisions.
 	ControllerRevisions(namespace string) ControllerRevisionNamespaceLister
 	ControllerRevisionListerExpansion
@@ -52,6 +56,15 @@ func (s *controllerRevisionLister) List(selector labels.Selector) (ret []*v1beta
 	return ret, err
 }
 
+// ListWithOptions lists all ControllerRevisions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *controllerRevisionLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ControllerRevision, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ControllerRevision))
+	})
+	return ret, err
+}
+
 // ControllerRevisions returns an object that can list and get ControllerRevisions.
 func (s *controllerRevisionLister) ControllerRevisions(namespace string) ControllerRevisionNamespaceLister {
 	return controllerRevisionNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *controllerRevisionLister) ControllerRevisions(namespace string) Control
 type ControllerRevisionNamespaceLister interface {
 	// List lists all ControllerRevisions in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error)
+	// ListWithOptions lists all ControllerRevisions that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ControllerRevision, err error)
 	// Get retrieves the ControllerRevision from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.ControllerRevision, error)
 	ControllerRevisionNamespaceListerExpansion
@@ -76,6 +93,15 @@ type controllerRevisionNamespaceLister struct {
 // List lists all ControllerRevisions in the indexer for a given namespace.
 func (s controllerRevisionNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ControllerRevision, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ControllerRevision))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ControllerRevisions that matches the options
+// in the indexer for a given namespace.
+func (s controllerRevisionNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ControllerRevision, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ControllerRevision))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/deployment.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
+	// ListWithOptions lists all Deployments in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -52,6 +56,15 @@ func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta1.Deploy
 	return ret, err
 }
 
+// ListWithOptions lists all Deployments in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *deploymentLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Deployment))
+	})
+	return ret, err
+}
+
 // Deployments returns an object that can list and get Deployments.
 func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceLister {
 	return deploymentNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceList
 type DeploymentNamespaceLister interface {
 	// List lists all Deployments in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
+	// ListWithOptions lists all Deployments that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error)
 	// Get retrieves the Deployment from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Deployment, error)
 	DeploymentNamespaceListerExpansion
@@ -76,6 +93,15 @@ type deploymentNamespaceLister struct {
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Deployment))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Deployments that matches the options
+// in the indexer for a given namespace.
+func (s deploymentNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/scale.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ScaleLister interface {
 	// List lists all Scales in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Scale, err error)
+	// ListWithOptions lists all Scales in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error)
 	// Scales returns an object that can list and get Scales.
 	Scales(namespace string) ScaleNamespaceLister
 	ScaleListerExpansion
@@ -52,6 +56,15 @@ func (s *scaleLister) List(selector labels.Selector) (ret []*v1beta1.Scale, err 
 	return ret, err
 }
 
+// ListWithOptions lists all Scales in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *scaleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Scale))
+	})
+	return ret, err
+}
+
 // Scales returns an object that can list and get Scales.
 func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 	return scaleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 type ScaleNamespaceLister interface {
 	// List lists all Scales in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Scale, err error)
+	// ListWithOptions lists all Scales that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error)
 	// Get retrieves the Scale from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Scale, error)
 	ScaleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type scaleNamespaceLister struct {
 // List lists all Scales in the indexer for a given namespace.
 func (s scaleNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Scale, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Scale))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Scales that matches the options
+// in the indexer for a given namespace.
+func (s scaleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Scale))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta1/statefulset.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/apps/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type StatefulSetLister interface {
 	// List lists all StatefulSets in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error)
+	// ListWithOptions lists all StatefulSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StatefulSet, err error)
 	// StatefulSets returns an object that can list and get StatefulSets.
 	StatefulSets(namespace string) StatefulSetNamespaceLister
 	StatefulSetListerExpansion
@@ -52,6 +56,15 @@ func (s *statefulSetLister) List(selector labels.Selector) (ret []*v1beta1.State
 	return ret, err
 }
 
+// ListWithOptions lists all StatefulSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *statefulSetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StatefulSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.StatefulSet))
+	})
+	return ret, err
+}
+
 // StatefulSets returns an object that can list and get StatefulSets.
 func (s *statefulSetLister) StatefulSets(namespace string) StatefulSetNamespaceLister {
 	return statefulSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *statefulSetLister) StatefulSets(namespace string) StatefulSetNamespaceL
 type StatefulSetNamespaceLister interface {
 	// List lists all StatefulSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error)
+	// ListWithOptions lists all StatefulSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StatefulSet, err error)
 	// Get retrieves the StatefulSet from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.StatefulSet, error)
 	StatefulSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type statefulSetNamespaceLister struct {
 // List lists all StatefulSets in the indexer for a given namespace.
 func (s statefulSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.StatefulSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.StatefulSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all StatefulSets that matches the options
+// in the indexer for a given namespace.
+func (s statefulSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StatefulSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.StatefulSet))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/controllerrevision.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ControllerRevisionLister interface {
 	// List lists all ControllerRevisions in the indexer.
 	List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error)
+	// ListWithOptions lists all ControllerRevisions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.ControllerRevision, err error)
 	// ControllerRevisions returns an object that can list and get ControllerRevisions.
 	ControllerRevisions(namespace string) ControllerRevisionNamespaceLister
 	ControllerRevisionListerExpansion
@@ -52,6 +56,15 @@ func (s *controllerRevisionLister) List(selector labels.Selector) (ret []*v1beta
 	return ret, err
 }
 
+// ListWithOptions lists all ControllerRevisions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *controllerRevisionLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.ControllerRevision, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.ControllerRevision))
+	})
+	return ret, err
+}
+
 // ControllerRevisions returns an object that can list and get ControllerRevisions.
 func (s *controllerRevisionLister) ControllerRevisions(namespace string) ControllerRevisionNamespaceLister {
 	return controllerRevisionNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *controllerRevisionLister) ControllerRevisions(namespace string) Control
 type ControllerRevisionNamespaceLister interface {
 	// List lists all ControllerRevisions in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error)
+	// ListWithOptions lists all ControllerRevisions that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.ControllerRevision, err error)
 	// Get retrieves the ControllerRevision from the indexer for a given namespace and name.
 	Get(name string) (*v1beta2.ControllerRevision, error)
 	ControllerRevisionNamespaceListerExpansion
@@ -76,6 +93,15 @@ type controllerRevisionNamespaceLister struct {
 // List lists all ControllerRevisions in the indexer for a given namespace.
 func (s controllerRevisionNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.ControllerRevision, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.ControllerRevision))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ControllerRevisions that matches the options
+// in the indexer for a given namespace.
+func (s controllerRevisionNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.ControllerRevision, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.ControllerRevision))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/daemonset.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type DaemonSetLister interface {
 	// List lists all DaemonSets in the indexer.
 	List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error)
+	// ListWithOptions lists all DaemonSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.DaemonSet, err error)
 	// DaemonSets returns an object that can list and get DaemonSets.
 	DaemonSets(namespace string) DaemonSetNamespaceLister
 	DaemonSetListerExpansion
@@ -52,6 +56,15 @@ func (s *daemonSetLister) List(selector labels.Selector) (ret []*v1beta2.DaemonS
 	return ret, err
 }
 
+// ListWithOptions lists all DaemonSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *daemonSetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.DaemonSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.DaemonSet))
+	})
+	return ret, err
+}
+
 // DaemonSets returns an object that can list and get DaemonSets.
 func (s *daemonSetLister) DaemonSets(namespace string) DaemonSetNamespaceLister {
 	return daemonSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *daemonSetLister) DaemonSets(namespace string) DaemonSetNamespaceLister 
 type DaemonSetNamespaceLister interface {
 	// List lists all DaemonSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error)
+	// ListWithOptions lists all DaemonSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.DaemonSet, err error)
 	// Get retrieves the DaemonSet from the indexer for a given namespace and name.
 	Get(name string) (*v1beta2.DaemonSet, error)
 	DaemonSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type daemonSetNamespaceLister struct {
 // List lists all DaemonSets in the indexer for a given namespace.
 func (s daemonSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.DaemonSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.DaemonSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all DaemonSets that matches the options
+// in the indexer for a given namespace.
+func (s daemonSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.DaemonSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.DaemonSet))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/deployment.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	List(selector labels.Selector) (ret []*v1beta2.Deployment, err error)
+	// ListWithOptions lists all Deployments in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -52,6 +56,15 @@ func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta2.Deploy
 	return ret, err
 }
 
+// ListWithOptions lists all Deployments in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *deploymentLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Deployment, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.Deployment))
+	})
+	return ret, err
+}
+
 // Deployments returns an object that can list and get Deployments.
 func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceLister {
 	return deploymentNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceList
 type DeploymentNamespaceLister interface {
 	// List lists all Deployments in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta2.Deployment, err error)
+	// ListWithOptions lists all Deployments that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Deployment, err error)
 	// Get retrieves the Deployment from the indexer for a given namespace and name.
 	Get(name string) (*v1beta2.Deployment, error)
 	DeploymentNamespaceListerExpansion
@@ -76,6 +93,15 @@ type deploymentNamespaceLister struct {
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.Deployment))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Deployments that matches the options
+// in the indexer for a given namespace.
+func (s deploymentNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Deployment, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.Deployment))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/scale.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/scale.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ScaleLister interface {
 	// List lists all Scales in the indexer.
 	List(selector labels.Selector) (ret []*v1beta2.Scale, err error)
+	// ListWithOptions lists all Scales in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Scale, err error)
 	// Scales returns an object that can list and get Scales.
 	Scales(namespace string) ScaleNamespaceLister
 	ScaleListerExpansion
@@ -52,6 +56,15 @@ func (s *scaleLister) List(selector labels.Selector) (ret []*v1beta2.Scale, err 
 	return ret, err
 }
 
+// ListWithOptions lists all Scales in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *scaleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Scale, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.Scale))
+	})
+	return ret, err
+}
+
 // Scales returns an object that can list and get Scales.
 func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 	return scaleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 type ScaleNamespaceLister interface {
 	// List lists all Scales in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta2.Scale, err error)
+	// ListWithOptions lists all Scales that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Scale, err error)
 	// Get retrieves the Scale from the indexer for a given namespace and name.
 	Get(name string) (*v1beta2.Scale, error)
 	ScaleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type scaleNamespaceLister struct {
 // List lists all Scales in the indexer for a given namespace.
 func (s scaleNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.Scale, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.Scale))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Scales that matches the options
+// in the indexer for a given namespace.
+func (s scaleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.Scale, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.Scale))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/listers/apps/v1beta2/statefulset.go
@@ -21,6 +21,7 @@ package v1beta2
 import (
 	v1beta2 "k8s.io/api/apps/v1beta2"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type StatefulSetLister interface {
 	// List lists all StatefulSets in the indexer.
 	List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error)
+	// ListWithOptions lists all StatefulSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.StatefulSet, err error)
 	// StatefulSets returns an object that can list and get StatefulSets.
 	StatefulSets(namespace string) StatefulSetNamespaceLister
 	StatefulSetListerExpansion
@@ -52,6 +56,15 @@ func (s *statefulSetLister) List(selector labels.Selector) (ret []*v1beta2.State
 	return ret, err
 }
 
+// ListWithOptions lists all StatefulSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *statefulSetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.StatefulSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.StatefulSet))
+	})
+	return ret, err
+}
+
 // StatefulSets returns an object that can list and get StatefulSets.
 func (s *statefulSetLister) StatefulSets(namespace string) StatefulSetNamespaceLister {
 	return statefulSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *statefulSetLister) StatefulSets(namespace string) StatefulSetNamespaceL
 type StatefulSetNamespaceLister interface {
 	// List lists all StatefulSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error)
+	// ListWithOptions lists all StatefulSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.StatefulSet, err error)
 	// Get retrieves the StatefulSet from the indexer for a given namespace and name.
 	Get(name string) (*v1beta2.StatefulSet, error)
 	StatefulSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type statefulSetNamespaceLister struct {
 // List lists all StatefulSets in the indexer for a given namespace.
 func (s statefulSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta2.StatefulSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta2.StatefulSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all StatefulSets that matches the options
+// in the indexer for a given namespace.
+func (s statefulSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta2.StatefulSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta2.StatefulSet))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authentication/v1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1/tokenreview.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type TokenReviewLister interface {
 	// List lists all TokenReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1.TokenReview, err error)
+	// ListWithOptions lists all TokenReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.TokenReview, err error)
 	// Get retrieves the TokenReview from the index for a given name.
 	Get(name string) (*v1.TokenReview, error)
 	TokenReviewListerExpansion
@@ -48,6 +52,15 @@ func NewTokenReviewLister(indexer cache.Indexer) TokenReviewLister {
 // List lists all TokenReviews in the indexer.
 func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1.TokenReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.TokenReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all TokenReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *tokenReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.TokenReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.TokenReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type TokenReviewLister interface {
 	// List lists all TokenReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.TokenReview, err error)
+	// ListWithOptions lists all TokenReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.TokenReview, err error)
 	// Get retrieves the TokenReview from the index for a given name.
 	Get(name string) (*v1beta1.TokenReview, error)
 	TokenReviewListerExpansion
@@ -48,6 +52,15 @@ func NewTokenReviewLister(indexer cache.Indexer) TokenReviewLister {
 // List lists all TokenReviews in the indexer.
 func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1beta1.TokenReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.TokenReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all TokenReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *tokenReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.TokenReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.TokenReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/localsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type LocalSubjectAccessReviewLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.LocalSubjectAccessReview, err error)
 	// LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister
 	LocalSubjectAccessReviewListerExpansion
@@ -52,6 +56,15 @@ func (s *localSubjectAccessReviewLister) List(selector labels.Selector) (ret []*
 	return ret, err
 }
 
+// ListWithOptions lists all LocalSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *localSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
 // LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister {
 	return localSubjectAccessReviewNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace str
 type LocalSubjectAccessReviewNamespaceLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.LocalSubjectAccessReview, err error)
 	// Get retrieves the LocalSubjectAccessReview from the indexer for a given namespace and name.
 	Get(name string) (*v1.LocalSubjectAccessReview, error)
 	LocalSubjectAccessReviewNamespaceListerExpansion
@@ -76,6 +93,15 @@ type localSubjectAccessReviewNamespaceLister struct {
 // List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 func (s localSubjectAccessReviewNamespaceLister) List(selector labels.Selector) (ret []*v1.LocalSubjectAccessReview, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+// in the indexer for a given namespace.
+func (s localSubjectAccessReviewNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.LocalSubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type SelfSubjectAccessReviewLister interface {
 	// List lists all SelfSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1.SelfSubjectAccessReview, err error)
+	// ListWithOptions lists all SelfSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.SelfSubjectAccessReview, err error)
 	// Get retrieves the SelfSubjectAccessReview from the index for a given name.
 	Get(name string) (*v1.SelfSubjectAccessReview, error)
 	SelfSubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSelfSubjectAccessReviewLister(indexer cache.Indexer) SelfSubjectAccessRe
 // List lists all SelfSubjectAccessReviews in the indexer.
 func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v1.SelfSubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.SelfSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SelfSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *selfSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.SelfSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.SelfSubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type SubjectAccessReviewLister interface {
 	// List lists all SubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1.SubjectAccessReview, err error)
+	// ListWithOptions lists all SubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.SubjectAccessReview, err error)
 	// Get retrieves the SubjectAccessReview from the index for a given name.
 	Get(name string) (*v1.SubjectAccessReview, error)
 	SubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSubjectAccessReviewLister(indexer cache.Indexer) SubjectAccessReviewList
 // List lists all SubjectAccessReviews in the indexer.
 func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1.SubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.SubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *subjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.SubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.SubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/localsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/localsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type LocalSubjectAccessReviewLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.LocalSubjectAccessReview, err error)
 	// LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 	LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister
 	LocalSubjectAccessReviewListerExpansion
@@ -52,6 +56,15 @@ func (s *localSubjectAccessReviewLister) List(selector labels.Selector) (ret []*
 	return ret, err
 }
 
+// ListWithOptions lists all LocalSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *localSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
 // LocalSubjectAccessReviews returns an object that can list and get LocalSubjectAccessReviews.
 func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace string) LocalSubjectAccessReviewNamespaceLister {
 	return localSubjectAccessReviewNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *localSubjectAccessReviewLister) LocalSubjectAccessReviews(namespace str
 type LocalSubjectAccessReviewNamespaceLister interface {
 	// List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.LocalSubjectAccessReview, err error)
+	// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.LocalSubjectAccessReview, err error)
 	// Get retrieves the LocalSubjectAccessReview from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.LocalSubjectAccessReview, error)
 	LocalSubjectAccessReviewNamespaceListerExpansion
@@ -76,6 +93,15 @@ type localSubjectAccessReviewNamespaceLister struct {
 // List lists all LocalSubjectAccessReviews in the indexer for a given namespace.
 func (s localSubjectAccessReviewNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.LocalSubjectAccessReview, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.LocalSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all LocalSubjectAccessReviews that matches the options
+// in the indexer for a given namespace.
+func (s localSubjectAccessReviewNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.LocalSubjectAccessReview, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.LocalSubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type SelfSubjectAccessReviewLister interface {
 	// List lists all SelfSubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.SelfSubjectAccessReview, err error)
+	// ListWithOptions lists all SelfSubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.SelfSubjectAccessReview, err error)
 	// Get retrieves the SelfSubjectAccessReview from the index for a given name.
 	Get(name string) (*v1beta1.SelfSubjectAccessReview, error)
 	SelfSubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSelfSubjectAccessReviewLister(indexer cache.Indexer) SelfSubjectAccessRe
 // List lists all SelfSubjectAccessReviews in the indexer.
 func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v1beta1.SelfSubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.SelfSubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SelfSubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *selfSubjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.SelfSubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.SelfSubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type SubjectAccessReviewLister interface {
 	// List lists all SubjectAccessReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.SubjectAccessReview, err error)
+	// ListWithOptions lists all SubjectAccessReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.SubjectAccessReview, err error)
 	// Get retrieves the SubjectAccessReview from the index for a given name.
 	Get(name string) (*v1beta1.SubjectAccessReview, error)
 	SubjectAccessReviewListerExpansion
@@ -48,6 +52,15 @@ func NewSubjectAccessReviewLister(indexer cache.Indexer) SubjectAccessReviewList
 // List lists all SubjectAccessReviews in the indexer.
 func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1beta1.SubjectAccessReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.SubjectAccessReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all SubjectAccessReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *subjectAccessReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.SubjectAccessReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.SubjectAccessReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v1/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v1/horizontalpodautoscaler.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/autoscaling/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -52,6 +56,15 @@ func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v
 	return ret, err
 }
 
+// ListWithOptions lists all HorizontalPodAutoscalers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *horizontalPodAutoscalerLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
 // HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister {
 	return horizontalPodAutoscalerNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace strin
 type HorizontalPodAutoscalerNamespaceLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.HorizontalPodAutoscaler, err error)
 	// Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 	Get(name string) (*v1.HorizontalPodAutoscaler, error)
 	HorizontalPodAutoscalerNamespaceListerExpansion
@@ -76,6 +93,15 @@ type horizontalPodAutoscalerNamespaceLister struct {
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+// in the indexer for a given namespace.
+func (s horizontalPodAutoscalerNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.HorizontalPodAutoscaler))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/autoscaling/v2alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/listers/autoscaling/v2alpha1/horizontalpodautoscaler.go
@@ -21,6 +21,7 @@ package v2alpha1
 import (
 	v2alpha1 "k8s.io/api/autoscaling/v2alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type HorizontalPodAutoscalerLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer.
 	List(selector labels.Selector) (ret []*v2alpha1.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.HorizontalPodAutoscaler, err error)
 	// HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 	HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister
 	HorizontalPodAutoscalerListerExpansion
@@ -52,6 +56,15 @@ func (s *horizontalPodAutoscalerLister) List(selector labels.Selector) (ret []*v
 	return ret, err
 }
 
+// ListWithOptions lists all HorizontalPodAutoscalers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *horizontalPodAutoscalerLister) ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v2alpha1.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
 // HorizontalPodAutoscalers returns an object that can list and get HorizontalPodAutoscalers.
 func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace string) HorizontalPodAutoscalerNamespaceLister {
 	return horizontalPodAutoscalerNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *horizontalPodAutoscalerLister) HorizontalPodAutoscalers(namespace strin
 type HorizontalPodAutoscalerNamespaceLister interface {
 	// List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v2alpha1.HorizontalPodAutoscaler, err error)
+	// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.HorizontalPodAutoscaler, err error)
 	// Get retrieves the HorizontalPodAutoscaler from the indexer for a given namespace and name.
 	Get(name string) (*v2alpha1.HorizontalPodAutoscaler, error)
 	HorizontalPodAutoscalerNamespaceListerExpansion
@@ -76,6 +93,15 @@ type horizontalPodAutoscalerNamespaceLister struct {
 // List lists all HorizontalPodAutoscalers in the indexer for a given namespace.
 func (s horizontalPodAutoscalerNamespaceLister) List(selector labels.Selector) (ret []*v2alpha1.HorizontalPodAutoscaler, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v2alpha1.HorizontalPodAutoscaler))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all HorizontalPodAutoscalers that matches the options
+// in the indexer for a given namespace.
+func (s horizontalPodAutoscalerNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.HorizontalPodAutoscaler, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v2alpha1.HorizontalPodAutoscaler))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1/job.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type JobLister interface {
 	// List lists all Jobs in the indexer.
 	List(selector labels.Selector) (ret []*v1.Job, err error)
+	// ListWithOptions lists all Jobs in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Job, err error)
 	// Jobs returns an object that can list and get Jobs.
 	Jobs(namespace string) JobNamespaceLister
 	JobListerExpansion
@@ -52,6 +56,15 @@ func (s *jobLister) List(selector labels.Selector) (ret []*v1.Job, err error) {
 	return ret, err
 }
 
+// ListWithOptions lists all Jobs in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *jobLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Job, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Job))
+	})
+	return ret, err
+}
+
 // Jobs returns an object that can list and get Jobs.
 func (s *jobLister) Jobs(namespace string) JobNamespaceLister {
 	return jobNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *jobLister) Jobs(namespace string) JobNamespaceLister {
 type JobNamespaceLister interface {
 	// List lists all Jobs in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Job, err error)
+	// ListWithOptions lists all Jobs that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Job, err error)
 	// Get retrieves the Job from the indexer for a given namespace and name.
 	Get(name string) (*v1.Job, error)
 	JobNamespaceListerExpansion
@@ -76,6 +93,15 @@ type jobNamespaceLister struct {
 // List lists all Jobs in the indexer for a given namespace.
 func (s jobNamespaceLister) List(selector labels.Selector) (ret []*v1.Job, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Job))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Jobs that matches the options
+// in the indexer for a given namespace.
+func (s jobNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Job, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Job))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/batch/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/batch/v1beta1/BUILD
@@ -17,6 +17,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/batch/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v1beta1/cronjob.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type CronJobLister interface {
 	// List lists all CronJobs in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.CronJob, err error)
+	// ListWithOptions lists all CronJobs in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CronJob, err error)
 	// CronJobs returns an object that can list and get CronJobs.
 	CronJobs(namespace string) CronJobNamespaceLister
 	CronJobListerExpansion
@@ -52,6 +56,15 @@ func (s *cronJobLister) List(selector labels.Selector) (ret []*v1beta1.CronJob, 
 	return ret, err
 }
 
+// ListWithOptions lists all CronJobs in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *cronJobLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CronJob, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.CronJob))
+	})
+	return ret, err
+}
+
 // CronJobs returns an object that can list and get CronJobs.
 func (s *cronJobLister) CronJobs(namespace string) CronJobNamespaceLister {
 	return cronJobNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *cronJobLister) CronJobs(namespace string) CronJobNamespaceLister {
 type CronJobNamespaceLister interface {
 	// List lists all CronJobs in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.CronJob, err error)
+	// ListWithOptions lists all CronJobs that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CronJob, err error)
 	// Get retrieves the CronJob from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.CronJob, error)
 	CronJobNamespaceListerExpansion
@@ -76,6 +93,15 @@ type cronJobNamespaceLister struct {
 // List lists all CronJobs in the indexer for a given namespace.
 func (s cronJobNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.CronJob, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.CronJob))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CronJobs that matches the options
+// in the indexer for a given namespace.
+func (s cronJobNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CronJob, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CronJob))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/batch/v2alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/batch/v2alpha1/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/batch/v2alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/listers/batch/v2alpha1/cronjob.go
@@ -21,6 +21,7 @@ package v2alpha1
 import (
 	v2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type CronJobLister interface {
 	// List lists all CronJobs in the indexer.
 	List(selector labels.Selector) (ret []*v2alpha1.CronJob, err error)
+	// ListWithOptions lists all CronJobs in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.CronJob, err error)
 	// CronJobs returns an object that can list and get CronJobs.
 	CronJobs(namespace string) CronJobNamespaceLister
 	CronJobListerExpansion
@@ -52,6 +56,15 @@ func (s *cronJobLister) List(selector labels.Selector) (ret []*v2alpha1.CronJob,
 	return ret, err
 }
 
+// ListWithOptions lists all CronJobs in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *cronJobLister) ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.CronJob, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v2alpha1.CronJob))
+	})
+	return ret, err
+}
+
 // CronJobs returns an object that can list and get CronJobs.
 func (s *cronJobLister) CronJobs(namespace string) CronJobNamespaceLister {
 	return cronJobNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *cronJobLister) CronJobs(namespace string) CronJobNamespaceLister {
 type CronJobNamespaceLister interface {
 	// List lists all CronJobs in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v2alpha1.CronJob, err error)
+	// ListWithOptions lists all CronJobs that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.CronJob, err error)
 	// Get retrieves the CronJob from the indexer for a given namespace and name.
 	Get(name string) (*v2alpha1.CronJob, error)
 	CronJobNamespaceListerExpansion
@@ -76,6 +93,15 @@ type cronJobNamespaceLister struct {
 // List lists all CronJobs in the indexer for a given namespace.
 func (s cronJobNamespaceLister) List(selector labels.Selector) (ret []*v2alpha1.CronJob, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v2alpha1.CronJob))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CronJobs that matches the options
+// in the indexer for a given namespace.
+func (s cronJobNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v2alpha1.CronJob, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v2alpha1.CronJob))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type CertificateSigningRequestLister interface {
 	// List lists all CertificateSigningRequests in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error)
+	// ListWithOptions lists all CertificateSigningRequests in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CertificateSigningRequest, err error)
 	// Get retrieves the CertificateSigningRequest from the index for a given name.
 	Get(name string) (*v1beta1.CertificateSigningRequest, error)
 	CertificateSigningRequestListerExpansion
@@ -48,6 +52,15 @@ func NewCertificateSigningRequestLister(indexer cache.Indexer) CertificateSignin
 // List lists all CertificateSigningRequests in the indexer.
 func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []*v1beta1.CertificateSigningRequest, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.CertificateSigningRequest))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all CertificateSigningRequests in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *certificateSigningRequestLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.CertificateSigningRequest, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.CertificateSigningRequest))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type ComponentStatusLister interface {
 	// List lists all ComponentStatuses in the indexer.
 	List(selector labels.Selector) (ret []*v1.ComponentStatus, err error)
+	// ListWithOptions lists all ComponentStatuses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ComponentStatus, err error)
 	// Get retrieves the ComponentStatus from the index for a given name.
 	Get(name string) (*v1.ComponentStatus, error)
 	ComponentStatusListerExpansion
@@ -48,6 +52,15 @@ func NewComponentStatusLister(indexer cache.Indexer) ComponentStatusLister {
 // List lists all ComponentStatuses in the indexer.
 func (s *componentStatusLister) List(selector labels.Selector) (ret []*v1.ComponentStatus, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.ComponentStatus))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ComponentStatuses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *componentStatusLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ComponentStatus, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.ComponentStatus))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/configmap.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ConfigMapLister interface {
 	// List lists all ConfigMaps in the indexer.
 	List(selector labels.Selector) (ret []*v1.ConfigMap, err error)
+	// ListWithOptions lists all ConfigMaps in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ConfigMap, err error)
 	// ConfigMaps returns an object that can list and get ConfigMaps.
 	ConfigMaps(namespace string) ConfigMapNamespaceLister
 	ConfigMapListerExpansion
@@ -52,6 +56,15 @@ func (s *configMapLister) List(selector labels.Selector) (ret []*v1.ConfigMap, e
 	return ret, err
 }
 
+// ListWithOptions lists all ConfigMaps in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *configMapLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ConfigMap, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.ConfigMap))
+	})
+	return ret, err
+}
+
 // ConfigMaps returns an object that can list and get ConfigMaps.
 func (s *configMapLister) ConfigMaps(namespace string) ConfigMapNamespaceLister {
 	return configMapNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *configMapLister) ConfigMaps(namespace string) ConfigMapNamespaceLister 
 type ConfigMapNamespaceLister interface {
 	// List lists all ConfigMaps in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.ConfigMap, err error)
+	// ListWithOptions lists all ConfigMaps that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ConfigMap, err error)
 	// Get retrieves the ConfigMap from the indexer for a given namespace and name.
 	Get(name string) (*v1.ConfigMap, error)
 	ConfigMapNamespaceListerExpansion
@@ -76,6 +93,15 @@ type configMapNamespaceLister struct {
 // List lists all ConfigMaps in the indexer for a given namespace.
 func (s configMapNamespaceLister) List(selector labels.Selector) (ret []*v1.ConfigMap, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.ConfigMap))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ConfigMaps that matches the options
+// in the indexer for a given namespace.
+func (s configMapNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ConfigMap, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.ConfigMap))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/endpoints.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type EndpointsLister interface {
 	// List lists all Endpoints in the indexer.
 	List(selector labels.Selector) (ret []*v1.Endpoints, err error)
+	// ListWithOptions lists all Endpoints in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Endpoints, err error)
 	// Endpoints returns an object that can list and get Endpoints.
 	Endpoints(namespace string) EndpointsNamespaceLister
 	EndpointsListerExpansion
@@ -52,6 +56,15 @@ func (s *endpointsLister) List(selector labels.Selector) (ret []*v1.Endpoints, e
 	return ret, err
 }
 
+// ListWithOptions lists all Endpoints in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *endpointsLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Endpoints, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Endpoints))
+	})
+	return ret, err
+}
+
 // Endpoints returns an object that can list and get Endpoints.
 func (s *endpointsLister) Endpoints(namespace string) EndpointsNamespaceLister {
 	return endpointsNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *endpointsLister) Endpoints(namespace string) EndpointsNamespaceLister {
 type EndpointsNamespaceLister interface {
 	// List lists all Endpoints in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Endpoints, err error)
+	// ListWithOptions lists all Endpoints that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Endpoints, err error)
 	// Get retrieves the Endpoints from the indexer for a given namespace and name.
 	Get(name string) (*v1.Endpoints, error)
 	EndpointsNamespaceListerExpansion
@@ -76,6 +93,15 @@ type endpointsNamespaceLister struct {
 // List lists all Endpoints in the indexer for a given namespace.
 func (s endpointsNamespaceLister) List(selector labels.Selector) (ret []*v1.Endpoints, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Endpoints))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Endpoints that matches the options
+// in the indexer for a given namespace.
+func (s endpointsNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Endpoints, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Endpoints))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/limitrange.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type LimitRangeLister interface {
 	// List lists all LimitRanges in the indexer.
 	List(selector labels.Selector) (ret []*v1.LimitRange, err error)
+	// ListWithOptions lists all LimitRanges in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.LimitRange, err error)
 	// LimitRanges returns an object that can list and get LimitRanges.
 	LimitRanges(namespace string) LimitRangeNamespaceLister
 	LimitRangeListerExpansion
@@ -52,6 +56,15 @@ func (s *limitRangeLister) List(selector labels.Selector) (ret []*v1.LimitRange,
 	return ret, err
 }
 
+// ListWithOptions lists all LimitRanges in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *limitRangeLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.LimitRange, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.LimitRange))
+	})
+	return ret, err
+}
+
 // LimitRanges returns an object that can list and get LimitRanges.
 func (s *limitRangeLister) LimitRanges(namespace string) LimitRangeNamespaceLister {
 	return limitRangeNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *limitRangeLister) LimitRanges(namespace string) LimitRangeNamespaceList
 type LimitRangeNamespaceLister interface {
 	// List lists all LimitRanges in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.LimitRange, err error)
+	// ListWithOptions lists all LimitRanges that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.LimitRange, err error)
 	// Get retrieves the LimitRange from the indexer for a given namespace and name.
 	Get(name string) (*v1.LimitRange, error)
 	LimitRangeNamespaceListerExpansion
@@ -76,6 +93,15 @@ type limitRangeNamespaceLister struct {
 // List lists all LimitRanges in the indexer for a given namespace.
 func (s limitRangeNamespaceLister) List(selector labels.Selector) (ret []*v1.LimitRange, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.LimitRange))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all LimitRanges that matches the options
+// in the indexer for a given namespace.
+func (s limitRangeNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.LimitRange, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.LimitRange))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type NamespaceLister interface {
 	// List lists all Namespaces in the indexer.
 	List(selector labels.Selector) (ret []*v1.Namespace, err error)
+	// ListWithOptions lists all Namespaces in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Namespace, err error)
 	// Get retrieves the Namespace from the index for a given name.
 	Get(name string) (*v1.Namespace, error)
 	NamespaceListerExpansion
@@ -48,6 +52,15 @@ func NewNamespaceLister(indexer cache.Indexer) NamespaceLister {
 // List lists all Namespaces in the indexer.
 func (s *namespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Namespace))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Namespaces in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *namespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Namespace, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Namespace))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/node.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type NodeLister interface {
 	// List lists all Nodes in the indexer.
 	List(selector labels.Selector) (ret []*v1.Node, err error)
+	// ListWithOptions lists all Nodes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Node, err error)
 	// Get retrieves the Node from the index for a given name.
 	Get(name string) (*v1.Node, error)
 	NodeListerExpansion
@@ -48,6 +52,15 @@ func NewNodeLister(indexer cache.Indexer) NodeLister {
 // List lists all Nodes in the indexer.
 func (s *nodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Node))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Nodes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *nodeLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Node, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Node))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type PersistentVolumeLister interface {
 	// List lists all PersistentVolumes in the indexer.
 	List(selector labels.Selector) (ret []*v1.PersistentVolume, err error)
+	// ListWithOptions lists all PersistentVolumes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.PersistentVolume, err error)
 	// Get retrieves the PersistentVolume from the index for a given name.
 	Get(name string) (*v1.PersistentVolume, error)
 	PersistentVolumeListerExpansion
@@ -48,6 +52,15 @@ func NewPersistentVolumeLister(indexer cache.Indexer) PersistentVolumeLister {
 // List lists all PersistentVolumes in the indexer.
 func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*v1.PersistentVolume, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.PersistentVolume))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PersistentVolumes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *persistentVolumeLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.PersistentVolume, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.PersistentVolume))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/pod.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type PodLister interface {
 	// List lists all Pods in the indexer.
 	List(selector labels.Selector) (ret []*v1.Pod, err error)
+	// ListWithOptions lists all Pods in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Pod, err error)
 	// Pods returns an object that can list and get Pods.
 	Pods(namespace string) PodNamespaceLister
 	PodListerExpansion
@@ -52,6 +56,15 @@ func (s *podLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
 	return ret, err
 }
 
+// ListWithOptions lists all Pods in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Pod, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Pod))
+	})
+	return ret, err
+}
+
 // Pods returns an object that can list and get Pods.
 func (s *podLister) Pods(namespace string) PodNamespaceLister {
 	return podNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podLister) Pods(namespace string) PodNamespaceLister {
 type PodNamespaceLister interface {
 	// List lists all Pods in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Pod, err error)
+	// ListWithOptions lists all Pods that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Pod, err error)
 	// Get retrieves the Pod from the indexer for a given namespace and name.
 	Get(name string) (*v1.Pod, error)
 	PodNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podNamespaceLister struct {
 // List lists all Pods in the indexer for a given namespace.
 func (s podNamespaceLister) List(selector labels.Selector) (ret []*v1.Pod, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Pod))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Pods that matches the options
+// in the indexer for a given namespace.
+func (s podNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Pod, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Pod))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/resourcequota.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ResourceQuotaLister interface {
 	// List lists all ResourceQuotas in the indexer.
 	List(selector labels.Selector) (ret []*v1.ResourceQuota, err error)
+	// ListWithOptions lists all ResourceQuotas in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ResourceQuota, err error)
 	// ResourceQuotas returns an object that can list and get ResourceQuotas.
 	ResourceQuotas(namespace string) ResourceQuotaNamespaceLister
 	ResourceQuotaListerExpansion
@@ -52,6 +56,15 @@ func (s *resourceQuotaLister) List(selector labels.Selector) (ret []*v1.Resource
 	return ret, err
 }
 
+// ListWithOptions lists all ResourceQuotas in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *resourceQuotaLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ResourceQuota, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.ResourceQuota))
+	})
+	return ret, err
+}
+
 // ResourceQuotas returns an object that can list and get ResourceQuotas.
 func (s *resourceQuotaLister) ResourceQuotas(namespace string) ResourceQuotaNamespaceLister {
 	return resourceQuotaNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *resourceQuotaLister) ResourceQuotas(namespace string) ResourceQuotaName
 type ResourceQuotaNamespaceLister interface {
 	// List lists all ResourceQuotas in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.ResourceQuota, err error)
+	// ListWithOptions lists all ResourceQuotas that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ResourceQuota, err error)
 	// Get retrieves the ResourceQuota from the indexer for a given namespace and name.
 	Get(name string) (*v1.ResourceQuota, error)
 	ResourceQuotaNamespaceListerExpansion
@@ -76,6 +93,15 @@ type resourceQuotaNamespaceLister struct {
 // List lists all ResourceQuotas in the indexer for a given namespace.
 func (s resourceQuotaNamespaceLister) List(selector labels.Selector) (ret []*v1.ResourceQuota, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.ResourceQuota))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ResourceQuotas that matches the options
+// in the indexer for a given namespace.
+func (s resourceQuotaNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ResourceQuota, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.ResourceQuota))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/secret.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type SecretLister interface {
 	// List lists all Secrets in the indexer.
 	List(selector labels.Selector) (ret []*v1.Secret, err error)
+	// ListWithOptions lists all Secrets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Secret, err error)
 	// Secrets returns an object that can list and get Secrets.
 	Secrets(namespace string) SecretNamespaceLister
 	SecretListerExpansion
@@ -52,6 +56,15 @@ func (s *secretLister) List(selector labels.Selector) (ret []*v1.Secret, err err
 	return ret, err
 }
 
+// ListWithOptions lists all Secrets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *secretLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Secret, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Secret))
+	})
+	return ret, err
+}
+
 // Secrets returns an object that can list and get Secrets.
 func (s *secretLister) Secrets(namespace string) SecretNamespaceLister {
 	return secretNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *secretLister) Secrets(namespace string) SecretNamespaceLister {
 type SecretNamespaceLister interface {
 	// List lists all Secrets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Secret, err error)
+	// ListWithOptions lists all Secrets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Secret, err error)
 	// Get retrieves the Secret from the indexer for a given namespace and name.
 	Get(name string) (*v1.Secret, error)
 	SecretNamespaceListerExpansion
@@ -76,6 +93,15 @@ type secretNamespaceLister struct {
 // List lists all Secrets in the indexer for a given namespace.
 func (s secretNamespaceLister) List(selector labels.Selector) (ret []*v1.Secret, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Secret))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Secrets that matches the options
+// in the indexer for a given namespace.
+func (s secretNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Secret, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Secret))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/service.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ServiceLister interface {
 	// List lists all Services in the indexer.
 	List(selector labels.Selector) (ret []*v1.Service, err error)
+	// ListWithOptions lists all Services in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Service, err error)
 	// Services returns an object that can list and get Services.
 	Services(namespace string) ServiceNamespaceLister
 	ServiceListerExpansion
@@ -52,6 +56,15 @@ func (s *serviceLister) List(selector labels.Selector) (ret []*v1.Service, err e
 	return ret, err
 }
 
+// ListWithOptions lists all Services in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *serviceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Service, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Service))
+	})
+	return ret, err
+}
+
 // Services returns an object that can list and get Services.
 func (s *serviceLister) Services(namespace string) ServiceNamespaceLister {
 	return serviceNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *serviceLister) Services(namespace string) ServiceNamespaceLister {
 type ServiceNamespaceLister interface {
 	// List lists all Services in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Service, err error)
+	// ListWithOptions lists all Services that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Service, err error)
 	// Get retrieves the Service from the indexer for a given namespace and name.
 	Get(name string) (*v1.Service, error)
 	ServiceNamespaceListerExpansion
@@ -76,6 +93,15 @@ type serviceNamespaceLister struct {
 // List lists all Services in the indexer for a given namespace.
 func (s serviceNamespaceLister) List(selector labels.Selector) (ret []*v1.Service, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Service))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Services that matches the options
+// in the indexer for a given namespace.
+func (s serviceNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Service, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Service))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/deployment.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type DeploymentLister interface {
 	// List lists all Deployments in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
+	// ListWithOptions lists all Deployments in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error)
 	// Deployments returns an object that can list and get Deployments.
 	Deployments(namespace string) DeploymentNamespaceLister
 	DeploymentListerExpansion
@@ -52,6 +56,15 @@ func (s *deploymentLister) List(selector labels.Selector) (ret []*v1beta1.Deploy
 	return ret, err
 }
 
+// ListWithOptions lists all Deployments in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *deploymentLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Deployment))
+	})
+	return ret, err
+}
+
 // Deployments returns an object that can list and get Deployments.
 func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceLister {
 	return deploymentNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *deploymentLister) Deployments(namespace string) DeploymentNamespaceList
 type DeploymentNamespaceLister interface {
 	// List lists all Deployments in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Deployment, err error)
+	// ListWithOptions lists all Deployments that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error)
 	// Get retrieves the Deployment from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Deployment, error)
 	DeploymentNamespaceListerExpansion
@@ -76,6 +93,15 @@ type deploymentNamespaceLister struct {
 // List lists all Deployments in the indexer for a given namespace.
 func (s deploymentNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Deployment, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Deployment))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Deployments that matches the options
+// in the indexer for a given namespace.
+func (s deploymentNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Deployment, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Deployment))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/ingress.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type IngressLister interface {
 	// List lists all Ingresses in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Ingress, err error)
+	// ListWithOptions lists all Ingresses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Ingress, err error)
 	// Ingresses returns an object that can list and get Ingresses.
 	Ingresses(namespace string) IngressNamespaceLister
 	IngressListerExpansion
@@ -52,6 +56,15 @@ func (s *ingressLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, 
 	return ret, err
 }
 
+// ListWithOptions lists all Ingresses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *ingressLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Ingress, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Ingress))
+	})
+	return ret, err
+}
+
 // Ingresses returns an object that can list and get Ingresses.
 func (s *ingressLister) Ingresses(namespace string) IngressNamespaceLister {
 	return ingressNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *ingressLister) Ingresses(namespace string) IngressNamespaceLister {
 type IngressNamespaceLister interface {
 	// List lists all Ingresses in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Ingress, err error)
+	// ListWithOptions lists all Ingresses that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Ingress, err error)
 	// Get retrieves the Ingress from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Ingress, error)
 	IngressNamespaceListerExpansion
@@ -76,6 +93,15 @@ type ingressNamespaceLister struct {
 // List lists all Ingresses in the indexer for a given namespace.
 func (s ingressNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Ingress, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Ingress))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Ingresses that matches the options
+// in the indexer for a given namespace.
+func (s ingressNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Ingress, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Ingress))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type PodSecurityPolicyLister interface {
 	// List lists all PodSecurityPolicies in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error)
+	// ListWithOptions lists all PodSecurityPolicies in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodSecurityPolicy, err error)
 	// Get retrieves the PodSecurityPolicy from the index for a given name.
 	Get(name string) (*v1beta1.PodSecurityPolicy, error)
 	PodSecurityPolicyListerExpansion
@@ -48,6 +52,15 @@ func NewPodSecurityPolicyLister(indexer cache.Indexer) PodSecurityPolicyLister {
 // List lists all PodSecurityPolicies in the indexer.
 func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1.PodSecurityPolicy, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.PodSecurityPolicy))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodSecurityPolicies in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podSecurityPolicyLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodSecurityPolicy, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodSecurityPolicy))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/replicaset.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ReplicaSetLister interface {
 	// List lists all ReplicaSets in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error)
+	// ListWithOptions lists all ReplicaSets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ReplicaSet, err error)
 	// ReplicaSets returns an object that can list and get ReplicaSets.
 	ReplicaSets(namespace string) ReplicaSetNamespaceLister
 	ReplicaSetListerExpansion
@@ -52,6 +56,15 @@ func (s *replicaSetLister) List(selector labels.Selector) (ret []*v1beta1.Replic
 	return ret, err
 }
 
+// ListWithOptions lists all ReplicaSets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *replicaSetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ReplicaSet, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ReplicaSet))
+	})
+	return ret, err
+}
+
 // ReplicaSets returns an object that can list and get ReplicaSets.
 func (s *replicaSetLister) ReplicaSets(namespace string) ReplicaSetNamespaceLister {
 	return replicaSetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *replicaSetLister) ReplicaSets(namespace string) ReplicaSetNamespaceList
 type ReplicaSetNamespaceLister interface {
 	// List lists all ReplicaSets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error)
+	// ListWithOptions lists all ReplicaSets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ReplicaSet, err error)
 	// Get retrieves the ReplicaSet from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.ReplicaSet, error)
 	ReplicaSetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type replicaSetNamespaceLister struct {
 // List lists all ReplicaSets in the indexer for a given namespace.
 func (s replicaSetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.ReplicaSet, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ReplicaSet))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ReplicaSets that matches the options
+// in the indexer for a given namespace.
+func (s replicaSetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ReplicaSet, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ReplicaSet))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/scale.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/scale.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type ScaleLister interface {
 	// List lists all Scales in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Scale, err error)
+	// ListWithOptions lists all Scales in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error)
 	// Scales returns an object that can list and get Scales.
 	Scales(namespace string) ScaleNamespaceLister
 	ScaleListerExpansion
@@ -52,6 +56,15 @@ func (s *scaleLister) List(selector labels.Selector) (ret []*v1beta1.Scale, err 
 	return ret, err
 }
 
+// ListWithOptions lists all Scales in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *scaleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Scale))
+	})
+	return ret, err
+}
+
 // Scales returns an object that can list and get Scales.
 func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 	return scaleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *scaleLister) Scales(namespace string) ScaleNamespaceLister {
 type ScaleNamespaceLister interface {
 	// List lists all Scales in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Scale, err error)
+	// ListWithOptions lists all Scales that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error)
 	// Get retrieves the Scale from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Scale, error)
 	ScaleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type scaleNamespaceLister struct {
 // List lists all Scales in the indexer for a given namespace.
 func (s scaleNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Scale, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Scale))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Scales that matches the options
+// in the indexer for a given namespace.
+func (s scaleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Scale, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Scale))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ThirdPartyResourceLister interface {
 	// List lists all ThirdPartyResources in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.ThirdPartyResource, err error)
+	// ListWithOptions lists all ThirdPartyResources in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ThirdPartyResource, err error)
 	// Get retrieves the ThirdPartyResource from the index for a given name.
 	Get(name string) (*v1beta1.ThirdPartyResource, error)
 	ThirdPartyResourceListerExpansion
@@ -48,6 +52,15 @@ func NewThirdPartyResourceLister(indexer cache.Indexer) ThirdPartyResourceLister
 // List lists all ThirdPartyResources in the indexer.
 func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*v1beta1.ThirdPartyResource, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ThirdPartyResource))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ThirdPartyResources in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *thirdPartyResourceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ThirdPartyResource, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ThirdPartyResource))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ImageReviewLister interface {
 	// List lists all ImageReviews in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.ImageReview, err error)
+	// ListWithOptions lists all ImageReviews in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ImageReview, err error)
 	// Get retrieves the ImageReview from the index for a given name.
 	Get(name string) (*v1alpha1.ImageReview, error)
 	ImageReviewListerExpansion
@@ -48,6 +52,15 @@ func NewImageReviewLister(indexer cache.Indexer) ImageReviewLister {
 // List lists all ImageReviews in the indexer.
 func (s *imageReviewLister) List(selector labels.Selector) (ret []*v1alpha1.ImageReview, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.ImageReview))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ImageReviews in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *imageReviewLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ImageReview, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ImageReview))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/networking/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/networking/v1/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/listers/networking/v1/networkpolicy.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type NetworkPolicyLister interface {
 	// List lists all NetworkPolicies in the indexer.
 	List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error)
+	// ListWithOptions lists all NetworkPolicies in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.NetworkPolicy, err error)
 	// NetworkPolicies returns an object that can list and get NetworkPolicies.
 	NetworkPolicies(namespace string) NetworkPolicyNamespaceLister
 	NetworkPolicyListerExpansion
@@ -52,6 +56,15 @@ func (s *networkPolicyLister) List(selector labels.Selector) (ret []*v1.NetworkP
 	return ret, err
 }
 
+// ListWithOptions lists all NetworkPolicies in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *networkPolicyLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.NetworkPolicy, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.NetworkPolicy))
+	})
+	return ret, err
+}
+
 // NetworkPolicies returns an object that can list and get NetworkPolicies.
 func (s *networkPolicyLister) NetworkPolicies(namespace string) NetworkPolicyNamespaceLister {
 	return networkPolicyNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *networkPolicyLister) NetworkPolicies(namespace string) NetworkPolicyNam
 type NetworkPolicyNamespaceLister interface {
 	// List lists all NetworkPolicies in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error)
+	// ListWithOptions lists all NetworkPolicies that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.NetworkPolicy, err error)
 	// Get retrieves the NetworkPolicy from the indexer for a given namespace and name.
 	Get(name string) (*v1.NetworkPolicy, error)
 	NetworkPolicyNamespaceListerExpansion
@@ -76,6 +93,15 @@ type networkPolicyNamespaceLister struct {
 // List lists all NetworkPolicies in the indexer for a given namespace.
 func (s networkPolicyNamespaceLister) List(selector labels.Selector) (ret []*v1.NetworkPolicy, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.NetworkPolicy))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all NetworkPolicies that matches the options
+// in the indexer for a given namespace.
+func (s networkPolicyNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.NetworkPolicy, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.NetworkPolicy))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/eviction.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type EvictionLister interface {
 	// List lists all Evictions in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Eviction, err error)
+	// ListWithOptions lists all Evictions in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Eviction, err error)
 	// Evictions returns an object that can list and get Evictions.
 	Evictions(namespace string) EvictionNamespaceLister
 	EvictionListerExpansion
@@ -52,6 +56,15 @@ func (s *evictionLister) List(selector labels.Selector) (ret []*v1beta1.Eviction
 	return ret, err
 }
 
+// ListWithOptions lists all Evictions in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *evictionLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Eviction, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Eviction))
+	})
+	return ret, err
+}
+
 // Evictions returns an object that can list and get Evictions.
 func (s *evictionLister) Evictions(namespace string) EvictionNamespaceLister {
 	return evictionNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *evictionLister) Evictions(namespace string) EvictionNamespaceLister {
 type EvictionNamespaceLister interface {
 	// List lists all Evictions in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Eviction, err error)
+	// ListWithOptions lists all Evictions that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Eviction, err error)
 	// Get retrieves the Eviction from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Eviction, error)
 	EvictionNamespaceListerExpansion
@@ -76,6 +93,15 @@ type evictionNamespaceLister struct {
 // List lists all Evictions in the indexer for a given namespace.
 func (s evictionNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Eviction, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Eviction))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Evictions that matches the options
+// in the indexer for a given namespace.
+func (s evictionNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Eviction, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Eviction))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/listers/policy/v1beta1/poddisruptionbudget.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type PodDisruptionBudgetLister interface {
 	// List lists all PodDisruptionBudgets in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error)
+	// ListWithOptions lists all PodDisruptionBudgets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodDisruptionBudget, err error)
 	// PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 	PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister
 	PodDisruptionBudgetListerExpansion
@@ -52,6 +56,15 @@ func (s *podDisruptionBudgetLister) List(selector labels.Selector) (ret []*v1bet
 	return ret, err
 }
 
+// ListWithOptions lists all PodDisruptionBudgets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podDisruptionBudgetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodDisruptionBudget, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.PodDisruptionBudget))
+	})
+	return ret, err
+}
+
 // PodDisruptionBudgets returns an object that can list and get PodDisruptionBudgets.
 func (s *podDisruptionBudgetLister) PodDisruptionBudgets(namespace string) PodDisruptionBudgetNamespaceLister {
 	return podDisruptionBudgetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podDisruptionBudgetLister) PodDisruptionBudgets(namespace string) PodDi
 type PodDisruptionBudgetNamespaceLister interface {
 	// List lists all PodDisruptionBudgets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error)
+	// ListWithOptions lists all PodDisruptionBudgets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodDisruptionBudget, err error)
 	// Get retrieves the PodDisruptionBudget from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.PodDisruptionBudget, error)
 	PodDisruptionBudgetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podDisruptionBudgetNamespaceLister struct {
 // List lists all PodDisruptionBudgets in the indexer for a given namespace.
 func (s podDisruptionBudgetNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.PodDisruptionBudget, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.PodDisruptionBudget))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodDisruptionBudgets that matches the options
+// in the indexer for a given namespace.
+func (s podDisruptionBudgetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.PodDisruptionBudget, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.PodDisruptionBudget))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	List(selector labels.Selector) (ret []*v1.ClusterRole, err error)
+	// ListWithOptions lists all ClusterRoles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	Get(name string) (*v1.ClusterRole, error)
 	ClusterRoleListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.ClusterRole))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ClusterRole, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterRole))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error)
+	// ListWithOptions lists all ClusterRoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	Get(name string) (*v1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.ClusterRoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.ClusterRoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.ClusterRoleBinding))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/role.go
@@ -21,6 +21,7 @@ package v1
 import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type RoleLister interface {
 	// List lists all Roles in the indexer.
 	List(selector labels.Selector) (ret []*v1.Role, err error)
+	// ListWithOptions lists all Roles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -52,6 +56,15 @@ func (s *roleLister) List(selector labels.Selector) (ret []*v1.Role, err error) 
 	return ret, err
 }
 
+// ListWithOptions lists all Roles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Role, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.Role))
+	})
+	return ret, err
+}
+
 // Roles returns an object that can list and get Roles.
 func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 	return roleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 type RoleNamespaceLister interface {
 	// List lists all Roles in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.Role, err error)
+	// ListWithOptions lists all Roles that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.Role, err error)
 	// Get retrieves the Role from the indexer for a given namespace and name.
 	Get(name string) (*v1.Role, error)
 	RoleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleNamespaceLister struct {
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.Role))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Roles that matches the options
+// in the indexer for a given namespace.
+func (s roleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.Role, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.Role))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error)
+	// ListWithOptions lists all ClusterRoles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	Get(name string) (*v1alpha1.ClusterRole, error)
 	ClusterRoleListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1alpha1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.ClusterRole))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ClusterRole, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ClusterRole))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error)
+	// ListWithOptions lists all ClusterRoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	Get(name string) (*v1alpha1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1alpha1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.ClusterRoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.ClusterRoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.ClusterRoleBinding))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/role.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type RoleLister interface {
 	// List lists all Roles in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.Role, err error)
+	// ListWithOptions lists all Roles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -52,6 +56,15 @@ func (s *roleLister) List(selector labels.Selector) (ret []*v1alpha1.Role, err e
 	return ret, err
 }
 
+// ListWithOptions lists all Roles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Role, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.Role))
+	})
+	return ret, err
+}
+
 // Roles returns an object that can list and get Roles.
 func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 	return roleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 type RoleNamespaceLister interface {
 	// List lists all Roles in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1alpha1.Role, err error)
+	// ListWithOptions lists all Roles that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Role, err error)
 	// Get retrieves the Role from the indexer for a given namespace and name.
 	Get(name string) (*v1alpha1.Role, error)
 	RoleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleNamespaceLister struct {
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.Role))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Roles that matches the options
+// in the indexer for a given namespace.
+func (s roleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Role, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Role))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/rolebinding.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -52,6 +56,15 @@ func (s *roleBindingLister) List(selector labels.Selector) (ret []*v1alpha1.Role
 	return ret, err
 }
 
+// ListWithOptions lists all RoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.RoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.RoleBinding))
+	})
+	return ret, err
+}
+
 // RoleBindings returns an object that can list and get RoleBindings.
 func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceLister {
 	return roleBindingNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceL
 type RoleBindingNamespaceLister interface {
 	// List lists all RoleBindings in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.RoleBinding, err error)
 	// Get retrieves the RoleBinding from the indexer for a given namespace and name.
 	Get(name string) (*v1alpha1.RoleBinding, error)
 	RoleBindingNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleBindingNamespaceLister struct {
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.RoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all RoleBindings that matches the options
+// in the indexer for a given namespace.
+func (s roleBindingNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.RoleBinding, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.RoleBinding))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleLister interface {
 	// List lists all ClusterRoles in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.ClusterRole, err error)
+	// ListWithOptions lists all ClusterRoles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ClusterRole, err error)
 	// Get retrieves the ClusterRole from the index for a given name.
 	Get(name string) (*v1beta1.ClusterRole, error)
 	ClusterRoleListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleLister(indexer cache.Indexer) ClusterRoleLister {
 // List lists all ClusterRoles in the indexer.
 func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1beta1.ClusterRole, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ClusterRole))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ClusterRole, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ClusterRole))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type ClusterRoleBindingLister interface {
 	// List lists all ClusterRoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error)
+	// ListWithOptions lists all ClusterRoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ClusterRoleBinding, err error)
 	// Get retrieves the ClusterRoleBinding from the index for a given name.
 	Get(name string) (*v1beta1.ClusterRoleBinding, error)
 	ClusterRoleBindingListerExpansion
@@ -48,6 +52,15 @@ func NewClusterRoleBindingLister(indexer cache.Indexer) ClusterRoleBindingLister
 // List lists all ClusterRoleBindings in the indexer.
 func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1beta1.ClusterRoleBinding, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.ClusterRoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all ClusterRoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *clusterRoleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.ClusterRoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.ClusterRoleBinding))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/role.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type RoleLister interface {
 	// List lists all Roles in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.Role, err error)
+	// ListWithOptions lists all Roles in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Role, err error)
 	// Roles returns an object that can list and get Roles.
 	Roles(namespace string) RoleNamespaceLister
 	RoleListerExpansion
@@ -52,6 +56,15 @@ func (s *roleLister) List(selector labels.Selector) (ret []*v1beta1.Role, err er
 	return ret, err
 }
 
+// ListWithOptions lists all Roles in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Role, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Role))
+	})
+	return ret, err
+}
+
 // Roles returns an object that can list and get Roles.
 func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 	return roleNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleLister) Roles(namespace string) RoleNamespaceLister {
 type RoleNamespaceLister interface {
 	// List lists all Roles in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.Role, err error)
+	// ListWithOptions lists all Roles that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Role, err error)
 	// Get retrieves the Role from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.Role, error)
 	RoleNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleNamespaceLister struct {
 // List lists all Roles in the indexer for a given namespace.
 func (s roleNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.Role, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.Role))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Roles that matches the options
+// in the indexer for a given namespace.
+func (s roleNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.Role, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.Role))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/rolebinding.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type RoleBindingLister interface {
 	// List lists all RoleBindings in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.RoleBinding, err error)
 	// RoleBindings returns an object that can list and get RoleBindings.
 	RoleBindings(namespace string) RoleBindingNamespaceLister
 	RoleBindingListerExpansion
@@ -52,6 +56,15 @@ func (s *roleBindingLister) List(selector labels.Selector) (ret []*v1beta1.RoleB
 	return ret, err
 }
 
+// ListWithOptions lists all RoleBindings in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *roleBindingLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.RoleBinding, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.RoleBinding))
+	})
+	return ret, err
+}
+
 // RoleBindings returns an object that can list and get RoleBindings.
 func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceLister {
 	return roleBindingNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *roleBindingLister) RoleBindings(namespace string) RoleBindingNamespaceL
 type RoleBindingNamespaceLister interface {
 	// List lists all RoleBindings in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error)
+	// ListWithOptions lists all RoleBindings that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.RoleBinding, err error)
 	// Get retrieves the RoleBinding from the indexer for a given namespace and name.
 	Get(name string) (*v1beta1.RoleBinding, error)
 	RoleBindingNamespaceListerExpansion
@@ -76,6 +93,15 @@ type roleBindingNamespaceLister struct {
 // List lists all RoleBindings in the indexer for a given namespace.
 func (s roleBindingNamespaceLister) List(selector labels.Selector) (ret []*v1beta1.RoleBinding, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.RoleBinding))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all RoleBindings that matches the options
+// in the indexer for a given namespace.
+func (s roleBindingNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.RoleBinding, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.RoleBinding))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type PriorityClassLister interface {
 	// List lists all PriorityClasses in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error)
+	// ListWithOptions lists all PriorityClasses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PriorityClass, err error)
 	// Get retrieves the PriorityClass from the index for a given name.
 	Get(name string) (*v1alpha1.PriorityClass, error)
 	PriorityClassListerExpansion
@@ -48,6 +52,15 @@ func NewPriorityClassLister(indexer cache.Indexer) PriorityClassLister {
 // List lists all PriorityClasses in the indexer.
 func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1alpha1.PriorityClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.PriorityClass))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PriorityClasses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *priorityClassLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PriorityClass, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.PriorityClass))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/settings/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/settings/v1alpha1/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/settings/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/listers/settings/v1alpha1/podpreset.go
@@ -21,6 +21,7 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/settings/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -29,6 +30,9 @@ import (
 type PodPresetLister interface {
 	// List lists all PodPresets in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.PodPreset, err error)
+	// ListWithOptions lists all PodPresets in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PodPreset, err error)
 	// PodPresets returns an object that can list and get PodPresets.
 	PodPresets(namespace string) PodPresetNamespaceLister
 	PodPresetListerExpansion
@@ -52,6 +56,15 @@ func (s *podPresetLister) List(selector labels.Selector) (ret []*v1alpha1.PodPre
 	return ret, err
 }
 
+// ListWithOptions lists all PodPresets in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *podPresetLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PodPreset, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.PodPreset))
+	})
+	return ret, err
+}
+
 // PodPresets returns an object that can list and get PodPresets.
 func (s *podPresetLister) PodPresets(namespace string) PodPresetNamespaceLister {
 	return podPresetNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *podPresetLister) PodPresets(namespace string) PodPresetNamespaceLister 
 type PodPresetNamespaceLister interface {
 	// List lists all PodPresets in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1alpha1.PodPreset, err error)
+	// ListWithOptions lists all PodPresets that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PodPreset, err error)
 	// Get retrieves the PodPreset from the indexer for a given namespace and name.
 	Get(name string) (*v1alpha1.PodPreset, error)
 	PodPresetNamespaceListerExpansion
@@ -76,6 +93,15 @@ type podPresetNamespaceLister struct {
 // List lists all PodPresets in the indexer for a given namespace.
 func (s podPresetNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.PodPreset, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.PodPreset))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all PodPresets that matches the options
+// in the indexer for a given namespace.
+func (s podPresetNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.PodPreset, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.PodPreset))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -30,6 +31,9 @@ import (
 type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	List(selector labels.Selector) (ret []*v1.StorageClass, err error)
+	// ListWithOptions lists all StorageClasses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.StorageClass, err error)
 	// Get retrieves the StorageClass from the index for a given name.
 	Get(name string) (*v1.StorageClass, error)
 	StorageClassListerExpansion
@@ -48,6 +52,15 @@ func NewStorageClassLister(indexer cache.Indexer) StorageClassLister {
 // List lists all StorageClasses in the indexer.
 func (s *storageClassLister) List(selector labels.Selector) (ret []*v1.StorageClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.StorageClass))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all StorageClasses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *storageClassLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.StorageClass, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.StorageClass))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -21,6 +21,7 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type StorageClassLister interface {
 	// List lists all StorageClasses in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error)
+	// ListWithOptions lists all StorageClasses in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StorageClass, err error)
 	// Get retrieves the StorageClass from the index for a given name.
 	Get(name string) (*v1beta1.StorageClass, error)
 	StorageClassListerExpansion
@@ -48,6 +52,15 @@ func NewStorageClassLister(indexer cache.Indexer) StorageClassLister {
 // List lists all StorageClasses in the indexer.
 func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.StorageClass, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.StorageClass))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all StorageClasses in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *storageClassLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.StorageClass, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.StorageClass))
 	})
 	return ret, err

--- a/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/processor_listener_test.go
@@ -38,7 +38,7 @@ func BenchmarkListener(b *testing.B) {
 		AddFunc: func(obj interface{}) {
 			swg.Done()
 		},
-	}, 0, 0, time.Now())
+	}, 0, 0, time.Now(), nil)
 	var wg wait.Group
 	defer wg.Wait()       // Wait for .run and .pop to stop
 	defer close(pl.addCh) // Tell .run and .pop to stop

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/factoryinterface.go
@@ -66,7 +66,7 @@ func (g *factoryInterfaceGenerator) GenerateType(c *generator.Context, t *types.
 		"cacheSharedIndexInformer": c.Universe.Type(cacheSharedIndexInformer),
 		"clientSetPackage":         c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"}),
 		"runtimeObject":            c.Universe.Type(runtimeObject),
-		"timeDuration":             c.Universe.Type(timeDuration),
+		"cacheInformerOptions":     c.Universe.Type(cacheInformerOptions),
 	}
 
 	sw.Do(externalSharedInformerFactoryInterface, m)
@@ -75,7 +75,7 @@ func (g *factoryInterfaceGenerator) GenerateType(c *generator.Context, t *types.
 }
 
 var externalSharedInformerFactoryInterface = `
-type NewInformerFunc func({{.clientSetPackage|raw}}, {{.timeDuration|raw}}) cache.SharedIndexInformer
+type NewInformerFunc func({{.clientSetPackage|raw}}, {{.cacheInformerOptions|raw}}) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -77,33 +77,36 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 	}
 
 	m := map[string]interface{}{
-		"apiScheme":                       c.Universe.Type(apiScheme),
-		"cacheIndexers":                   c.Universe.Type(cacheIndexers),
-		"cacheListWatch":                  c.Universe.Type(cacheListWatch),
-		"cacheMetaNamespaceIndexFunc":     c.Universe.Function(cacheMetaNamespaceIndexFunc),
-		"cacheNamespaceIndex":             c.Universe.Variable(cacheNamespaceIndex),
-		"cacheNewSharedIndexInformer":     c.Universe.Function(cacheNewSharedIndexInformer),
-		"cacheSharedIndexInformer":        c.Universe.Type(cacheSharedIndexInformer),
-		"clientSetInterface":              clientSetInterface,
-		"group":                           namer.IC(g.groupVersion.Group.NonEmpty()),
-		"informerFor":                     informerFor,
-		"interfacesSharedInformerFactory": c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "SharedInformerFactory"}),
-		"listOptions":                     c.Universe.Type(listOptions),
-		"lister":                          c.Universe.Type(types.Name{Package: listerPackage, Name: t.Name.Name + "Lister"}),
-		"namespaceAll":                    c.Universe.Type(metav1NamespaceAll),
-		"namespaced":                      !tags.NonNamespaced,
-		"newLister":                       c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
-		"runtimeObject":                   c.Universe.Type(runtimeObject),
-		"timeDuration":                    c.Universe.Type(timeDuration),
-		"type":                            t,
-		"v1ListOptions":                   c.Universe.Type(v1ListOptions),
-		"version":                         namer.IC(g.groupVersion.Version.String()),
-		"watchInterface":                  c.Universe.Type(watchInterface),
+		"apiScheme":                              c.Universe.Type(apiScheme),
+		"cacheIndexers":                          c.Universe.Type(cacheIndexers),
+		"cacheListWatch":                         c.Universe.Type(cacheListWatch),
+		"cacheMetaNamespaceIndexFunc":            c.Universe.Function(cacheMetaNamespaceIndexFunc),
+		"cacheNamespaceIndex":                    c.Universe.Variable(cacheNamespaceIndex),
+		"cacheNewSharedIndexInformer":            c.Universe.Function(cacheNewSharedIndexInformer),
+		"cacheSharedIndexInformer":               c.Universe.Type(cacheSharedIndexInformer),
+		"cacheInformerOptions":                   c.Universe.Type(cacheInformerOptions),
+		"cacheNewSharedIndexInformerWithOptions": c.Universe.Type(cacheNewSharedIndexInformerWithOptions),
+		"clientSetInterface":                     clientSetInterface,
+		"group":                                  namer.IC(g.groupVersion.Group.NonEmpty()),
+		"informerFor":                            informerFor,
+		"interfacesSharedInformerFactory":        c.Universe.Type(types.Name{Package: g.internalInterfacesPackage, Name: "SharedInformerFactory"}),
+		"listOptions":                            c.Universe.Type(listOptions),
+		"lister":                                 c.Universe.Type(types.Name{Package: listerPackage, Name: t.Name.Name + "Lister"}),
+		"namespaceAll":                           c.Universe.Type(metav1NamespaceAll),
+		"namespaced":                             !tags.NonNamespaced,
+		"newLister":                              c.Universe.Function(types.Name{Package: listerPackage, Name: "New" + t.Name.Name + "Lister"}),
+		"runtimeObject":                          c.Universe.Type(runtimeObject),
+		"timeDuration":                           c.Universe.Type(timeDuration),
+		"type":                                   t,
+		"v1ListOptions":                          c.Universe.Type(v1ListOptions),
+		"version":                                namer.IC(g.groupVersion.Version.String()),
+		"watchInterface":                         c.Universe.Type(watchInterface),
 	}
 
 	sw.Do(typeInformerInterface, m)
 	sw.Do(typeInformerStruct, m)
 	sw.Do(typeInformerPublicConstructor, m)
+	sw.Do(typeInformerPublicConstructorWithOptions, m)
 	sw.Do(typeInformerConstructor, m)
 	sw.Do(typeInformerInformer, m)
 	sw.Do(typeInformerLister, m)
@@ -146,10 +149,30 @@ func New$.type|public$Informer(client $.clientSetInterface|raw$$if .namespaced$,
 	)
 }
 `
+var typeInformerPublicConstructorWithOptions = `
+// New$.type|public$InformerWithOptions constructs a new informer for $.type|public$ type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func New$.type|public$InformerWithOptions(client $.clientSetInterface|raw$$if .namespaced$, namespace string$end$, options $.cacheInformerOptions|raw$, indexers $.cacheIndexers|raw$) $.cacheSharedIndexInformer|raw$ {
+	return $.cacheNewSharedIndexInformerWithOptions|raw$(
+		&$.cacheListWatch|raw${
+			ListFunc: func(options $.v1ListOptions|raw$) ($.runtimeObject|raw$, error) {
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).List(options)
+			},
+			WatchFunc: func(options $.v1ListOptions|raw$) ($.watchInterface|raw$, error) {
+				return client.$.group$$.version$().$.type|publicPlural$($if .namespaced$namespace$end$).Watch(options)
+			},
+		},
+		options,
+		&$.type|raw${},
+		indexers,
+	)
+}
+`
 
 var typeInformerConstructor = `
-func default$.type|public$Informer(client $.clientSetInterface|raw$, resyncPeriod $.timeDuration|raw$) $.cacheSharedIndexInformer|raw$ {
-	return New$.type|public$Informer(client, $if .namespaced$$.namespaceAll|raw$, $end$resyncPeriod, $.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$})
+func default$.type|public$Informer(client $.clientSetInterface|raw$, options $.cacheInformerOptions|raw$) $.cacheSharedIndexInformer|raw$ {
+	return New$.type|public$InformerWithOptions(client, $if .namespaced$$.namespaceAll|raw$, $end$options, $.cacheIndexers|raw${$.cacheNamespaceIndex|raw$: $.cacheMetaNamespaceIndexFunc|raw$})
 }
 `
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/types.go
@@ -19,23 +19,25 @@ package generators
 import "k8s.io/gengo/types"
 
 var (
-	apiScheme                   = types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "Scheme"}
-	cacheGenericLister          = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
-	cacheIndexers               = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
-	cacheListWatch              = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "ListWatch"}
-	cacheMetaNamespaceIndexFunc = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "MetaNamespaceIndexFunc"}
-	cacheNamespaceIndex         = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NamespaceIndex"}
-	cacheNewGenericLister       = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewGenericLister"}
-	cacheNewSharedIndexInformer = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformer"}
-	cacheSharedIndexInformer    = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
-	listOptions                 = types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ListOptions"}
-	reflectType                 = types.Name{Package: "reflect", Name: "Type"}
-	runtimeObject               = types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}
-	schemaGroupResource         = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupResource"}
-	schemaGroupVersionResource  = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersionResource"}
-	syncMutex                   = types.Name{Package: "sync", Name: "Mutex"}
-	timeDuration                = types.Name{Package: "time", Name: "Duration"}
-	v1ListOptions               = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ListOptions"}
-	metav1NamespaceAll          = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "NamespaceAll"}
-	watchInterface              = types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}
+	apiScheme                              = types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "Scheme"}
+	cacheGenericLister                     = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "GenericLister"}
+	cacheIndexers                          = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "Indexers"}
+	cacheListWatch                         = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "ListWatch"}
+	cacheMetaNamespaceIndexFunc            = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "MetaNamespaceIndexFunc"}
+	cacheNamespaceIndex                    = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NamespaceIndex"}
+	cacheNewGenericLister                  = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewGenericLister"}
+	cacheNewSharedIndexInformer            = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformer"}
+	cacheNewSharedIndexInformerWithOptions = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "NewSharedIndexInformerWithOptions"}
+	cacheSharedIndexInformer               = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedIndexInformer"}
+	cacheInformerOptions                   = types.Name{Package: "k8s.io/client-go/tools/cache", Name: "SharedInformerOptions"}
+	listOptions                            = types.Name{Package: "k8s.io/kubernetes/pkg/api", Name: "ListOptions"}
+	reflectType                            = types.Name{Package: "reflect", Name: "Type"}
+	runtimeObject                          = types.Name{Package: "k8s.io/apimachinery/pkg/runtime", Name: "Object"}
+	schemaGroupResource                    = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupResource"}
+	schemaGroupVersionResource             = types.Name{Package: "k8s.io/apimachinery/pkg/runtime/schema", Name: "GroupVersionResource"}
+	syncMutex                              = types.Name{Package: "sync", Name: "Mutex"}
+	timeDuration                           = types.Name{Package: "time", Name: "Duration"}
+	v1ListOptions                          = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "ListOptions"}
+	metav1NamespaceAll                     = types.Name{Package: "k8s.io/apimachinery/pkg/apis/meta/v1", Name: "NamespaceAll"}
+	watchInterface                         = types.Name{Package: "k8s.io/apimachinery/pkg/watch", Name: "Interface"}
 )

--- a/staging/src/k8s.io/code-generator/test/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/test/informers/externalversions/factory.go
@@ -31,9 +31,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        versioned.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  versioned.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,7 +45,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client versioned.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client versioned.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -97,7 +108,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/code-generator/test/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/test/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	versioned "k8s.io/code-generator/test/clientset/versioned"
-	time "time"
 )
 
-type NewInformerFunc func(versioned.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(versioned.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/code-generator/test/informers/externalversions/testgroup/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/test/informers/externalversions/testgroup/v1/testtype.go
@@ -60,8 +60,27 @@ func NewTestTypeInformer(client versioned.Interface, namespace string, resyncPer
 	)
 }
 
-func defaultTestTypeInformer(client versioned.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformer(client, meta_v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewTestTypeInformerWithOptions constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTestTypeInformerWithOptions(client versioned.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options meta_v1.ListOptions) (runtime.Object, error) {
+				return client.TestgroupV1().TestTypes(namespace).List(options)
+			},
+			WatchFunc: func(options meta_v1.ListOptions) (watch.Interface, error) {
+				return client.TestgroupV1().TestTypes(namespace).Watch(options)
+			},
+		},
+		options,
+		&testgroup_v1.TestType{},
+		indexers,
+	)
+}
+
+func defaultTestTypeInformer(client versioned.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewTestTypeInformerWithOptions(client, meta_v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/test/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/test/informers/internalversion/factory.go
@@ -31,9 +31,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        internal.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  internal.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,7 +45,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client internal.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client internal.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -97,7 +108,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/code-generator/test/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/code-generator/test/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	internal "k8s.io/code-generator/test/clientset/internal"
-	time "time"
 )
 
-type NewInformerFunc func(internal.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(internal.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/code-generator/test/informers/internalversion/testgroup/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/test/informers/internalversion/testgroup/internalversion/testtype.go
@@ -60,8 +60,27 @@ func NewTestTypeInformer(client internal.Interface, namespace string, resyncPeri
 	)
 }
 
-func defaultTestTypeInformer(client internal.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewTestTypeInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewTestTypeInformerWithOptions constructs a new informer for TestType type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewTestTypeInformerWithOptions(client internal.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Testgroup().TestTypes(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Testgroup().TestTypes(namespace).Watch(options)
+			},
+		},
+		options,
+		&testgroup.TestType{},
+		indexers,
+	)
+}
+
+func defaultTestTypeInformer(client internal.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewTestTypeInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *testTypeInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/code-generator/test/listers/testgroup/internalversion/BUILD
+++ b/staging/src/k8s.io/code-generator/test/listers/testgroup/internalversion/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/code-generator/test/apis/testgroup:go_default_library",

--- a/staging/src/k8s.io/code-generator/test/listers/testgroup/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/test/listers/testgroup/internalversion/testtype.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	testgroup "k8s.io/code-generator/test/apis/testgroup"
@@ -29,6 +30,9 @@ import (
 type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	List(selector labels.Selector) (ret []*testgroup.TestType, err error)
+	// ListWithOptions lists all TestTypes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*testgroup.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -52,6 +56,15 @@ func (s *testTypeLister) List(selector labels.Selector) (ret []*testgroup.TestTy
 	return ret, err
 }
 
+// ListWithOptions lists all TestTypes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *testTypeLister) ListWithOptions(options metav1.ListOptions) (ret []*testgroup.TestType, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*testgroup.TestType))
+	})
+	return ret, err
+}
+
 // TestTypes returns an object that can list and get TestTypes.
 func (s *testTypeLister) TestTypes(namespace string) TestTypeNamespaceLister {
 	return testTypeNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *testTypeLister) TestTypes(namespace string) TestTypeNamespaceLister {
 type TestTypeNamespaceLister interface {
 	// List lists all TestTypes in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*testgroup.TestType, err error)
+	// ListWithOptions lists all TestTypes that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*testgroup.TestType, err error)
 	// Get retrieves the TestType from the indexer for a given namespace and name.
 	Get(name string) (*testgroup.TestType, error)
 	TestTypeNamespaceListerExpansion
@@ -76,6 +93,15 @@ type testTypeNamespaceLister struct {
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*testgroup.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*testgroup.TestType))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all TestTypes that matches the options
+// in the indexer for a given namespace.
+func (s testTypeNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*testgroup.TestType, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*testgroup.TestType))
 	})
 	return ret, err

--- a/staging/src/k8s.io/code-generator/test/listers/testgroup/v1/BUILD
+++ b/staging/src/k8s.io/code-generator/test/listers/testgroup/v1/BUILD
@@ -13,6 +13,7 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/code-generator/test/apis/testgroup/v1:go_default_library",

--- a/staging/src/k8s.io/code-generator/test/listers/testgroup/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/test/listers/testgroup/v1/testtype.go
@@ -20,6 +20,7 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1 "k8s.io/code-generator/test/apis/testgroup/v1"
@@ -29,6 +30,9 @@ import (
 type TestTypeLister interface {
 	// List lists all TestTypes in the indexer.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
+	// ListWithOptions lists all TestTypes in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.TestType, err error)
 	// TestTypes returns an object that can list and get TestTypes.
 	TestTypes(namespace string) TestTypeNamespaceLister
 	TestTypeListerExpansion
@@ -52,6 +56,15 @@ func (s *testTypeLister) List(selector labels.Selector) (ret []*v1.TestType, err
 	return ret, err
 }
 
+// ListWithOptions lists all TestTypes in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *testTypeLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.TestType, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1.TestType))
+	})
+	return ret, err
+}
+
 // TestTypes returns an object that can list and get TestTypes.
 func (s *testTypeLister) TestTypes(namespace string) TestTypeNamespaceLister {
 	return testTypeNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *testTypeLister) TestTypes(namespace string) TestTypeNamespaceLister {
 type TestTypeNamespaceLister interface {
 	// List lists all TestTypes in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1.TestType, err error)
+	// ListWithOptions lists all TestTypes that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1.TestType, err error)
 	// Get retrieves the TestType from the indexer for a given namespace and name.
 	Get(name string) (*v1.TestType, error)
 	TestTypeNamespaceListerExpansion
@@ -76,6 +93,15 @@ type testTypeNamespaceLister struct {
 // List lists all TestTypes in the indexer for a given namespace.
 func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestType, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1.TestType))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all TestTypes that matches the options
+// in the indexer for a given namespace.
+func (s testTypeNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1.TestType, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1.TestType))
 	})
 	return ret, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -31,9 +31,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        clientset.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  clientset.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,7 +45,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client clientset.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -97,7 +108,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	clientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
-	time "time"
 )
 
-type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(clientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/internalversion/apiservice.go
@@ -60,8 +60,27 @@ func NewAPIServiceInformer(client internalclientset.Interface, resyncPeriod time
 	)
 }
 
-func defaultAPIServiceInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewAPIServiceInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewAPIServiceInformerWithOptions constructs a new informer for APIService type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewAPIServiceInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Apiregistration().APIServices().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Apiregistration().APIServices().Watch(options)
+			},
+		},
+		options,
+		&apiregistration.APIService{},
+		indexers,
+	)
+}
+
+func defaultAPIServiceInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewAPIServiceInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *aPIServiceInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	internalclientset "k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset"
-	time "time"
 )
 
-type NewInformerFunc func(internalclientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(internalclientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type APIServiceLister interface {
 	// List lists all APIServices in the indexer.
 	List(selector labels.Selector) (ret []*apiregistration.APIService, err error)
+	// ListWithOptions lists all APIServices in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*apiregistration.APIService, err error)
 	// Get retrieves the APIService from the index for a given name.
 	Get(name string) (*apiregistration.APIService, error)
 	APIServiceListerExpansion
@@ -48,6 +52,15 @@ func NewAPIServiceLister(indexer cache.Indexer) APIServiceLister {
 // List lists all APIServices in the indexer.
 func (s *aPIServiceLister) List(selector labels.Selector) (ret []*apiregistration.APIService, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*apiregistration.APIService))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all APIServices in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *aPIServiceLister) ListWithOptions(options metav1.ListOptions) (ret []*apiregistration.APIService, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*apiregistration.APIService))
 	})
 	return ret, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
@@ -20,6 +20,7 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type APIServiceLister interface {
 	// List lists all APIServices in the indexer.
 	List(selector labels.Selector) (ret []*v1beta1.APIService, err error)
+	// ListWithOptions lists all APIServices in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.APIService, err error)
 	// Get retrieves the APIService from the index for a given name.
 	Get(name string) (*v1beta1.APIService, error)
 	APIServiceListerExpansion
@@ -48,6 +52,15 @@ func NewAPIServiceLister(indexer cache.Indexer) APIServiceLister {
 // List lists all APIServices in the indexer.
 func (s *aPIServiceLister) List(selector labels.Selector) (ret []*v1beta1.APIService, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1beta1.APIService))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all APIServices in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *aPIServiceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1beta1.APIService, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1beta1.APIService))
 	})
 	return ret, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/factory.go
@@ -31,9 +31,9 @@ import (
 )
 
 type sharedInformerFactory struct {
-	client        clientset.Interface
-	lock          sync.Mutex
-	defaultResync time.Duration
+	client  clientset.Interface
+	lock    sync.Mutex
+	options cache.SharedInformerOptions
 
 	informers map[reflect.Type]cache.SharedIndexInformer
 	// startedInformers is used for tracking which informers have been started.
@@ -45,7 +45,18 @@ type sharedInformerFactory struct {
 func NewSharedInformerFactory(client clientset.Interface, defaultResync time.Duration) SharedInformerFactory {
 	return &sharedInformerFactory{
 		client:           client,
-		defaultResync:    defaultResync,
+		options:          cache.SharedInformerOptions{ResyncPeriod: defaultResync},
+		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
+		startedInformers: make(map[reflect.Type]bool),
+	}
+}
+
+// NewSharedInformerFactoryWithOptions constructs a new instance of sharedInformerFactory.
+// Callers can specify resync period and if to include uninitialized objects via options.
+func NewSharedInformerFactoryWithOptions(client clientset.Interface, options cache.SharedInformerOptions) SharedInformerFactory {
+	return &sharedInformerFactory{
+		client:           client,
+		options:          options,
 		informers:        make(map[reflect.Type]cache.SharedIndexInformer),
 		startedInformers: make(map[reflect.Type]bool),
 	}
@@ -97,7 +108,7 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
-	informer = newFunc(f.client, f.defaultResync)
+	informer = newFunc(f.client, f.options)
 	f.informers[informerType] = informer
 
 	return informer

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	clientset "k8s.io/sample-apiserver/pkg/client/clientset_generated/clientset"
-	time "time"
 )
 
-type NewInformerFunc func(clientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(clientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/wardle/v1alpha1/fischer.go
@@ -60,8 +60,27 @@ func NewFischerInformer(client clientset.Interface, resyncPeriod time.Duration, 
 	)
 }
 
-func defaultFischerInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFischerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewFischerInformerWithOptions constructs a new informer for Fischer type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFischerInformerWithOptions(client clientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.WardleV1alpha1().Fischers().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.WardleV1alpha1().Fischers().Watch(options)
+			},
+		},
+		options,
+		&wardle_v1alpha1.Fischer{},
+		indexers,
+	)
+}
+
+func defaultFischerInformer(client clientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewFischerInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *fischerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/wardle/v1alpha1/flunder.go
@@ -60,8 +60,27 @@ func NewFlunderInformer(client clientset.Interface, namespace string, resyncPeri
 	)
 }
 
-func defaultFlunderInformer(client clientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlunderInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewFlunderInformerWithOptions constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFlunderInformerWithOptions(client clientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.WardleV1alpha1().Flunders(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.WardleV1alpha1().Flunders(namespace).Watch(options)
+			},
+		},
+		options,
+		&wardle_v1alpha1.Flunder{},
+		indexers,
+	)
+}
+
+func defaultFlunderInformer(client clientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewFlunderInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/internalinterfaces/factory_interfaces.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/internalinterfaces/factory_interfaces.go
@@ -22,10 +22,9 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"
 	internalclientset "k8s.io/sample-apiserver/pkg/client/clientset_generated/internalclientset"
-	time "time"
 )
 
-type NewInformerFunc func(internalclientset.Interface, time.Duration) cache.SharedIndexInformer
+type NewInformerFunc func(internalclientset.Interface, cache.SharedInformerOptions) cache.SharedIndexInformer
 
 // SharedInformerFactory a small interface to allow for adding an informer without an import cycle
 type SharedInformerFactory interface {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/fischer.go
@@ -60,8 +60,27 @@ func NewFischerInformer(client internalclientset.Interface, resyncPeriod time.Du
 	)
 }
 
-func defaultFischerInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFischerInformer(client, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewFischerInformerWithOptions constructs a new informer for Fischer type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFischerInformerWithOptions(client internalclientset.Interface, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Wardle().Fischers().List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Wardle().Fischers().Watch(options)
+			},
+		},
+		options,
+		&wardle.Fischer{},
+		indexers,
+	)
+}
+
+func defaultFischerInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewFischerInformerWithOptions(client, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *fischerInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle/internalversion/flunder.go
@@ -60,8 +60,27 @@ func NewFlunderInformer(client internalclientset.Interface, namespace string, re
 	)
 }
 
-func defaultFlunderInformer(client internalclientset.Interface, resyncPeriod time.Duration) cache.SharedIndexInformer {
-	return NewFlunderInformer(client, v1.NamespaceAll, resyncPeriod, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
+// NewFlunderInformerWithOptions constructs a new informer for Flunder type.
+// Always prefer using an informer factory to get a shared informer instead of getting an independent
+// one. This reduces memory footprint and number of connections to the server.
+func NewFlunderInformerWithOptions(client internalclientset.Interface, namespace string, options cache.SharedInformerOptions, indexers cache.Indexers) cache.SharedIndexInformer {
+	return cache.NewSharedIndexInformerWithOptions(
+		&cache.ListWatch{
+			ListFunc: func(options v1.ListOptions) (runtime.Object, error) {
+				return client.Wardle().Flunders(namespace).List(options)
+			},
+			WatchFunc: func(options v1.ListOptions) (watch.Interface, error) {
+				return client.Wardle().Flunders(namespace).Watch(options)
+			},
+		},
+		options,
+		&wardle.Flunder{},
+		indexers,
+	)
+}
+
+func defaultFlunderInformer(client internalclientset.Interface, options cache.SharedInformerOptions) cache.SharedIndexInformer {
+	return NewFlunderInformerWithOptions(client, v1.NamespaceAll, options, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 }
 
 func (f *flunderInformer) Informer() cache.SharedIndexInformer {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/internalversion/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/internalversion/fischer.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type FischerLister interface {
 	// List lists all Fischers in the indexer.
 	List(selector labels.Selector) (ret []*wardle.Fischer, err error)
+	// ListWithOptions lists all Fischers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*wardle.Fischer, err error)
 	// Get retrieves the Fischer from the index for a given name.
 	Get(name string) (*wardle.Fischer, error)
 	FischerListerExpansion
@@ -48,6 +52,15 @@ func NewFischerLister(indexer cache.Indexer) FischerLister {
 // List lists all Fischers in the indexer.
 func (s *fischerLister) List(selector labels.Selector) (ret []*wardle.Fischer, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*wardle.Fischer))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Fischers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *fischerLister) ListWithOptions(options metav1.ListOptions) (ret []*wardle.Fischer, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*wardle.Fischer))
 	})
 	return ret, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/internalversion/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/internalversion/flunder.go
@@ -20,6 +20,7 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	wardle "k8s.io/sample-apiserver/pkg/apis/wardle"
@@ -29,6 +30,9 @@ import (
 type FlunderLister interface {
 	// List lists all Flunders in the indexer.
 	List(selector labels.Selector) (ret []*wardle.Flunder, err error)
+	// ListWithOptions lists all Flunders in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*wardle.Flunder, err error)
 	// Flunders returns an object that can list and get Flunders.
 	Flunders(namespace string) FlunderNamespaceLister
 	FlunderListerExpansion
@@ -52,6 +56,15 @@ func (s *flunderLister) List(selector labels.Selector) (ret []*wardle.Flunder, e
 	return ret, err
 }
 
+// ListWithOptions lists all Flunders in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *flunderLister) ListWithOptions(options metav1.ListOptions) (ret []*wardle.Flunder, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*wardle.Flunder))
+	})
+	return ret, err
+}
+
 // Flunders returns an object that can list and get Flunders.
 func (s *flunderLister) Flunders(namespace string) FlunderNamespaceLister {
 	return flunderNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *flunderLister) Flunders(namespace string) FlunderNamespaceLister {
 type FlunderNamespaceLister interface {
 	// List lists all Flunders in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*wardle.Flunder, err error)
+	// ListWithOptions lists all Flunders that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*wardle.Flunder, err error)
 	// Get retrieves the Flunder from the indexer for a given namespace and name.
 	Get(name string) (*wardle.Flunder, error)
 	FlunderNamespaceListerExpansion
@@ -76,6 +93,15 @@ type flunderNamespaceLister struct {
 // List lists all Flunders in the indexer for a given namespace.
 func (s flunderNamespaceLister) List(selector labels.Selector) (ret []*wardle.Flunder, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*wardle.Flunder))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Flunders that matches the options
+// in the indexer for a given namespace.
+func (s flunderNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*wardle.Flunder, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*wardle.Flunder))
 	})
 	return ret, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/v1alpha1/fischer.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
@@ -30,6 +31,9 @@ import (
 type FischerLister interface {
 	// List lists all Fischers in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.Fischer, err error)
+	// ListWithOptions lists all Fischers in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Fischer, err error)
 	// Get retrieves the Fischer from the index for a given name.
 	Get(name string) (*v1alpha1.Fischer, error)
 	FischerListerExpansion
@@ -48,6 +52,15 @@ func NewFischerLister(indexer cache.Indexer) FischerLister {
 // List lists all Fischers in the indexer.
 func (s *fischerLister) List(selector labels.Selector) (ret []*v1alpha1.Fischer, err error) {
 	err = cache.ListAll(s.indexer, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.Fischer))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Fischers in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *fischerLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Fischer, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Fischer))
 	})
 	return ret, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers_generated/wardle/v1alpha1/flunder.go
@@ -20,6 +20,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
@@ -29,6 +30,9 @@ import (
 type FlunderLister interface {
 	// List lists all Flunders in the indexer.
 	List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error)
+	// ListWithOptions lists all Flunders in the indexer that matches the options.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Flunder, err error)
 	// Flunders returns an object that can list and get Flunders.
 	Flunders(namespace string) FlunderNamespaceLister
 	FlunderListerExpansion
@@ -52,6 +56,15 @@ func (s *flunderLister) List(selector labels.Selector) (ret []*v1alpha1.Flunder,
 	return ret, err
 }
 
+// ListWithOptions lists all Flunders in the indexer.
+// Only options.Selector and options.IncludeUninitialized are respected.
+func (s *flunderLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Flunder, err error) {
+	err = cache.ListAllWithOptions(s.indexer, options, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.Flunder))
+	})
+	return ret, err
+}
+
 // Flunders returns an object that can list and get Flunders.
 func (s *flunderLister) Flunders(namespace string) FlunderNamespaceLister {
 	return flunderNamespaceLister{indexer: s.indexer, namespace: namespace}
@@ -61,6 +74,10 @@ func (s *flunderLister) Flunders(namespace string) FlunderNamespaceLister {
 type FlunderNamespaceLister interface {
 	// List lists all Flunders in the indexer for a given namespace.
 	List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error)
+	// ListWithOptions lists all Flunders that matches the options
+	// in the indexer for a given namespace.
+	// Only options.Selector and options.IncludeUninitialized are respected.
+	ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Flunder, err error)
 	// Get retrieves the Flunder from the indexer for a given namespace and name.
 	Get(name string) (*v1alpha1.Flunder, error)
 	FlunderNamespaceListerExpansion
@@ -76,6 +93,15 @@ type flunderNamespaceLister struct {
 // List lists all Flunders in the indexer for a given namespace.
 func (s flunderNamespaceLister) List(selector labels.Selector) (ret []*v1alpha1.Flunder, err error) {
 	err = cache.ListAllByNamespace(s.indexer, s.namespace, selector, func(m interface{}) {
+		ret = append(ret, m.(*v1alpha1.Flunder))
+	})
+	return ret, err
+}
+
+// ListWithOptions lists all Flunders that matches the options
+// in the indexer for a given namespace.
+func (s flunderNamespaceLister) ListWithOptions(options metav1.ListOptions) (ret []*v1alpha1.Flunder, err error) {
+	err = cache.ListAllByNamespaceWithOptions(s.indexer, s.namespace, options, func(m interface{}) {
 		ret = append(ret, m.(*v1alpha1.Flunder))
 	})
 	return ret, err

--- a/test/integration/auth/bootstraptoken_test.go
+++ b/test/integration/auth/bootstraptoken_test.go
@@ -42,6 +42,10 @@ func (b bootstrapSecrets) List(selector labels.Selector) (ret []*api.Secret, err
 	return b, nil
 }
 
+func (b bootstrapSecrets) ListWithOptions(options metav1.ListOptions) (ret []*api.Secret, err error) {
+	return b, nil
+}
+
 func (b bootstrapSecrets) Get(name string) (*api.Secret, error) {
 	return b[0], nil
 }


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/48893.

* Allow user to specify whether the list/watch should include uninitialized object when constructing shared informer factory. This only affects what will be stored in the cache. User still have to opt-in to let the individual informer/lister include uninitialized objects. See below.
* Add `AddEventHandlerWithOptions`. User can choose if the `ResourceEventHandler` will be invoked for events about uninitialized objects.
  * even if the shared informer factory is constructed to list/watch uninitialized objects, if the handlers are registered with the old `AddEventHandler()` method, they won't receive events about uninitialized objects. So it's backward compatible
* Add `ListWithOptions()` to listers. User can choose if to include uninitialized objects.
  * even if the shared informer factory is constructed to list/watch uninitialized objects, though the cache will include uninitialized objects, the old `List()` call will filter the uninitialized objects. So it's backward compatible.

Updated these controllers to observe uninitialized controllees:
* job
* replicaset
* replicationcontroller
* daemon
* garbage collector
* quota (for replenishing), which fixes the remaining issue in https://github.com/kubernetes/kubernetes/pull/51174.

TODO (in followup PRs):
* pv controller definitely needs to handle pv initialization failure ([provisionClaimOperation](https://github.com/kubernetes/kubernetes/blob/402e48b072b32ae79f59074d2fc67856f5a58849/pkg/controller/volume/persistentvolume/pv_controller.go#L1356))
* [TODO](https://github.com/kubernetes/kubernetes/pull/51247/commits/9eb1adf9df4bb669d96751518125512bbd3dbe61#diff-8059f32db3104eff877d689c93f31e25R393) in pkg/controller/history/controller_history.go
* [TODO](https://github.com/kubernetes/kubernetes/pull/51247/commits/9eb1adf9df4bb669d96751518125512bbd3dbe61#diff-bb67392bdbc46009f737d998596bf079R111) in pkg/controller/cronjob/cronjob_controller.go