### PR TITLE
Remove storage class beta annotations.

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -527,24 +527,9 @@ func PodAnnotationsFromSysctls(sysctls []core.Sysctl) string {
 	return strings.Join(kvs, ",")
 }
 
-// GetPersistentVolumeClass returns StorageClassName.
-func GetPersistentVolumeClass(volume *core.PersistentVolume) string {
-	// Use beta annotation first
-	if class, found := volume.Annotations[core.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
-	return volume.Spec.StorageClassName
-}
-
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
 	}
@@ -554,11 +539,6 @@ func GetPersistentVolumeClaimClass(claim *core.PersistentVolumeClaim) string {
 
 // PersistentVolumeClaimHasClass returns true if given claim has set StorageClassName field.
 func PersistentVolumeClaimHasClass(claim *core.PersistentVolumeClaim) bool {
-	// Use beta annotation first
-	if _, found := claim.Annotations[core.BetaStorageClassAnnotation]; found {
-		return true
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return true
 	}

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -406,10 +406,6 @@ type PersistentVolumeClaimVolumeSource struct {
 }
 
 const (
-	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
-	// It's deprecated and will be removed in a future release. (#51440)
-	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
-
 	// MountOptionAnnotation defines mount option annotation used in PVs
 	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )

--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -400,24 +400,9 @@ func PodAnnotationsFromSysctls(sysctls []v1.Sysctl) string {
 	return strings.Join(kvs, ",")
 }
 
-// GetPersistentVolumeClass returns StorageClassName.
-func GetPersistentVolumeClass(volume *v1.PersistentVolume) string {
-	// Use beta annotation first
-	if class, found := volume.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
-	return volume.Spec.StorageClassName
-}
-
 // GetPersistentVolumeClaimClass returns StorageClassName. If no storage class was
 // requested, it returns "".
 func GetPersistentVolumeClaimClass(claim *v1.PersistentVolumeClaim) string {
-	// Use beta annotation first
-	if class, found := claim.Annotations[v1.BetaStorageClassAnnotation]; found {
-		return class
-	}
-
 	if claim.Spec.StorageClassName != nil {
 		return *claim.Spec.StorageClassName
 	}

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -1,8 +1,4 @@
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-    "go_test",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -75,6 +71,7 @@ filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
     tags = ["automanaged"],
+    visibility = ["//visibility:private"],
 )
 
 filegroup(

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1844,15 +1844,7 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 		oldPvcClone.Spec.VolumeName = newPvcClone.Spec.VolumeName
 	}
 
-	if validateStorageClassUpgrade(oldPvcClone.Annotations, newPvcClone.Annotations,
-		oldPvcClone.Spec.StorageClassName, newPvcClone.Spec.StorageClassName) {
-		newPvcClone.Spec.StorageClassName = nil
-		metav1.SetMetaDataAnnotation(&newPvcClone.ObjectMeta, core.BetaStorageClassAnnotation, oldPvcClone.Annotations[core.BetaStorageClassAnnotation])
-	} else {
-		// storageclass annotation should be immutable after creation
-		// TODO: remove Beta when no longer needed
-		allErrs = append(allErrs, ValidateImmutableAnnotation(newPvc.ObjectMeta.Annotations[v1.BetaStorageClassAnnotation], oldPvc.ObjectMeta.Annotations[v1.BetaStorageClassAnnotation], v1.BetaStorageClassAnnotation, field.NewPath("metadata"))...)
-	}
+	allErrs = append(allErrs, ValidateImmutableField(newPvc.Spec.StorageClassName, oldPvc.Spec.StorageClassName, field.NewPath("storageClassName"))...)
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ExpandPersistentVolumes) {
 		// lets make sure storage values are same.
@@ -1882,22 +1874,6 @@ func ValidatePersistentVolumeClaimUpdate(newPvc, oldPvc *core.PersistentVolumeCl
 		allErrs = append(allErrs, ValidateImmutableField(newPvc.Spec.VolumeMode, oldPvc.Spec.VolumeMode, field.NewPath("volumeMode"))...)
 	}
 	return allErrs
-}
-
-// Provide an upgrade path from PVC with storage class specified in beta
-// annotation to storage class specified in attribute. We allow update of
-// StorageClassName only if following four conditions are met at the same time:
-// 1. The old pvc's StorageClassAnnotation is set
-// 2. The old pvc's StorageClassName is not set
-// 3. The new pvc's StorageClassName is set and equal to the old value in annotation
-// 4. If the new pvc's StorageClassAnnotation is set,it must be equal to the old pv/pvc's StorageClassAnnotation
-func validateStorageClassUpgrade(oldAnnotations, newAnnotations map[string]string, oldScName, newScName *string) bool {
-	oldSc, oldAnnotationExist := oldAnnotations[core.BetaStorageClassAnnotation]
-	newScInAnnotation, newAnnotationExist := newAnnotations[core.BetaStorageClassAnnotation]
-	return oldAnnotationExist /* condition 1 */ &&
-		oldScName == nil /* condition 2*/ &&
-		(newScName != nil && *newScName == oldSc) /* condition 3 */ &&
-		(!newAnnotationExist || newScInAnnotation == oldSc) /* condition 4 */
 }
 
 // ValidatePersistentVolumeClaimStatusUpdate validates an update to status of a PersistentVolumeClaim

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -674,15 +674,12 @@ func testVolumeClaimWithStatus(
 }
 
 func testVolumeClaimStorageClass(name string, namespace string, annval string, spec core.PersistentVolumeClaimSpec) *core.PersistentVolumeClaim {
-	annotations := map[string]string{
-		v1.BetaStorageClassAnnotation: annval,
-	}
+	spec.StorageClassName = &annval
 
 	return &core.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: annotations,
+			Name:      name,
+			Namespace: namespace,
 		},
 		Spec: spec,
 	}
