### PR TITLE
Start shared informer automatically if factory already started

### DIFF
--- a/pkg/client/informers/informers_generated/internalversion/BUILD
+++ b/pkg/client/informers/informers_generated/internalversion/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//pkg/client/informers/informers_generated/internalversion/scheduling:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion/settings:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion/storage:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/client/informers/informers_generated/internalversion/factory.go
+++ b/pkg/client/informers/informers_generated/internalversion/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -38,19 +39,21 @@ import (
 	settings "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/settings"
 	storage "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion/storage"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        internalclientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -68,12 +71,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -98,8 +111,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -109,8 +123,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/pkg/controller/certificates/certificate_controller.go
+++ b/pkg/controller/certificates/certificate_controller.go
@@ -62,8 +62,10 @@ func NewCertificateController(
 
 	cc := &CertificateController{
 		kubeClient: kubeClient,
-		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "certificate"),
+		csrLister:  csrInformer.Lister(),
+		csrsSynced: csrInformer.Informer().HasSynced,
 		handler:    handler,
+		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "certificate"),
 	}
 
 	// Manage the addition/update of certificate requests
@@ -96,9 +98,7 @@ func NewCertificateController(
 			cc.enqueueCertificateRequest(obj)
 		},
 	})
-	cc.csrLister = csrInformer.Lister()
-	cc.csrsSynced = csrInformer.Informer().HasSynced
-	cc.handler = handler
+
 	return cc, nil
 }
 

--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -119,10 +119,22 @@ func NewDisruptionController(
 	kubeClient clientset.Interface,
 ) *DisruptionController {
 	dc := &DisruptionController{
-		kubeClient:   kubeClient,
-		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "disruption"),
-		recheckQueue: workqueue.NewNamedDelayingQueue("disruption-recheck"),
-		broadcaster:  record.NewBroadcaster(),
+		kubeClient:      kubeClient,
+		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "disruption"),
+		recheckQueue:    workqueue.NewNamedDelayingQueue("disruption-recheck"),
+		broadcaster:     record.NewBroadcaster(),
+		podLister:       podInformer.Lister(),
+		podListerSynced: podInformer.Informer().HasSynced,
+		pdbLister:       pdbInformer.Lister(),
+		pdbListerSynced: pdbInformer.Informer().HasSynced,
+		rcLister:        rcInformer.Lister(),
+		rcListerSynced:  rcInformer.Informer().HasSynced,
+		rsLister:        rsInformer.Lister(),
+		rsListerSynced:  rsInformer.Informer().HasSynced,
+		dLister:         dInformer.Lister(),
+		dListerSynced:   dInformer.Informer().HasSynced,
+		ssLister:        ssInformer.Lister(),
+		ssListerSynced:  ssInformer.Informer().HasSynced,
 	}
 	dc.recorder = dc.broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "controllermanager"})
 
@@ -133,8 +145,6 @@ func NewDisruptionController(
 		UpdateFunc: dc.updatePod,
 		DeleteFunc: dc.deletePod,
 	})
-	dc.podLister = podInformer.Lister()
-	dc.podListerSynced = podInformer.Informer().HasSynced
 
 	pdbInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
@@ -144,20 +154,6 @@ func NewDisruptionController(
 		},
 		30*time.Second,
 	)
-	dc.pdbLister = pdbInformer.Lister()
-	dc.pdbListerSynced = pdbInformer.Informer().HasSynced
-
-	dc.rcLister = rcInformer.Lister()
-	dc.rcListerSynced = rcInformer.Informer().HasSynced
-
-	dc.rsLister = rsInformer.Lister()
-	dc.rsListerSynced = rsInformer.Informer().HasSynced
-
-	dc.dLister = dInformer.Lister()
-	dc.dListerSynced = dInformer.Informer().HasSynced
-
-	dc.ssLister = ssInformer.Lister()
-	dc.ssListerSynced = ssInformer.Informer().HasSynced
 
 	return dc
 }

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -83,6 +83,12 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 		client:           client,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "endpoint"),
 		workerLoopPeriod: time.Second,
