### PR TITLE
fixing GroupVersionForDiscovery struct comment in staging/src/k8s.io/…

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -65787,7 +65787,7 @@
     ]
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/admissionregistration.k8s.io.json
+++ b/api/swagger-spec/admissionregistration.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/apis.json
+++ b/api/swagger-spec/apis.json
@@ -100,7 +100,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/apps.json
+++ b/api/swagger-spec/apps.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/authentication.k8s.io.json
+++ b/api/swagger-spec/authentication.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/authorization.k8s.io.json
+++ b/api/swagger-spec/authorization.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/autoscaling.json
+++ b/api/swagger-spec/autoscaling.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/batch.json
+++ b/api/swagger-spec/batch.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/certificates.k8s.io.json
+++ b/api/swagger-spec/certificates.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/extensions.json
+++ b/api/swagger-spec/extensions.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/networking.k8s.io.json
+++ b/api/swagger-spec/networking.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/policy.json
+++ b/api/swagger-spec/policy.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/rbac.authorization.k8s.io.json
+++ b/api/swagger-spec/rbac.authorization.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/scheduling.k8s.io.json
+++ b/api/swagger-spec/scheduling.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/settings.k8s.io.json
+++ b/api/swagger-spec/settings.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/api/swagger-spec/storage.k8s.io.json
+++ b/api/swagger-spec/storage.k8s.io.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -13402,7 +13402,7 @@
     ]
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/federation/apis/swagger-spec/apis.json
+++ b/federation/apis/swagger-spec/apis.json
@@ -100,7 +100,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/federation/apis/swagger-spec/extensions.json
+++ b/federation/apis/swagger-spec/extensions.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/federation/apis/swagger-spec/federation.json
+++ b/federation/apis/swagger-spec/federation.json
@@ -76,7 +76,7 @@
    },
    "v1.GroupVersionForDiscovery": {
     "id": "v1.GroupVersionForDiscovery",
-    "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "description": "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
     "required": [
      "groupVersion",
      "version"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/generated.proto
@@ -203,7 +203,7 @@ message GroupVersion {
   optional string version = 2;
 }
 
-// GroupVersion contains the "group/version" and "version" string of a version.
+// GroupVersionForDiscovery contains the "group/version" and "version" string of a version.
 // It is made a struct to keep extensibility.
 message GroupVersionForDiscovery {
   // groupVersion specifies the API group and version in the form "group/version"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -758,7 +758,7 @@ type ServerAddressByClientCIDR struct {
 	ServerAddress string `json:"serverAddress" protobuf:"bytes,2,opt,name=serverAddress"`
 }
 
-// GroupVersion contains the "group/version" and "version" string of a version.
+// GroupVersionForDiscovery contains the "group/version" and "version" string of a version.
 // It is made a struct to keep extensibility.
 type GroupVersionForDiscovery struct {
 	// groupVersion specifies the API group and version in the form "group/version"

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types_swagger_doc_generated.go
@@ -116,7 +116,7 @@ func (GetOptions) SwaggerDoc() map[string]string {
 }
 
 var map_GroupVersionForDiscovery = map[string]string{
-	"":             "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+	"":             "GroupVersionForDiscovery contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
 	"groupVersion": "groupVersion specifies the API group and version in the form \"group/version\"",
 	"version":      "version specifies the version in the form of \"version\". This is to save the clients the trouble of splitting the GroupVersion.",
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR fix the comment of GroupVersionForDiscovery struct in `staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`
