### PR TITLE
Consistently attach internal ELB to public subnets

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2458,7 +2458,7 @@ func (c *Cloud) findELBSubnets(internalELB bool) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		if !internalELB && !isPublic {
+		if !isPublic {
 			glog.V(2).Infof("Ignoring private subnet for public ELB %q", id)
 			continue
 		}

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -845,22 +845,24 @@ func TestSubnetIDsinVPC(t *testing.T) {
 	routeTables["subnet-d0000001"] = true
 	routeTables["subnet-d0000002"] = true
 	awsServices.ec2.RouteTables = constructRouteTables(routeTables)
-	result, err = c.findELBSubnets(false)
-	if err != nil {
-		t.Errorf("Error listing subnets: %v", err)
-		return
-	}
-
-	if len(result) != 3 {
-		t.Errorf("Expected 3 subnets but got %d", len(result))
-		return
-	}
-
-	expected = []*string{aws.String("subnet-c0000000"), aws.String("subnet-d0000001"), aws.String("subnet-d0000002")}
-	for _, s := range result {
-		if !contains(expected, s) {
-			t.Errorf("Unexpected subnet '%s' found", s)
+	for _, internalElb := range [2]bool{false, true} {
+		result, err = c.findELBSubnets(internalElb)
+		if err != nil {
+			t.Errorf("Error listing subnets: %v", err)
 			return
+		}
+
+		if len(result) != 3 {
+			t.Errorf("Expected 3 subnets but got %d", len(result))
+			return
+		}
+
+		expected = []*string{aws.String("subnet-c0000000"), aws.String("subnet-d0000001"), aws.String("subnet-d0000002")}
+		for _, s := range result {
+			if !contains(expected, s) {
+				t.Errorf("Unexpected subnet '%s' found", s)
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Treat internal AWS ELBs the same as external AWS ELBs to prevent mixed public and private subnets

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50400

**Special notes for your reviewer**:

**Release note**: I chose to attach the ELB to the public subnet rather then the private as attaching to the private appears to duplicate exactly what a Service resource does. Public however lets me only listen for internal traffic, as expected with an internal ELB, but accept internal traffic from other internal subnets or peered VPCs, which is exactly how I personally expected it to work in the first place. This bug specifically affected me when using kops and setting the private and utility subnets to be the same network size, as it appears AWS orders subnets returned by the api based on network size, and this triggered a random mixing of public and utility networks on the elb.
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
