### PR TITLE
kubeadm: Rename FeatureFlags to FeatureGates

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -42,7 +42,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ImageRepository = "foo"
 			obj.CIImageRepository = ""
 			obj.UnifiedControlPlaneImage = "foo"
-			obj.FeatureFlags = map[string]bool{}
+			obj.FeatureGates = map[string]bool{}
 		},
 		func(obj *kubeadm.NodeConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -57,8 +57,8 @@ type MasterConfiguration struct {
 	// UnifiedControlPlaneImage specifies if a specific container image should be used for all control plane components
 	UnifiedControlPlaneImage string
 
-	// FeatureFlags enabled by the user
-	FeatureFlags map[string]bool
+	// FeatureGates enabled by the user
+	FeatureGates map[string]bool
 }
 
 type API struct {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -52,8 +52,8 @@ type MasterConfiguration struct {
 	// UnifiedControlPlaneImage specifies if a specific container image should be used for all control plane components
 	UnifiedControlPlaneImage string `json:"unifiedControlPlaneImage"`
 
-	// FeatureFlags enabled by the user
-	FeatureFlags map[string]bool `json:"featureFlags"`
+	// FeatureGates enabled by the user
+	FeatureGates map[string]bool `json:"featureGates"`
 }
 
 type API struct {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -132,7 +132,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.CertificatesDir = in.CertificatesDir
 	out.ImageRepository = in.ImageRepository
 	out.UnifiedControlPlaneImage = in.UnifiedControlPlaneImage
-	out.FeatureFlags = *(*map[string]bool)(unsafe.Pointer(&in.FeatureFlags))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 
@@ -173,7 +173,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.ImageRepository = in.ImageRepository
 	// INFO: in.CIImageRepository opted out of conversion generation
 	out.UnifiedControlPlaneImage = in.UnifiedControlPlaneImage
-	out.FeatureFlags = *(*map[string]bool)(unsafe.Pointer(&in.FeatureFlags))
+	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
@@ -140,8 +140,8 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.FeatureFlags != nil {
-		in, out := &in.FeatureFlags, &out.FeatureFlags
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -68,7 +68,7 @@ func ValidateMasterConfiguration(c *kubeadm.MasterConfiguration) field.ErrorList
 	allErrs = append(allErrs, ValidateAbsolutePath(c.CertificatesDir, field.NewPath("certificates-dir"))...)
 	allErrs = append(allErrs, ValidateNodeName(c.NodeName, field.NewPath("node-name"))...)
 	allErrs = append(allErrs, ValidateToken(c.Token, field.NewPath("token"))...)
-	allErrs = append(allErrs, ValidateFeatureFlags(c.FeatureFlags, field.NewPath("feature-flags"))...)
+	allErrs = append(allErrs, ValidateFeatureGates(c.FeatureGates, field.NewPath("feature-gates"))...)
 	allErrs = append(allErrs, ValidateAPIEndpoint(c, field.NewPath("api-endpoint"))...)
 	return allErrs
 }
@@ -297,14 +297,14 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 	return nil
 }
 
-func ValidateFeatureFlags(featureFlags map[string]bool, fldPath *field.Path) field.ErrorList {
+func ValidateFeatureGates(featureGates map[string]bool, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	validFeatures := features.Keys(features.InitFeatureGates)
 
 	// check valid feature names are provided
-	for k := range featureFlags {
+	for k := range featureGates {
 		if !features.Supports(features.InitFeatureGates, k) {
-			allErrs = append(allErrs, field.Invalid(fldPath, featureFlags,
+			allErrs = append(allErrs, field.Invalid(fldPath, featureGates,
 				fmt.Sprintf("%s is not a valid feature name. Valid features are: %s", k, validFeatures)))
 		}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation_test.go
@@ -436,10 +436,10 @@ func TestValidateMixedArguments(t *testing.T) {
 	}
 }
 
-func TestValidateFeatureFlags(t *testing.T) {
+func TestValidateFeatureGates(t *testing.T) {
 	type featureFlag map[string]bool
 	var tests = []struct {
-		featureFlags featureFlag
+		featureGates featureFlag
 		expected     bool
 	}{
 		{featureFlag{"SelfHosting": true}, true},
@@ -449,10 +449,10 @@ func TestValidateFeatureFlags(t *testing.T) {
 		{featureFlag{"Foo": true}, false},
 	}
 	for _, rt := range tests {
-		actual := ValidateFeatureFlags(rt.featureFlags, nil)
+		actual := ValidateFeatureGates(rt.featureGates, nil)
 		if (len(actual) == 0) != rt.expected {
 			t.Errorf(
-				"failed featureFlags:\n\texpected: %t\n\t  actual: %t",
+				"failed featureGates:\n\texpected: %t\n\t  actual: %t",
 				rt.expected,
 				(len(actual) == 0),
 			)

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -145,8 +145,8 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.FeatureFlags != nil {
-		in, out := &in.FeatureFlags, &out.FeatureFlags
+	if in.FeatureGates != nil {
+		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -130,7 +130,7 @@ func NewCmdConfigUploadFromFlags(out io.Writer, kubeConfigFile *string) *cobra.C
 	cfg := &kubeadmapiext.MasterConfiguration{}
 	api.Scheme.Default(cfg)
 
-	var featureFlagsString string
+	var featureGatesString string
 
 	cmd := &cobra.Command{
 		Use:   "from-flags",
@@ -144,7 +144,7 @@ func NewCmdConfigUploadFromFlags(out io.Writer, kubeConfigFile *string) *cobra.C
 		`), metav1.NamespaceSystem, constants.MasterConfigurationConfigMap),
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			if cfg.FeatureFlags, err = features.NewFeatureGate(&features.InitFeatureGates, featureFlagsString); err != nil {
+			if cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, featureGatesString); err != nil {
 				kubeadmutil.CheckErr(err)
 			}
 
@@ -157,7 +157,7 @@ func NewCmdConfigUploadFromFlags(out io.Writer, kubeConfigFile *string) *cobra.C
 			kubeadmutil.CheckErr(err)
 		},
 	}
-	AddInitConfigFlags(cmd.PersistentFlags(), cfg, &featureFlagsString)
+	AddInitConfigFlags(cmd.PersistentFlags(), cfg, &featureGatesString)
 	return cmd
 }
 

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -92,14 +92,14 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 	var skipPreFlight bool
 	var skipTokenPrint bool
 	var dryRun bool
-	var featureFlagsString string
+	var featureGatesString string
 
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Run this in order to set up the Kubernetes master",
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			if cfg.FeatureFlags, err = features.NewFeatureGate(&features.InitFeatureGates, featureFlagsString); err != nil {
+			if cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, featureGatesString); err != nil {
 				kubeadmutil.CheckErr(err)
 			}
 
@@ -120,14 +120,14 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 		},
 	}
 
-	AddInitConfigFlags(cmd.PersistentFlags(), cfg, &featureFlagsString)
+	AddInitConfigFlags(cmd.PersistentFlags(), cfg, &featureGatesString)
 	AddInitOtherFlags(cmd.PersistentFlags(), &cfgPath, &skipPreFlight, &skipTokenPrint, &dryRun)
 
 	return cmd
 }
 
 // AddInitConfigFlags adds init flags bound to the config to the specified flagset
-func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfiguration, featureFlagsString *string) {
+func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfiguration, featureGatesString *string) {
 	flagSet.StringVar(
 		&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress,
 		"The IP address the API Server will advertise it's listening on. 0.0.0.0 means the default network interface's address.",
@@ -172,7 +172,7 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfigur
 		&cfg.TokenTTL, "token-ttl", cfg.TokenTTL,
 		"The duration before the bootstrap token is automatically deleted. 0 means 'never expires'.",
 	)
-	flagSet.StringVar(featureFlagsString, "feature-gates", *featureFlagsString, "A set of key=value pairs that describe feature gates for various features. "+
+	flagSet.StringVar(featureGatesString, "feature-gates", *featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 }
 
@@ -381,7 +381,7 @@ func (i *Init) Run(out io.Writer) error {
 	}
 
 	// PHASE 7: Make the control plane self-hosted if feature gate is enabled
-	if features.Enabled(i.cfg.FeatureFlags, features.SelfHosting) {
+	if features.Enabled(i.cfg.FeatureGates, features.SelfHosting) {
 		// Temporary control plane is up, now we create our self hosted control
 		// plane components and remove the static manifests:
 		fmt.Println("[self-hosted] Creating self-hosted control plane...")

--- a/cmd/kubeadm/app/cmd/phases/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/phases/selfhosting.go
@@ -56,7 +56,7 @@ func getSelfhostingSubCommand() *cobra.Command {
 	// Default values for the cobra help text
 	api.Scheme.Default(cfg)
 
-	var cfgPath, kubeConfigFile, featureFlagsString string
+	var cfgPath, kubeConfigFile, featureGatesString string
 
 	// Creates the UX Command
 	cmd := &cobra.Command{
@@ -65,7 +65,7 @@ func getSelfhostingSubCommand() *cobra.Command {
 		Short:   "Converts a Static Pod-hosted control plane into a self-hosted one.",
 		Run: func(cmd *cobra.Command, args []string) {
 			var err error
-			if cfg.FeatureFlags, err = features.NewFeatureGate(&features.InitFeatureGates, featureFlagsString); err != nil {
+			if cfg.FeatureGates, err = features.NewFeatureGate(&features.InitFeatureGates, featureGatesString); err != nil {
 				kubeadmutil.CheckErr(err)
 			}
 
@@ -92,7 +92,7 @@ func getSelfhostingSubCommand() *cobra.Command {
 	// flags bound to the configuration object
 	cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, `The path where certificates are stored`)
 	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
-	cmd.Flags().StringVar(&featureFlagsString, "feature-gates", featureFlagsString, "A set of key=value pairs that describe feature gates for various features."+
+	cmd.Flags().StringVar(&featureGatesString, "feature-gates", featureGatesString, "A set of key=value pairs that describe feature gates for various features."+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
 
 	// flags that are not bound to the configuration object

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -55,7 +55,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  extraArgs: null
 	  image: ""
 	  keyFile: ""
-	featureFlags: null
+	featureGates: null
 	imageRepository: ""
 	kubernetesVersion: v1.7.1
 	networking:
@@ -94,7 +94,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  extraArgs: null
 	  image: ""
 	  keyFile: ""
-	featureFlags: null
+	featureGates: null
 	imageRepository: ""
 	kubernetesVersion: v1.7.1
 	networking:

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -63,7 +63,7 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 	mutators := getDefaultMutators()
 
 	// Some extra work to be done if we should store the control plane certificates in Secrets
-	if features.Enabled(cfg.FeatureFlags, features.StoreCertsInSecrets) {
+	if features.Enabled(cfg.FeatureGates, features.StoreCertsInSecrets) {
 
 		// Upload the certificates and kubeconfig files from disk to the cluster as Secrets
 		if err := uploadTLSSecrets(client, cfg.CertificatesDir); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Automatic rename from `FeatureFlags` to `FeatureGates`, as I noticed that's the real name for this feature. This is for consistency in the API and generally in the code.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @fabriziopandini @jamiehannaford 