### PR TITLE
Detect connection closed and surface reasonable error

### DIFF
--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -58,6 +58,7 @@ go_library(
     ],
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
Try to detect connection closure when API server closed the connection due to timeout.
Surface reasonable error when connection closed.

Further improvement may be retrying when detect connection closure

related to #51353

```release-note
Surface reasonable error when client detects connection closed.
```

/assign @mml @caesarxuchao 
