### PR TITLE
Replace storage-class annotations with field in examples

### DIFF
--- a/cluster/juju/layers/kubernetes-master/templates/rbd-persistent-volume.yaml
+++ b/cluster/juju/layers/kubernetes-master/templates/rbd-persistent-volume.yaml
@@ -4,13 +4,12 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: {{ RBD_NAME }}
-  annotations:
-    volume.beta.kubernetes.io/storage-class: "rbd"
 spec:
   capacity:
     storage: {{ RBD_SIZE }}M
   accessModes:
     - {{ PV_MODE }}
+  storageClassName: "rbd"
   rbd:
     monitors:
       {% for host in monitors %}

--- a/examples/cockroachdb/cockroachdb-statefulset.yaml
+++ b/examples/cockroachdb/cockroachdb-statefulset.yaml
@@ -163,8 +163,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/examples/storage/cassandra/cassandra-statefulset.yaml
+++ b/examples/storage/cassandra/cassandra-statefulset.yaml
@@ -82,13 +82,12 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: cassandra-data
-      annotations:
-        volume.beta.kubernetes.io/storage-class: fast
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
           storage: 1Gi
+      storageClassName: fast
 ---
 kind: StorageClass
 apiVersion: storage.k8s.io/v1beta1

--- a/examples/storage/minio/minio-distributed-statefulset.yaml
+++ b/examples/storage/minio/minio-distributed-statefulset.yaml
@@ -39,8 +39,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: data
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - ReadWriteOnce

--- a/examples/storage/minio/minio-standalone-pvc.yaml
+++ b/examples/storage/minio/minio-standalone-pvc.yaml
@@ -3,8 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   # This name uniquely identifies the PVC. Will be used in deployment below.
   name: minio-pv-claim
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: anything
   labels:
     app: minio-storage-claim
 spec:

--- a/examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
+++ b/examples/volumes/nfs/provisioner/nfs-server-gce-pv.yaml
@@ -4,8 +4,6 @@ metadata:
   name: nfs-pv-provisioning-demo
   labels:
     demo: nfs-pv-provisioning
-  annotations:
-    volume.alpha.kubernetes.io/storage-class: any
 spec:
   accessModes: [ "ReadWriteOnce" ]
   resources:

--- a/examples/volumes/portworx/portworx-volume-pvcsc.yaml
+++ b/examples/volumes/portworx/portworx-volume-pvcsc.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvcsc001
-  annotations:
-    volume.beta.kubernetes.io/storage-class: portworx-io-priority-high
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
+  storageClassName: portworx-io-priority-high

--- a/examples/volumes/scaleio/sc-pvc.yaml
+++ b/examples/volumes/scaleio/sc-pvc.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvc-sio-small
-  annotations:
-      volume.beta.kubernetes.io/storage-class: sio-small
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 10Gi
+  storageClassName: sio-small

--- a/examples/volumes/vsphere/simple-statefulset.yaml
+++ b/examples/volumes/vsphere/simple-statefulset.yaml
@@ -37,10 +37,9 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: www
-      annotations:
-        volume.beta.kubernetes.io/storage-class: thin-disk
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
           storage: 1Gi
+      storageClassName: thin-disk

--- a/examples/volumes/vsphere/vsphere-volume-pvcsc.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcsc.yaml
@@ -2,11 +2,10 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: pvcsc001
-  annotations:
-    volume.beta.kubernetes.io/storage-class: fast
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
       storage: 2Gi
+  storageClassName: fast

--- a/test/e2e/framework/statefulset_utils.go
+++ b/test/e2e/framework/statefulset_utils.go
@@ -751,9 +751,6 @@ func NewStatefulSetPVC(name string) v1.PersistentVolumeClaim {
 	return v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
-			Annotations: map[string]string{
-				"volume.alpha.kubernetes.io/storage-class": "anything",
-			},
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{

--- a/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
@@ -92,8 +92,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -166,8 +166,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes:
         - "ReadWriteOnce"
@@ -175,4 +173,3 @@ spec:
         requests:
           # upstream recommended max is 700M
           storage: 1Gi
-

--- a/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
@@ -77,8 +77,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
@@ -71,8 +71,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:

--- a/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
@@ -78,8 +78,6 @@ spec:
   volumeClaimTemplates:
   - metadata:
       name: datadir
-      annotations:
-        volume.alpha.kubernetes.io/storage-class: anything
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
storage class is already GA. Replace annotations with field `StorageClassName` in examples.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51435 (update: thanks @gyliu513 for the issue)
ref: https://github.com/kubernetes/kubernetes/pull/50654#discussion_r134954171

**Special notes for your reviewer**:
We may also want to remove the beta annotations in 1.8 since the field will have already been in two releases. If @kubernetes/sig-storage-api-reviews confirm this, I'd like to help remove it.

/cc @liggitt @jsafrane @msau42 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
