### PR TITLE
Remove previous local storage resource name 'scratch" and "overlay"

### DIFF
--- a/pkg/api/resource.go
+++ b/pkg/api/resource.go
@@ -54,13 +54,6 @@ func (self *ResourceList) NvidiaGPU() *resource.Quantity {
 	return &resource.Quantity{}
 }
 
-func (self *ResourceList) StorageOverlay() *resource.Quantity {
-	if val, ok := (*self)[ResourceStorageOverlay]; ok {
-		return &val
-	}
-	return &resource.Quantity{}
-}
-
 func (self *ResourceList) StorageEphemeral() *resource.Quantity {
 	if val, ok := (*self)[ResourceEphemeralStorage]; ok {
 		return &val

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -3272,12 +3272,6 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
 	ResourceStorage ResourceName = "storage"
-	// Local Storage for overlay filesystem, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceStorageOverlay is alpha and it can change across releases.
-	ResourceStorageOverlay ResourceName = "storage.kubernetes.io/overlay"
-	// Local Storage for scratch space, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceStorageScratch is alpha and it can change across releases.
-	ResourceStorageScratch ResourceName = "storage.kubernetes.io/scratch"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	// The resource name for ResourceEphemeralStorage is alpha and it can change across releases.
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"

--- a/staging/src/k8s.io/api/core/v1/resource.go
+++ b/staging/src/k8s.io/api/core/v1/resource.go
@@ -55,13 +55,6 @@ func (self *ResourceList) NvidiaGPU() *resource.Quantity {
 	return &resource.Quantity{}
 }
 
-func (self *ResourceList) StorageOverlay() *resource.Quantity {
-	if val, ok := (*self)[ResourceStorageOverlay]; ok {
-		return &val
-	}
-	return &resource.Quantity{}
-}
-
 func (self *ResourceList) StorageEphemeral() *resource.Quantity {
 	if val, ok := (*self)[ResourceEphemeralStorage]; ok {
 		return &val

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3699,12 +3699,6 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
 	ResourceStorage ResourceName = "storage"
-	// Local Storage for container overlay filesystem, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceStorageOverlay is alpha and it can change across releases.
-	ResourceStorageOverlay ResourceName = "storage.kubernetes.io/overlay"
-	// Local Storage for scratch space, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
-	// The resource name for ResourceStorageScratch is alpha and it can change across releases.
-	ResourceStorageScratch ResourceName = "storage.kubernetes.io/scratch"
 	// Local ephemeral storage, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	// The resource name for ResourceEphemeralStorage is alpha and it can change across releases.
 	ResourceEphemeralStorage ResourceName = "ephemeral-storage"


### PR DESCRIPTION
Remove previous local storage resource name 'scratch" and "overlay"

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:  part of #50818

**Special notes for your reviewer**:
Now local ephemeral storage resource name is "ResourceEphemeralStorage",  remove previous names as @vishh  suggested in PR #51070

**Release note**:
```release-note
Remove previous local ephemeral storage resource names: "ResourceStorageOverlay" and "ResourceStorageScratch"
```