+		serviceLister:    serviceInformer.Lister(),
+		servicesSynced:   serviceInformer.Informer().HasSynced,
+		podLister:        podInformer.Lister(),
+		podsSynced:       podInformer.Informer().HasSynced,
+		endpointsLister:  endpointsInformer.Lister(),
+		endpointsSynced:  endpointsInformer.Informer().HasSynced,
 	}
 
 	serviceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -92,19 +98,12 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 		},
 		DeleteFunc: e.enqueueService,
 	})
-	e.serviceLister = serviceInformer.Lister()
-	e.servicesSynced = serviceInformer.Informer().HasSynced
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.addPod,
 		UpdateFunc: e.updatePod,
 		DeleteFunc: e.deletePod,
 	})
-	e.podLister = podInformer.Lister()
-	e.podsSynced = podInformer.Informer().HasSynced
-
-	e.endpointsLister = endpointsInformer.Lister()
-	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 
 	return e
 }

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -267,7 +267,8 @@ func (gb *GraphBuilder) syncMonitors(resources map[schema.GroupVersionResource]s
 }
 
 // startMonitors ensures the current set of monitors are running. Any newly
-// started monitors will also cause shared informers to be started.
+// started monitors will also cause associated shared informers to be started if they have not been
+// started yet..
 //
 // If called before Run, startMonitors does nothing (as there is no stop channel
 // to support monitor/informer execution).
@@ -284,7 +285,6 @@ func (gb *GraphBuilder) startMonitors() {
 	for _, monitor := range monitors {
 		if monitor.stopCh == nil {
 			monitor.stopCh = make(chan struct{})
-			gb.sharedInformers.Start(gb.stopCh)
 			go monitor.Run()
 			started++
 		}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -94,10 +94,16 @@ func NewJobController(podInformer coreinformers.PodInformer, jobInformer batchin
 			KubeClient: kubeClient,
 			Recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
 		},
-		expectations: controller.NewControllerExpectations(),
-		queue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "job"),
-		recorder:     eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
+		expectations:   controller.NewControllerExpectations(),
+		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "job"),
+		recorder:       eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "job-controller"}),
+		jobLister:      jobInformer.Lister(),
+		jobStoreSynced: jobInformer.Informer().HasSynced,
+		podStore:       podInformer.Lister(),
+		podStoreSynced: podInformer.Informer().HasSynced,
 	}
+	jm.updateHandler = jm.updateJobStatus
+	jm.syncHandler = jm.syncJob
 
 	jobInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: jm.enqueueController,
@@ -108,19 +114,13 @@ func NewJobController(podInformer coreinformers.PodInformer, jobInformer batchin
 		},
 		DeleteFunc: jm.enqueueController,
 	})
-	jm.jobLister = jobInformer.Lister()
-	jm.jobStoreSynced = jobInformer.Informer().HasSynced
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    jm.addPod,
 		UpdateFunc: jm.updatePod,
 		DeleteFunc: jm.deletePod,
 	})
-	jm.podStore = podInformer.Lister()
-	jm.podStoreSynced = podInformer.Informer().HasSynced
 
-	jm.updateHandler = jm.updateJobStatus
-	jm.syncHandler = jm.syncJob
 	return jm
 }
 

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -73,6 +73,8 @@ func NewNamespaceController(
 	namespaceController := &NamespaceController{
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "namespace"),
 		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(kubeClient.Core().Namespaces(), clientPool, kubeClient.Core(), discoverResourcesFn, finalizerToken, true),
+		lister:       namespaceInformer.Lister(),
+		listerSynced: namespaceInformer.Informer().HasSynced,
 	}
 
 	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
@@ -93,8 +95,6 @@ func NewNamespaceController(
 		},
 		resyncPeriod,
 	)
