### PR TITLE
Remove unused pod from TestUpdateNodeWithMultiplePods

### DIFF
--- a/pkg/controller/node/scheduler/taint_controller_test.go
+++ b/pkg/controller/node/scheduler/taint_controller_test.go
@@ -457,7 +457,6 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 			pods: []v1.Pod{
 				*testutil.NewPod("pod1", "node1"),
 				*addToleration(testutil.NewPod("pod2", "node1"), 1, 1),
-				*addToleration(testutil.NewPod("pod3", "node1"), 1, -1),
 			},
 			oldNode: testutil.NewNode("node1"),
 			newNode: addTaintsToNode(testutil.NewNode("node1"), "testTaint1", "taint1", []int{1}),
@@ -528,7 +527,7 @@ func TestUpdateNodeWithMultiplePods(t *testing.T) {
 					}
 				}
 				if !deleted {
-					t.Errorf("Failed to deleted pod %v after %v", podName, delay)
+					t.Errorf("Failed to delete pod %v after %v", podName, delay)
 				}
 			}
 			for _, action := range fakeClientset.Actions() {


### PR DESCRIPTION
**What this PR does / why we need it**:

pod3 is not used on TestUpdateNodeWithMultiplePods, then this PR
removes the pod for the code cleanup. In addition, this fixes a
small typo on an error message.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

`NONE`

**Special notes for your reviewer**:

This issue is found during investigating issue #46222 and we need more work for fixing the root problem of the issue.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

`NONE`
