### PR TITLE
fix fuzzer for hostpath type that the path can be an empty string

### DIFF
--- a/pkg/api/fuzzer/fuzzer.go
+++ b/pkg/api/fuzzer/fuzzer.go
@@ -360,7 +360,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			types := []api.HostPathType{api.HostPathUnset, api.HostPathDirectoryOrCreate, api.HostPathDirectory,
 				api.HostPathFileOrCreate, api.HostPathFile, api.HostPathSocket, api.HostPathCharDev, api.HostPathBlockDev}
 			typeVol := types[c.Rand.Intn(len(types))]
-			if obj.Path != "" && obj.Type == nil {
+			if obj.Type == nil {
 				obj.Type = &typeVol
 			}
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It seems the path of `HostPath` generated by fuzzer can be an empty string. This is causing [pull-kubernetes-unit](https://k8s-gubernator.appspot.com/builds/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-unit) failing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51260

**Special notes for your reviewer**:
/assign @thockin @luxas @ixdy 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
