### PR TITLE
[cli] exit when Validate() returns an error

### DIFF
--- a/pkg/kubectl/cmd/config/rename_context.go
+++ b/pkg/kubectl/cmd/config/rename_context.go
@@ -43,7 +43,7 @@ const (
 
 var (
 	renameContextLong = templates.LongDesc(`
-		Renames a context from the kubeconfig file .
+		Renames a context from the kubeconfig file.
 
 		CONTEXT_NAME is the context name that you wish change.
 
@@ -70,7 +70,7 @@ func NewCmdConfigRenameContext(out io.Writer, configAccess clientcmd.ConfigAcces
 				cmdutil.CheckErr(err)
 			}
 			if err := options.Validate(); err != nil {
-				cmdutil.UsageErrorf(cmd, err.Error())
+				cmdutil.CheckErr(cmdutil.UsageErrorf(cmd, err.Error()))
 			}
 			if err := options.RunRenameContext(out); err != nil {
 				cmdutil.CheckErr(err)

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -124,7 +124,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 		return err
 	}
 	if !scheme.Registry.IsEnabledVersion(o.outputVersion) {
-		cmdutil.UsageErrorf(cmd, "'%s' is not a registered version.", o.outputVersion)
+		return cmdutil.UsageErrorf(cmd, "'%s' is not a registered version.", o.outputVersion)
 	}
 
 	// build the builder


### PR DESCRIPTION
cmdutil.UsageErrorf() does nothing but returna a string. When Validate()
returns an error, we should call exit() function.

fix: https://github.com/kubernetes/kubectl/issues/119

**Release note**:
```
NONE
```
