### PR TITLE
convert generated obj before printing

### DIFF
--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -396,7 +396,13 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 
 	outputFormat := cmdutil.GetFlagString(cmd, "output")
 	if outputFormat != "" || cmdutil.GetDryRunFlag(cmd) {
-		return f.PrintObject(cmd, false, runObject.Mapper, runObject.Object, cmdOut)
+		// convert to internal version before passing to the printer
+		internalObj, err := runObject.Mapping.ConvertToVersion(runObject.Object, schema.GroupVersion{Group: runObject.Mapping.GroupVersionKind.Group, Version: runtime.APIVersionInternal})
+		if err != nil {
+			return err
+		}
+
+		return f.PrintObject(cmd, false, runObject.Mapper, internalObj, cmdOut)
 	}
 	cmdutil.PrintSuccess(runObject.Mapper, false, cmdOut, runObject.Mapping.Resource, args[0], cmdutil.GetDryRunFlag(cmd), "created")
 	return nil


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```
Ensure that a generated object is an internalversion before attempting to print with humanreadable printer.

**Before**
```
$kubectl run mysql --image=mysql --dry-run
NAME      AGE
mysql     <unknown>
```

**After**
```
NAME      DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
mysql     1         0         0            0           <unknown>
```

Related downstream bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1455115
Related downstream PR: https://github.com/openshift/origin/pull/16020

cc @fabianofranz @kubernetes/sig-cli-misc