### PR TITLE
Fix NodeIdentifier godocs: IdentifyNode -> NodeIdentity

### DIFF
--- a/pkg/auth/nodeidentifier/interfaces.go
+++ b/pkg/auth/nodeidentifier/interfaces.go
@@ -22,7 +22,7 @@ import (
 
 // NodeIdentifier determines node information from a given user
 type NodeIdentifier interface {
-	// IdentifyNode determines node information from the given user.Info.
+	// NodeIdentity determines node information from the given user.Info.
 	// nodeName is the name of the Node API object associated with the user.Info,
 	// and may be empty if a specific node cannot be determined.
 	// isNode is true if the user.Info represents an identity issued to a node.

--- a/plugin/pkg/auth/authorizer/node/node_authorizer.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer.go
@@ -32,8 +32,8 @@ import (
 )
 
 // NodeAuthorizer authorizes requests from kubelets, with the following logic:
-// 1. If a request is not from a node (IdentifyNode() returns isNode=false), reject
-// 2. If a specific node cannot be identified (IdentifyNode() returns nodeName=""), reject
+// 1. If a request is not from a node (NodeIdentity() returns isNode=false), reject
+// 2. If a specific node cannot be identified (NodeIdentity() returns nodeName=""), reject
 // 3. If a request is for a secret, configmap, persistent volume or persistent volume claim, reject unless the verb is get, and the requested object is related to the requesting node:
 //    node <- pod
 //    node <- pod <- secret


### PR DESCRIPTION
The godocs had an older name for the NodeIdentity function.