### PR TITLE
Refactor node taint conditions

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -5004,7 +5004,7 @@ func TestValidatePod(t *testing.T) {
 				Name:      "pod-forgiveness-invalid",
 				Namespace: "ns",
 			},
-			Spec: extendPodSpecwithTolerations(validPodSpec(nil), []api.Toleration{{Key: "node.alpha.kubernetes.io/notReady", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: &[]int64{-2}[0]}}),
+			Spec: extendPodSpecwithTolerations(validPodSpec(nil), []api.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoExecute", TolerationSeconds: &[]int64{-2}[0]}}),
 		},
 		{ // docker default seccomp profile
 			ObjectMeta: metav1.ObjectMeta{
@@ -5562,7 +5562,7 @@ func TestValidatePod(t *testing.T) {
 					Name:      "pod-forgiveness-invalid",
 					Namespace: "ns",
 				},
-				Spec: extendPodSpecwithTolerations(validPodSpec(nil), []api.Toleration{{Key: "node.alpha.kubernetes.io/notReady", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: &[]int64{20}[0]}}),
+				Spec: extendPodSpecwithTolerations(validPodSpec(nil), []api.Toleration{{Key: "node.kubernetes.io/not-ready", Operator: "Exists", Effect: "NoSchedule", TolerationSeconds: &[]int64{20}[0]}}),
 			},
 		},
 		"must be a valid pod seccomp profile": {

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -404,6 +404,17 @@ func NewNodeController(
 		})
 	}
 
+	// NOTE(resouer): nodeInformer to substitute deprecated taint key (notReady -> not-ready).
+	// Remove this logic when we don't need this backwards compatibility
+	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: util.CreateAddNodeHandler(func(node *v1.Node) error {
+			return nc.doFixDeprecatedTaintKeyPass(node)
+		}),
+		UpdateFunc: util.CreateUpdateNodeHandler(func(_, newNode *v1.Node) error {
+			return nc.doFixDeprecatedTaintKeyPass(newNode)
+		}),
+	})
+
 	nc.nodeLister = nodeInformer.Lister()
 	nc.nodeInformerSynced = nodeInformer.Informer().HasSynced
 
@@ -440,6 +451,38 @@ func (nc *Controller) doEvictionPass() {
 			return true, 0
 		})
 	}
+}
+
+// doFixDeprecatedTaintKeyPass checks and replaces deprecated taint key with proper key name if needed.
+func (nc *Controller) doFixDeprecatedTaintKeyPass(node *v1.Node) error {
+	taintsToAdd := []*v1.Taint{}
+	taintsToDel := []*v1.Taint{}
+
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == algorithm.DeprecatedTaintNodeNotReady {
+			// delete old taint
+			tDel := taint
+			taintsToDel = append(taintsToDel, &tDel)
+
+			// add right taint
+			tAdd := taint
+			tAdd.Key = algorithm.TaintNodeNotReady
+			taintsToAdd = append(taintsToAdd, &tAdd)
+
+			glog.Warningf("Detected deprecated taint key: %v on node: %v, will substitute it with %v",
+				algorithm.DeprecatedTaintNodeNotReady, node.GetName(), algorithm.TaintNodeNotReady)
+
+			break
+		}
+	}
+
+	if len(taintsToAdd) == 0 && len(taintsToDel) == 0 {
+		return nil
+	}
+	if !util.SwapNodeControllerTaint(nc.kubeClient, taintsToAdd, taintsToDel, node) {
+		return fmt.Errorf("failed to swap taints of node %+v", node)
+	}
+	return nil
 }
 
 func (nc *Controller) doNoScheduleTaintingPass(node *v1.Node) error {

--- a/plugin/pkg/scheduler/algorithm/well_known_labels.go
+++ b/plugin/pkg/scheduler/algorithm/well_known_labels.go
@@ -20,7 +20,7 @@ const (
 	// When feature-gate for TaintBasedEvictions=true flag is enabled,
 	// TaintNodeNotReady would be automatically added by node controller
 	// when node is not ready, and removed when node becomes ready.
-	TaintNodeNotReady = "node.alpha.kubernetes.io/notReady"
+	TaintNodeNotReady = "node.kubernetes.io/not-ready"
 
 	// When feature-gate for TaintBasedEvictions=true flag is enabled,
 	// TaintNodeUnreachable would be automatically added by node controller

--- a/plugin/pkg/scheduler/algorithm/well_known_labels.go
+++ b/plugin/pkg/scheduler/algorithm/well_known_labels.go
@@ -22,6 +22,10 @@ const (
 	// when node is not ready, and removed when node becomes ready.
 	TaintNodeNotReady = "node.kubernetes.io/not-ready"
 
+	// DeprecatedTaintNodeNotReady is the deprecated version of TaintNodeNotReady.
+	// It is deprecated since 1.9
+	DeprecatedTaintNodeNotReady = "node.alpha.kubernetes.io/notReady"
+
 	// When feature-gate for TaintBasedEvictions=true flag is enabled,
 	// TaintNodeUnreachable would be automatically added by node controller
 	// when node becomes unreachable (corresponding to NodeReady status ConditionUnknown)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
We should use `not-ready` etc as node condition taint key.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #51246 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use `not-ready` to replace `notReady` in node condition taint keys.
```
