### PR TITLE
Fix swallowed errs in volume util package

### DIFF
--- a/pkg/volume/util/device_util_linux_test.go
+++ b/pkg/volume/util/device_util_linux_test.go
@@ -119,7 +119,13 @@ func TestFindDeviceForPath(t *testing.T) {
 	if disk != "sde" {
 		t.Fatalf("disk [%s] didn't match expected sde", disk)
 	}
+	if err != nil {
+		t.Fatalf("error finding device for path /dev/sde:%v", err)
+	}
 	disk, err = findDeviceForPath("/returns/a/dev", io)
+	if err != nil {
+		t.Fatalf("error finding device for path /returns/a/dev:%v", err)
+	}
 	if disk != "sde" {
 		t.Fatalf("disk [%s] didn't match expected sde", disk)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes two swallowed errors in the volume util package.

```release-note NONE
```
