### PR TITLE
Make coreos test images sshd not allow password login.

### DIFF
--- a/test/e2e_node/jenkins/coreos-init.json
+++ b/test/e2e_node/jenkins/coreos-init.json
@@ -24,6 +24,21 @@
         "groups": ["docker", "sudo"]
       }
     }]
+  },
+  "storage": {
+    "files": [
+      {
+        "filesystem": "root",
+        "path": "/etc/ssh/sshd_config",
+        "contents": {
+          "source": "data:,%23%20Use%20most%20defaults%20for%20sshd%20configuration.%0AUsePrivilegeSeparation%20sandbox%0ASubsystem%20sftp%20internal-sftp%0AClientAliveInterval%20180%0AUseDNS%20no%0AUsePAM%20yes%0APrintLastLog%20no%20%23%20handled%20by%20PAM%0APrintMotd%20no%20%23%20handled%20by%20PAM%0AAuthenticationMethods%20publickey",
+          "verification": {}
+        },
+        "mode": 384,
+        "user": {},
+        "group": {}
+      }
+    ]
   }
 }
 


### PR DESCRIPTION
This will prevent security scanners from triggering.

Configuration is verbatim from:
https://coreos.com/os/docs/latest/customizing-sshd.html

```release-note
NONE
```
