### PR TITLE
Expose default service IP CIDR in apiserver

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -113,6 +113,8 @@ func NewServerRunOptions() *ServerRunOptions {
 		},
 		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
 	}
+	s.ServiceClusterIPRange = kubeoptions.DefaultServiceIPCIDR
+
 	// Overwrite the default for storage data format.
 	s.Etcd.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
 

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -99,6 +99,7 @@ func TestAddFlags(t *testing.T) {
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
 		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
+		ServiceClusterIPRange:  kubeoptions.DefaultServiceIPCIDR,
 		MasterCount:            5,
 		EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
 		AllowPrivileged:        false,

--- a/pkg/kubeapiserver/options/options.go
+++ b/pkg/kubeapiserver/options/options.go
@@ -17,8 +17,13 @@ limitations under the License.
 package options
 
 import (
+	"net"
+
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 )
 
 // DefaultServiceNodePortRange is the default port range for NodePort services.
 var DefaultServiceNodePortRange = utilnet.PortRange{Base: 30000, Size: 2768}
+
+// DefaultServiceIPCIDR is a CIDR notation of IP range from which to allocate service cluster IPs
+var DefaultServiceIPCIDR net.IPNet = net.IPNet{IP: net.ParseIP("10.0.0.0"), Mask: net.CIDRMask(24, 32)}

--- a/pkg/master/services.go
+++ b/pkg/master/services.go
@@ -21,7 +21,7 @@ import (
 	"net"
 
 	"github.com/golang/glog"
-
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 )
 
@@ -31,13 +31,8 @@ import (
 func DefaultServiceIPRange(passedServiceClusterIPRange net.IPNet) (net.IPNet, net.IP, error) {
 	serviceClusterIPRange := passedServiceClusterIPRange
 	if passedServiceClusterIPRange.IP == nil {
-		defaultNet := "10.0.0.0/24"
-		glog.Infof("Network range for service cluster IPs is unspecified. Defaulting to %v.", defaultNet)
-		_, defaultServiceClusterIPRange, err := net.ParseCIDR(defaultNet)
-		if err != nil {
-			return net.IPNet{}, net.IP{}, err
-		}
-		serviceClusterIPRange = *defaultServiceClusterIPRange
+		glog.Infof("Network range for service cluster IPs is unspecified. Defaulting to %v.", kubeoptions.DefaultServiceIPCIDR)
+		serviceClusterIPRange = kubeoptions.DefaultServiceIPCIDR
 	}
 	if size := ipallocator.RangeSize(&serviceClusterIPRange); size < 8 {
 		return net.IPNet{}, net.IP{}, fmt.Errorf("The service cluster IP range must be at least %d IP addresses", 8)


### PR DESCRIPTION
**What this PR does / why we need it**:
The `--service-cluster-ip-range` parameter of API server is very important for deploying Kubernetes on some clouds. The default CIDR "10.0.0.0/24" should be exposed at least from the API server's help message so that users have a better idea whether they need to change it.
This patch exposes this default value in API server's help message.

**Which issue this PR fixes** : fixes #51248

**Release note**:
```
NONE
```