-	namespaceController.lister = namespaceInformer.Lister()
-	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced
 
 	return namespaceController
 }

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -121,7 +121,9 @@ func NewHorizontalController(
 		hpaNamespacer:            hpaNamespacer,
 		upscaleForbiddenWindow:   upscaleForbiddenWindow,
 		downscaleForbiddenWindow: downscaleForbiddenWindow,
-		queue: workqueue.NewNamedRateLimitingQueue(NewDefaultHPARateLimiter(resyncPeriod), "horizontalpodautoscaler"),
+		queue:           workqueue.NewNamedRateLimitingQueue(NewDefaultHPARateLimiter(resyncPeriod), "horizontalpodautoscaler"),
+		hpaLister:       hpaInformer.Lister(),
+		hpaListerSynced: hpaInformer.Informer().HasSynced,
 	}
 
 	hpaInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -132,8 +134,6 @@ func NewHorizontalController(
 		},
 		resyncPeriod,
 	)
-	hpaController.hpaLister = hpaInformer.Lister()
-	hpaController.hpaListerSynced = hpaInformer.Informer().HasSynced
 
 	return hpaController
 }

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -113,16 +113,18 @@ func New(
 	}
 
 	s := &ServiceController{
-		cloud:            cloud,
-		knownHosts:       []*v1.Node{},
-		kubeClient:       kubeClient,
-		clusterName:      clusterName,
-		cache:            &serviceCache{serviceMap: make(map[string]*cachedService)},
-		eventBroadcaster: broadcaster,
-		eventRecorder:    recorder,
-		nodeLister:       nodeInformer.Lister(),
-		nodeListerSynced: nodeInformer.Informer().HasSynced,
-		workingQueue:     workqueue.NewNamedDelayingQueue("service"),
+		cloud:               cloud,
+		knownHosts:          []*v1.Node{},
+		kubeClient:          kubeClient,
+		clusterName:         clusterName,
+		cache:               &serviceCache{serviceMap: make(map[string]*cachedService)},
+		eventBroadcaster:    broadcaster,
+		eventRecorder:       recorder,
+		nodeLister:          nodeInformer.Lister(),
+		nodeListerSynced:    nodeInformer.Informer().HasSynced,
+		workingQueue:        workqueue.NewNamedDelayingQueue("service"),
+		serviceLister:       serviceInformer.Lister(),
+		serviceListerSynced: serviceInformer.Informer().HasSynced,
 	}
 
 	serviceInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -139,8 +141,6 @@ func New(
 		},
 		serviceSyncPeriod,
 	)
-	s.serviceLister = serviceInformer.Lister()
-	s.serviceListerSynced = serviceInformer.Informer().HasSynced
 
 	if err := s.init(); err != nil {
 		return nil, err

--- a/pkg/controller/statefulset/stateful_set.go
+++ b/pkg/controller/statefulset/stateful_set.go
@@ -104,6 +104,10 @@ func NewStatefulSetController(
 		pvcListerSynced: pvcInformer.Informer().HasSynced,
 		queue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "statefulset"),
 		podControl:      controller.RealPodControl{KubeClient: kubeClient, Recorder: recorder},
+		podLister:       podInformer.Lister(),
+		podListerSynced: podInformer.Informer().HasSynced,
+		setLister:       setInformer.Lister(),
+		setListerSynced: setInformer.Informer().HasSynced,
 	}
 
 	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -114,8 +118,6 @@ func NewStatefulSetController(
 		// lookup statefulset accounting for deletion tombstones
 		DeleteFunc: ssc.deletePod,
 	})
