### PR TITLE
fix issue(#51245)1、kubectl printObj should not print header when occur…

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -66,3 +66,16 @@ filegroup(
     ],
     tags = ["automanaged"],
 )
+
+go_test(
+    name = "go_default_test",
+    srcs = ["humanreadable_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/printers",
+    library = ":go_default_library",
+    deps = [
+        "//pkg/api:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)

--- a/pkg/printers/humanreadable_test.go
+++ b/pkg/printers/humanreadable_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1alpha1 "k8s.io/apimachinery/pkg/apis/meta/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+var testNamespaceColumnDefinitions = []metav1alpha1.TableColumnDefinition{
+	{Name: "Name", Type: "string", Format: "name", Description: metav1.ObjectMeta{}.SwaggerDoc()["name"]},
+	{Name: "Status", Type: "string", Description: "The status of the namespace"},
+	{Name: "Age", Type: "string", Description: metav1.ObjectMeta{}.SwaggerDoc()["creationTimestamp"]},
+}
+
+func testPrintNamespace(obj *api.Namespace, options PrintOptions) ([]metav1alpha1.TableRow, error) {
+	if options.WithNamespace {
+		return nil, fmt.Errorf("namespace is not namespaced")
+	}
+	row := metav1alpha1.TableRow{
+		Object: runtime.RawExtension{Object: obj},
+	}
+	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, "<unknow>")
+	return []metav1alpha1.TableRow{row}, nil
+}
+
+func testPrintNamespaceList(list *api.NamespaceList, options PrintOptions) ([]metav1alpha1.TableRow, error) {
+	rows := make([]metav1alpha1.TableRow, 0, len(list.Items))
+	for i := range list.Items {
+		r, err := testPrintNamespace(&list.Items[i], options)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, r...)
+	}
+	return rows, nil
+}
+func TestPrintRowsForHandlerEntry(t *testing.T) {
+	printFunc := reflect.ValueOf(testPrintNamespace)
+
+	testCase := map[string]struct {
+		h             *handlerEntry
+		opt           PrintOptions
+		obj           runtime.Object
+		includeHeader bool
+		expectOut     string
+		expectErr     string
+	}{
+		"no tablecolumndefinition and includeheader flase": {
+			h: &handlerEntry{
+				columnDefinitions: []metav1alpha1.TableColumnDefinition{},
+				printRows:         true,
+				printFunc:         printFunc,
+			},
+			opt: PrintOptions{},
+			obj: &api.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			includeHeader: false,
+			expectOut:     "test\t\t<unknow>\n",
+		},
+		"no tablecolumndefinition and includeheader true": {
+			h: &handlerEntry{
+				columnDefinitions: []metav1alpha1.TableColumnDefinition{},
+				printRows:         true,
+				printFunc:         printFunc,
+			},
+			opt: PrintOptions{},
+			obj: &api.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			includeHeader: true,
+			expectOut:     "\ntest\t\t<unknow>\n",
+		},
+		"have tablecolumndefinition and includeheader true": {
+			h: &handlerEntry{
+				columnDefinitions: testNamespaceColumnDefinitions,
+				printRows:         true,
+				printFunc:         printFunc,
+			},
+			opt: PrintOptions{},
+			obj: &api.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			includeHeader: true,
+			expectOut:     "NAME\tSTATUS\tAGE\ntest\t\t<unknow>\n",
+		},
+		"print namespace and withnamespace true, should not print header": {
+			h: &handlerEntry{
+				columnDefinitions: testNamespaceColumnDefinitions,
+				printRows:         true,
+				printFunc:         printFunc,
+			},
+			opt: PrintOptions{
+				WithNamespace: true,
+			},
+			obj: &api.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			},
+			includeHeader: true,
+			expectOut:     "",
+			expectErr:     "namespace is not namespaced",
+		},
+	}
+	for name, test := range testCase {
+		buffer := &bytes.Buffer{}
+		err := printRowsForHandlerEntry(buffer, test.h, test.obj, test.opt, test.includeHeader)
+		if err != nil {
+			if err.Error() != test.expectErr {
+				t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", name, test.expectErr, err)
+			}
+		}
+		if test.expectOut != buffer.String() {
+			t.Errorf("[%s]expect:\n %v\n but got:\n %v\n", name, test.expectOut, buffer.String())
+		}
+	}
+}


### PR DESCRIPTION
… error. 2、kubectl get ns --all-namespaces should not have NAMESPACE column

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
closes #51245

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
now we will just get this.
```
admindeMacBook-Pro-2:kubectl admin$ ./kubectl get ns --all-namespaces
error: namespace is not namespaced
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
