### PR TITLE
GCE metadata proxy blocks instance identity & recursive calls, & excludes port from redirects

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
@@ -28,13 +28,13 @@ data:
 
         # Allow for REST discovery.
         location = / {
-            if ($args ~ "recursive=true") {
+            if ($args ~* "recursive") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location = /computeMetadata/ {
-            if ($args ~ "recursive=true") {
+            if ($args ~* "recursive") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
@@ -42,19 +42,19 @@ data:
 
         # By default, allow the v0.1, v1beta1, and v1 APIs.
         location /0.1/ {
-            if ($args ~ "recursive=true") {
+            if ($args ~* "recursive") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1beta1/ {
-            if ($args ~ "recursive=true") {
+            if ($args ~* "recursive") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1/ {
-            if ($args ~ "recursive=true") {
+            if ($args ~* "recursive") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
@@ -20,6 +20,8 @@ data:
       access_log /dev/stdout;
       server {
         listen 127.0.0.1:988;
+        # When serving 301s, don't redirect to port 988.
+        port_in_redirect off;
 
         # By default, return 403. This protects us from new API versions.
         location / {
@@ -28,13 +30,13 @@ data:
 
         # Allow for REST discovery.
         location = / {
-            if ($args ~* "recursive") {
+            if ($args ~* "^(.+&)?recursive=") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location = /computeMetadata/ {
-            if ($args ~* "recursive") {
+            if ($args ~* "^(.+&)?recursive=") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
@@ -42,19 +44,19 @@ data:
 
         # By default, allow the v0.1, v1beta1, and v1 APIs.
         location /0.1/ {
-            if ($args ~* "recursive") {
+            if ($args ~* "^(.+&)?recursive=") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1beta1/ {
-            if ($args ~* "recursive") {
+            if ($args ~* "^(.+&)?recursive=") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1/ {
-            if ($args ~* "recursive") {
+            if ($args ~* "^(.+&)?recursive=") {
                     return 403 "?recursive calls are not allowed by the metadata proxy.";
             }
             proxy_pass http://169.254.169.254;

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
@@ -23,37 +23,63 @@ data:
 
         # By default, return 403. This protects us from new API versions.
         location / {
-            return 403;
+            return 403 "This metadata API is not allowed by the metadata proxy.";
         }
 
         # Allow for REST discovery.
         location = / {
+            if ($args ~ "recursive=true") {
+                    return 403 "?recursive calls are not allowed by the metadata proxy.";
+            }
             proxy_pass http://169.254.169.254;
         }
         location = /computeMetadata/ {
+            if ($args ~ "recursive=true") {
+                    return 403 "?recursive calls are not allowed by the metadata proxy.";
+            }
             proxy_pass http://169.254.169.254;
         }
 
         # By default, allow the v0.1, v1beta1, and v1 APIs.
         location /0.1/ {
+            if ($args ~ "recursive=true") {
+                    return 403 "?recursive calls are not allowed by the metadata proxy.";
+            }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1beta1/ {
+            if ($args ~ "recursive=true") {
+                    return 403 "?recursive calls are not allowed by the metadata proxy.";
+            }
             proxy_pass http://169.254.169.254;
         }
         location /computeMetadata/v1/ {
+            if ($args ~ "recursive=true") {
+                    return 403 "?recursive calls are not allowed by the metadata proxy.";
+            }
             proxy_pass http://169.254.169.254;
         }
 
         # Return a 403 for the kube-env attribute in all allowed API versions.
         location /0.1/meta-data/attributes/kube-env {
-            return 403;
+            return 403 "This metadata endpoint is concealed.";
         }
         location /computeMetadata/v1beta1/instance/attributes/kube-env {
-            return 403;
+            return 403 "This metadata endpoint is concealed.";
         }
         location /computeMetadata/v1/instance/attributes/kube-env {
-            return 403;
+            return 403 "This metadata endpoint is concealed.";
+        }
+
+        # Return a 403 for instance identity in all allowed API versions.
+        location ~ /0.1/meta-data/service-accounts/.+/identity {
+            return 403 "This metadata endpoint is concealed.";
+        }
+        location ~ /computeMetadata/v1beta1/instance/service-accounts/.+/identity {
+            return 403 "This metadata endpoint is concealed.";
+        }
+        location ~ /computeMetadata/v1/instance/service-accounts/.+/identity {
+            return 403 "This metadata endpoint is concealed.";
         }
       }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Metadata proxy blocks [instance identity](https://cloud.google.com/compute/docs/instances/verifying-instance-identity) & [recursive](https://cloud.google.com/compute/docs/storing-retrieving-metadata#aggcontents) calls, and no longer includes port in redirects (it was serving redirects to `http://metadata.google.internal:988`, which doesn't resolve.  Ref #8867.

**Special notes for your reviewer**: Container is defined https://github.com/kubernetes/contrib/tree/master/metadata-proxy; I plan to send a separate PR to remove the `nginx.conf` directly in the container to reduce confusion.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix security holes in GCE metadata proxy.
```