-	ssc.podLister = podInformer.Lister()
-	ssc.podListerSynced = podInformer.Informer().HasSynced
 
 	setInformer.Informer().AddEventHandlerWithResyncPeriod(
 		cache.ResourceEventHandlerFuncs{
@@ -132,8 +134,6 @@ func NewStatefulSetController(
 		},
 		statefulSetResyncPeriod,
 	)
-	ssc.setLister = setInformer.Lister()
-	ssc.setListerSynced = setInformer.Informer().HasSynced
 
 	// TODO: Watch volumes
 	return ssc

--- a/pkg/controller/ttl/ttl_controller.go
+++ b/pkg/controller/ttl/ttl_controller.go
@@ -79,6 +79,8 @@ func NewTTLController(nodeInformer informers.NodeInformer, kubeClient clientset.
 	ttlc := &TTLController{
 		kubeClient: kubeClient,
 		queue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ttlcontroller"),
+		nodeStore:  listers.NewNodeLister(nodeInformer.Informer().GetIndexer()),
+		hasSynced:  nodeInformer.Informer().HasSynced,
 	}
 
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -86,9 +88,6 @@ func NewTTLController(nodeInformer informers.NodeInformer, kubeClient clientset.
 		UpdateFunc: ttlc.updateNode,
 		DeleteFunc: ttlc.deleteNode,
 	})
-
-	ttlc.nodeStore = listers.NewNodeLister(nodeInformer.Informer().GetIndexer())
-	ttlc.hasSynced = nodeInformer.Informer().HasSynced
 
 	return ttlc
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -88,6 +88,12 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 		claimQueue:                    workqueue.NewNamed("claims"),
 		volumeQueue:                   workqueue.NewNamed("volumes"),
 		resyncPeriod:                  p.SyncPeriod,
+		volumeLister:                  p.VolumeInformer.Lister(),
+		volumeListerSynced:            p.VolumeInformer.Informer().HasSynced,
+		claimLister:                   p.ClaimInformer.Lister(),
+		claimListerSynced:             p.ClaimInformer.Informer().HasSynced,
+		classLister:                   p.ClassInformer.Lister(),
+		classListerSynced:             p.ClassInformer.Informer().HasSynced,
 	}
 
 	// Prober is nil because PV is not aware of Flexvolume.
@@ -102,8 +108,6 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
 		},
 	)
-	controller.volumeLister = p.VolumeInformer.Lister()
-	controller.volumeListerSynced = p.VolumeInformer.Informer().HasSynced
 
 	p.ClaimInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
@@ -112,11 +116,7 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
 		},
 	)
-	controller.claimLister = p.ClaimInformer.Lister()
-	controller.claimListerSynced = p.ClaimInformer.Informer().HasSynced
 
-	controller.classLister = p.ClassInformer.Lister()
-	controller.classListerSynced = p.ClassInformer.Informer().HasSynced
 	return controller, nil
 }
 

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -149,9 +149,13 @@ func NewConfigFactory(
 		schedulerName:                  schedulerName,
 		hardPodAffinitySymmetricWeight: hardPodAffinitySymmetricWeight,
 		enableEquivalenceClassCache:    enableEquivalenceClassCache,
+		scheduledPodsHasSynced:         podInformer.Informer().HasSynced,
+		// scheduledPodLister is something we provide to plug-in functions that
+		// they may need to call.
+		scheduledPodLister: assignedPodLister{podInformer.Lister()},
+		nodeLister:         nodeInformer.Lister(),
 	}
 
-	c.scheduledPodsHasSynced = podInformer.Informer().HasSynced
 	// scheduled pod cache
 	podInformer.Informer().AddEventHandler(
 		cache.FilteringResourceEventHandler{
@@ -202,9 +206,6 @@ func NewConfigFactory(
 			},
 		},
 	)
-	// ScheduledPodLister is something we provide to plug-in functions that
-	// they may need to call.
-	c.scheduledPodLister = assignedPodLister{podInformer.Lister()}
 
 	// Only nodes in the "Ready" condition with status == "True" are schedulable
 	nodeInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -215,7 +216,6 @@ func NewConfigFactory(
 		},
 		0,
 	)
-	c.nodeLister = nodeInformer.Lister()
 
 	// On add and delete of PVs, it will affect equivalence cache items
 	// related to persistent volume
@@ -227,7 +227,6 @@ func NewConfigFactory(
 		},
 		0,
 	)
-	c.pVLister = pvInformer.Lister()
 
 	// This is for MaxPDVolumeCountPredicate: add/delete PVC will affect counts of PV when it is bound.
 	pvcInformer.Informer().AddEventHandlerWithResyncPeriod(
@@ -237,7 +236,6 @@ func NewConfigFactory(
 		},
 		0,
 	)
-	c.pVCLister = pvcInformer.Lister()
 
 	// This is for ServiceAffinity: affected by the selector of the service is updated.
 	// Also, if new service is added, equivalence cache will also become invalid since
@@ -250,7 +248,6 @@ func NewConfigFactory(
 		},
 		0,
 	)
