### PR TITLE
exposes a method on AdmissionOptions

### DIFF
--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -100,9 +100,10 @@ func TestAddFlags(t *testing.T) {
 			MinRequestTimeout:           1800,
 		},
 		Admission: &apiserveroptions.AdmissionOptions{
-			PluginNames: []string{"AlwaysDeny"},
-			ConfigFile:  "/admission-control-config",
-			Plugins:     s.Admission.Plugins,
+			RecommendedPluginOrder: []string{"NamespaceLifecycle"},
+			PluginNames:            []string{"AlwaysDeny"},
+			ConfigFile:             "/admission-control-config",
+			Plugins:                s.Admission.Plugins,
 		},
 		Etcd: &apiserveroptions.EtcdOptions{
 			StorageConfig: storagebackend.Config{

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -1,28 +1,4 @@
-package(default_visibility = ["//visibility:public"])
-
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-    "go_test",
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["serving_test.go"],
-    data = glob(["testdata/**"]),
-    library = ":go_default_library",
-    deps = [
-        "//vendor/github.com/stretchr/testify/assert:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
-        "//vendor/k8s.io/client-go/discovery:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
-    ],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -39,6 +15,7 @@ go_library(
         "server_run_options.go",
         "serving.go",
     ],
+    visibility = ["//visibility:public"],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
@@ -52,6 +29,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit/policy:go_default_library",
@@ -80,9 +58,25 @@ go_library(
     ],
 )
 
-filegroup(
-    name = "testdata",
-    srcs = glob(["testdata/*"]),
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "admission_test.go",
+        "serving_test.go",
+    ],
+    data = glob(["testdata/**"]),
+    library = ":go_default_library",
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
+        "//vendor/k8s.io/client-go/discovery:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
 )
 
 filegroup(
@@ -99,4 +93,5 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestEnabledPluginNamesMethod(t *testing.T) {
+	scenarios := []struct {
+		expectedPluginNames       []string
+		setDefaultOffPluginNames  []string
+		setRecommendedPluginOrder []string
+	}{
+		// scenario 1: check if a call to enabledPluginNames sets expected values.
+		{
+			expectedPluginNames: []string{"NamespaceLifecycle"},
+		},
+
+		// scenario 2: overwrite RecommendedPluginOrder and set DefaultOffPluginNames
+		// make sure that plugins which are on DefaultOffPluginNames list do not get to PluginNames list.
+		{
+			expectedPluginNames:       []string{"pluginA"},
+			setRecommendedPluginOrder: []string{"pluginA", "pluginB"},
+			setDefaultOffPluginNames:  []string{"pluginB"},
+		},
+	}
+
+	// act
+	for index, scenario := range scenarios {
+		t.Run(fmt.Sprintf("scenario %d", index), func(t *testing.T) {
+			target := NewAdmissionOptions()
+
+			if len(scenario.setDefaultOffPluginNames) > 0 {
+				target.DefaultOffPlugins = scenario.setDefaultOffPluginNames
+			}
+			if len(scenario.setRecommendedPluginOrder) > 0 {
+				target.RecommendedPluginOrder = scenario.setRecommendedPluginOrder
+			}
+
+			actualPluginNames := target.enabledPluginNames()
+
+			if len(actualPluginNames) != len(scenario.expectedPluginNames) {
+				t.Errorf("incorrect number of items, got %d, expected = %d", len(actualPluginNames), len(scenario.expectedPluginNames))
+			}
+			for i := range actualPluginNames {
+				if scenario.expectedPluginNames[i] != actualPluginNames[i] {
+					t.Errorf("missmatch at index = %d, got = %s, expected = %s", i, actualPluginNames[i], scenario.expectedPluginNames[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
exposes a method on AdmissionOptions that will set default admission plugin names when none were provided from the command line.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
