### PR TITLE
Implement InstanceExistsByProviderID() for cloud providers

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -89,7 +89,20 @@ func (az *Cloud) ExternalID(name types.NodeName) (string, error) {
 // InstanceExistsByProviderID returns true if the instance with the given provider id still exists and is running.
 // If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 func (az *Cloud) InstanceExistsByProviderID(providerID string) (bool, error) {
-	return false, cloudprovider.NotImplemented
+	name, err := splitProviderID(providerID)
+	if err != nil {
+		return false, err
+	}
+
+	_, err = az.InstanceID(name)
+	if err != nil {
+		if err == cloudprovider.InstanceNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }
 
 func (az *Cloud) isCurrentInstance(name types.NodeName) (bool, error) {


### PR DESCRIPTION
Fix #51406
If cloud providers(like aws, gce etc...) implement ExternalID()
and support getting instance by ProviderID , they also implement
InstanceExistsByProviderID().

/assign wlan0
/assign @luxas

**Release note**:
```release-note
NONE
```
