### PR TITLE
Revert "Re-enable OIR e2e tests."

### DIFF
--- a/test/e2e/scheduling/opaque_resource.go
+++ b/test/e2e/scheduling/opaque_resource.go
@@ -33,7 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = SIGDescribe("Opaque resources", func() {
+var _ = SIGDescribe("Opaque resources [Feature:OpaqueResources]", func() {
 	f := framework.NewDefaultFramework("opaque-resource")
 	opaqueResName := v1helper.OpaqueIntResourceName("foo")
 	var node *v1.Node


### PR DESCRIPTION
Reverts kubernetes/kubernetes#42689

e2e tests are very flaky since that pr merged, and it's very likely related:
https://storage.googleapis.com/k8s-gubernator/triage/index.html?pr=1&test=Opaque%20resources