### PR TITLE
Fix swallowed errors in portworx tests

### DIFF
--- a/pkg/volume/portworx/portworx_test.go
+++ b/pkg/volume/portworx/portworx_test.go
@@ -205,6 +205,9 @@ func TestPlugin(t *testing.T) {
 	}
 
 	provisioner, err := plug.(*portworxVolumePlugin).newProvisionerInternal(options, &fakePortworxManager{})
+	if err != nil {
+		t.Errorf("Error creating a new provisioner:%v", err)
+	}
 	persistentSpec, err := provisioner.Provision()
 	if err != nil {
 		t.Errorf("Provision() failed: %v", err)
@@ -228,6 +231,9 @@ func TestPlugin(t *testing.T) {
 		PersistentVolume: persistentSpec,
 	}
 	deleter, err := plug.(*portworxVolumePlugin).newDeleterInternal(volSpec, &fakePortworxManager{})
+	if err != nil {
+		t.Errorf("Error creating a new Deleter:%v", err)
+	}
 	err = deleter.Delete()
 	if err != nil {
 		t.Errorf("Deleter() failed: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes two swallowed errors in the portworx tests.
```release-note NONE
```