-	c.serviceLister = serviceInformer.Lister()
 
 	// Existing equivalence cache should not be affected by add/delete RC/Deployment etc,
 	// it only make sense when pod is scheduled or deleted

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -61,14 +61,13 @@ func NewDiscoveryController(crdInformer informers.CustomResourceDefinitionInform
 
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "DiscoveryController"),
 	}
+	c.syncFn = c.sync
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addCustomResourceDefinition,
 		UpdateFunc: c.updateCustomResourceDefinition,
 		DeleteFunc: c.deleteCustomResourceDefinition,
 	})
-
-	c.syncFn = c.sync
 
 	return c
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	"github.com/golang/glog"
 	clientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/apiextensions"
 	internalinterfaces "k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions/internalinterfaces"
@@ -26,19 +27,21 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        clientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"github.com/golang/glog"
 	internalclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset"
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions"
 	internalinterfaces "k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/internalinterfaces"
@@ -26,19 +27,21 @@ import (
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        internalclientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -81,13 +81,12 @@ func NewCRDFinalizer(
 		crClientGetter: crClientGetter,
 		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CustomResourceDefinition-CRDFinalizer"),
 	}
+	c.syncFn = c.sync
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addCustomResourceDefinition,
 		UpdateFunc: c.updateCustomResourceDefinition,
 	})
-
-	c.syncFn = c.sync
 
 	return c
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -71,14 +71,13 @@ func NewNamingConditionController(
 
 	informerIndexer := crdInformer.Informer().GetIndexer()
 	c.crdMutationCache = cache.NewIntegerResourceVersionMutationCache(informerIndexer, informerIndexer, 60*time.Second, false)
+	c.syncFn = c.sync
 
 	crdInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addCustomResourceDefinition,
 		UpdateFunc: c.updateCustomResourceDefinition,
 		DeleteFunc: c.deleteCustomResourceDefinition,
 	})
-
-	c.syncFn = c.sync
 
 	return c
 }

--- a/staging/src/k8s.io/client-go/informers/BUILD
+++ b/staging/src/k8s.io/client-go/informers/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",

--- a/staging/src/k8s.io/code-generator/test/informers/externalversions/BUILD
+++ b/staging/src/k8s.io/code-generator/test/informers/externalversions/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/code-generator/test/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/code-generator/test/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	internalinterfaces "k8s.io/code-generator/test/informers/externalversions/internalinterfaces"
 	testgroup "k8s.io/code-generator/test/informers/externalversions/testgroup"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        versioned.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/code-generator/test/informers/internalversion/BUILD
+++ b/staging/src/k8s.io/code-generator/test/informers/internalversion/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/code-generator/test/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/code-generator/test/informers/internalversion/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	internalinterfaces "k8s.io/code-generator/test/informers/internalversion/internalinterfaces"
 	testgroup "k8s.io/code-generator/test/informers/internalversion/testgroup"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        internal.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiservice_controller.go
@@ -68,6 +68,7 @@ func NewAPIServiceRegistrationController(apiServiceInformer informers.APIService
 		servicesSynced:    serviceInformer.Informer().HasSynced,
 		queue:             workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "APIServiceRegistrationController"),
 	}
+	c.syncFn = c.sync
 
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addAPIService,
@@ -80,8 +81,6 @@ func NewAPIServiceRegistrationController(apiServiceInformer informers.APIService
 		UpdateFunc: c.updateService,
 		DeleteFunc: c.deleteService,
 	})
-
-	c.syncFn = c.sync
 
 	return c
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	apiregistration "k8s.io/kube-aggregator/pkg/client/informers/externalversions/apiregistration"
 	internalinterfaces "k8s.io/kube-aggregator/pkg/client/informers/externalversions/internalinterfaces"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        clientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/factory.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	apiregistration "k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration"
 	internalinterfaces "k8s.io/kube-aggregator/pkg/client/informers/internalversion/internalinterfaces"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        internalclientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -77,6 +77,7 @@ func NewAvailableConditionController(
 		endpointsSynced:  endpointsInformer.Informer().HasSynced,
 		queue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "AvailableConditionController"),
 	}
+	c.syncFn = c.sync
 
 	apiServiceInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    c.addAPIService,
