### PR TITLE
[WIP] Fix hardcoded string, add fetch validResource from APIServer

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -64,7 +64,7 @@ type AnnotateOptions struct {
 }
 
 var (
-	annotateLong = templates.LongDesc(`
+	annotateLong = `
 		Update the annotations on one or more resources.
 
 		* An annotation is a key/value pair that can hold larger (compared to a label), and possibly not human-readable, data.
@@ -72,7 +72,7 @@ var (
 		* If --overwrite is true, then existing annotations can be overwritten, otherwise attempting to overwrite an annotation will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
 
-		%[1]s`)
+		%[1]s`
 
 	annotateExample = templates.Examples(i18n.T(`
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend'.
@@ -113,7 +113,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
 		Short:   i18n.T("Update the annotations on a resource"),
-		Long:    fmt.Sprintf(annotateLong, f.ValidResourcesFromDiscoveryClient()),
+		Long:    templates.LongDesc(fmt.Sprintf(annotateLong, f.ValidResourcesFromDiscoveryClient())),
 		Example: annotateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(out, cmd, args); err != nil {

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -72,7 +72,7 @@ var (
 		* If --overwrite is true, then existing annotations can be overwritten, otherwise attempting to overwrite an annotation will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
 
-		` + validResources)
+		%[1]s`)
 
 	annotateExample = templates.Examples(i18n.T(`
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend'.
@@ -113,7 +113,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
 		Short:   i18n.T("Update the annotations on a resource"),
-		Long:    annotateLong,
+		Long:    fmt.Sprintf(annotateLong, f.ValidResourcesFromDiscoveryClient()),
 		Example: annotateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(out, cmd, args); err != nil {

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -195,51 +195,6 @@ __custom_func() {
     esac
 }
 `
-
-	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
-	// and add a short forms entry in expandResourceShortcut() when appropriate.
-	// TODO: This should be populated using the discovery information from apiserver.
-	validResources = `Valid resource types include:
-
-    * all
-    * certificatesigningrequests (aka 'csr')
-    * clusterrolebindings
-    * clusterroles
-    * clusters (valid only for federation apiservers)
-    * componentstatuses (aka 'cs')
-    * configmaps (aka 'cm')
-    * controllerrevisions
-    * cronjobs
-    * customresourcedefinition (aka 'crd')
-    * daemonsets (aka 'ds')
-    * deployments (aka 'deploy')
-    * endpoints (aka 'ep')
-    * events (aka 'ev')
-    * horizontalpodautoscalers (aka 'hpa')
-    * ingresses (aka 'ing')
-    * jobs
-    * limitranges (aka 'limits')
-    * namespaces (aka 'ns')
-    * networkpolicies (aka 'netpol')
-    * nodes (aka 'no')
-    * persistentvolumeclaims (aka 'pvc')
-    * persistentvolumes (aka 'pv')
-    * poddisruptionbudgets (aka 'pdb')
-    * podpreset
-    * pods (aka 'po')
-    * podsecuritypolicies (aka 'psp')
-    * podtemplates
-    * replicasets (aka 'rs')
-    * replicationcontrollers (aka 'rc')
-    * resourcequotas (aka 'quota')
-    * rolebindings
-    * roles
-    * secrets
-    * serviceaccounts (aka 'sa')
-    * services (aka 'svc')
-    * statefulsets
-    * storageclasses
-    `
 )
 
 var (

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	describe_long = templates.LongDesc(`
+	describeLong = templates.LongDesc(`
 		Show details of a specific resource or group of resources.
 		This command joins many API calls together to form a detailed description of a
 		given resource or group of resources.
@@ -47,9 +47,9 @@ var (
 		will first check for an exact match on TYPE and NAME_PREFIX. If no such resource
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
 
-		` + validResources)
+		%[1]s`)
 
-	describe_example = templates.Examples(i18n.T(`
+	describeExample = templates.Examples(i18n.T(`
 		# Describe a node
 		kubectl describe nodes kubernetes-node-emt8.c.myproject.internal
 
@@ -82,8 +82,8 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		Short:   i18n.T("Show details of a specific resource or group of resources"),
-		Long:    describe_long,
-		Example: describe_example,
+		Long:    fmt.Sprintf(describeLong, f.ValidResourcesFromDiscoveryClient()),
+		Example: describeExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)
 			cmdutil.CheckErr(err)
@@ -111,7 +111,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		enforceNamespace = false
 	}
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
-		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", validResources)
+		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", f.ValidResourcesFromDiscoveryClient())
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	describeLong = templates.LongDesc(`
+	describeLong = `
 		Show details of a specific resource or group of resources.
 		This command joins many API calls together to form a detailed description of a
 		given resource or group of resources.
@@ -47,7 +47,7 @@ var (
 		will first check for an exact match on TYPE and NAME_PREFIX. If no such resource
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
 
-		%[1]s`)
+		%[1]s`
 
 	describeExample = templates.Examples(i18n.T(`
 		# Describe a node
@@ -82,7 +82,7 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		Short:   i18n.T("Show details of a specific resource or group of resources"),
-		Long:    fmt.Sprintf(describeLong, f.ValidResourcesFromDiscoveryClient()),
+		Long:    templates.LongDesc(fmt.Sprintf(describeLong, f.ValidResourcesFromDiscoveryClient())),
 		Example: describeExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -31,10 +31,10 @@ import (
 )
 
 var (
-	explainLong = templates.LongDesc(`
+	explainLong = `
 		Documentation of resources.
 
-		%[1]s`)
+		%[1]s`
 
 	explainExamples = templates.Examples(i18n.T(`
 		# Get the documentation of the resource and its fields
@@ -49,7 +49,7 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "explain RESOURCE",
 		Short:   i18n.T("Documentation of resources"),
-		Long:    fmt.Sprintf(explainLong, f.ValidResourcesFromDiscoveryClient()),
+		Long:    templates.LongDesc(fmt.Sprintf(explainLong, f.ValidResourcesFromDiscoveryClient())),
 		Example: explainExamples,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExplain(f, out, cmdErr, cmd, args)

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -34,7 +34,7 @@ var (
 	explainLong = templates.LongDesc(`
 		Documentation of resources.
 
-		` + validResources)
+		%[1]s`)
 
 	explainExamples = templates.Examples(i18n.T(`
 		# Get the documentation of the resource and its fields
@@ -49,7 +49,7 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "explain RESOURCE",
 		Short:   i18n.T("Documentation of resources"),
-		Long:    explainLong,
+		Long:    fmt.Sprintf(explainLong, f.ValidResourcesFromDiscoveryClient()),
 		Example: explainExamples,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExplain(f, out, cmdErr, cmd, args)
@@ -65,7 +65,7 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		fmt.Fprintf(cmdErr, "You must specify the type of resource to explain. %s\n", validResources)
+		fmt.Fprintf(cmdErr, "You must specify the type of resource to explain. %s\n", f.ValidResourcesFromDiscoveryClient())
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 	if len(args) > 1 {

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -51,7 +51,7 @@ type GetOptions struct {
 }
 
 var (
-	getLong = templates.LongDesc(`
+	getLong = `
 		Display one or many resources.
 
 		%[1]s` +
@@ -61,7 +61,7 @@ var (
 		resource by providing the '--show-all' flag.
 
 		By specifying the output as 'template' and providing a Go template as the value
-		of the --template flag, you can filter the attributes of the fetched resources.`)
+		of the --template flag, you can filter the attributes of the fetched resources.`
 
 	getExample = templates.Examples(i18n.T(`
 		# List all pods in ps output format.
@@ -115,7 +115,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:     "get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
 		Short:   i18n.T("Display one or many resources"),
-		Long:    fmt.Sprintf(getLong, f.ValidResourcesFromDiscoveryClient()),
+		Long:    templates.LongDesc(fmt.Sprintf(getLong, f.ValidResourcesFromDiscoveryClient())),
 		Example: getExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunGet(f, out, errOut, cmd, args, options)

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -54,9 +54,9 @@ var (
 	getLong = templates.LongDesc(`
 		Display one or many resources.
 
-		` + validResources + `
+		%[1]s` +
 
-		This command will hide resources that have completed, such as pods that are
+		`This command will hide resources that have completed, such as pods that are
 		in the Succeeded or Failed phases. You can see the full results for any
 		resource by providing the '--show-all' flag.
 
@@ -115,7 +115,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:     "get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
 		Short:   i18n.T("Display one or many resources"),
-		Long:    getLong,
+		Long:    fmt.Sprintf(getLong, f.ValidResourcesFromDiscoveryClient()),
 		Example: getExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunGet(f, out, errOut, cmd, args, options)
@@ -183,7 +183,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	}
 
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
-		fmt.Fprint(errOut, "You must specify the type of resource to get. ", validResources)
+		fmt.Fprint(errOut, "You must specify the type of resource to get. ", f.ValidResourcesFromDiscoveryClient())
 
 		fullCmdName := cmd.Parent().CommandPath()
 		usageString := "Required resource not specified."

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -428,6 +428,10 @@ func (f *FakeFactory) OpenAPISchema(cacheDir string) (openapi.Resources, error) 
 	return nil, nil
 }
 
+func (f *FakeFactory) ValidResourcesFromDiscoveryClient() string {
+	return ""
+}
+
 func (f *FakeFactory) DefaultNamespace() (string, bool, error) {
 	return f.tf.Namespace, false, f.tf.Err
 }

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -803,6 +803,10 @@ func (f *fakeAPIFactory) OpenAPISchema(cacheDir string) (openapi.Resources, erro
 	return nil, nil
 }
 
+func (f *fakeAPIFactory) ValidResourcesFromDiscoveryClient() string {
+	return ""
+}
+
 func NewAPIFactory() (cmdutil.Factory, *TestFactory, runtime.Codec, runtime.NegotiatedSerializer) {
 	t := &TestFactory{
 		Validator: validation.NullSchema{},

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -230,6 +230,8 @@ type ObjectMappingFactory interface {
 	SwaggerSchema(schema.GroupVersionKind) (*swagger.ApiDeclaration, error)
 	// OpenAPISchema returns the schema openapi schema definiton
 	OpenAPISchema(cacheDir string) (openapi.Resources, error)
+	// ValidResourcesFromDiscoveryClient fetch valiedResource from apiserver.
+	ValidResourcesFromDiscoveryClient() string
 }
 
 // BuilderFactory holds the second level of factory methods.  These functions depend upon ObjectMappingFactory and ClientAccessFactory methods.

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+	"strings"
 
 	swagger "github.com/emicklei/go-restful-swagger12"
 	"github.com/golang/glog"
@@ -489,3 +490,69 @@ func (f *ring1Factory) OpenAPISchema(cacheDir string) (openapi.Resources, error)
 	// Delegate to the OpenAPIGetter
 	return f.openAPIGetter.getter.Get()
 }
+
+func (f *ring1Factory) ValidResourcesFromDiscoveryClient() string {
+	resourceMap := make(map[string]metav1.APIResource)
+	var keys []string
+	discoveryClient, err := f.clientAccessFactory.DiscoveryClient()
+	if err != nil {
+		return validLegacyGroupResources
+	}
+	apiResList, err := discoveryClient.ServerResources()
+	if err != nil {
+		return validLegacyGroupResources
+	}
+
+	for _, apiResources := range apiResList {
+		for _, apiRes := range apiResources.APIResources {
+			if !strings.Contains(apiRes.Name, "/") {
+				if _, ok := resourceMap[apiRes.Name]; !ok {
+					resourceMap[apiRes.Name] = apiRes
+					keys = append(keys, apiRes.Name)
+				}
+			}
+		}
+	}
+	sort.Strings(keys)
+	row := "Valid resource types include:\n\n  * all\n"
+	for _, k := range keys {
+		//add resource name
+		row = row + fmt.Sprintf("  * %s ", resourceMap[k].Name)
+		//concatenate shortnames
+		if len(resourceMap[k].ShortNames) > 0 {
+			row = row + " (aka "
+			for i, shortName := range resourceMap[k].ShortNames {
+				row = row + "'" + shortName + "'"
+				if i < len(resourceMap[k].ShortNames)-1 {
+					row = row + ","
+				}
+			}
+			row = row + ")"
+		}
+		//add newline
+		row = row + "\n"
+	}
+	return row
+}
+
+const validLegacyGroupResources = `Valid resource types include:
+
+    * all
+    * bindings
+    * componentstatuses (aka 'cs')
+    * configmaps (aka 'cm')
+    * endpoints (aka 'ep')
+    * events (aka 'ev')
+    * limitranges (aka 'limits')
+    * namespaces (aka 'ns')
+    * nodes (aka 'no')
+    * persistentvolumeclaims (aka 'pvc')
+    * persistentvolumes (aka 'pv')
+    * pods (aka 'po')
+    * podtemplates
+    * replicationcontrollers (aka 'rc')
+    * resourcequotas (aka 'quota')
+    * secrets
+    * serviceaccounts (aka 'sa')
+    * services (aka 'svc')
+`

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -24,9 +24,9 @@ import (
 	"os"
 	"path"
 	"sort"
+	"strings"
 	"sync"
 	"time"
-	"strings"
 
 	swagger "github.com/emicklei/go-restful-swagger12"
 	"github.com/golang/glog"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/51023

if DiscoveryClient failed, return previous hard coded string.
this change may make `kubectl get/annotate.. -h` a little slow first time, @deads2k do you think it's acceptable ?
```console
kubectl get -h  0.13s user 0.02s system 128% cpu 0.117 total
./kubectl get -h  0.13s user 0.02s system 5% cpu 2.600 total
```
before:
```
shiywang:amd64 root [dynamicResource] $ kubectl get -h
Display one or many resources. 

Valid resource types include: 

  * all  
  * certificatesigningrequests (aka 'csr')  
  * clusters (valid only for federation apiservers)  
  * clusterrolebindings  
  * clusterroles  
  * componentstatuses (aka 'cs')  
  * configmaps (aka 'cm')  
  * daemonsets (aka 'ds')  
  * deployments (aka 'deploy')  
  * endpoints (aka 'ep')  
  * events (aka 'ev')  
  * horizontalpodautoscalers (aka 'hpa')  
  * ingresses (aka 'ing')  
  * jobs  
  * limitranges (aka 'limits')  
  * namespaces (aka 'ns')  
  * networkpolicies  
  * nodes (aka 'no')  
  * persistentvolumeclaims (aka 'pvc')  
  * persistentvolumes (aka 'pv')  
  * pods (aka 'po')  
  * poddisruptionbudgets (aka 'pdb')  
  * podsecuritypolicies (aka 'psp')  
  * podtemplates  
  * replicasets (aka 'rs')  
  * replicationcontrollers (aka 'rc')  
  * resourcequotas (aka 'quota')  
  * rolebindings  
  * roles  
  * secrets  
  * serviceaccounts (aka 'sa')  
  * services (aka 'svc')  
  * statefulsets  
  * storageclasses  
  * thirdpartyresources  

This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases. You can
see the full results for any resource by providing the '--show-all' flag. 

```
after:
```
shiywang:amd64 root [dynamicResource] $ ./kubectl get -h
Display one or many resources. 

Valid resource types include:

  * all
  * bindings 
  * certificatesigningrequests  (aka 'csr')
  * clusterrolebindings 
  * clusterroles 
  * clusters (valid only for federation apiservers)
  * componentstatuses  (aka 'cs')
  * configmaps  (aka 'cm')
  * controllerrevisions 
  * customresourcedefinitions  (aka 'crd')
  * daemonsets  (aka 'ds')
  * deployments  (aka 'deploy')
  * endpoints  (aka 'ep')
  * events  (aka 'ev')
  * externaladmissionhookconfigurations 
  * horizontalpodautoscalers  (aka 'hpa')
  * ingresses  (aka 'ing')
  * initializerconfigurations 
  * jobs 
  * limitranges  (aka 'limits')
  * localsubjectaccessreviews 
  * namespaces  (aka 'ns')
  * networkpolicies  (aka 'netpol')
  * nodes  (aka 'no')
  * persistentvolumeclaims  (aka 'pvc')
  * persistentvolumes  (aka 'pv')
  * poddisruptionbudgets  (aka 'pdb')
  * podpresets 
  * pods  (aka 'po')
  * podsecuritypolicies  (aka 'psp')
  * podtemplates 
  * replicasets  (aka 'rs')
  * replicationcontrollers 
  * resourcequotas  (aka 'quota')
  * rolebindings 
  * roles 
  * secrets 
  * selfsubjectaccessreviews 
  * serviceaccounts  (aka 'sa')
  * services  (aka 'svc')
  * statefulsets  (aka 'sts')
  * storageclasses  (aka 'sc')
  * subjectaccessreviews 
  * tokenreviews 
 

This command will hide resources that have completed, such as pods that are in the Succeeded or Failed phases. You can
see the full results for any resource by providing the '--show-all' flag. 
```