### PR TITLE
Autodetect kubemark Cloud Provider

### DIFF
--- a/pkg/kubemark/BUILD
+++ b/pkg/kubemark/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
+        "//pkg/kubelet/apis/kubeletconfig/v1alpha1:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubelet/app/options"
 	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig"
+	kubeletv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	containertest "k8s.io/kubernetes/pkg/kubelet/container/testing"
@@ -110,6 +111,7 @@ func GetHollowKubeletConfig(
 	f := &options.KubeletFlags{
 		RootDirectory:    testRootDir,
 		HostnameOverride: nodeName,
+		CloudProvider:    kubeletv1alpha1.AutoDetectCloudProvider,
 		// Use the default runtime options.
 		ContainerRuntimeOptions: *options.NewContainerRuntimeOptions(),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is needed for CloudProviderId to be properly
filled for Hollow Nodes.

**Release note**:
```
NONE
```
