### PR TITLE
Admit NoNewPrivs for remote and rkt runtimes

### DIFF
--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -187,45 +187,34 @@ func (a *noNewPrivsAdmitHandler) Admit(attrs *PodAdmitAttributes) PodAdmitResult
 		return PodAdmitResult{Admit: true}
 	}
 
-	// Always admit for remote runtime.
-	if a.Runtime.Type() == kubetypes.RemoteContainerRuntime {
+	// Always admit runtimes except docker.
+	if a.Runtime.Type() != kubetypes.DockerContainerRuntime {
 		return PodAdmitResult{Admit: true}
 	}
 
-	// Make sure it is either docker or rkt runtimes.
-	if a.Runtime.Type() != kubetypes.DockerContainerRuntime && a.Runtime.Type() != kubetypes.RktContainerRuntime {
+	// Make sure docker api version is valid.
+	rversion, err := a.Runtime.APIVersion()
+	if err != nil {
 		return PodAdmitResult{
 			Admit:   false,
 			Reason:  "NoNewPrivs",
-			Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %s runtime not supported", a.Runtime.Type()),
+			Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %v", err),
 		}
 	}
-
-	if a.Runtime.Type() == kubetypes.DockerContainerRuntime {
-		// Make sure docker api version is valid.
-		rversion, err := a.Runtime.APIVersion()
-		if err != nil {
-			return PodAdmitResult{
-				Admit:   false,
-				Reason:  "NoNewPrivs",
-				Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %v", err),
-			}
+	v, err := rversion.Compare("1.23.0")
+	if err != nil {
+		return PodAdmitResult{
+			Admit:   false,
+			Reason:  "NoNewPrivs",
+			Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %v", err),
 		}
-		v, err := rversion.Compare("1.23.0")
-		if err != nil {
-			return PodAdmitResult{
-				Admit:   false,
-				Reason:  "NoNewPrivs",
-				Message: fmt.Sprintf("Cannot enforce NoNewPrivs: %v", err),
-			}
-		}
-		// If the version is less than 1.23 it will return -1 above.
-		if v == -1 {
-			return PodAdmitResult{
-				Admit:   false,
-				Reason:  "NoNewPrivs",
-				Message: fmt.Sprintf("Cannot enforce NoNewPrivs: docker runtime API version %q must be greater than or equal to 1.23", rversion.String()),
-			}
+	}
+	// If the version is less than 1.23 it will return -1 above.
+	if v == -1 {
+		return PodAdmitResult{
+			Admit:   false,
+			Reason:  "NoNewPrivs",
+			Message: fmt.Sprintf("Cannot enforce NoNewPrivs: docker runtime API version %q must be greater than or equal to 1.23", rversion.String()),
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

#51347 is aiming to admit NoNewPrivis for remote container runtime, but it didn't actually solve the problem. See @miaoyq 's comments [here](https://github.com/kubernetes/kubernetes/pull/51347#discussion_r135379446).

This PR always admit NoNewPrivs for runtimes except docker, which should fix the problem.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Fixes #51319.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
