### PR TITLE
Add http check to internet test

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -46,9 +46,9 @@ var _ = SIGDescribe("Networking", func() {
 	})
 
 	It("should provide Internet connection for containers [Conformance]", func() {
-		By("Running container which tries to ping 8.8.8.8")
+		By("Running container which tries to reach www.google.com")
 		framework.ExpectNoError(
-			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", 30))
+			framework.CheckConnectivityToHost(f, "", "www.google.com", 30))
 	})
 
 	// First test because it has no dependencies on variables created later on.


### PR DESCRIPTION
**What this PR does / why we need it**:

When operating conformance test for k8s cluster system on a company
internal, only one test "should provide Internet connection for
containers [Conformance]" fails, because ICMP is denied between the
internet and the company inside network. This kind of thing is common
between data centors and the internet also.
So this PR adds a http check to the internet test as a fallback.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

fixes #51145

**Special notes for your reviewer**:

NOTE: The reasons why using http://google.com are
      - https connection requires another openssl package as [1]
      - the original 8.8.8.8 is the google DNS address

[1]: https://github.com/google/cadvisor/issues/1131

**Release note**:
`NONE`