### PR TITLE
Fix `gcloud compute instance-groups managed list` call

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -336,7 +336,7 @@ function detect-node-names() {
   INSTANCE_GROUPS+=($(gcloud compute instance-groups managed list \
     --zones "${ZONE}" --project "${PROJECT}" \
     --regexp "${NODE_INSTANCE_PREFIX}-.+" \
-    --format='value(instanceGroup)' || true))
+    --format='value(name)' || true))
   NODE_NAMES=()
   if [[ -n "${INSTANCE_GROUPS[@]:-}" ]]; then
     for group in "${INSTANCE_GROUPS[@]}"; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: gcloud 168.0.0 makes the `gcloud compute instance-groups managed list --format='value(instanceGroup)'` call return a URL instead of just the name, which is causing `list-instances` to fail. Switching to `--format='value(name)'` seems to restore the old behavior.

x-ref #49673 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @wojtek-t @mwielgus @shyamjvs @jiayingz @mindprince 