### PR TITLE
Fix swallowed error in tests of host_path package

### DIFF
--- a/pkg/volume/host_path/host_path_test.go
+++ b/pkg/volume/host_path/host_path_test.go
@@ -158,7 +158,9 @@ func TestProvisioner(t *testing.T) {
 	tempPath := fmt.Sprintf("/tmp/hostpath/%s", uuid.NewUUID())
 	defer os.RemoveAll(tempPath)
 	err := os.MkdirAll(tempPath, 0750)
-
+	if err != nil {
+		t.Errorf("Failed to create tempPath %s error:%v", tempPath, err)
+	}
 	plugMgr := volume.VolumePluginMgr{}
 	plugMgr.InitPlugins(ProbeVolumePlugins(volume.VolumeConfig{ProvisioningEnabled: true}),
 		volumetest.NewFakeVolumeHost("/tmp/fake", nil, nil))


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes a swallowed error in the tests of the host_path package.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #


```release-note NONE
```
