### PR TITLE
fix etcdv2 timeout about and gofmt

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd2.go
@@ -45,8 +45,9 @@ func newETCD2Storage(c storagebackend.Config) (storage.Interface, DestroyFunc, e
 
 func newETCD2Client(tr *http.Transport, serverList []string) (etcd2client.Client, error) {
 	cli, err := etcd2client.New(etcd2client.Config{
-		Endpoints: serverList,
-		Transport: tr,
+		Endpoints:               serverList,
+		Transport:               tr,
+		HeaderTimeoutPerRequest: 10 * time.Second,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
What this PR does / why we need it:
Set etcdv2 per request timeout.
In my test cluster, when I power off a host that running a etcd container, we wait for fifteen minutes, then the test cluster recover from unscheduled status.

Which issue this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged): fixes #

Special notes for your reviewer:
Etcdv3 has the same problem, it need update "google.golang.org/grpc" and "google.golang.org/grpc/keepalive" package