### PR TITLE
Add PVCRef to VolumeStats

### DIFF
--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -195,6 +195,15 @@ type VolumeStats struct {
 	// Name is the name given to the Volume
 	// +optional
 	Name string `json:"name,omitempty"`
+	// Reference to the PVC, if one exists
+	// +optional
+	PVCRef *PVCReference `json:"pvcRef,omitempty"`
+}
+
+// PVCReference contains enough information to describe the referenced PVC.
+type PVCReference struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
 }
 
 // FsStats contains data about filesystem usage.

--- a/pkg/kubelet/server/stats/BUILD
+++ b/pkg/kubelet/server/stats/BUILD
@@ -29,15 +29,20 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["summary_test.go"],
+    srcs = [
+        "summary_test.go",
+        "volume_stat_calculator_test.go",
+    ],
     library = ":go_default_library",
     deps = [
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/server/stats/testing:go_default_library",
+        "//pkg/volume:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/kubelet/server/stats/volume_stat_calculator_test.go
+++ b/pkg/kubelet/server/stats/volume_stat_calculator_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stats
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubestats "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	statstest "k8s.io/kubernetes/pkg/kubelet/server/stats/testing"
+	"k8s.io/kubernetes/pkg/volume"
+)
+
+const (
+	namespace0  = "test0"
+	pName0      = "pod0"
+	capacity    = int64(10000000)
+	available   = int64(5000000)
+	inodesTotal = int64(2000)
+	inodesFree  = int64(1000)
+
+	vol0         = "vol0"
+	vol1         = "vol1"
+	pvcClaimName = "pvc-fake"
+)
+
+func TestPVCRef(t *testing.T) {
+	// Create pod spec to test against
+	podVolumes := []k8sv1.Volume{
+		{
+			Name: vol0,
+			VolumeSource: k8sv1.VolumeSource{
+				GCEPersistentDisk: &k8sv1.GCEPersistentDiskVolumeSource{
+					PDName: "fake-device1",
+				},
+			},
+		},
+		{
+			Name: vol1,
+			VolumeSource: k8sv1.VolumeSource{
+				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+					ClaimName: pvcClaimName,
+				},
+			},
+		},
+	}
+
+	fakePod := &k8sv1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pName0,
+			Namespace: namespace0,
+			UID:       "UID" + pName0,
+		},
+		Spec: k8sv1.PodSpec{
+			Volumes: podVolumes,
+		},
+	}
+
+	// Setup mock stats provider
+	mockStats := new(statstest.StatsProvider)
+	volumes := map[string]volume.Volume{vol0: &fakeVolume{}, vol1: &fakeVolume{}}
+	mockStats.On("ListVolumesForPod", fakePod.UID).Return(volumes, true)
+
+	// Calculate stats for pod
+	statsCalculator := newVolumeStatCalculator(mockStats, time.Minute, fakePod)
+	statsCalculator.calcAndStoreStats()
+	vs, _ := statsCalculator.GetLatest()
+
+	assert.Len(t, vs.Volumes, 2)
+	// Verify 'vol0' doesn't have a PVC reference
+	assert.Contains(t, vs.Volumes, kubestats.VolumeStats{
+		Name:    vol0,
+		FsStats: expectedFSStats(),
+	})
+	// Verify 'vol1' has a PVC reference
+	assert.Contains(t, vs.Volumes, kubestats.VolumeStats{
+		Name: vol1,
+		PVCRef: &kubestats.PVCReference{
+			Name:      pvcClaimName,
+			Namespace: namespace0,
+		},
+		FsStats: expectedFSStats(),
+	})
+}
+
+// Fake volume/metrics provider
+var _ volume.Volume = &fakeVolume{}
+
+type fakeVolume struct{}
+
+func (v *fakeVolume) GetPath() string { return "" }
+
+func (v *fakeVolume) GetMetrics() (*volume.Metrics, error) {
+	return expectedMetrics(), nil
+}
+
+func expectedMetrics() *volume.Metrics {
+	return &volume.Metrics{
+		Available:  resource.NewQuantity(available, resource.BinarySI),
+		Capacity:   resource.NewQuantity(capacity, resource.BinarySI),
+		Used:       resource.NewQuantity(available-capacity, resource.BinarySI),
+		Inodes:     resource.NewQuantity(inodesTotal, resource.BinarySI),
+		InodesFree: resource.NewQuantity(inodesFree, resource.BinarySI),
+		InodesUsed: resource.NewQuantity(inodesTotal-inodesFree, resource.BinarySI),
+	}
+}
+
+func expectedFSStats() kubestats.FsStats {
+	metric := expectedMetrics()
+	available := uint64(metric.Available.Value())
+	capacity := uint64(metric.Capacity.Value())
+	used := uint64(metric.Used.Value())
+	inodes := uint64(metric.Inodes.Value())
+	inodesFree := uint64(metric.InodesFree.Value())
+	inodesUsed := uint64(metric.InodesUsed.Value())
+	return kubestats.FsStats{
+		AvailableBytes: &available,
+		CapacityBytes:  &capacity,
+		UsedBytes:      &used,
+		Inodes:         &inodes,
+		InodesFree:     &inodesFree,
+		InodesUsed:     &inodesUsed,
+	}
+}

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -181,7 +181,8 @@ var _ = framework.KubeDescribe("Summary API", func() {
 				}),
 				"VolumeStats": gstruct.MatchAllElements(summaryObjectID, gstruct.Elements{
 					"test-empty-dir": gstruct.MatchAllFields(gstruct.Fields{
-						"Name": Equal("test-empty-dir"),
+						"Name":   Equal("test-empty-dir"),
+						"PVCRef": BeNil(),
 						"FsStats": gstruct.MatchAllFields(gstruct.Fields{
 							"Time":           recent(maxStatsAge),
 							"AvailableBytes": fsCapacityBounds,


### PR DESCRIPTION
**What this PR does / why we need it**:
For pod volumes that reference a PVC, add a PVCRef to the corresponding
volume stat. This allows metrics to be indexed/queried by PVC name
which is more user-friendly than Pod reference

**Which issue this PR fixes** : [#363](https://github.com/kubernetes/features/issues/363)

**Special notes for your reviewer**:

**Release note**:
```
`VolumeStats` reported by the kubelet stats summary API 
(http://<node>:10255/stats/summary) now include a PVCRef
field describing the PVC referenced by the volume (if any). 
```
