### PR TITLE
Change default validation to openapi

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -3571,7 +3571,7 @@ run_kubectl_create_error_tests() {
   ERROR_FILE="${KUBE_TEMP}/validation-error"
   kubectl create -f hack/testdata/invalid-rc-with-empty-args.yaml "${kube_flags[@]}" 2> "${ERROR_FILE}" || true
   # Post-condition: should get an error reporting the empty string
-  if grep -q "unexpected nil value for field" "${ERROR_FILE}"; then
+  if grep -q "unknown object type \"nil\" in ReplicationController" "${ERROR_FILE}"; then
     kube::log::status "\"kubectl create with empty string list returns error as expected: $(cat ${ERROR_FILE})"
   else
     kube::log::status "\"kubectl create with empty string list returns unexpected error or non-error: $(cat ${ERROR_FILE})"

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -395,19 +395,19 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 func AddValidateFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("validate", true, "If true, use a schema to validate the input before sending it")
 	cmd.Flags().String("schema-cache-dir", fmt.Sprintf("~/%s/%s", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName), fmt.Sprintf("If non-empty, load/store cached API schemas in this directory, default is '$HOME/%s/%s'", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName))
-	cmd.Flags().Bool("openapi-validation", false, "If true, use openapi rather than swagger for validation.")
+	cmd.Flags().Bool("openapi-validation", true, "If true, use openapi rather than swagger for validation.")
 	cmd.MarkFlagFilename("schema-cache-dir")
 }
 
 func AddValidateOptionFlags(cmd *cobra.Command, options *ValidateOptions) {
 	cmd.Flags().BoolVar(&options.EnableValidation, "validate", true, "If true, use a schema to validate the input before sending it")
 	cmd.Flags().StringVar(&options.SchemaCacheDir, "schema-cache-dir", fmt.Sprintf("~/%s/%s", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName), fmt.Sprintf("If non-empty, load/store cached API schemas in this directory, default is '$HOME/%s/%s'", clientcmd.RecommendedHomeDir, clientcmd.RecommendedSchemaName))
-	cmd.Flags().BoolVar(&options.UseOpenAPI, "openapi-validation", false, "If true, use openapi rather than swagger for validation")
+	cmd.Flags().BoolVar(&options.UseOpenAPI, "openapi-validation", true, "If true, use openapi rather than swagger for validation")
 	cmd.MarkFlagFilename("schema-cache-dir")
 }
 
 func AddOpenAPIFlags(cmd *cobra.Command) {
-	cmd.Flags().Bool("openapi-validation", false, "If true, use openapi rather than swagger for validation")
+	cmd.Flags().Bool("openapi-validation", true, "If true, use openapi rather than swagger for validation")
 }
 
 func AddFilenameOptionFlags(cmd *cobra.Command, options *resource.FilenameOptions, usage string) {


### PR DESCRIPTION
**What this PR does / why we need it**:
And also update the test to match the new error string.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubectl/issues/49

**Special notes for your reviewer**:

**Release note**:
```release-note
Performs validation (when applying for example) against OpenAPI schema rather than Swagger 1.0.
```