### PR TITLE
hide help options when run "kubectl create" symply

### DIFF
--- a/pkg/kubectl/cmd/templates/templater.go
+++ b/pkg/kubectl/cmd/templates/templater.go
@@ -58,6 +58,16 @@ func UseOptionsTemplates(cmd *cobra.Command) {
 	cmd.SetHelpFunc(templater.HelpFunc())
 }
 
+func UseMainUsageTemplatesWithoutFlags(cmd *cobra.Command) {
+	templater := &templater{
+		RootCmd:       cmd,
+		UsageTemplate: MainUsageTemplateWithoutFlags(),
+		HelpTemplate:  MainHelpTemplateWithoutFlags(),
+	}
+	cmd.SetUsageFunc(templater.UsageFunc())
+	cmd.SetHelpFunc(templater.HelpFunc())
+}
+
 type templater struct {
 	UsageTemplate string
 	HelpTemplate  string

--- a/pkg/kubectl/cmd/templates/templates.go
+++ b/pkg/kubectl/cmd/templates/templates.go
@@ -100,3 +100,25 @@ func OptionsUsageTemplate() string {
 
 {{flagsUsages .InheritedFlags}}{{end}}`
 }
+
+// MainHelpTemplateWithoutFlags if the template for 'help' used by most commands
+// without options information
+func MainHelpTemplateWithoutFlags() string {
+	return `{{with or .Long .Short }}{{. | trim}}{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+}
+
+// MainUsageTemplateWithoutFlags if the template for 'usage' used by most commands
+// without options information
+func MainUsageTemplateWithoutFlags() string {
+	sections := []string{
+		"\n\n",
+		SectionVars,
+		SectionAliases,
+		SectionExamples,
+		SectionSubcommands,
+		SectionUsage,
+		SectionTipsHelp,
+		SectionTipsGlobalOptions,
+	}
+	return strings.TrimRightFunc(strings.Join(sections, ""), unicode.IsSpace)
+}

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/client/unversioned:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/kubectl:go_default_library",
+        "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util/openapi:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/validation:go_default_library",
         "//pkg/kubectl/plugins:go_default_library",

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/printers"
 	utilexec "k8s.io/utils/exec"
@@ -780,6 +781,7 @@ func IsSiblingCommandExists(cmd *cobra.Command, targetCmdName string) bool {
 // arguments (sub-commands) are provided, or a usage error otherwise.
 func DefaultSubCommandRun(out io.Writer) func(c *cobra.Command, args []string) {
 	return func(c *cobra.Command, args []string) {
+		templates.UseMainUsageTemplatesWithoutFlags(c)
 		c.SetOutput(out)
 		RequireNoArguments(c, args)
 		c.Help()


### PR DESCRIPTION
**What this PR does / why we need it**:
hide help options when run "kubectl create" symply

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51175 

**Special notes for your reviewer**:
N/A

**Release note**:
```release-note
N/A
```