### PR TITLE
PodSecurityPolicy.allowedCapabilities: add support for * to allow to request any capabilities

### DIFF
--- a/examples/podsecuritypolicy/rbac/policies.yaml
+++ b/examples/podsecuritypolicy/rbac/policies.yaml
@@ -14,6 +14,8 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
+  allowedCapabilities:
+  - '*'
 ---
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -898,6 +898,7 @@ type PodSecurityPolicySpec struct {
 	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
 	// Capabilities in this field may be added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
+	// To allow all capabilities you may use '*'.
 	// +optional
 	AllowedCapabilities []api.Capability
 	// Volumes is a white list of allowed volume plugins.  Empty indicates that all plugins
@@ -965,6 +966,10 @@ type HostPortRange struct {
 	// Max is the end of the range, inclusive.
 	Max int
 }
+
+// AllowAllCapabilities can be used as a value for the PodSecurityPolicy.AllowAllCapabilities
+// field and means that any capabilities are allowed to be requested.
+var AllowAllCapabilities api.Capability = "*"
 
 // FSType gives strong typing to different file systems that are used by volumes.
 type FSType string

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -660,6 +660,10 @@ func ValidatePodSecurityPolicySpec(spec *extensions.PodSecurityPolicySpec, fldPa
 	allErrs = append(allErrs, validatePSPSupplementalGroup(fldPath.Child("supplementalGroups"), &spec.SupplementalGroups)...)
 	allErrs = append(allErrs, validatePSPFSGroup(fldPath.Child("fsGroup"), &spec.FSGroup)...)
 	allErrs = append(allErrs, validatePodSecurityPolicyVolumes(fldPath, spec.Volumes)...)
+	if len(spec.RequiredDropCapabilities) > 0 && hasCap(extensions.AllowAllCapabilities, spec.AllowedCapabilities) {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("requiredDropCapabilities"), spec.RequiredDropCapabilities,
+			"must be empty when all capabilities are allowed by a wildcard"))
+	}
 	allErrs = append(allErrs, validatePSPCapsAgainstDrops(spec.RequiredDropCapabilities, spec.DefaultAddCapabilities, field.NewPath("defaultAddCapabilities"))...)
 	allErrs = append(allErrs, validatePSPCapsAgainstDrops(spec.RequiredDropCapabilities, spec.AllowedCapabilities, field.NewPath("allowedCapabilities"))...)
 	allErrs = append(allErrs, validatePSPDefaultAllowPrivilegeEscalation(fldPath.Child("defaultAllowPrivilegeEscalation"), spec.DefaultAllowPrivilegeEscalation, spec.AllowPrivilegeEscalation)...)

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -2472,6 +2472,10 @@ func TestValidatePodSecurityPolicy(t *testing.T) {
 		{Min: 1, Max: -10},
 	}
 
+	wildcardAllowedCapAndRequiredDrop := validPSP()
+	wildcardAllowedCapAndRequiredDrop.Spec.RequiredDropCapabilities = []api.Capability{"foo"}
+	wildcardAllowedCapAndRequiredDrop.Spec.AllowedCapabilities = []api.Capability{extensions.AllowAllCapabilities}
+
 	requiredCapAddAndDrop := validPSP()
 	requiredCapAddAndDrop.Spec.DefaultAddCapabilities = []api.Capability{"foo"}
 	requiredCapAddAndDrop.Spec.RequiredDropCapabilities = []api.Capability{"foo"}
@@ -2585,6 +2589,11 @@ func TestValidatePodSecurityPolicy(t *testing.T) {
 			psp:         invalidRangeNegativeMax,
 			errorType:   field.ErrorTypeInvalid,
 			errorDetail: "max cannot be negative",
+		},
+		"non-empty required drops and all caps are allowed by a wildcard": {
+			psp:         wildcardAllowedCapAndRequiredDrop,
+			errorType:   field.ErrorTypeInvalid,
+			errorDetail: "must be empty when all capabilities are allowed by a wildcard",
 		},
 		"invalid required caps": {
 			psp:         requiredCapAddAndDrop,

--- a/pkg/security/podsecuritypolicy/capabilities/BUILD
+++ b/pkg/security/podsecuritypolicy/capabilities/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
@@ -24,7 +25,10 @@ go_test(
     name = "go_default_test",
     srcs = ["mustrunas_test.go"],
     library = ":go_default_library",
-    deps = ["//pkg/api:go_default_library"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/security/podsecuritypolicy/capabilities/mustrunas_test.go
+++ b/pkg/security/podsecuritypolicy/capabilities/mustrunas_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 func TestGenerateAdds(t *testing.T) {
@@ -246,6 +247,12 @@ func TestValidateAdds(t *testing.T) {
 		// container requests match allowed
 		"no required, allowed, container requests valid": {
 			allowedCaps: []api.Capability{"foo"},
+			containerCaps: &api.Capabilities{
+				Add: []api.Capability{"foo"},
+			},
+		},
+		"no required, all allowed, container requests valid": {
+			allowedCaps: []api.Capability{extensions.AllowAllCapabilities},
 			containerCaps: &api.Capabilities{
 				Add: []api.Capability{"foo"},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior this change there was no way to allow to pods to request any capabilities. Cluster admin had always specify a full list of capabilities explicitly. Because there are many of them, it gets tedious. This PR makes possible to use `*` to allow all possible capabilities. Non-paranoid (and lazy) cluster admins can use it. Those who are super strict and paranoid of course won't use it because `*` allows capabilities that don't exist today but may be introduced in the future.

"privileged" PSP in examples was modified to allow privileged users to use this feature.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50055

**Special notes for your reviewer**:
This functional is already present in OpenShift: https://github.com/openshift/origin/pull/12875 and https://github.com/openshift/origin/pull/15135

**Release note**:
```release-note
PSP: add support for using `*` as a value in `allowedCapabilities` to allow to request any capabilities
```

CC @simo5 @pweil- @gyliu513 @liqlin2015 