### PR TITLE
kubeadm: Move the uploadconfig phase right in the beginning of cluster init

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -327,6 +327,13 @@ func (i *Init) Run(out io.Writer) error {
 		return err
 	}
 
+	// Upload currently used configuration to the cluster
+	// Note: This is done right in the beginning of cluster initialization; as we might want to make other phases
+	// depend on centralized information from this source in the future
+	if err := uploadconfigphase.UploadConfiguration(i.cfg, client); err != nil {
+		return err
+	}
+
 	// PHASE 4: Mark the master with the right label/taint
 	if err := markmasterphase.MarkMaster(client, i.cfg.NodeName); err != nil {
 		return err
@@ -360,11 +367,6 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	// PHASE 6: Install and deploy all addons, and configure things as necessary
-
-	// Upload currently used configuration to the cluster
-	if err := uploadconfigphase.UploadConfiguration(i.cfg, client); err != nil {
-		return err
-	}
 
 	if err := apiconfigphase.CreateRBACRules(client, k8sVersion); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In order to be forwards-compatible, I'm moving the uploadconfig to be the first thing in the chain in order to make it possible to rely on it being present in future releases when we have a beta or higher API to rely on.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 