### PR TITLE
Deprecate controller APIs in extensions/v1beta1 and apps/v1beta1

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -54821,7 +54821,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.ControllerRevision": {
-    "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+    "description": "DEPRECATED. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
     "required": [
      "revision"
     ],
@@ -54857,7 +54857,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.ControllerRevisionList": {
-    "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+    "description": "DEPRECATED. ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
     "required": [
      "items"
     ],
@@ -54891,7 +54891,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.Deployment": {
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -54923,7 +54923,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -54956,7 +54956,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -55029,7 +55029,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -55077,7 +55077,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -55126,7 +55126,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -55149,7 +55149,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.RollingUpdateDeployment": {
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
@@ -55162,7 +55162,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy": {
-    "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "description": "DEPRECATED. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
     "properties": {
      "partition": {
       "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
@@ -55238,7 +55238,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.StatefulSet": {
-    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "description": "DEPRECATED. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -55269,7 +55269,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.StatefulSetList": {
-    "description": "StatefulSetList is a collection of StatefulSets.",
+    "description": "DEPRECATED. StatefulSetList is a collection of StatefulSets.",
     "required": [
      "items"
     ],
@@ -55301,7 +55301,7 @@
     ]
    },
    "io.k8s.api.apps.v1beta1.StatefulSetSpec": {
-    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "description": "DEPRECATED. A StatefulSetSpec is the specification of a StatefulSet.",
     "required": [
      "template",
      "serviceName"
@@ -55347,7 +55347,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.StatefulSetStatus": {
-    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "description": "DEPRECATED. StatefulSetStatus represents the current state of a StatefulSet.",
     "required": [
      "replicas"
     ],
@@ -55393,7 +55393,7 @@
     }
    },
    "io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy": {
-    "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "description": "DEPRECATED. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "rollingUpdate": {
       "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
@@ -62355,7 +62355,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSet": {
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED. DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -62387,7 +62387,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DEPRECATED. DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -62421,7 +62421,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DEPRECATED. DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -62456,7 +62456,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DEPRECATED. DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -62512,6 +62512,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy": {
+    "description": "DEPRECATED.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -62524,7 +62525,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Deployment": {
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -62556,7 +62557,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -62589,7 +62590,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -62662,7 +62663,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -62710,7 +62711,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -62759,7 +62760,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -63275,7 +63276,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -63307,7 +63308,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -63336,7 +63337,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "DEPRECATED. ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -63370,7 +63371,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -63393,7 +63394,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -63445,7 +63446,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet": {
-    "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -63454,7 +63455,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDeployment": {
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -3339,7 +3339,7 @@
   "models": {
    "v1beta1.ControllerRevisionList": {
     "id": "v1beta1.ControllerRevisionList",
-    "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+    "description": "DEPRECATED. ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
     "required": [
      "items"
     ],
@@ -3381,7 +3381,7 @@
    },
    "v1beta1.ControllerRevision": {
     "id": "v1beta1.ControllerRevision",
-    "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+    "description": "DEPRECATED. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
     "required": [
      "revision"
     ],
@@ -3718,7 +3718,7 @@
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -3746,7 +3746,7 @@
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -3772,7 +3772,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -5841,7 +5841,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -5855,7 +5855,7 @@
    },
    "v1beta1.RollingUpdateDeployment": {
     "id": "v1beta1.RollingUpdateDeployment",
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -5880,7 +5880,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -5928,7 +5928,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -6051,7 +6051,7 @@
    },
    "v1beta1.StatefulSetList": {
     "id": "v1beta1.StatefulSetList",
-    "description": "StatefulSetList is a collection of StatefulSets.",
+    "description": "DEPRECATED. StatefulSetList is a collection of StatefulSets.",
     "required": [
      "items"
     ],
@@ -6077,7 +6077,7 @@
    },
    "v1beta1.StatefulSet": {
     "id": "v1beta1.StatefulSet",
-    "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "description": "DEPRECATED. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6102,7 +6102,7 @@
    },
    "v1beta1.StatefulSetSpec": {
     "id": "v1beta1.StatefulSetSpec",
-    "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "description": "DEPRECATED. A StatefulSetSpec is the specification of a StatefulSet.",
     "required": [
      "template",
      "serviceName"
@@ -6229,7 +6229,7 @@
    },
    "v1beta1.StatefulSetUpdateStrategy": {
     "id": "v1beta1.StatefulSetUpdateStrategy",
-    "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "description": "DEPRECATED. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "type": {
       "type": "string",
@@ -6243,7 +6243,7 @@
    },
    "v1beta1.RollingUpdateStatefulSetStrategy": {
     "id": "v1beta1.RollingUpdateStatefulSetStrategy",
-    "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "description": "DEPRECATED. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
     "properties": {
      "partition": {
       "type": "integer",
@@ -6254,7 +6254,7 @@
    },
    "v1beta1.StatefulSetStatus": {
     "id": "v1beta1.StatefulSetStatus",
-    "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "description": "DEPRECATED. StatefulSetStatus represents the current state of a StatefulSet.",
     "required": [
      "replicas"
     ],

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -6171,7 +6171,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DEPRECATED. DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -6213,7 +6213,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED. DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "kind": {
       "type": "string",
@@ -6477,7 +6477,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DEPRECATED. DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -8533,6 +8533,7 @@
    },
    "v1beta1.DaemonSetUpdateStrategy": {
     "id": "v1beta1.DaemonSetUpdateStrategy",
+    "description": "DEPRECATED.",
     "properties": {
      "type": {
       "type": "string",
@@ -8546,7 +8547,7 @@
    },
    "v1beta1.RollingUpdateDaemonSet": {
     "id": "v1beta1.RollingUpdateDaemonSet",
-    "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -8556,7 +8557,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DEPRECATED. DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -8682,7 +8683,7 @@
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -8710,7 +8711,7 @@
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -8736,7 +8737,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -8785,7 +8786,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -8799,7 +8800,7 @@
    },
    "v1beta1.RollingUpdateDeployment": {
     "id": "v1beta1.RollingUpdateDeployment",
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -8824,7 +8825,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -8872,7 +8873,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -9566,7 +9567,7 @@
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "DEPRECATED. ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -9594,7 +9595,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9620,7 +9621,7 @@
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -9644,7 +9645,7 @@
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -9685,7 +9686,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -403,7 +403,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</h3>
 <div class="paragraph">
-<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -589,7 +589,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatestatefulsetstrategy">v1beta1.RollingUpdateStatefulSetStrategy</h3>
 <div class="paragraph">
-<p>RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.</p>
+<p>DEPRECATED. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1147,7 +1147,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatedeployment">v1beta1.RollingUpdateDeployment</h3>
 <div class="paragraph">
-<p>Spec to control the desired behavior of rolling update.</p>
+<p>DEPRECATED. Spec to control the desired behavior of rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1536,7 +1536,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_statefulsetspec">v1beta1.StatefulSetSpec</h3>
 <div class="paragraph">
-<p>A StatefulSetSpec is the specification of a StatefulSet.</p>
+<p>DEPRECATED. A StatefulSetSpec is the specification of a StatefulSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1808,7 +1808,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deployment">v1beta1.Deployment</h3>
 <div class="paragraph">
-<p>Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2921,7 +2921,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_statefulset">v1beta1.StatefulSet</h3>
 <div class="paragraph">
-<p>StatefulSet represents a set of pods with consistent identities. Identities are defined as:<br>
+<p>DEPRECATED. StatefulSet represents a set of pods with consistent identities. Identities are defined as:<br>
  - Network: A single stable DNS and hostname.<br>
  - Storage: As many VolumeClaims as requested.<br>
 The StatefulSet guarantees that a given network identity will always map to the same storage identity.</p>
@@ -3429,7 +3429,7 @@ The StatefulSet guarantees that a given network identity will always map to the 
 <div class="sect2">
 <h3 id="_v1beta1_deploymentspec">v1beta1.DeploymentSpec</h3>
 <div class="paragraph">
-<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4089,7 +4089,7 @@ The StatefulSet guarantees that a given network identity will always map to the 
 <div class="sect2">
 <h3 id="_v1beta1_statefulsetlist">v1beta1.StatefulSetList</h3>
 <div class="paragraph">
-<p>StatefulSetList is a collection of StatefulSets.</p>
+<p>DEPRECATED. StatefulSetList is a collection of StatefulSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4258,7 +4258,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_controllerrevision">v1beta1.ControllerRevision</h3>
 <div class="paragraph">
-<p>ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.</p>
+<p>DEPRECATED. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4816,7 +4816,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentlist">v1beta1.DeploymentList</h3>
 <div class="paragraph">
-<p>DeploymentList is a list of Deployments.</p>
+<p>DEPRECATED. DeploymentList is a list of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5077,7 +5077,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_statefulsetstatus">v1beta1.StatefulSetStatus</h3>
 <div class="paragraph">
-<p>StatefulSetStatus represents the current state of a StatefulSet.</p>
+<p>DEPRECATED. StatefulSetStatus represents the current state of a StatefulSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5164,7 +5164,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstrategy">v1beta1.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5677,7 +5677,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_controllerrevisionlist">v1beta1.ControllerRevisionList</h3>
 <div class="paragraph">
-<p>ControllerRevisionList is a resource containing a list of ControllerRevision objects.</p>
+<p>DEPRECATED. ControllerRevisionList is a resource containing a list of ControllerRevision objects.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6493,7 +6493,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentcondition">v1beta1.DeploymentCondition</h3>
 <div class="paragraph">
-<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6668,7 +6668,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_statefulsetupdatestrategy">v1beta1.StatefulSetUpdateStrategy</h3>
 <div class="paragraph">
-<p>StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.</p>
+<p>DEPRECATED. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -421,7 +421,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</h3>
 <div class="paragraph">
-<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -607,7 +607,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetstatus">v1beta1.DaemonSetStatus</h3>
 <div class="paragraph">
-<p>DaemonSetStatus represents the current status of a daemon set.</p>
+<p>DEPRECATED. DaemonSetStatus represents the current status of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1080,7 +1080,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetlist">v1beta1.ReplicaSetList</h3>
 <div class="paragraph">
-<p>ReplicaSetList is a collection of ReplicaSets.</p>
+<p>DEPRECATED. ReplicaSetList is a collection of ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1279,7 +1279,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetcondition">v1beta1.ReplicaSetCondition</h3>
 <div class="paragraph">
-<p>ReplicaSetCondition describes the state of a replica set at a certain point.</p>
+<p>DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1509,7 +1509,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatedeployment">v1beta1.RollingUpdateDeployment</h3>
 <div class="paragraph">
-<p>Spec to control the desired behavior of rolling update.</p>
+<p>DEPRECATED. Spec to control the desired behavior of rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2007,7 +2007,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatedaemonset">v1beta1.RollingUpdateDaemonSet</h3>
 <div class="paragraph">
-<p>Spec to control the desired behavior of daemon set rolling update.</p>
+<p>DEPRECATED. Spec to control the desired behavior of daemon set rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2196,7 +2196,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</h3>
 <div class="paragraph">
-<p>ReplicaSetSpec is the specification of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2251,7 +2251,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deployment">v1beta1.Deployment</h3>
 <div class="paragraph">
-<p>Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2313,7 +2313,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetspec">v1beta1.DaemonSetSpec</h3>
 <div class="paragraph">
-<p>DaemonSetSpec is the specification of a daemon set.</p>
+<p>DEPRECATED. DaemonSetSpec is the specification of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3417,6 +3417,9 @@ When an object is created, the system will populate this list with the current s
 </div>
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetupdatestrategy">v1beta1.DaemonSetUpdateStrategy</h3>
+<div class="paragraph">
+<p>DEPRECATED.</p>
+</div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
 <col style="width:20%;">
@@ -3580,7 +3583,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetlist">v1beta1.DaemonSetList</h3>
 <div class="paragraph">
-<p>DaemonSetList is a collection of daemon sets.</p>
+<p>DEPRECATED. DaemonSetList is a collection of daemon sets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4078,7 +4081,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deploymentspec">v1beta1.DeploymentSpec</h3>
 <div class="paragraph">
-<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5541,7 +5544,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentlist">v1beta1.DeploymentList</h3>
 <div class="paragraph">
-<p>DeploymentList is a list of Deployments.</p>
+<p>DEPRECATED. DeploymentList is a list of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5806,7 +5809,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstrategy">v1beta1.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6478,7 +6481,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</h3>
 <div class="paragraph">
-<p>ReplicaSetStatus represents the current status of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6671,7 +6674,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicaset">v1beta1.ReplicaSet</h3>
 <div class="paragraph">
-<p>ReplicaSet represents the configuration of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6825,7 +6828,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_daemonset">v1beta1.DaemonSet</h3>
 <div class="paragraph">
-<p>DaemonSet represents the configuration of a daemon set.</p>
+<p>DEPRECATED. DaemonSet represents the configuration of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7650,7 +7653,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_deploymentcondition">v1beta1.DeploymentCondition</h3>
 <div class="paragraph">
-<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -12161,7 +12161,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSet": {
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED. DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -12193,7 +12193,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DEPRECATED. DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -12227,7 +12227,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DEPRECATED. DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -12262,7 +12262,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DEPRECATED. DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -12318,6 +12318,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy": {
+    "description": "DEPRECATED.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -12330,7 +12331,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Deployment": {
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -12362,7 +12363,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -12395,7 +12396,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -12468,7 +12469,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -12516,7 +12517,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -12565,7 +12566,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -12752,7 +12753,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -12784,7 +12785,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -12813,7 +12814,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "DEPRECATED. ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -12847,7 +12848,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -12870,7 +12871,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -12922,7 +12923,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet": {
-    "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -12931,7 +12932,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDeployment": {
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",

--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -4530,7 +4530,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "DEPRECATED. DaemonSetList is a collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -4572,7 +4572,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED. DaemonSet represents the configuration of a daemon set.",
     "properties": {
      "kind": {
       "type": "string",
@@ -4836,7 +4836,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "DEPRECATED. DaemonSetSpec is the specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -6892,6 +6892,7 @@
    },
    "v1beta1.DaemonSetUpdateStrategy": {
     "id": "v1beta1.DaemonSetUpdateStrategy",
+    "description": "DEPRECATED.",
     "properties": {
      "type": {
       "type": "string",
@@ -6905,7 +6906,7 @@
    },
    "v1beta1.RollingUpdateDaemonSet": {
     "id": "v1beta1.RollingUpdateDaemonSet",
-    "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of daemon set rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -6915,7 +6916,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "DEPRECATED. DaemonSetStatus represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -7041,7 +7042,7 @@
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "DEPRECATED. DeploymentList is a list of Deployments.",
     "required": [
      "items"
     ],
@@ -7069,7 +7070,7 @@
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7095,7 +7096,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -7144,7 +7145,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -7158,7 +7159,7 @@
    },
    "v1beta1.RollingUpdateDeployment": {
     "id": "v1beta1.RollingUpdateDeployment",
-    "description": "Spec to control the desired behavior of rolling update.",
+    "description": "DEPRECATED. Spec to control the desired behavior of rolling update.",
     "properties": {
      "maxUnavailable": {
       "type": "string",
@@ -7183,7 +7184,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -7231,7 +7232,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -7550,7 +7551,7 @@
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "DEPRECATED. ReplicaSetList is a collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -7578,7 +7579,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "ReplicaSet represents the configuration of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7604,7 +7605,7 @@
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -7628,7 +7629,7 @@
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -7669,7 +7670,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"

--- a/federation/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/federation/docs/api-reference/extensions/v1beta1/definitions.html
@@ -409,7 +409,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</h3>
 <div class="paragraph">
-<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -595,7 +595,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetstatus">v1beta1.DaemonSetStatus</h3>
 <div class="paragraph">
-<p>DaemonSetStatus represents the current status of a daemon set.</p>
+<p>DEPRECATED. DaemonSetStatus represents the current status of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1068,7 +1068,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetlist">v1beta1.ReplicaSetList</h3>
 <div class="paragraph">
-<p>ReplicaSetList is a collection of ReplicaSets.</p>
+<p>DEPRECATED. ReplicaSetList is a collection of ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1267,7 +1267,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetcondition">v1beta1.ReplicaSetCondition</h3>
 <div class="paragraph">
-<p>ReplicaSetCondition describes the state of a replica set at a certain point.</p>
+<p>DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1387,7 +1387,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatedeployment">v1beta1.RollingUpdateDeployment</h3>
 <div class="paragraph">
-<p>Spec to control the desired behavior of rolling update.</p>
+<p>DEPRECATED. Spec to control the desired behavior of rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1844,7 +1844,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_rollingupdatedaemonset">v1beta1.RollingUpdateDaemonSet</h3>
 <div class="paragraph">
-<p>Spec to control the desired behavior of daemon set rolling update.</p>
+<p>DEPRECATED. Spec to control the desired behavior of daemon set rolling update.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2033,7 +2033,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</h3>
 <div class="paragraph">
-<p>ReplicaSetSpec is the specification of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2088,7 +2088,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deployment">v1beta1.Deployment</h3>
 <div class="paragraph">
-<p>Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2150,7 +2150,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetspec">v1beta1.DaemonSetSpec</h3>
 <div class="paragraph">
-<p>DaemonSetSpec is the specification of a daemon set.</p>
+<p>DEPRECATED. DaemonSetSpec is the specification of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3131,6 +3131,9 @@ When an object is created, the system will populate this list with the current s
 </div>
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetupdatestrategy">v1beta1.DaemonSetUpdateStrategy</h3>
+<div class="paragraph">
+<p>DEPRECATED.</p>
+</div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
 <col style="width:20%;">
@@ -3294,7 +3297,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetlist">v1beta1.DaemonSetList</h3>
 <div class="paragraph">
-<p>DaemonSetList is a collection of daemon sets.</p>
+<p>DEPRECATED. DaemonSetList is a collection of daemon sets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3792,7 +3795,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deploymentspec">v1beta1.DeploymentSpec</h3>
 <div class="paragraph">
-<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5103,7 +5106,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentlist">v1beta1.DeploymentList</h3>
 <div class="paragraph">
-<p>DeploymentList is a list of Deployments.</p>
+<p>DEPRECATED. DeploymentList is a list of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5368,7 +5371,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstrategy">v1beta1.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5961,7 +5964,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</h3>
 <div class="paragraph">
-<p>ReplicaSetStatus represents the current status of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6154,7 +6157,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicaset">v1beta1.ReplicaSet</h3>
 <div class="paragraph">
-<p>ReplicaSet represents the configuration of a ReplicaSet.</p>
+<p>DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6308,7 +6311,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_daemonset">v1beta1.DaemonSet</h3>
 <div class="paragraph">
-<p>DaemonSet represents the configuration of a daemon set.</p>
+<p>DEPRECATED. DaemonSet represents the configuration of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6911,7 +6914,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_deploymentcondition">v1beta1.DeploymentCondition</h3>
 <div class="paragraph">
-<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -168,6 +168,7 @@ type ThirdPartyResourceData struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 type Deployment struct {
 	metav1.TypeMeta
 	// +optional
@@ -182,6 +183,7 @@ type Deployment struct {
 	Status DeploymentStatus
 }
 
+// DEPRECATED.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
@@ -260,6 +262,7 @@ const (
 	DefaultDeploymentUniqueLabelKey string = "pod-template-hash"
 )
 
+// DEPRECATED.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
 	// +optional
@@ -284,6 +287,7 @@ const (
 	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
+// DEPRECATED.
 // Spec to control the desired behavior of rolling update.
 type RollingUpdateDeployment struct {
 	// The maximum number of pods that can be unavailable during the update.
@@ -313,6 +317,7 @@ type RollingUpdateDeployment struct {
 	MaxSurge intstr.IntOrString
 }
 
+// DEPRECATED.
 type DeploymentStatus struct {
 	// The generation observed by the deployment controller.
 	// +optional
@@ -365,6 +370,7 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
+// DEPRECATED.
 // DeploymentCondition describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
@@ -383,6 +389,7 @@ type DeploymentCondition struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 type DeploymentList struct {
 	metav1.TypeMeta
 	// +optional
@@ -392,6 +399,7 @@ type DeploymentList struct {
 	Items []Deployment
 }
 
+// DEPRECATED.
 type DaemonSetUpdateStrategy struct {
 	// Type of daemon set update. Can be "RollingUpdate" or "OnDelete".
 	// Default is OnDelete.
@@ -417,6 +425,7 @@ const (
 	OnDeleteDaemonSetStrategyType DaemonSetUpdateStrategyType = "OnDelete"
 )
 
+// DEPRECATED.
 // Spec to control the desired behavior of daemon set rolling update.
 type RollingUpdateDaemonSet struct {
 	// The maximum number of DaemonSet pods that can be unavailable during the
@@ -437,6 +446,7 @@ type RollingUpdateDaemonSet struct {
 	MaxUnavailable intstr.IntOrString
 }
 
+// DEPRECATED.
 // DaemonSetSpec is the specification of a daemon set.
 type DaemonSetSpec struct {
 	// A label query over pods that are managed by the daemon set.
@@ -477,6 +487,7 @@ type DaemonSetSpec struct {
 	RevisionHistoryLimit *int32
 }
 
+// DEPRECATED.
 // DaemonSetStatus represents the current status of a daemon set.
 type DaemonSetStatus struct {
 	// The number of nodes that are running at least 1
@@ -525,6 +536,7 @@ type DaemonSetStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSet struct {
 	metav1.TypeMeta
@@ -557,6 +569,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetList struct {
 	metav1.TypeMeta
@@ -753,6 +766,7 @@ type IngressBackend struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ReplicaSet represents the configuration of a replica set.
 type ReplicaSet struct {
 	metav1.TypeMeta
@@ -771,6 +785,7 @@ type ReplicaSet struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetList struct {
 	metav1.TypeMeta
@@ -780,6 +795,7 @@ type ReplicaSetList struct {
 	Items []ReplicaSet
 }
 
+// DEPRECATED.
 // ReplicaSetSpec is the specification of a ReplicaSet.
 // As the internal representation of a ReplicaSet, it must have
 // a Template set.
@@ -806,6 +822,7 @@ type ReplicaSetSpec struct {
 	Template api.PodTemplateSpec
 }
 
+// DEPRECATED.
 // ReplicaSetStatus represents the current status of a ReplicaSet.
 type ReplicaSetStatus struct {
 	// Replicas is the number of actual replicas.
@@ -842,6 +859,7 @@ const (
 	ReplicaSetReplicaFailure ReplicaSetConditionType = "ReplicaFailure"
 )
 
+// DEPRECATED.
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 type ReplicaSetCondition struct {
 	// Type of replica set condition.

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -31,6 +31,7 @@ import "k8s.io/apimachinery/pkg/util/intstr/generated.proto";
 // Package-wide variables from generator "generated".
 option go_package = "v1beta1";
 
+// DEPRECATED.
 // ControllerRevision implements an immutable snapshot of state data. Clients
 // are responsible for serializing and deserializing the objects that contain
 // their internal state.
@@ -53,6 +54,7 @@ message ControllerRevision {
   optional int64 revision = 3;
 }
 
+// DEPRECATED.
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 message ControllerRevisionList {
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -63,6 +65,7 @@ message ControllerRevisionList {
   repeated ControllerRevision items = 2;
 }
 
+// DEPRECATED.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 message Deployment {
   // Standard object metadata.
@@ -78,6 +81,7 @@ message Deployment {
   optional DeploymentStatus status = 3;
 }
 
+// DEPRECATED.
 // DeploymentCondition describes the state of a deployment at a certain point.
 message DeploymentCondition {
   // Type of deployment condition.
@@ -99,6 +103,7 @@ message DeploymentCondition {
   optional string message = 5;
 }
 
+// DEPRECATED.
 // DeploymentList is a list of Deployments.
 message DeploymentList {
   // Standard list metadata.
@@ -123,6 +128,7 @@ message DeploymentRollback {
   optional RollbackConfig rollbackTo = 3;
 }
 
+// DEPRECATED.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 message DeploymentSpec {
   // Number of desired pods. This is a pointer to distinguish between explicit
@@ -173,6 +179,7 @@ message DeploymentSpec {
   optional int32 progressDeadlineSeconds = 9;
 }
 
+// DEPRECATED.
 // DeploymentStatus is the most recently observed status of the Deployment.
 message DeploymentStatus {
   // The generation observed by the deployment controller.
@@ -211,6 +218,7 @@ message DeploymentStatus {
   optional int32 collisionCount = 8;
 }
 
+// DEPRECATED.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 message DeploymentStrategy {
   // Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -233,6 +241,7 @@ message RollbackConfig {
   optional int64 revision = 1;
 }
 
+// DEPRECATED.
 // Spec to control the desired behavior of rolling update.
 message RollingUpdateDeployment {
   // The maximum number of pods that can be unavailable during the update.
@@ -263,6 +272,7 @@ message RollingUpdateDeployment {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
+// DEPRECATED.
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
 message RollingUpdateStatefulSetStrategy {
   // Partition indicates the ordinal at which the StatefulSet should be
@@ -311,6 +321,7 @@ message ScaleStatus {
   optional string targetSelector = 3;
 }
 
+// DEPRECATED.
 // StatefulSet represents a set of pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
@@ -331,6 +342,7 @@ message StatefulSet {
   optional StatefulSetStatus status = 3;
 }
 
+// DEPRECATED.
 // StatefulSetList is a collection of StatefulSets.
 message StatefulSetList {
   // +optional
@@ -339,6 +351,7 @@ message StatefulSetList {
   repeated StatefulSet items = 2;
 }
 
+// DEPRECATED.
 // A StatefulSetSpec is the specification of a StatefulSet.
 message StatefulSetSpec {
   // replicas is the desired number of replicas of the given Template.
@@ -401,6 +414,7 @@ message StatefulSetSpec {
   optional int32 revisionHistoryLimit = 8;
 }
 
+// DEPRECATED.
 // StatefulSetStatus represents the current state of a StatefulSet.
 message StatefulSetStatus {
   // observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
@@ -437,6 +451,7 @@ message StatefulSetStatus {
   optional int32 collisionCount = 9;
 }
 
+// DEPRECATED.
 // StatefulSetUpdateStrategy indicates the strategy that the StatefulSet
 // controller will use to perform updates. It includes any additional parameters
 // necessary to perform the update for the indicated strategy.

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -77,6 +77,7 @@ type Scale struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // StatefulSet represents a set of pods with consistent identities.
 // Identities are defined as:
 //  - Network: A single stable DNS and hostname.
@@ -113,6 +114,7 @@ const (
 	ParallelPodManagement = "Parallel"
 )
 
+// DEPRECATED.
 // StatefulSetUpdateStrategy indicates the strategy that the StatefulSet
 // controller will use to perform updates. It includes any additional parameters
 // necessary to perform the update for the indicated strategy.
@@ -142,6 +144,7 @@ const (
 	OnDeleteStatefulSetStrategyType = "OnDelete"
 )
 
+// DEPRECATED.
 // RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.
 type RollingUpdateStatefulSetStrategy struct {
 	// Partition indicates the ordinal at which the StatefulSet should be
@@ -149,6 +152,7 @@ type RollingUpdateStatefulSetStrategy struct {
 	Partition *int32 `json:"partition,omitempty" protobuf:"varint,1,opt,name=partition"`
 }
 
+// DEPRECATED.
 // A StatefulSetSpec is the specification of a StatefulSet.
 type StatefulSetSpec struct {
 	// replicas is the desired number of replicas of the given Template.
@@ -211,6 +215,7 @@ type StatefulSetSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,8,opt,name=revisionHistoryLimit"`
 }
 
+// DEPRECATED.
 // StatefulSetStatus represents the current state of a StatefulSet.
 type StatefulSetStatus struct {
 	// observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the
@@ -249,6 +254,7 @@ type StatefulSetStatus struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // StatefulSetList is a collection of StatefulSets.
 type StatefulSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -260,6 +266,7 @@ type StatefulSetList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
@@ -276,6 +283,7 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+// DEPRECATED.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
@@ -355,6 +363,7 @@ const (
 	DefaultDeploymentUniqueLabelKey string = "pod-template-hash"
 )
 
+// DEPRECATED.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -380,6 +389,7 @@ const (
 	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
+// DEPRECATED.
 // Spec to control the desired behavior of rolling update.
 type RollingUpdateDeployment struct {
 	// The maximum number of pods that can be unavailable during the update.
@@ -410,6 +420,7 @@ type RollingUpdateDeployment struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty" protobuf:"bytes,2,opt,name=maxSurge"`
 }
 
+// DEPRECATED.
 // DeploymentStatus is the most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// The generation observed by the deployment controller.
@@ -465,6 +476,7 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
+// DEPRECATED.
 // DeploymentCondition describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
@@ -483,6 +495,7 @@ type DeploymentCondition struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DeploymentList is a list of Deployments.
 type DeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -497,6 +510,7 @@ type DeploymentList struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ControllerRevision implements an immutable snapshot of state data. Clients
 // are responsible for serializing and deserializing the objects that contain
 // their internal state.
@@ -522,6 +536,7 @@ type ControllerRevision struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ControllerRevisionList is a resource containing a list of ControllerRevision objects.
 type ControllerRevisionList struct {
 	metav1.TypeMeta `json:",inline"`

--- a/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
@@ -28,7 +28,7 @@ package v1beta1
 
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_ControllerRevision = map[string]string{
-	"":         "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+	"":         "DEPRECATED. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"data":     "Data is the serialized representation of the state.",
 	"revision": "Revision indicates the revision of the state represented by Data.",
@@ -39,7 +39,7 @@ func (ControllerRevision) SwaggerDoc() map[string]string {
 }
 
 var map_ControllerRevisionList = map[string]string{
-	"":         "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+	"":         "DEPRECATED. ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
 	"metadata": "More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"items":    "Items is the list of ControllerRevisions",
 }
@@ -49,7 +49,7 @@ func (ControllerRevisionList) SwaggerDoc() map[string]string {
 }
 
 var map_Deployment = map[string]string{
-	"":         "Deployment enables declarative updates for Pods and ReplicaSets.",
+	"":         "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
 	"metadata": "Standard object metadata.",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
@@ -60,7 +60,7 @@ func (Deployment) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentCondition = map[string]string{
-	"":                   "DeploymentCondition describes the state of a deployment at a certain point.",
+	"":                   "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
 	"type":               "Type of deployment condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastUpdateTime":     "The last time this condition was updated.",
@@ -74,7 +74,7 @@ func (DeploymentCondition) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentList = map[string]string{
-	"":         "DeploymentList is a list of Deployments.",
+	"":         "DEPRECATED. DeploymentList is a list of Deployments.",
 	"metadata": "Standard list metadata.",
 	"items":    "Items is the list of Deployments.",
 }
@@ -95,7 +95,7 @@ func (DeploymentRollback) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentSpec = map[string]string{
-	"":                        "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+	"":                        "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
 	"replicas":                "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 	"selector":                "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
 	"template":                "Template describes the pods that will be created.",
@@ -112,7 +112,7 @@ func (DeploymentSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStatus = map[string]string{
-	"":                    "DeploymentStatus is the most recently observed status of the Deployment.",
+	"":                    "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
 	"observedGeneration":  "The generation observed by the deployment controller.",
 	"replicas":            "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
 	"updatedReplicas":     "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
@@ -128,7 +128,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStrategy = map[string]string{
-	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
+	"":              "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
 }
@@ -147,7 +147,7 @@ func (RollbackConfig) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateDeployment = map[string]string{
-	"":               "Spec to control the desired behavior of rolling update.",
+	"":               "DEPRECATED. Spec to control the desired behavior of rolling update.",
 	"maxUnavailable": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. Defaults to 25%. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
 	"maxSurge":       "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
 }
@@ -157,7 +157,7 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateStatefulSetStrategy = map[string]string{
-	"":          "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+	"":          "DEPRECATED. RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
 	"partition": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
 }
 
@@ -197,7 +197,7 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSet = map[string]string{
-	"":       "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+	"":       "DEPRECATED. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
 	"spec":   "Spec defines the desired identities of pods in this set.",
 	"status": "Status is the current status of Pods in this StatefulSet. This data may be out of date by some window of time.",
 }
@@ -207,7 +207,7 @@ func (StatefulSet) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetList = map[string]string{
-	"": "StatefulSetList is a collection of StatefulSets.",
+	"": "DEPRECATED. StatefulSetList is a collection of StatefulSets.",
 }
 
 func (StatefulSetList) SwaggerDoc() map[string]string {
@@ -215,7 +215,7 @@ func (StatefulSetList) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetSpec = map[string]string{
-	"":                     "A StatefulSetSpec is the specification of a StatefulSet.",
+	"":                     "DEPRECATED. A StatefulSetSpec is the specification of a StatefulSet.",
 	"replicas":             "replicas is the desired number of replicas of the given Template. These are replicas in the sense that they are instantiations of the same Template, but individual replicas also have a consistent identity. If unspecified, defaults to 1.",
 	"selector":             "selector is a label query over pods that should match the replica count. If empty, defaulted to labels on the pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 	"template":             "template is the object that describes the pod that will be created if insufficient replicas are detected. Each pod stamped out by the StatefulSet will fulfill this Template, but have a unique identity from the rest of the StatefulSet.",
@@ -231,7 +231,7 @@ func (StatefulSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetStatus = map[string]string{
-	"":                   "StatefulSetStatus represents the current state of a StatefulSet.",
+	"":                   "DEPRECATED. StatefulSetStatus represents the current state of a StatefulSet.",
 	"observedGeneration": "observedGeneration is the most recent generation observed for this StatefulSet. It corresponds to the StatefulSet's generation, which is updated on mutation by the API Server.",
 	"replicas":           "replicas is the number of Pods created by the StatefulSet controller.",
 	"readyReplicas":      "readyReplicas is the number of Pods created by the StatefulSet controller that have a Ready Condition.",
@@ -247,7 +247,7 @@ func (StatefulSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_StatefulSetUpdateStrategy = map[string]string{
-	"":              "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+	"":              "DEPRECATED. StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
 	"type":          "Type indicates the type of the StatefulSetUpdateStrategy.",
 	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -64,6 +64,7 @@ message CustomMetricTargetList {
   repeated CustomMetricTarget items = 1;
 }
 
+// DEPRECATED.
 // DaemonSet represents the configuration of a daemon set.
 message DaemonSet {
   // Standard object's metadata.
@@ -85,6 +86,7 @@ message DaemonSet {
   optional DaemonSetStatus status = 3;
 }
 
+// DEPRECATED.
 // DaemonSetList is a collection of daemon sets.
 message DaemonSetList {
   // Standard list metadata.
@@ -96,6 +98,7 @@ message DaemonSetList {
   repeated DaemonSet items = 2;
 }
 
+// DEPRECATED.
 // DaemonSetSpec is the specification of a daemon set.
 message DaemonSetSpec {
   // A label query over pods that are managed by the daemon set.
@@ -136,6 +139,7 @@ message DaemonSetSpec {
   optional int32 revisionHistoryLimit = 6;
 }
 
+// DEPRECATED.
 // DaemonSetStatus represents the current status of a daemon set.
 message DaemonSetStatus {
   // The number of nodes that are running at least 1
@@ -184,6 +188,7 @@ message DaemonSetStatus {
   optional int32 collisionCount = 9;
 }
 
+// DEPRECATED.
 message DaemonSetUpdateStrategy {
   // Type of daemon set update. Can be "RollingUpdate" or "OnDelete".
   // Default is OnDelete.
@@ -199,6 +204,7 @@ message DaemonSetUpdateStrategy {
   optional RollingUpdateDaemonSet rollingUpdate = 2;
 }
 
+// DEPRECATED.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 message Deployment {
   // Standard object metadata.
@@ -214,6 +220,7 @@ message Deployment {
   optional DeploymentStatus status = 3;
 }
 
+// DEPRECATED.
 // DeploymentCondition describes the state of a deployment at a certain point.
 message DeploymentCondition {
   // Type of deployment condition.
@@ -235,6 +242,7 @@ message DeploymentCondition {
   optional string message = 5;
 }
 
+// DEPRECATED.
 // DeploymentList is a list of Deployments.
 message DeploymentList {
   // Standard list metadata.
@@ -259,6 +267,7 @@ message DeploymentRollback {
   optional RollbackConfig rollbackTo = 3;
 }
 
+// DEPRECATED.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 message DeploymentSpec {
   // Number of desired pods. This is a pointer to distinguish between explicit
@@ -309,6 +318,7 @@ message DeploymentSpec {
   optional int32 progressDeadlineSeconds = 9;
 }
 
+// DEPRECATED.
 // DeploymentStatus is the most recently observed status of the Deployment.
 message DeploymentStatus {
   // The generation observed by the deployment controller.
@@ -347,6 +357,7 @@ message DeploymentStatus {
   optional int32 collisionCount = 8;
 }
 
+// DEPRECATED.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 message DeploymentStrategy {
   // Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -737,6 +748,7 @@ message PodSecurityPolicySpec {
   optional bool allowPrivilegeEscalation = 16;
 }
 
+// DEPRECATED.
 // ReplicaSet represents the configuration of a ReplicaSet.
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
@@ -759,6 +771,7 @@ message ReplicaSet {
   optional ReplicaSetStatus status = 3;
 }
 
+// DEPRECATED.
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 message ReplicaSetCondition {
   // Type of replica set condition.
@@ -780,6 +793,7 @@ message ReplicaSetCondition {
   optional string message = 5;
 }
 
+// DEPRECATED.
 // ReplicaSetList is a collection of ReplicaSets.
 message ReplicaSetList {
   // Standard list metadata.
@@ -792,6 +806,7 @@ message ReplicaSetList {
   repeated ReplicaSet items = 2;
 }
 
+// DEPRECATED.
 // ReplicaSetSpec is the specification of a ReplicaSet.
 message ReplicaSetSpec {
   // Replicas is the number of desired replicas.
@@ -821,6 +836,7 @@ message ReplicaSetSpec {
   optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
+// DEPRECATED.
 // ReplicaSetStatus represents the current status of a ReplicaSet.
 message ReplicaSetStatus {
   // Replicas is the most recently oberved number of replicas.
@@ -861,6 +877,7 @@ message RollbackConfig {
   optional int64 revision = 1;
 }
 
+// DEPRECATED.
 // Spec to control the desired behavior of daemon set rolling update.
 message RollingUpdateDaemonSet {
   // The maximum number of DaemonSet pods that can be unavailable during the
@@ -881,6 +898,7 @@ message RollingUpdateDaemonSet {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxUnavailable = 1;
 }
 
+// DEPRECATED.
 // Spec to control the desired behavior of rolling update.
 message RollingUpdateDeployment {
   // The maximum number of pods that can be unavailable during the update.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -160,6 +160,7 @@ type ThirdPartyResourceData struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // Deployment enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
@@ -176,6 +177,7 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
+// DEPRECATED.
 // DeploymentSpec is the specification of the desired behavior of the Deployment.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
@@ -255,6 +257,7 @@ const (
 	DefaultDeploymentUniqueLabelKey string = "pod-template-hash"
 )
 
+// DEPRECATED.
 // DeploymentStrategy describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
@@ -280,6 +283,7 @@ const (
 	RollingUpdateDeploymentStrategyType DeploymentStrategyType = "RollingUpdate"
 )
 
+// DEPRECATED.
 // Spec to control the desired behavior of rolling update.
 type RollingUpdateDeployment struct {
 	// The maximum number of pods that can be unavailable during the update.
@@ -310,6 +314,7 @@ type RollingUpdateDeployment struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty" protobuf:"bytes,2,opt,name=maxSurge"`
 }
 
+// DEPRECATED.
 // DeploymentStatus is the most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// The generation observed by the deployment controller.
@@ -365,6 +370,7 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
+// DEPRECATED.
 // DeploymentCondition describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
@@ -383,6 +389,7 @@ type DeploymentCondition struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DeploymentList is a list of Deployments.
 type DeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -394,6 +401,7 @@ type DeploymentList struct {
 	Items []Deployment `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// DEPRECATED.
 type DaemonSetUpdateStrategy struct {
 	// Type of daemon set update. Can be "RollingUpdate" or "OnDelete".
 	// Default is OnDelete.
@@ -419,6 +427,7 @@ const (
 	OnDeleteDaemonSetStrategyType DaemonSetUpdateStrategyType = "OnDelete"
 )
 
+// DEPRECATED.
 // Spec to control the desired behavior of daemon set rolling update.
 type RollingUpdateDaemonSet struct {
 	// The maximum number of DaemonSet pods that can be unavailable during the
@@ -439,6 +448,7 @@ type RollingUpdateDaemonSet struct {
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,1,opt,name=maxUnavailable"`
 }
 
+// DEPRECATED.
 // DaemonSetSpec is the specification of a daemon set.
 type DaemonSetSpec struct {
 	// A label query over pods that are managed by the daemon set.
@@ -479,6 +489,7 @@ type DaemonSetSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,6,opt,name=revisionHistoryLimit"`
 }
 
+// DEPRECATED.
 // DaemonSetStatus represents the current status of a daemon set.
 type DaemonSetStatus struct {
 	// The number of nodes that are running at least 1
@@ -530,6 +541,7 @@ type DaemonSetStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DaemonSet represents the configuration of a daemon set.
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
@@ -567,6 +579,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // DaemonSetList is a collection of daemon sets.
 type DaemonSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -765,6 +778,7 @@ type IngressBackend struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ReplicaSet represents the configuration of a ReplicaSet.
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
@@ -791,6 +805,7 @@ type ReplicaSet struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// DEPRECATED.
 // ReplicaSetList is a collection of ReplicaSets.
 type ReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
@@ -804,6 +819,7 @@ type ReplicaSetList struct {
 	Items []ReplicaSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+// DEPRECATED.
 // ReplicaSetSpec is the specification of a ReplicaSet.
 type ReplicaSetSpec struct {
 	// Replicas is the number of desired replicas.
@@ -833,6 +849,7 @@ type ReplicaSetSpec struct {
 	Template v1.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,3,opt,name=template"`
 }
 
+// DEPRECATED.
 // ReplicaSetStatus represents the current status of a ReplicaSet.
 type ReplicaSetStatus struct {
 	// Replicas is the most recently oberved number of replicas.
@@ -872,6 +889,7 @@ const (
 	ReplicaSetReplicaFailure ReplicaSetConditionType = "ReplicaFailure"
 )
 
+// DEPRECATED.
 // ReplicaSetCondition describes the state of a replica set at a certain point.
 type ReplicaSetCondition struct {
 	// Type of replica set condition.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -56,7 +56,7 @@ func (CustomMetricTarget) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSet = map[string]string{
-	"":         "DaemonSet represents the configuration of a daemon set.",
+	"":         "DEPRECATED. DaemonSet represents the configuration of a daemon set.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 	"status":   "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
@@ -67,7 +67,7 @@ func (DaemonSet) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetList = map[string]string{
-	"":         "DaemonSetList is a collection of daemon sets.",
+	"":         "DEPRECATED. DaemonSetList is a collection of daemon sets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"items":    "A list of daemon sets.",
 }
@@ -77,7 +77,7 @@ func (DaemonSetList) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetSpec = map[string]string{
-	"":                     "DaemonSetSpec is the specification of a daemon set.",
+	"":                     "DEPRECATED. DaemonSetSpec is the specification of a daemon set.",
 	"selector":             "A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 	"template":             "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
 	"updateStrategy":       "An update strategy to replace existing DaemonSet pods with new pods.",
@@ -91,7 +91,7 @@ func (DaemonSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetStatus = map[string]string{
-	"": "DaemonSetStatus represents the current status of a daemon set.",
+	"": "DEPRECATED. DaemonSetStatus represents the current status of a daemon set.",
 	"currentNumberScheduled": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"numberMisscheduled":     "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"desiredNumberScheduled": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
@@ -108,6 +108,7 @@ func (DaemonSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetUpdateStrategy = map[string]string{
+	"":              "DEPRECATED.",
 	"type":          "Type of daemon set update. Can be \"RollingUpdate\" or \"OnDelete\". Default is OnDelete.",
 	"rollingUpdate": "Rolling update config params. Present only if type = \"RollingUpdate\".",
 }
@@ -117,7 +118,7 @@ func (DaemonSetUpdateStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_Deployment = map[string]string{
-	"":         "Deployment enables declarative updates for Pods and ReplicaSets.",
+	"":         "DEPRECATED. Deployment enables declarative updates for Pods and ReplicaSets.",
 	"metadata": "Standard object metadata.",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
@@ -128,7 +129,7 @@ func (Deployment) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentCondition = map[string]string{
-	"":                   "DeploymentCondition describes the state of a deployment at a certain point.",
+	"":                   "DEPRECATED. DeploymentCondition describes the state of a deployment at a certain point.",
 	"type":               "Type of deployment condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastUpdateTime":     "The last time this condition was updated.",
@@ -142,7 +143,7 @@ func (DeploymentCondition) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentList = map[string]string{
-	"":         "DeploymentList is a list of Deployments.",
+	"":         "DEPRECATED. DeploymentList is a list of Deployments.",
 	"metadata": "Standard list metadata.",
 	"items":    "Items is the list of Deployments.",
 }
@@ -163,7 +164,7 @@ func (DeploymentRollback) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentSpec = map[string]string{
-	"":                        "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+	"":                        "DEPRECATED. DeploymentSpec is the specification of the desired behavior of the Deployment.",
 	"replicas":                "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 	"selector":                "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
 	"template":                "Template describes the pods that will be created.",
@@ -180,7 +181,7 @@ func (DeploymentSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStatus = map[string]string{
-	"":                    "DeploymentStatus is the most recently observed status of the Deployment.",
+	"":                    "DEPRECATED. DeploymentStatus is the most recently observed status of the Deployment.",
 	"observedGeneration":  "The generation observed by the deployment controller.",
 	"replicas":            "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
 	"updatedReplicas":     "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
@@ -196,7 +197,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStrategy = map[string]string{
-	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
+	"":              "DEPRECATED. DeploymentStrategy describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
 }
@@ -434,7 +435,7 @@ func (PodSecurityPolicySpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSet = map[string]string{
-	"":         "ReplicaSet represents the configuration of a ReplicaSet.",
+	"":         "DEPRECATED. ReplicaSet represents the configuration of a ReplicaSet.",
 	"metadata": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 	"status":   "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
@@ -445,7 +446,7 @@ func (ReplicaSet) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetCondition = map[string]string{
-	"":                   "ReplicaSetCondition describes the state of a replica set at a certain point.",
+	"":                   "DEPRECATED. ReplicaSetCondition describes the state of a replica set at a certain point.",
 	"type":               "Type of replica set condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "The last time the condition transitioned from one status to another.",
@@ -458,7 +459,7 @@ func (ReplicaSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetList = map[string]string{
-	"":         "ReplicaSetList is a collection of ReplicaSets.",
+	"":         "DEPRECATED. ReplicaSetList is a collection of ReplicaSets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
 	"items":    "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
 }
@@ -468,7 +469,7 @@ func (ReplicaSetList) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetSpec = map[string]string{
-	"":                "ReplicaSetSpec is the specification of a ReplicaSet.",
+	"":                "DEPRECATED. ReplicaSetSpec is the specification of a ReplicaSet.",
 	"replicas":        "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"minReadySeconds": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
 	"selector":        "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
@@ -480,7 +481,7 @@ func (ReplicaSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetStatus = map[string]string{
-	"":                     "ReplicaSetStatus represents the current status of a ReplicaSet.",
+	"":                     "DEPRECATED. ReplicaSetStatus represents the current status of a ReplicaSet.",
 	"replicas":             "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"fullyLabeledReplicas": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
 	"readyReplicas":        "The number of ready replicas for this replica set.",
@@ -511,7 +512,7 @@ func (RollbackConfig) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateDaemonSet = map[string]string{
-	"":               "Spec to control the desired behavior of daemon set rolling update.",
+	"":               "DEPRECATED. Spec to control the desired behavior of daemon set rolling update.",
 	"maxUnavailable": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
 }
 
@@ -520,7 +521,7 @@ func (RollingUpdateDaemonSet) SwaggerDoc() map[string]string {
 }
 
 var map_RollingUpdateDeployment = map[string]string{
-	"":               "Spec to control the desired behavior of rolling update.",
+	"":               "DEPRECATED. Spec to control the desired behavior of rolling update.",
 	"maxUnavailable": "The maximum number of pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). Absolute number is calculated from percentage by rounding down. This can not be 0 if MaxSurge is 0. By default, a fixed value of 1 is used. Example: when this is set to 30%, the old RC can be scaled down to 70% of desired pods immediately when the rolling update starts. Once new pods are ready, old RC can be scaled down further, followed by scaling up the new RC, ensuring that the total number of pods available at all times during the update is at least 70% of desired pods.",
 	"maxSurge":       "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
 }


### PR DESCRIPTION
xref https://github.com/kubernetes/features/issues/353

**Release note:**
```release-note
Deprecate extensions/v1beta1 ReplicaSet, Deployment, DaemonSet, and deprecate apps/v1beta1 Deployment, StatefulSet, ControllerRevision
```
