### PR TITLE
Set flexvolumeplugin.host so that it's not nil

### DIFF
--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -86,6 +86,7 @@ func NewFlexVolumePlugin(pluginDir, name string) (volume.VolumePlugin, error) {
 
 // Init is part of the volume.VolumePlugin interface.
 func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
+	plugin.host = host
 	// Hardwired 'success' as any errors from calling init() will be caught by NewFlexVolumePlugin()
 	return nil
 }


### PR DESCRIPTION
@TerraTech @MikaelCluseau  @chakri-nelluri @verult

I assume this line was removed inadvertently, without plugin.host set the flexvolume silently fails at Mount/Attach* time. https://github.com/kubernetes/kubernetes/pull/50843

https://github.com/kubernetes/kubernetes/issues/51123

Please review, thanks!

```release-note
NONE
```