### PR TITLE
fix invalid format of help message

### DIFF
--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -33,7 +33,7 @@ var (
 		Edit the latest last-applied-configuration annotations of resources from the default editor.
 
 		The edit-last-applied command allows you to directly edit any API resource you can retrieve via the
-		command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+		command line tools. It will open the editor defined by your ` + "`KUBE_EDITOR`" + `, or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts filenames as well as command line arguments, although the files you point to must

--- a/pkg/kubectl/cmd/completion.go
+++ b/pkg/kubectl/cmd/completion.go
@@ -48,7 +48,7 @@ var (
 		Output shell completion code for the specified shell (bash or zsh).
 		The shell code must be evaluated to provide interactive
 		completion of kubectl commands.  This can be done by sourcing it from
-		the .bash_profile.
+		the ` + "`.bash_profile.`" + `
 
 		Detailed instructions on how to do this are available here:
 		https://kubernetes.io/docs/tasks/tools/install-kubectl/#enabling-shell-autocompletion

--- a/pkg/kubectl/cmd/config/rename_context.go
+++ b/pkg/kubectl/cmd/config/rename_context.go
@@ -36,7 +36,7 @@ type RenameContextOptions struct {
 }
 
 const (
-	renameContextUse = "rename-context CONTEXT_NAME NEW_NAME"
+	renameContextUse = "rename-context CONTEXT-NAME NEW-NAME"
 
 	renameContextShort = "Renames a context from the kubeconfig file."
 )
@@ -45,9 +45,9 @@ var (
 	renameContextLong = templates.LongDesc(`
 		Renames a context from the kubeconfig file.
 
-		CONTEXT_NAME is the context name that you wish change.
+		CONTEXT-NAME is the context name that you wish change.
 
-		NEW_NAME is the new name you wish to set.
+		NEW-NAME is the new name you wish to set.
 		
 		Note: In case the context being renamed is the 'current-context', this field will also be updated.`)
 

--- a/pkg/kubectl/cmd/config/set.go
+++ b/pkg/kubectl/cmd/config/set.go
@@ -48,15 +48,15 @@ type setOptions struct {
 var set_long = templates.LongDesc(`
 	Sets an individual value in a kubeconfig file
 
-	PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.
+	PROPERTY-NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.
 
-	PROPERTY_VALUE is the new value you wish to set. Binary fields such as 'certificate-authority-data' expect a base64 encoded string unless the --set-raw-bytes flag is used.`)
+	PROPERTY-VALUE is the new value you wish to set. Binary fields such as 'certificate-authority-data' expect a base64 encoded string unless the --set-raw-bytes flag is used.`)
 
 func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &setOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
-		Use: "set PROPERTY_NAME PROPERTY_VALUE",
+		Use: "set PROPERTY-NAME PROPERTY-VALUE",
 		DisableFlagsInUseLine: true,
 		Short: i18n.T("Sets an individual value in a kubeconfig file"),
 		Long:  set_long,
@@ -67,7 +67,7 @@ func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.
 		},
 	}
 
-	f := cmd.Flags().VarPF(&options.setRawBytes, "set-raw-bytes", "", "When writing a []byte PROPERTY_VALUE, write the given string directly without base64 decoding.")
+	f := cmd.Flags().VarPF(&options.setRawBytes, "set-raw-bytes", "", "When writing a []byte PROPERTY-VALUE, write the given string directly without base64 decoding.")
 	f.NoOptDefVal = "true"
 	return cmd
 }

--- a/pkg/kubectl/cmd/config/unset.go
+++ b/pkg/kubectl/cmd/config/unset.go
@@ -39,7 +39,7 @@ var (
 	unsetLong = templates.LongDesc(`
 	Unsets an individual value in a kubeconfig file
 
-	PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.`)
+	PROPERTY-NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.`)
 
 	unsetExample = templates.Examples(`
 		# Unset the current-context.
@@ -53,7 +53,7 @@ func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobr
 	options := &unsetOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
-		Use: "unset PROPERTY_NAME",
+		Use: "unset PROPERTY-NAME",
 		DisableFlagsInUseLine: true,
 		Short:   i18n.T("Unsets an individual value in a kubeconfig file"),
 		Long:    unsetLong,

--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -133,7 +133,7 @@ var (
 		Dockercfg secrets are used to authenticate against Docker registries.
 
 		When using the Docker command line to push images, you can authenticate to a given registry by running:
-			'$ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
+			'$ docker login DOCKER-REGISTRY-SERVER --username=DOCKER-USER --password=DOCKER-PASSWORD --email=DOCKER-EMAIL'.
 
     	That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
 		authenticate to the registry. The email address is optional.
@@ -144,7 +144,7 @@ var (
 
 	secretForDockerRegistryExample = templates.Examples(i18n.T(`
 		  # If you don't already have a .dockercfg file, you can create a dockercfg secret directly by using:
-		  kubectl create secret docker-registry my-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL`))
+		  kubectl create secret docker-registry my-secret --docker-server=DOCKER-REGISTRY-SERVER --docker-username=DOCKER-USER --docker-password=DOCKER-PASSWORD --docker-email=DOCKER-EMAIL`))
 )
 
 // NewCmdCreateSecretDockerRegistry is a macro command for creating secrets to work with Docker registries

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -35,7 +35,7 @@ var (
 		Edit a resource from the default editor.
 
 		The edit command allows you to directly edit any API resource you can retrieve via the
-		command line tools. It will open the editor defined by your KUBE_EDITOR, or EDITOR
+		command line tools. It will open the editor defined by your ` + "`KUBE_EDITOR`" + `, or EDITOR
 		environment variables, or fall back to 'vi' for Linux or 'notepad' for Windows.
 		You can edit multiple objects, although changes are applied one at a time. The command
 		accepts filenames as well as command line arguments, although the files you point to must


### PR DESCRIPTION
I found that blackfriday.Markdown() does some magic when words have
`_` inside it, a space is inserted before the `_`.
https://github.com/russross/blackfriday#extensions

This makes the help message looks odd for cli users. And in the web
page, there is also an extra space:
https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands

**Release note**:
```
NONE
```