@@ -709,18 +706,6 @@ func testVolumeClaimStorageClassInSpec(name, namespace, scName string, spec core
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-		},
-		Spec: spec,
-	}
-}
-
-func testVolumeClaimStorageClassInAnnotationAndSpec(name, namespace, scNameInAnn, scName string, spec core.PersistentVolumeClaimSpec) *core.PersistentVolumeClaim {
-	spec.StorageClassName = &scName
-	return &core.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        name,
-			Namespace:   namespace,
-			Annotations: map[string]string{v1.BetaStorageClassAnnotation: scNameInAnn},
 		},
 		Spec: spec,
 	}
@@ -1263,30 +1248,6 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 		},
 	})
 
-	validClaimStorageClassInAnnotationAndSpec := testVolumeClaimStorageClassInAnnotationAndSpec(
-		"foo", "ns", "fast", "fast", core.PersistentVolumeClaimSpec{
-			AccessModes: []core.PersistentVolumeAccessMode{
-				core.ReadOnlyMany,
-			},
-			Resources: core.ResourceRequirements{
-				Requests: core.ResourceList{
-					core.ResourceName(core.ResourceStorage): resource.MustParse("10G"),
-				},
-			},
-		})
-
-	invalidClaimStorageClassInAnnotationAndSpec := testVolumeClaimStorageClassInAnnotationAndSpec(
-		"foo", "ns", "fast2", "fast", core.PersistentVolumeClaimSpec{
-			AccessModes: []core.PersistentVolumeAccessMode{
-				core.ReadOnlyMany,
-			},
-			Resources: core.ResourceRequirements{
-				Requests: core.ResourceList{
-					core.ResourceName(core.ResourceStorage): resource.MustParse("10G"),
-				},
-			},
-		})
-
 	scenarios := map[string]struct {
 		isExpectedFailure bool
 		oldClaim          *core.PersistentVolumeClaim
@@ -1462,31 +1423,10 @@ func TestValidatePersistentVolumeClaimUpdate(t *testing.T) {
 			enableResize:      false,
 			enableBlock:       false,
 		},
-		"valid-upgrade-storage-class-annotation-to-annotation-and-spec": {
-			isExpectedFailure: false,
-			oldClaim:          validClaimStorageClass,
-			newClaim:          validClaimStorageClassInAnnotationAndSpec,
-			enableResize:      false,
-			enableBlock:       false,
-		},
-		"invalid-upgrade-storage-class-annotation-to-annotation-and-spec": {
-			isExpectedFailure: true,
-			oldClaim:          validClaimStorageClass,
-			newClaim:          invalidClaimStorageClassInAnnotationAndSpec,
-			enableResize:      false,
-			enableBlock:       false,
-		},
 		"invalid-upgrade-storage-class-in-spec": {
 			isExpectedFailure: true,
 			oldClaim:          validClaimStorageClassInSpec,
 			newClaim:          invalidClaimStorageClassInSpec,
-			enableResize:      false,
-			enableBlock:       false,
-		},
-		"invalid-downgrade-storage-class-spec-to-annotation": {
-			isExpectedFailure: true,
-			oldClaim:          validClaimStorageClassInSpec,
-			newClaim:          validClaimStorageClass,
 			enableResize:      false,
 			enableBlock:       false,
 		},

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -220,7 +220,7 @@ func findMatchingVolume(
 		} else if selector != nil && !selector.Matches(labels.Set(volume.Labels)) {
 			continue
 		}
-		if v1helper.GetPersistentVolumeClass(volume) != requestedClass {
+		if volume.Spec.StorageClassName != requestedClass {
 			continue
 		}
 		if !nodeAffinityValid {

--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -253,7 +253,7 @@ func checkVolumeSatisfyClaim(volume *v1.PersistentVolume, claim *v1.PersistentVo
 	}
 
 	requestedClass := v1helper.GetPersistentVolumeClaimClass(claim)
-	if v1helper.GetPersistentVolumeClass(volume) != requestedClass {
+	if volume.Spec.StorageClassName != requestedClass {
 		return fmt.Errorf("storageClasseName does not match")
 	}
 

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -1183,7 +1183,7 @@ func describePersistentVolume(pv *api.PersistentVolume, events *api.EventList) (
 		printLabelsMultiline(w, "Labels", pv.Labels)
 		printAnnotationsMultiline(w, "Annotations", pv.Annotations)
 		w.Write(LEVEL_0, "Finalizers:\t%v\n", pv.ObjectMeta.Finalizers)
-		w.Write(LEVEL_0, "StorageClass:\t%s\n", helper.GetPersistentVolumeClass(pv))
+		w.Write(LEVEL_0, "StorageClass:\t%s\n", pv.Spec.StorageClassName)
 		if pv.ObjectMeta.DeletionTimestamp != nil {
 			w.Write(LEVEL_0, "Status:\tTerminating (lasts %s)\n", translateTimestamp(*pv.ObjectMeta.DeletionTimestamp))
 		} else {

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1224,7 +1224,7 @@ func printPersistentVolume(obj *api.PersistentVolume, options printers.PrintOpti
 	}
 
 	row.Cells = append(row.Cells, obj.Name, aSize, modesStr, reclaimPolicyStr,
-		string(phase), claimRefUID, helper.GetPersistentVolumeClass(obj),
+		string(phase), claimRefUID, obj.Spec.StorageClassName,
 		obj.Status.Reason,
 		translateTimestamp(obj.CreationTimestamp))
 	return []metav1beta1.TableRow{row}, nil

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -491,7 +491,7 @@ func (plugin *glusterfsPlugin) collectGids(className string, gidTable *MinMaxAll
 	}
 
 	for _, pv := range pvList.Items {
-		if v1helper.GetPersistentVolumeClass(&pv) != className {
+		if pv.Spec.StorageClassName != className {
 			continue
 		}
 

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -251,7 +251,7 @@ func GetClassForVolume(kubeClient clientset.Interface, pv *v1.PersistentVolume) 
 	if kubeClient == nil {
 		return nil, fmt.Errorf("Cannot get kube client")
 	}
-	className := v1helper.GetPersistentVolumeClass(pv)
+	className := pv.Spec.StorageClassName
 	if className == "" {
 		return nil, fmt.Errorf("Volume has no storage class")
 	}

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -452,10 +452,6 @@ type PersistentVolumeSource struct {
 }
 
 const (
-	// BetaStorageClassAnnotation represents the beta/previous StorageClass annotation.
-	// It's currently still used and will be held for backwards compatibility
-	BetaStorageClassAnnotation = "volume.beta.kubernetes.io/storage-class"
-
 	// MountOptionAnnotation defines mount option annotation used in PVs
 	MountOptionAnnotation = "volume.beta.kubernetes.io/mount-options"
 )

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -359,11 +359,10 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 			},
 			Prebind: nil,
 		}
+		noClass := ""
 		pvcConfig := framework.PersistentVolumeClaimConfig{
-			Annotations: map[string]string{
-				v1.BetaStorageClassAnnotation: "",
-			},
-			Selector: selector,
+			Selector:         selector,
+			StorageClassName: &noClass,
 		}
 
 		pv, pvc, err := framework.CreatePVPVC(c, pvConfig, pvcConfig, f.Namespace.Name, false)

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -29,7 +29,6 @@ go_library(
     deps = [
         "//pkg/api/testapi:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
-        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/apis/storage/v1/util:go_default_library",
         "//pkg/client/conditions:go_default_library",
         "//pkg/kubelet/apis:go_default_library",

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -78,11 +78,10 @@ var _ = utils.SIGDescribe("NFSPersistentVolumes[Disruptive][Flaky]", func() {
 				},
 			},
 		}
+		noClass := ""
 		pvcConfig = framework.PersistentVolumeClaimConfig{
-			Annotations: map[string]string{
-				v1.BetaStorageClassAnnotation: "",
-			},
-			Selector: selector,
+			Selector:         selector,
+			StorageClassName: &noClass,
 		}
 		// Get the first ready node IP that is not hosting the NFS pod.
 		if clientNodeIP == "" {

--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -93,11 +93,10 @@ var _ = utils.SIGDescribe("PersistentVolumes GCEPD", func() {
 			},
 			Prebind: nil,
 		}
+		noClass := ""
 		pvcConfig = framework.PersistentVolumeClaimConfig{
-			Annotations: map[string]string{
-				v1.BetaStorageClassAnnotation: "",
-			},
-			Selector: selector,
+			Selector:         selector,
+			StorageClassName: &noClass,
 		}
 		clientPod, pv, pvc = initializeGCETestSpec(c, ns, pvConfig, pvcConfig, false)
 		node = types.NodeName(clientPod.Spec.NodeName)

--- a/test/e2e/storage/persistent_volumes.go
+++ b/test/e2e/storage/persistent_volumes.go
@@ -132,11 +132,10 @@ var _ = utils.SIGDescribe("PersistentVolumes", func() {
 					},
 				},
 			}
+			noClass := ""
 			pvcConfig = framework.PersistentVolumeClaimConfig{
-				Annotations: map[string]string{
-					v1.BetaStorageClassAnnotation: "",
-				},
-				Selector: selector,
+				Selector:         selector,
+				StorageClassName: &noClass,
 			}
 		})
 

--- a/test/e2e/storage/pv_protection.go
+++ b/test/e2e/storage/pv_protection.go
@@ -64,11 +64,10 @@ var _ = utils.SIGDescribe("PV Protection", func() {
 			},
 		}
 
+		noClass := ""
 		pvcConfig = framework.PersistentVolumeClaimConfig{
-			Annotations: map[string]string{
-				v1.BetaStorageClassAnnotation: "",
-			},
-			Selector: selector,
+			Selector:         selector,
+			StorageClassName: &noClass,
 		}
 
 		By("Creating a PV")

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	clientset "k8s.io/client-go/kubernetes"
-	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	storageutil "k8s.io/kubernetes/pkg/apis/storage/v1/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
@@ -250,6 +249,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			// This test checks that dynamic provisioning can provision a volume
 			// that can be used to persist data among pods.
 			tests := []storageClassTest{
+				// GCE/GKE
 				{
 					name:           "SSD PD on GCE/GKE",
 					cloudProviders: []string{"gce", "gke"},
@@ -377,6 +377,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 					expectedSize:   "1.5Gi",
 					pvCheck:        nil,
 				},
+				// Azure
 				{
 					name:           "Azure disk volume with empty sku and location",
 					cloudProviders: []string{"azure"},
@@ -410,7 +411,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				testDynamicProvisioning(test, c, claim, class)
 			}
 
-			// Run the last test with storage.k8s.io/v1beta1 and beta annotation on pvc
+			// Run the last test with storage.k8s.io/v1beta1 on pvc
 			if betaTest != nil {
 				By("Testing " + betaTest.name + " with beta volume provisioning")
 				class := newBetaStorageClass(*betaTest, "beta")
@@ -420,9 +421,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 				defer deleteStorageClass(c, class.Name)
 
 				claim := newClaim(*betaTest, ns, "beta")
-				claim.Annotations = map[string]string{
-					v1.BetaStorageClassAnnotation: class.Name,
-				}
+				claim.Spec.StorageClassName = &(class.Name)
 				testDynamicProvisioning(*betaTest, c, claim, nil)
 			}
 		})
@@ -694,12 +693,7 @@ var _ = utils.SIGDescribe("Dynamic Provisioning", func() {
 			class := newStorageClass(test, ns, "external")
 			className := class.Name
 			claim := newClaim(test, ns, "external")
-			// the external provisioner understands Beta only right now, see
-			// https://github.com/kubernetes-incubator/external-storage/issues/37
-			// claim.Spec.StorageClassName = &className
-			claim.Annotations = map[string]string{
-				v1.BetaStorageClassAnnotation: className,
-			}
+			claim.Spec.StorageClassName = &className
 
 			By("creating a claim with a external provisioning annotation")
 			testDynamicProvisioning(test, c, claim, class)
@@ -953,8 +947,7 @@ func newStorageClass(t storageClassTest, ns string, suffix string) *storage.Stor
 	}
 }
 
-// TODO: remove when storage.k8s.io/v1beta1 and beta storage class annotations
-// are removed.
+// TODO: remove when storage.k8s.io/v1beta1 is removed.
 func newBetaStorageClass(t storageClassTest, suffix string) *storagebeta.StorageClass {
 	pluginName := t.provisioner
 
@@ -1063,7 +1056,7 @@ func waitForProvisionedVolumesDeleted(c clientset.Interface, scName string) ([]*
 			return true, err
 		}
 		for _, pv := range allPVs.Items {
-			if v1helper.GetPersistentVolumeClass(&pv) == scName {
+			if pv.Spec.StorageClassName == scName {
 				remainingPVs = append(remainingPVs, &pv)
 			}
 		}

--- a/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/vsphere/persistent_volumes-vsphere.go
@@ -87,11 +87,10 @@ var _ = utils.SIGDescribe("PersistentVolumes:vsphere", func() {
 				},
 				Prebind: nil,
 			}
+			noClass := ""
 			pvcConfig = framework.PersistentVolumeClaimConfig{
-				Annotations: map[string]string{
-					v1.BetaStorageClassAnnotation: "",
-				},
-				Selector: selector,
+				Selector:         selector,
+				StorageClassName: &noClass,
 			}
 		}
 		By("Creating the PV and PVC")

--- a/test/e2e/storage/vsphere/vsphere_utils.go
+++ b/test/e2e/storage/vsphere/vsphere_utils.go
@@ -253,14 +253,10 @@ func getVSphereStorageClassSpec(name string, scParameters map[string]string) *st
 }
 
 func getVSphereClaimSpecWithStorageClassAnnotation(ns string, diskSize string, storageclass *storage.StorageClass) *v1.PersistentVolumeClaim {
-	scAnnotation := make(map[string]string)
-	scAnnotation[v1.BetaStorageClassAnnotation] = storageclass.Name
-
 	claim := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "pvc-",
 			Namespace:    ns,
-			Annotations:  scAnnotation,
 		},
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{
@@ -271,6 +267,7 @@ func getVSphereClaimSpecWithStorageClassAnnotation(ns string, diskSize string, s
 					v1.ResourceName(v1.ResourceStorage): resource.MustParse(diskSize),
 				},
 			},
+			StorageClassName: &(storageclass.Name),
 		},
 	}
 	return claim

--- a/test/e2e/upgrades/storage/persistent_volumes.go
+++ b/test/e2e/upgrades/storage/persistent_volumes.go
@@ -62,11 +62,8 @@ func (t *PersistentVolumeUpgradeTest) Setup(f *framework.Framework) {
 		PVSource:   *t.pvSource,
 		Prebind:    nil,
 	}
-	pvcConfig := framework.PersistentVolumeClaimConfig{
-		Annotations: map[string]string{
-			v1.BetaStorageClassAnnotation: "",
-		},
-	}
+	noClass := ""
+	pvcConfig := framework.PersistentVolumeClaimConfig{StorageClassName: &noClass}
 
 	By("Creating the PV and PVC")
 	t.pv, t.pvc, err = framework.CreatePVPVC(f.ClientSet, pvConfig, pvcConfig, ns, true)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The field `StorageClassName` will have existed for 2 releases when 1.8 is released. We can remove the beta annotations `volume.beta.kubernetes.io/storage-class` then.

~~UPDATE: mark `storage.k8s.io/v1beta1` as deprecated in the release note of this PR.~~

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51434  (thanks @gyliu513 for the issue)
ref: #51310

**Special notes for your reviewer**:
/cc @msau42 @jsafrane

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
action required: Beta annotation `volume.beta.kubernetes.io/storage-class` has been removed. In place of the annotation use `v1.PersistentVolumeClaim.Spec.StorageClassName` and `v1.PersistentVolume.Spec.StorageClassName` instead.
```

  