### PR TITLE
modify the return value, to make it quit when the service controller  started failed

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -67,7 +67,7 @@ func startServiceController(ctx ControllerContext) (bool, error) {
 	)
 	if err != nil {
 		glog.Errorf("Failed to start service controller: %v", err)
-		return false, nil
+		return true, err
 	}
 	go serviceController.Run(ctx.Stop, int(ctx.Options.ConcurrentServiceSyncs))
 	return true, nil

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -103,7 +103,7 @@ func New(
 	serviceInformer coreinformers.ServiceInformer,
 	nodeInformer coreinformers.NodeInformer,
 	clusterName string,
-) (*ServiceController, error) {
+) *ServiceController {
 	broadcaster := record.NewBroadcaster()
 	broadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.Core().RESTClient()).Events("")})
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "service-controller"})
@@ -142,10 +142,7 @@ func New(
 	s.serviceLister = serviceInformer.Lister()
 	s.serviceListerSynced = serviceInformer.Informer().HasSynced
 
-	if err := s.init(); err != nil {
-		return nil, err
-	}
-	return s, nil
+	return s
 }
 
 // obj could be an *v1.Service, or a DeletionFinalStateUnknown marker item.
@@ -205,7 +202,7 @@ func (s *ServiceController) worker() {
 	}
 }
 
-func (s *ServiceController) init() error {
+func (s *ServiceController) Init() error {
 	if s.cloud == nil {
 		return fmt.Errorf("WARNING: no cloud provider provided, services of type LoadBalancer will fail.")
 	}

--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -59,12 +59,12 @@ func newController() (*ServiceController, *fakecloud.FakeCloud, *fake.Clientset)
 	serviceInformer := informerFactory.Core().V1().Services()
 	nodeInformer := informerFactory.Core().V1().Nodes()
 
-	controller, _ := New(cloud, client, serviceInformer, nodeInformer, "test-cluster")
+	controller := New(cloud, client, serviceInformer, nodeInformer, "test-cluster")
 	controller.nodeListerSynced = alwaysReady
 	controller.serviceListerSynced = alwaysReady
 	controller.eventRecorder = record.NewFakeRecorder(100)
 
-	controller.init()
+	controller.Init()
 	cloud.Calls = nil     // ignore any cloud calls made in init()
 	client.ClearActions() // ignore any client calls made in init()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Service controller is the important controller for kubernetes. If it startd failed , I think the kubernetes can not work normal in most senses. So I think it's an suitable way to make the controller manager explicitly show this error.

I modified the return value when the service controller  started failed. By return an error message, it make the main thread of  controller manager know.
