### PR TITLE
DeploymentRollback: take Revisions in historyRevisionAnnotation into consideration when looking for corresponding RS

### DIFF
--- a/pkg/controller/deployment/rollback.go
+++ b/pkg/controller/deployment/rollback.go
@@ -46,13 +46,13 @@ func (dc *DeploymentController) rollback(d *extensions.Deployment, rsList []*ext
 		}
 	}
 	for _, rs := range allRSs {
-		v, err := deploymentutil.Revision(rs)
+		hasRevision, err := deploymentutil.HasRevision(rs, *toRevision)
 		if err != nil {
 			glog.V(4).Infof("Unable to extract revision from deployment's replica set %q: %v", rs.Name, err)
 			continue
 		}
-		if v == *toRevision {
-			glog.V(4).Infof("Found replica set %q with desired revision %d", rs.Name, v)
+		if hasRevision {
+			glog.V(4).Infof("Found replica set %q with desired revision %d", rs.Name, *toRevision)
 			// rollback by copying podTemplate.Spec from the replica set
 			// revision number will be incremented during the next getAllReplicaSetsAndSyncRevision call
 			// no-op if the the spec matches current deployment's podTemplate.Spec


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

When looking for RS to Rollback to, controller just consider the revision in revisionAnnotation in RS. Thus, if the deployment has been rollbacked to the revision before, the controller would not find target revision in RS , which is in historyRevisionAnnotation in fact.

**Which issue this PR fixes** 
#51315
