### PR TITLE
Fix NoNewPrivs and also allow remote runtime to provide the support.

### DIFF
--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -187,6 +187,11 @@ func (a *noNewPrivsAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult
 		return PodAdmitResult{Admit: true}
 	}
 
+	// Always admit for remote runtime.
+	if a.Runtime.Type() == kubetypes.RemoteContainerRuntime {
+		return PodAdmitResult{Admit: true}
+	}
+
 	// Make sure it is either docker or rkt runtimes.
 	if a.Runtime.Type() != kubetypes.DockerContainerRuntime && a.Runtime.Type() != kubetypes.RktContainerRuntime {
 		return PodAdmitResult{
@@ -196,7 +201,7 @@ func (a *noNewPrivsAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult
 		}
 	}
 
-	if a.Runtime.Type() != kubetypes.DockerContainerRuntime {
+	if a.Runtime.Type() == kubetypes.DockerContainerRuntime {
 		// Make sure docker api version is valid.
 		rversion, err := a.Runtime.APIVersion()
 		if err != nil {
@@ -206,7 +211,7 @@ func (a *noNewPrivsAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult
 				Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %v", err),
 			}
 		}
-		v, err := rversion.Compare("1.23")
+		v, err := rversion.Compare("1.23.0")
 		if err != nil {
 			return PodAdmitResult{
 				Admit:   false,


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/51319.

This PR:
1) Let kubelet admit remote runtime for `NoNewPrivis` container runtime.
2) Fix a `NoNewPrivis` bug which checks wrong runtime type.

/cc @kubernetes/sig-node-bugs @jessfraz 