@@ -95,8 +96,6 @@ func NewAvailableConditionController(
 		UpdateFunc: c.updateEndpoints,
 		DeleteFunc: c.deleteEndpoints,
 	})
-
-	c.syncFn = c.sync
 
 	return c
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package externalversions
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	internalinterfaces "k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/internalinterfaces"
 	wardle "k8s.io/sample-apiserver/pkg/client/informers_generated/externalversions/wardle"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        clientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/BUILD
@@ -12,6 +12,7 @@ go_library(
         "generic.go",
     ],
     deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/factory.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/factory.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"github.com/golang/glog"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
@@ -26,19 +27,21 @@ import (
 	internalinterfaces "k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/internalinterfaces"
 	wardle "k8s.io/sample-apiserver/pkg/client/informers_generated/internalversion/wardle"
 	reflect "reflect"
+	"runtime/debug"
 	sync "sync"
 	time "time"
 )
 
 type sharedInformerFactory struct {
 	client        internalclientset.Interface
-	lock          sync.Mutex
 	defaultResync time.Duration
 
-	informers map[reflect.Type]cache.SharedIndexInformer
-	// startedInformers is used for tracking which informers have been started.
-	// This allows Start() to be called multiple times safely.
+	// lock guards informers, started, startedInformers, stopCh
+	lock             sync.Mutex
+	informers        map[reflect.Type]cache.SharedIndexInformer
+	started          bool
 	startedInformers map[reflect.Type]bool
+	stopCh           <-chan struct{}
 }
 
 // NewSharedInformerFactory constructs a new instance of sharedInformerFactory
@@ -56,12 +59,22 @@ func (f *sharedInformerFactory) Start(stopCh <-chan struct{}) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.started {
+		glog.Warning("Invalid attempt to try to start the shared informer factory multiple times. This is a no-op but you should remove this invocation")
+		debug.PrintStack()
+		return
+	}
+
+	f.stopCh = stopCh
+
 	for informerType, informer := range f.informers {
 		if !f.startedInformers[informerType] {
-			go informer.Run(stopCh)
+			go informer.Run(f.stopCh)
 			f.startedInformers[informerType] = true
 		}
 	}
+
+	f.started = true
 }
 
 // WaitForCacheSync waits for all started informers' cache were synced.
@@ -86,8 +99,9 @@ func (f *sharedInformerFactory) WaitForCacheSync(stopCh <-chan struct{}) map[ref
 	return res
 }
 
-// InternalInformerFor returns the SharedIndexInformer for obj using an internal
-// client.
+// InformerFor returns the SharedIndexInformer for obj. If the factory has already been started and
+// this is the first time this particular informer has been referenced, the informer will be
+// automatically started. Otherwise, the informer will be started when Start() is invoked.
 func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internalinterfaces.NewInformerFunc) cache.SharedIndexInformer {
 	f.lock.Lock()
 	defer f.lock.Unlock()
@@ -97,8 +111,14 @@ func (f *sharedInformerFactory) InformerFor(obj runtime.Object, newFunc internal
 	if exists {
 		return informer
 	}
+
 	informer = newFunc(f.client, f.defaultResync)
 	f.informers[informerType] = informer
+
+	if f.started {
+		go informer.Run(f.stopCh)
+		f.startedInformers[informerType] = true
+	}
 
 	return informer
 }

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -264,6 +264,7 @@ func setup(t *testing.T, workerCount int) *testContext {
 	}
 	syncPeriod := 5 * time.Second
 	startGC := func(workers int) {
+		go sharedInformers.Start(stopCh)
 		go gc.Run(workers, stopCh)
 		go gc.Sync(clientSet.Discovery(), syncPeriod, stopCh)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
1. Make trying to start the shared informer factory multiple times a no-op
1. If the shared informer factory is already started and a shared informer is referenced for the first time, automatically start it
1. Ensure all controller fields (such as listers, sync handler functions, etc.) are assigned prior to adding any shared informer event handlers
1. In the garbage collector controller, no longer attempt to start the shared informer factory

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51013

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

@kubernetes/sig-api-machinery-misc @ironcladlou @caesarxuchao @timothysc @sttts @liggitt @deads2k @derekwaynecarr