### PR TITLE
Fix swallowed error in tests for flocker package

### DIFF
--- a/pkg/volume/flocker/flocker_volume_test.go
+++ b/pkg/volume/flocker/flocker_volume_test.go
@@ -41,7 +41,7 @@ func newTestableProvisioner(assert *assert.Assertions, options volume.VolumeOpti
 	assert.NoError(err, "Can't find the plugin by name")
 
 	provisioner, err := plug.(*flockerPlugin).newProvisionerInternal(options, &fakeFlockerUtil{})
-
+	assert.NoError(err, fmt.Sprintf("Can't create new provisioner:%v", err))
 	return tmpDir, provisioner
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes swallowed error in the tests for the flocker package.

-->
```release-note NONE
```
