### PR TITLE
Correct default cluster-ip-range subnet

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -85,15 +85,15 @@ function get-node-ip-range {
 }
 
 function get-cluster-ip-range {
-  local suggested_range="10.100.0.0/14"
+  local suggested_range="10.64.0.0/14"
   if [[ "${NUM_NODES}" -gt 1000 ]]; then
-    suggested_range="10.100.0.0/13"
+    suggested_range="10.64.0.0/13"
   fi
   if [[ "${NUM_NODES}" -gt 2000 ]]; then
-    suggested_range="10.100.0.0/12"
+    suggested_range="10.64.0.0/12"
   fi
   if [[ "${NUM_NODES}" -gt 4000 ]]; then
-    suggested_range="10.100.0.0/11"
+    suggested_range="10.64.0.0/11"
   fi
   echo "${suggested_range}" 
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -235,7 +235,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws. If there is more than one group: comma separated list of groups.")
 	flag.StringVar(&cloudConfig.Network, "network", "e2e", "The cloud provider network for this e2e cluster.")
 	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
-	flag.StringVar(&cloudConfig.ClusterIPRange, "cluster-ip-range", "10.100.0.0/14", "A CIDR notation IP range from which to assign IPs in the cluster.")
+	flag.StringVar(&cloudConfig.ClusterIPRange, "cluster-ip-range", "10.64.0.0/14", "A CIDR notation IP range from which to assign IPs in the cluster.")
 	flag.StringVar(&cloudConfig.NodeTag, "node-tag", "", "Network tags used on node instances. Valid only for gce, gke")
 	flag.StringVar(&cloudConfig.MasterTag, "master-tag", "", "Network tags used on master instances. Valid only for gce, gke")
 


### PR DESCRIPTION
The current IP is creating a problem for /11 mask (not with any k8s components themselves) but while creating firewall-rule.
It complains saying `Must be a valid IPV4 CIDR address range` because of non-zero digits in the non-masked part.

[Edit] Fixes #51379