### PR TITLE
Add host mountpath to controller-manager for flexvolume dir

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -30,9 +30,11 @@ import (
 )
 
 const (
-	caCertsVolumeName    = "ca-certs"
-	caCertsVolumePath    = "/etc/ssl/certs"
-	caCertsPkiVolumeName = "ca-certs-etc-pki"
+	caCertsVolumeName       = "ca-certs"
+	caCertsVolumePath       = "/etc/ssl/certs"
+	caCertsPkiVolumeName    = "ca-certs-etc-pki"
+	flexvolumeDirVolumeName = "flexvolume-dir"
+	flexvolumeDirVolumePath = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec"
 )
 
 // caCertsPkiVolumePath specifies the path that can be conditionally mounted into the apiserver and controller-manager containers
@@ -68,6 +70,9 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	// Read-only mount for the controller manager kubeconfig file
 	controllerManagerKubeConfigFile := filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ControllerManagerKubeConfigFileName)
 	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeConfigVolumeName, controllerManagerKubeConfigFile, controllerManagerKubeConfigFile, true, &hostPathFileOrCreate)
+	// Mount for the flexvolume directory (/usr/libexec/kubernetes/kubelet-plugins/volume/exec) directory
+	// Flexvolume dir must NOT be readonly as it is used for third-party plugins to integrate with their storage backends via unix domain socket.
+	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, flexvolumeDirVolumeName, flexvolumeDirVolumePath, flexvolumeDirVolumePath, false, &hostPathDirectoryOrCreate)
 
 	// HostPath volumes for the scheduler
 	// Read-only mount for the scheduler kubeconfig file

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -309,6 +309,15 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name: "flexvolume-dir",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
+								Type: &hostPathDirectoryOrCreate,
+							},
+						},
+					},
 				},
 				kubeadmconstants.KubeScheduler: {
 					{
@@ -350,6 +359,11 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 						Name:      "kubeconfig",
 						MountPath: "/etc/kubernetes/controller-manager.conf",
 						ReadOnly:  true,
+					},
+					{
+						Name:      "flexvolume-dir",
+						MountPath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
+						ReadOnly:  false,
 					},
 				},
 				kubeadmconstants.KubeScheduler: {
@@ -439,6 +453,15 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 							},
 						},
 					},
+					{
+						Name: "flexvolume-dir",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
+								Type: &hostPathDirectoryOrCreate,
+							},
+						},
+					},
 				},
 				kubeadmconstants.KubeScheduler: {
 					{
@@ -490,6 +513,11 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 						Name:      "kubeconfig",
 						MountPath: "/etc/kubernetes/controller-manager.conf",
 						ReadOnly:  true,
+					},
+					{
+						Name:      "flexvolume-dir",
+						MountPath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
+						ReadOnly:  false,
 					},
 				},
 				kubeadmconstants.KubeScheduler: {


### PR DESCRIPTION
Controller manager needs access to Flexvolume plugin when using attach-detach controller interface.

This PR adds the host mount path for the default directory of flexvolume plugins

Fixes https://github.com/kubernetes/kubeadm/issues/410