### PR TITLE
addons/dns: changing probes for ANY IP record type

### DIFF
--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /metrics
@@ -197,8 +197,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.__PILLAR__DNS__DOMAIN__,5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.__PILLAR__DNS__DOMAIN__,5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.__PILLAR__DNS__DOMAIN__,5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.__PILLAR__DNS__DOMAIN__,5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /metrics
@@ -197,8 +197,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ pillar['dns_domain'] }},5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.5
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
         livenessProbe:
           httpGet:
             path: /metrics
@@ -197,8 +197,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.$DNS_DOMAIN,5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.$DNS_DOMAIN,5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.$DNS_DOMAIN,5,SRV
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.$DNS_DOMAIN,5,SRV
         ports:
         - containerPort: 10054
           name: metrics

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -53,12 +53,13 @@ func EnsureDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interf
 
 	// Get the YAML manifest conditionally based on the k8s version
 	kubeDNSDeploymentBytes := GetKubeDNSManifest(k8sVersion)
-	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(kubeDNSDeploymentBytes, struct{ ImageRepository, Arch, Version, DNSDomain, MasterTaintKey string }{
+	dnsDeploymentBytes, err := kubeadmutil.ParseTemplate(kubeDNSDeploymentBytes, struct{ ImageRepository, Arch, Version, DNSDomain, DNSProbeType, MasterTaintKey string }{
 		ImageRepository: cfg.ImageRepository,
 		Arch:            runtime.GOARCH,
 		// Get the kube-dns version conditionally based on the k8s version
 		Version:        GetKubeDNSVersion(k8sVersion),
 		DNSDomain:      cfg.Networking.DNSDomain,
+		DNSProbeType:   GetKubeDNSProbeType(k8sVersion),
 		MasterTaintKey: kubeadmconstants.LabelNodeRoleMaster,
 	})
 	if err != nil {

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -90,12 +90,13 @@ func TestCompileManifests(t *testing.T) {
 		expected bool
 	}{
 		{
-			manifest: v170AndAboveKubeDNSDeployment,
-			data: struct{ ImageRepository, Arch, Version, DNSDomain, MasterTaintKey string }{
+			manifest: v180AndAboveKubeDNSDeployment,
+			data: struct{ ImageRepository, Arch, Version, DNSDomain, DNSProbeType, MasterTaintKey string }{
 				ImageRepository: "foo",
 				Arch:            "foo",
 				Version:         "foo",
 				DNSDomain:       "foo",
+				DNSProbeType:    "foo",
 				MasterTaintKey:  "foo",
 			},
 			expected: true,

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -17,8 +17,8 @@ limitations under the License.
 package dns
 
 const (
-	// v170AndAboveKubeDNSDeployment is the kube-dns Deployment manifest for the kube-dns manifest for v1.7+
-	v170AndAboveKubeDNSDeployment = `
+	// v180AndAboveKubeDNSDeployment is the kube-dns Deployment manifest for the kube-dns manifest for v1.7+
+	v180AndAboveKubeDNSDeployment = `
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
@@ -156,8 +156,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ .DNSDomain }},5,A
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ .DNSDomain }},5,A
+        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
+        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
         ports:
         - containerPort: 10054
           name: metrics

--- a/cmd/kubeadm/app/phases/addons/dns/versions.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions.go
@@ -21,20 +21,39 @@ import (
 )
 
 const (
-	kubeDNSv170AndAboveVersion = "1.14.5"
+	kubeDNSv180AndAboveVersion = "1.14.5"
+	kubeDNSv190AndAboveVersion = "1.14.6"
+
+	kubeDNSProbeSRV = "SRV"
+	kubeDNSProbeA   = "A"
 )
 
 // GetKubeDNSVersion returns the right kube-dns version for a specific k8s version
 func GetKubeDNSVersion(kubeVersion *version.Version) string {
-	// v1.7.0+ uses 1.14.5, just return that here
+	// v1.8.0+ uses 1.14.5
+	// v1.9.0+ uses 1.14.6
 	// In the future when the kube-dns version is bumped at HEAD; add conditional logic to return the right versions
 	// Also, the version might be bumped for different k8s releases on the same branch
-	return kubeDNSv170AndAboveVersion
+	if kubeVersion.Major() == 1 && kubeVersion.Minor() >= 9 {
+		return kubeDNSv190AndAboveVersion
+	}
+	return kubeDNSv180AndAboveVersion
+}
+
+// GetKubeDNSProbeType returns the right kube-dns probe for a specific k8s version
+func GetKubeDNSProbeType(kubeVersion *version.Version) string {
+	// v1.8.0+ uses type A, just return that here
+	// In the future when the kube-dns version is bumped at HEAD; add conditional logic to return the right versions
+	// Also, the version might be bumped for different k8s releases on the same branch
+	if kubeVersion.Major() == 1 && kubeVersion.Minor() >= 9 {
+		return kubeDNSProbeSRV
+	}
+	return kubeDNSProbeA
 }
 
 // GetKubeDNSManifest returns the right kube-dns YAML manifest for a specific k8s version
 func GetKubeDNSManifest(kubeVersion *version.Version) string {
-	// v1.7.0+ has only one known YAML manifest spec, just return that here
+	// v1.8.0+ has only one known YAML manifest spec, just return that here
 	// In the future when the kube-dns version is bumped at HEAD; add conditional logic to return the right manifest
-	return v170AndAboveKubeDNSDeployment
+	return v180AndAboveKubeDNSDeployment
 }

--- a/cmd/kubeadm/app/phases/addons/dns/versions_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/versions_test.go
@@ -50,6 +50,10 @@ func TestGetKubeDNSVersion(t *testing.T) {
 			k8sVersion: "v1.8.0",
 			expected:   "1.14.5",
 		},
+		{
+			k8sVersion: "v1.9.0",
+			expected:   "1.14.6",
+		},
 	}
 	for _, rt := range tests {
 
@@ -64,6 +68,57 @@ func TestGetKubeDNSVersion(t *testing.T) {
 				"failed GetKubeDNSVersion:\n\texpected: %s\n\t  actual: %s",
 				rt.expected,
 				actualDNSVersion,
+			)
+		}
+	}
+}
+
+func TestGetKubeDNSProbeType(t *testing.T) {
+	var tests = []struct {
+		k8sVersion, expected string
+	}{
+		{
+			k8sVersion: "v1.7.0",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.7.1",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.7.2",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.7.3",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.8.0-alpha.2",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.8.0",
+			expected:   "A",
+		},
+		{
+			k8sVersion: "v1.9.0",
+			expected:   "SRV",
+		},
+	}
+	for _, rt := range tests {
+
+		k8sVersion, err := version.ParseSemantic(rt.k8sVersion)
+		if err != nil {
+			t.Fatalf("couldn't parse kubernetes version %q: %v", rt.k8sVersion, err)
+		}
+
+		actualDNSProbeType := GetKubeDNSProbeType(k8sVersion)
+		if actualDNSProbeType != rt.expected {
+			t.Errorf(
+				"failed GetKubeDNSProbeType:\n\texpected: %s\n\t  actual: %s",
+				rt.expected,
+				actualDNSProbeType,
 			)
 		}
 	}

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -399,7 +399,7 @@ func TestGetAvailableUpgrades(t *testing.T) {
 					After: ClusterState{
 						KubeVersion:    "v1.9.0-alpha.1",
 						KubeadmVersion: "v1.9.0-alpha.1",
-						DNSVersion:     "1.14.5",
+						DNSVersion:     "1.14.6",
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: André Martins <aanm90@gmail.com>

**What this PR does / why we need it**:
Changes the kube-dns probes to ANY IP record to solve kube-dns probes failures when kubernetes master is running with an IPv6 only address.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51371

/sig network
/area ipv6