### PR TITLE
podgc not delete all pod when "--terminated-pod-gc-threshold=0"

### DIFF
--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -93,9 +93,9 @@ func (gcc *PodGCController) gc() {
 	}
 	if gcc.terminatedPodThreshold > 0 {
 		gcc.gcTerminated(pods)
+		gcc.gcOrphaned(pods)
+		gcc.gcUnscheduledTerminating(pods)
 	}
-	gcc.gcOrphaned(pods)
-	gcc.gcUnscheduledTerminating(pods)
 }
 
 func isPodTerminated(pod *v1.Pod) bool {


### PR DESCRIPTION
According to the cli description,when set the cli flag "--terminated-pod-gc-threshold=0",the pod gc collector is disabled.But in the code ,when "--terminated-pod-gc-threshold=0",the pod gc will still delete orphaned pod and unscheduledTerminating pod

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
