### PR TITLE
Validate pod prior to charging for quota

### DIFF
--- a/pkg/quota/evaluator/core/pods_test.go
+++ b/pkg/quota/evaluator/core/pods_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/quota"
@@ -33,39 +34,62 @@ func TestPodConstraintsFunc(t *testing.T) {
 	}{
 		"init container resource invalid": {
 			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: api.PodSpec{
 					InitContainers: []api.Container{{
+						Name:                     "ctr",
+						Image:                    "image",
+						ImagePullPolicy:          "IfNotPresent",
+						TerminationMessagePolicy: "File",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("2m")},
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
 						},
 					}},
+					Containers:    []api.Container{{Name: "ctr1", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+					RestartPolicy: api.RestartPolicyAlways,
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 			err: `spec.initContainers[0].resources.requests: Invalid value: "2m": must be less than or equal to cpu limit`,
 		},
 		"container resource invalid": {
 			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: api.PodSpec{
 					Containers: []api.Container{{
+						Name:                     "ctr",
+						Image:                    "image",
+						ImagePullPolicy:          "IfNotPresent",
+						TerminationMessagePolicy: "File",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("2m")},
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
 						},
 					}},
+					RestartPolicy: api.RestartPolicyAlways,
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 			err: `spec.containers[0].resources.requests: Invalid value: "2m": must be less than or equal to cpu limit`,
 		},
 		"init container resource missing": {
 			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: api.PodSpec{
 					InitContainers: []api.Container{{
+						Name:                     "ctr",
+						Image:                    "image",
+						ImagePullPolicy:          "IfNotPresent",
+						TerminationMessagePolicy: "File",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("2m")},
 						},
 					}},
+					Containers:    []api.Container{{Name: "ctr1", Image: "image", ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"}},
+					RestartPolicy: api.RestartPolicyAlways,
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 			required: []api.ResourceName{api.ResourceMemory},
@@ -73,13 +97,20 @@ func TestPodConstraintsFunc(t *testing.T) {
 		},
 		"container resource missing": {
 			pod: &api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: "ns"},
 				Spec: api.PodSpec{
 					Containers: []api.Container{{
+						Name:                     "ctr",
+						Image:                    "image",
+						ImagePullPolicy:          "IfNotPresent",
+						TerminationMessagePolicy: "File",
 						Resources: api.ResourceRequirements{
 							Requests: api.ResourceList{api.ResourceCPU: resource.MustParse("1m")},
 							Limits:   api.ResourceList{api.ResourceCPU: resource.MustParse("2m")},
 						},
 					}},
+					RestartPolicy: api.RestartPolicyAlways,
+					DNSPolicy:     api.DNSClusterFirst,
 				},
 			},
 			required: []api.ResourceName{api.ResourceMemory},

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -62,13 +62,19 @@ func getResourceRequirements(requests, limits api.ResourceList) api.ResourceRequ
 func validPod(name string, numContainers int, resources api.ResourceRequirements) *api.Pod {
 	pod := &api.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "test"},
-		Spec:       api.PodSpec{},
+		Spec: api.PodSpec{
+			RestartPolicy: api.RestartPolicyAlways,
+			DNSPolicy:     api.DNSClusterFirst,
+		},
 	}
 	pod.Spec.Containers = make([]api.Container, 0, numContainers)
 	for i := 0; i < numContainers; i++ {
 		pod.Spec.Containers = append(pod.Spec.Containers, api.Container{
-			Image:     "foo:V" + strconv.Itoa(i),
-			Resources: resources,
+			Name:                     "ctr-" + strconv.Itoa(i),
+			Image:                    "foo:V" + strconv.Itoa(i),
+			Resources:                resources,
+			ImagePullPolicy:          "IfNotPresent",
+			TerminationMessagePolicy: "File",
 		})
 	}
 	return pod


### PR DESCRIPTION
**What this PR does / why we need it**:
An invalid Pod can exhaust end-user compute quota as quota is charged before object validation.  Pending our ability to move quota post-validation, this is a compromise that is pro-user.

Fixes https://github.com/kubernetes/kubernetes/issues/51476

```release-note
NONE
```
