### PR TITLE
Fix swallowed error in scaleio package tests

### DIFF
--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -212,10 +212,13 @@ func TestUtilLoadConfig(t *testing.T) {
 	configFile := path.Join(tmpDir, sioConfigFileName)
 
 	if err := saveConfig(configFile, config); err != nil {
-		t.Fatal("failed while saving data", err)
+		t.Fatalf("failed to save configFile %s error:%v", configFile, err)
 	}
 
 	dataRcvd, err := loadConfig(configFile)
+	if err != nil {
+		t.Fatalf("failed to load configFile %s error:%v", configFile, err)
+	}
 	if dataRcvd[confKey.gateway] != config[confKey.gateway] ||
 		dataRcvd[confKey.system] != config[confKey.system] {
 		t.Fatal("loaded config data not matching saved config data")


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a dropped error in the tests of the scaleio package.

**Release note**:
```release-note NONE
```
