### PR TITLE
Fix golint warnings for kubectl/cmd

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -189,10 +189,6 @@ pkg/kubeapiserver/options
 pkg/kubeapiserver/server
 pkg/kubectl
 pkg/kubectl/cmd
-pkg/kubectl/cmd/auth
-pkg/kubectl/cmd/config
-pkg/kubectl/cmd/rollout
-pkg/kubectl/cmd/set
 pkg/kubectl/cmd/templates
 pkg/kubectl/cmd/testing
 pkg/kubectl/cmd/util

--- a/pkg/kubectl/cmd/auth/auth.go
+++ b/pkg/kubectl/cmd/auth/auth.go
@@ -24,6 +24,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
+// NewCmdAuth creates the `auth` sub command.
 func NewCmdAuth(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
@@ -33,6 +34,7 @@ func NewCmdAuth(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
 
+	// Add subcommand to `auth`.
 	cmds.AddCommand(NewCmdCanI(f, out, errOut))
 	cmds.AddCommand(NewCmdReconcile(f, out, errOut))
 

--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -81,6 +81,7 @@ var (
 		kubectl auth can-i get /logs/`)
 )
 
+// NewCmdCanI creates the `can-i` subcommand.
 func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	o := &CanIOptions{
 		Out: out,
@@ -96,7 +97,7 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 			cmdutil.CheckErr(o.Complete(f, args))
 			cmdutil.CheckErr(o.Validate())
 
-			allowed, err := o.RunAccessCheck()
+			allowed, err := o.Run()
 			if err == nil {
 				if o.Quiet && !allowed {
 					os.Exit(1)
@@ -113,6 +114,7 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	return cmd
 }
 
+// Complete completes all the required options.
 func (o *CanIOptions) Complete(f cmdutil.Factory, args []string) error {
 	if o.Quiet {
 		o.Out = ioutil.Discard
@@ -153,6 +155,7 @@ func (o *CanIOptions) Complete(f cmdutil.Factory, args []string) error {
 	return nil
 }
 
+// Validate command options for sufficient information to run the command.
 func (o *CanIOptions) Validate() error {
 	if o.NonResourceURL != "" {
 		if o.Subresource != "" {
@@ -165,7 +168,8 @@ func (o *CanIOptions) Validate() error {
 	return nil
 }
 
-func (o *CanIOptions) RunAccessCheck() (bool, error) {
+// Run implements the actual command.
+func (o *CanIOptions) Run() (bool, error) {
 	var sar *authorizationapi.SelfSubjectAccessReview
 	if o.NonResourceURL == "" {
 		sar = &authorizationapi.SelfSubjectAccessReview{

--- a/pkg/kubectl/cmd/auth/cani_test.go
+++ b/pkg/kubectl/cmd/auth/cani_test.go
@@ -30,7 +30,7 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 )
 
-func TestRunAccessCheck(t *testing.T) {
+func TestRun(t *testing.T) {
 	tests := []struct {
 		name      string
 		o         *CanIOptions
@@ -159,7 +159,7 @@ func TestRunAccessCheck(t *testing.T) {
 			continue
 		}
 
-		actualAllowed, err := test.o.RunAccessCheck()
+		actualAllowed, err := test.o.Run()
 		switch {
 		case test.serverErr == nil && err == nil:
 			// pass

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -56,6 +56,7 @@ var (
 		kubectl auth reconcile -f my-rbac-rules.yaml`)
 )
 
+// NewCmdReconcile creates the `reconcile` sub command.
 func NewCmdReconcile(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	fileOptions := &resource.FilenameOptions{}
 	o := &ReconcileOptions{
@@ -71,7 +72,7 @@ func NewCmdReconcile(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(cmd, f, args, fileOptions))
 			cmdutil.CheckErr(o.Validate())
-			cmdutil.CheckErr(o.RunReconcile())
+			cmdutil.CheckErr(o.Run())
 		},
 	}
 
@@ -83,6 +84,7 @@ func NewCmdReconcile(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	return cmd
 }
 
+// Complete completes all the required options.
 func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args []string, options *resource.FilenameOptions) error {
 	if len(args) > 0 {
 		return errors.New("no arguments are allowed")
@@ -120,11 +122,13 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 	return nil
 }
 
+// Validate command options for sufficient information to run the command.
 func (o *ReconcileOptions) Validate() error {
 	return nil
 }
 
-func (o *ReconcileOptions) RunReconcile() error {
+// Run implements the actual command.
+func (o *ReconcileOptions) Run() error {
 	r := o.ResourceBuilder.Do()
 	err := r.Err()
 	if err != nil {

--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -86,5 +86,5 @@ func toBool(propertyValue string) (bool, error) {
 func helpErrorf(cmd *cobra.Command, format string, args ...interface{}) error {
 	cmd.Help()
 	msg := fmt.Sprintf(format, args...)
-	return fmt.Errorf("%s\n", msg)
+	return fmt.Errorf("%s", msg)
 }

--- a/pkg/kubectl/cmd/config/create_authinfo.go
+++ b/pkg/kubectl/cmd/config/create_authinfo.go
@@ -56,7 +56,7 @@ const (
 )
 
 var (
-	create_authinfo_long = fmt.Sprintf(templates.LongDesc(`
+	createAuthInfoLong = fmt.Sprintf(templates.LongDesc(`
 		Sets a user entry in kubeconfig
 
 		Specifying a name that already exists will merge new fields on top of existing values.
@@ -72,7 +72,7 @@ var (
 
 		Bearer token and basic auth are mutually exclusive.`), clientcmd.FlagCertFile, clientcmd.FlagKeyFile, clientcmd.FlagBearerToken, clientcmd.FlagUsername, clientcmd.FlagPassword)
 
-	create_authinfo_example = templates.Examples(`
+	createAuthInfoExample = templates.Examples(`
 		# Set only the "client-key" field on the "cluster-admin"
 		# entry, without touching other values:
 		kubectl config set-credentials cluster-admin --client-key=~/.kube/admin.key
@@ -93,17 +93,19 @@ var (
 		kubectl config set-credentials cluster-admin --auth-provider=oidc --auth-provider-arg=client-secret-`)
 )
 
+// NewCmdConfigSetAuthInfo creates the `set-credentials` subcommand.
 func NewCmdConfigSetAuthInfo(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &createAuthInfoOptions{configAccess: configAccess}
 	return newCmdConfigSetAuthInfo(out, options)
 }
 
+// newCmdConfigSetAuthInfo implemented as helper to facilitate testing.
 func newCmdConfigSetAuthInfo(out io.Writer, options *createAuthInfoOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("set-credentials NAME [--%v=path/to/certfile] [--%v=path/to/keyfile] [--%v=bearer_token] [--%v=basic_user] [--%v=basic_password] [--%v=provider_name] [--%v=key=value]", clientcmd.FlagCertFile, clientcmd.FlagKeyFile, clientcmd.FlagBearerToken, clientcmd.FlagUsername, clientcmd.FlagPassword, flagAuthProvider, flagAuthProviderArg),
 		Short:   i18n.T("Sets a user entry in kubeconfig"),
-		Long:    create_authinfo_long,
-		Example: create_authinfo_example,
+		Long:    createAuthInfoLong,
+		Example: createAuthInfoExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := options.complete(cmd, out)
 			if err != nil {
@@ -148,11 +150,7 @@ func (o createAuthInfoOptions) run() error {
 	authInfo := o.modifyAuthInfo(*startingStanza)
 	config.AuthInfos[o.name] = &authInfo
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
-		return err
-	}
-
-	return nil
+	return clientcmd.ModifyConfig(o.configAccess, *config, true)
 }
 
 // authInfo builds an AuthInfo object from the options
@@ -241,18 +239,18 @@ func (o *createAuthInfoOptions) modifyAuthInfo(existingAuthInfo clientcmdapi.Aut
 func (o *createAuthInfoOptions) complete(cmd *cobra.Command, out io.Writer) error {
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
-		return fmt.Errorf("Unexpected args: %v", args)
+		return fmt.Errorf("unexpected args: %v", args)
 	}
 
 	authProviderArgs, err := cmd.Flags().GetStringSlice(flagAuthProviderArg)
 	if err != nil {
-		return fmt.Errorf("Error: %s\n", err)
+		return fmt.Errorf("error: %s", err)
 	}
 
 	if len(authProviderArgs) > 0 {
 		newPairs, removePairs, err := cmdutil.ParsePairs(authProviderArgs, flagAuthProviderArg, true)
 		if err != nil {
-			return fmt.Errorf("Error: %s\n", err)
+			return fmt.Errorf("Error: %s", err)
 		}
 		o.authProviderArgs = newPairs
 		o.authProviderArgsToRemove = removePairs

--- a/pkg/kubectl/cmd/config/create_context.go
+++ b/pkg/kubectl/cmd/config/create_context.go
@@ -40,24 +40,25 @@ type createContextOptions struct {
 }
 
 var (
-	create_context_long = templates.LongDesc(`
+	createContextLong = templates.LongDesc(`
 		Sets a context entry in kubeconfig
 
 		Specifying a name that already exists will merge new fields on top of existing values for those fields.`)
 
-	create_context_example = templates.Examples(`
+	createContextExample = templates.Examples(`
 		# Set the user field on the gce context entry without touching other values
 		kubectl config set-context gce --user=cluster-admin`)
 )
 
+// NewCmdConfigSetContext creates the `set-context` subcommand.
 func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &createContextOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:     fmt.Sprintf("set-context NAME [--%v=cluster_nickname] [--%v=user_nickname] [--%v=namespace]", clientcmd.FlagClusterName, clientcmd.FlagAuthInfoName, clientcmd.FlagNamespace),
 		Short:   i18n.T("Sets a context entry in kubeconfig"),
-		Long:    create_context_long,
-		Example: create_context_example,
+		Long:    createContextLong,
+		Example: createContextExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			exists, err := options.run()
@@ -77,6 +78,7 @@ func NewCmdConfigSetContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	return cmd
 }
 
+// run implements the actual command.
 func (o createContextOptions) run() (bool, error) {
 	err := o.validate()
 	if err != nil {
@@ -118,6 +120,7 @@ func (o *createContextOptions) modifyContext(existingContext clientcmdapi.Contex
 	return modifiedContext
 }
 
+// complete completes all the required options.
 func (o *createContextOptions) complete(cmd *cobra.Command) error {
 	args := cmd.Flags().Args()
 	if len(args) != 1 {
@@ -128,6 +131,7 @@ func (o *createContextOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
+// validate command options for sufficient information to run the command.
 func (o createContextOptions) validate() error {
 	if len(o.name) == 0 {
 		return errors.New("you must specify a non-empty context name")

--- a/pkg/kubectl/cmd/config/current_context.go
+++ b/pkg/kubectl/cmd/config/current_context.go
@@ -28,27 +28,29 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
+// CurrentContextOptions holds command line options required to run the command.
 type CurrentContextOptions struct {
 	ConfigAccess clientcmd.ConfigAccess
 }
 
 var (
-	current_context_long = templates.LongDesc(`
+	currentContextLong = templates.LongDesc(`
 		Displays the current-context`)
 
-	current_context_example = templates.Examples(`
+	currentContextExample = templates.Examples(`
 		# Display the current-context
 		kubectl config current-context`)
 )
 
+// NewCmdConfigCurrentContext creates the `current-context` subcommand.
 func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &CurrentContextOptions{ConfigAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:     "current-context",
 		Short:   i18n.T("Displays the current-context"),
-		Long:    current_context_long,
-		Example: current_context_example,
+		Long:    currentContextLong,
+		Example: currentContextExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunCurrentContext(out, options)
 			cmdutil.CheckErr(err)
@@ -58,6 +60,7 @@ func NewCmdConfigCurrentContext(out io.Writer, configAccess clientcmd.ConfigAcce
 	return cmd
 }
 
+// RunCurrentContext implements the actual command.
 func RunCurrentContext(out io.Writer, options *CurrentContextOptions) error {
 	config, err := options.ConfigAccess.GetStartingConfig()
 	if err != nil {
@@ -65,10 +68,10 @@ func RunCurrentContext(out io.Writer, options *CurrentContextOptions) error {
 	}
 
 	if config.CurrentContext == "" {
-		err = fmt.Errorf("current-context is not set\n")
+		err = fmt.Errorf("current-context is not set")
 		return err
 	}
 
-	fmt.Fprintf(out, "%s\n", config.CurrentContext)
+	fmt.Fprintf(out, "%s", config.CurrentContext)
 	return nil
 }

--- a/pkg/kubectl/cmd/config/delete_cluster.go
+++ b/pkg/kubectl/cmd/config/delete_cluster.go
@@ -28,17 +28,18 @@ import (
 )
 
 var (
-	delete_cluster_example = templates.Examples(`
+	deleteClusterExample = templates.Examples(`
 		# Delete the minikube cluster
 		kubectl config delete-cluster minikube`)
 )
 
+// NewCmdConfigDeleteCluster creates the `delete-cluster` subcommand.
 func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete-cluster NAME",
 		Short:   i18n.T("Delete the specified cluster from the kubeconfig"),
 		Long:    "Delete the specified cluster from the kubeconfig",
-		Example: delete_cluster_example,
+		Example: deleteClusterExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runDeleteCluster(out, configAccess, cmd)
 			cmdutil.CheckErr(err)
@@ -48,6 +49,7 @@ func NewCmdConfigDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAcces
 	return cmd
 }
 
+// runDeleteCluster implements the actual command.
 func runDeleteCluster(out io.Writer, configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {

--- a/pkg/kubectl/cmd/config/delete_context.go
+++ b/pkg/kubectl/cmd/config/delete_context.go
@@ -28,17 +28,18 @@ import (
 )
 
 var (
-	delete_context_example = templates.Examples(`
+	deleteContextExample = templates.Examples(`
 		# Delete the context for the minikube cluster
 		kubectl config delete-context minikube`)
 )
 
+// NewCmdConfigDeleteContext creates the `delete-context` subcommand.
 func NewCmdConfigDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "delete-context NAME",
 		Short:   i18n.T("Delete the specified context from the kubeconfig"),
 		Long:    "Delete the specified context from the kubeconfig",
-		Example: delete_context_example,
+		Example: deleteContextExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runDeleteContext(out, errOut, configAccess, cmd)
 			cmdutil.CheckErr(err)
@@ -48,6 +49,7 @@ func NewCmdConfigDeleteContext(out, errOut io.Writer, configAccess clientcmd.Con
 	return cmd
 }
 
+// runDeleteContext implements the actual command.
 func runDeleteContext(out, errOut io.Writer, configAccess clientcmd.ConfigAccess, cmd *cobra.Command) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {

--- a/pkg/kubectl/cmd/config/get_clusters.go
+++ b/pkg/kubectl/cmd/config/get_clusters.go
@@ -28,19 +28,18 @@ import (
 )
 
 var (
-	get_clusters_example = templates.Examples(`
+	getClustersExample = templates.Examples(`
 		# List the clusters kubectl knows about
 		kubectl config get-clusters`)
 )
 
-// NewCmdConfigGetClusters creates a command object for the "get-clusters" action, which
-// lists all clusters defined in the kubeconfig.
+// NewCmdConfigGetClusters creates the `get-clusters` subcommand.
 func NewCmdConfigGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "get-clusters",
 		Short:   i18n.T("Display clusters defined in the kubeconfig"),
 		Long:    "Display clusters defined in the kubeconfig.",
-		Example: get_clusters_example,
+		Example: getClustersExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := runGetClusters(out, configAccess)
 			cmdutil.CheckErr(err)
@@ -50,6 +49,7 @@ func NewCmdConfigGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess)
 	return cmd
 }
 
+// runGetClusters implements the actual command.
 func runGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {

--- a/pkg/kubectl/cmd/config/rename_context.go
+++ b/pkg/kubectl/cmd/config/rename_context.go
@@ -28,7 +28,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-// RenameContextOptions contains the options for running the rename-context cli command.
+// RenameContextOptions holds command line options required to run the command.
 type RenameContextOptions struct {
 	configAccess clientcmd.ConfigAccess
 	contextName  string
@@ -91,6 +91,7 @@ func (o *RenameContextOptions) Complete(cmd *cobra.Command, args []string, out i
 	return nil
 }
 
+// Validate command options for sufficient information to run the command.
 func (o RenameContextOptions) Validate() error {
 	if len(o.newName) == 0 {
 		return errors.New("You must specify a new non-empty context name")
@@ -98,6 +99,7 @@ func (o RenameContextOptions) Validate() error {
 	return nil
 }
 
+// RunRenameContext implements the actual command.
 func (o RenameContextOptions) RunRenameContext(out io.Writer) error {
 	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {

--- a/pkg/kubectl/cmd/config/rename_context_test.go
+++ b/pkg/kubectl/cmd/config/rename_context_test.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	contextData *clientcmdapi.Context = clientcmdapi.NewContext()
+	contextData = clientcmdapi.NewContext()
 )
 
 type renameContextTest struct {

--- a/pkg/kubectl/cmd/config/set.go
+++ b/pkg/kubectl/cmd/config/set.go
@@ -38,6 +38,7 @@ const (
 	additionStepRequiredUnlessUnsettingError = "Must have additional steps after %v unless you are unsetting it"
 )
 
+// setOptions holds command line options required to run the command.
 type setOptions struct {
 	configAccess  clientcmd.ConfigAccess
 	propertyName  string
@@ -45,20 +46,21 @@ type setOptions struct {
 	setRawBytes   flag.Tristate
 }
 
-var set_long = templates.LongDesc(`
+var setLong = templates.LongDesc(`
 	Sets an individual value in a kubeconfig file
 
 	PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.
 
 	PROPERTY_VALUE is the new value you wish to set. Binary fields such as 'certificate-authority-data' expect a base64 encoded string unless the --set-raw-bytes flag is used.`)
 
+// NewCmdConfigSet creates the `set` subcommand.
 func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &setOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:   "set PROPERTY_NAME PROPERTY_VALUE",
 		Short: i18n.T("Sets an individual value in a kubeconfig file"),
-		Long:  set_long,
+		Long:  setLong,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
@@ -71,6 +73,7 @@ func NewCmdConfigSet(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.
 	return cmd
 }
 
+// run implements the actual command.
 func (o setOptions) run() error {
 	err := o.validate()
 	if err != nil {
@@ -96,13 +99,10 @@ func (o setOptions) run() error {
 		return err
 	}
 
-	if err := clientcmd.ModifyConfig(o.configAccess, *config, false); err != nil {
-		return err
-	}
-
-	return nil
+	return clientcmd.ModifyConfig(o.configAccess, *config, false)
 }
 
+// complete completes all the required options.
 func (o *setOptions) complete(cmd *cobra.Command) error {
 	endingArgs := cmd.Flags().Args()
 	if len(endingArgs) != 2 {
@@ -114,6 +114,7 @@ func (o *setOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
+// validate command options for sufficient information to run the command.
 func (o setOptions) validate() error {
 	if len(o.propertyValue) == 0 {
 		return errors.New("you cannot use set to unset a property")

--- a/pkg/kubectl/cmd/config/unset.go
+++ b/pkg/kubectl/cmd/config/unset.go
@@ -30,23 +30,25 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
+// unsetOptions holds command line options required to run the command.
 type unsetOptions struct {
 	configAccess clientcmd.ConfigAccess
 	propertyName string
 }
 
-var unset_long = templates.LongDesc(`
+var unsetLong = templates.LongDesc(`
 	Unsets an individual value in a kubeconfig file
 
 	PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.`)
 
+// NewCmdConfigUnset creates the `unset` subcommand.
 func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &unsetOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
 		Use:   "unset PROPERTY_NAME",
 		Short: i18n.T("Unsets an individual value in a kubeconfig file"),
-		Long:  unset_long,
+		Long:  unsetLong,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd, args))
 			cmdutil.CheckErr(options.run(out))
@@ -57,6 +59,7 @@ func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobr
 	return cmd
 }
 
+// run implements the actual command.
 func (o unsetOptions) run(out io.Writer) error {
 	err := o.validate()
 	if err != nil {
@@ -86,6 +89,7 @@ func (o unsetOptions) run(out io.Writer) error {
 	return nil
 }
 
+// complete completes all the required options.
 func (o *unsetOptions) complete(cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return helpErrorf(cmd, "Unexpected args: %v", args)
@@ -95,6 +99,7 @@ func (o *unsetOptions) complete(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// validate command options for sufficient information to run the command.
 func (o unsetOptions) validate() error {
 	if len(o.propertyName) == 0 {
 		return errors.New("you must specify a property")

--- a/pkg/kubectl/cmd/config/use_context.go
+++ b/pkg/kubectl/cmd/config/use_context.go
@@ -31,16 +31,18 @@ import (
 )
 
 var (
-	use_context_example = templates.Examples(`
+	useContextExample = templates.Examples(`
 		# Use the context for the minikube cluster
 		kubectl config use-context minikube`)
 )
 
+// useContextOptions holds command line options required to run the command.
 type useContextOptions struct {
 	configAccess clientcmd.ConfigAccess
 	contextName  string
 }
 
+// NewCmdConfigUseContext creates the `use-context` subcommand.
 func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &useContextOptions{configAccess: configAccess}
 
@@ -49,7 +51,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 		Short:   i18n.T("Sets the current-context in a kubeconfig file"),
 		Aliases: []string{"use"},
 		Long:    `Sets the current-context in a kubeconfig file`,
-		Example: use_context_example,
+		Example: useContextExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd))
 			cmdutil.CheckErr(options.run())
@@ -60,6 +62,7 @@ func NewCmdConfigUseContext(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	return cmd
 }
 
+// run implements the actual command.
 func (o useContextOptions) run() error {
 	config, err := o.configAccess.GetStartingConfig()
 	if err != nil {
@@ -76,6 +79,7 @@ func (o useContextOptions) run() error {
 	return clientcmd.ModifyConfig(o.configAccess, *config, true)
 }
 
+// complete completes all the required options.
 func (o *useContextOptions) complete(cmd *cobra.Command) error {
 	endingArgs := cmd.Flags().Args()
 	if len(endingArgs) != 1 {
@@ -86,6 +90,7 @@ func (o *useContextOptions) complete(cmd *cobra.Command) error {
 	return nil
 }
 
+// validate command options for sufficient information to run the command.
 func (o useContextOptions) validate(config *clientcmdapi.Config) error {
 	if len(o.contextName) == 0 {
 		return errors.New("you must specify a current-context")
@@ -97,5 +102,5 @@ func (o useContextOptions) validate(config *clientcmdapi.Config) error {
 		}
 	}
 
-	return fmt.Errorf("no context exists with the name: %q.", o.contextName)
+	return fmt.Errorf("no context exists with the name: %q", o.contextName)
 }

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 )
 
+// ViewOptions holds command line options required to run the command.
 type ViewOptions struct {
 	ConfigAccess clientcmd.ConfigAccess
 	Merge        flag.Tristate
@@ -44,12 +45,12 @@ type ViewOptions struct {
 }
 
 var (
-	view_long = templates.LongDesc(`
+	viewLong = templates.LongDesc(`
 		Display merged kubeconfig settings or a specified kubeconfig file.
 
 		You can use --output jsonpath={...} to extract specific values using a jsonpath expression.`)
 
-	view_example = templates.Examples(`
+	viewExample = templates.Examples(`
 		# Show Merged kubeconfig settings.
 		kubectl config view
 
@@ -57,6 +58,7 @@ var (
 		kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'`)
 )
 
+// NewCmdConfigView creates the `view` subcommand.
 func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &ViewOptions{ConfigAccess: ConfigAccess}
 	// Default to yaml
@@ -65,8 +67,8 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 	cmd := &cobra.Command{
 		Use:     "view",
 		Short:   i18n.T("Display merged kubeconfig settings or a specified kubeconfig file"),
-		Long:    view_long,
-		Example: view_example,
+		Long:    viewLong,
+		Example: viewExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			options.Complete()
 			outputFormat := cmdutil.GetFlagString(cmd, "output")
@@ -101,6 +103,7 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 	return cmd
 }
 
+// Run implements the actual command.
 func (o ViewOptions) Run(out io.Writer, printer printers.ResourcePrinter) error {
 	config, err := o.loadConfig()
 	if err != nil {
@@ -129,6 +132,7 @@ func (o ViewOptions) Run(out io.Writer, printer printers.ResourcePrinter) error 
 	return nil
 }
 
+// Complete completes all the required options.
 func (o *ViewOptions) Complete() bool {
 	if o.ConfigAccess.IsExplicitFile() {
 		if !o.Merge.Provided() {
@@ -149,6 +153,7 @@ func (o ViewOptions) loadConfig() (*clientcmdapi.Config, error) {
 	return config, err
 }
 
+// Validate command options for sufficient information to run the command.
 func (o ViewOptions) Validate() error {
 	if !o.Merge.Value() && !o.ConfigAccess.IsExplicitFile() {
 		return errors.New("if merge==false a precise file must to specified")

--- a/pkg/kubectl/cmd/rollout/rollout.go
+++ b/pkg/kubectl/cmd/rollout/rollout.go
@@ -27,17 +27,17 @@ import (
 )
 
 var (
-	rollout_long = templates.LongDesc(`
-		Manage the rollout of a resource.` + rollout_valid_resources)
+	rolloutLong = templates.LongDesc(`
+		Manage the rollout of a resource.` + rolloutValidResources)
 
-	rollout_example = templates.Examples(`
+	rolloutExample = templates.Examples(`
 		# Rollback to the previous deployment
 		kubectl rollout undo deployment/abc
 		
 		# Check the rollout status of a daemonset
 		kubectl rollout status daemonset/foo`)
 
-	rollout_valid_resources = dedent.Dedent(`
+	rolloutValidResources = dedent.Dedent(`
 		Valid resource types include:
 
 		   * deployments
@@ -46,16 +46,18 @@ var (
 		`)
 )
 
+// NewCmdRollout creates the `rollout` subcommand.
 func NewCmdRollout(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "rollout SUBCOMMAND",
 		Short:   i18n.T("Manage the rollout of a resource"),
-		Long:    rollout_long,
-		Example: rollout_example,
+		Long:    rolloutLong,
+		Example: rolloutExample,
 		Run:     cmdutil.DefaultSubCommandRun(errOut),
 	}
-	// subcommands
+
+	// Add subcommands to `rollout`
 	cmd.AddCommand(NewCmdRolloutHistory(f, out))
 	cmd.AddCommand(NewCmdRolloutPause(f, out))
 	cmd.AddCommand(NewCmdRolloutResume(f, out))

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -30,10 +30,10 @@ import (
 )
 
 var (
-	history_long = templates.LongDesc(`
+	historyLong = templates.LongDesc(`
 		View previous rollout revisions and configurations.`)
 
-	history_example = templates.Examples(`
+	historyExample = templates.Examples(`
 		# View the rollout history of a deployment
 		kubectl rollout history deployment/abc
 
@@ -41,6 +41,7 @@ var (
 		kubectl rollout history daemonset/abc --revision=3`)
 )
 
+// NewCmdRolloutHistory creates the `history` subcommand.
 func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
@@ -50,8 +51,8 @@ func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "history (TYPE NAME | TYPE/NAME) [flags]",
 		Short:   i18n.T("View rollout history"),
-		Long:    history_long,
-		Example: history_example,
+		Long:    historyLong,
+		Example: historyExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(RunHistory(f, cmd, out, args, options))
 		},
@@ -65,6 +66,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
+// RunHistory implements the actual command.
 func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string, options *resource.FilenameOptions) error {
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	status_long = templates.LongDesc(`
+	statusLong = templates.LongDesc(`
 		Show the status of the rollout.
 
 		By default 'rollout status' will watch the status of the latest rollout
@@ -42,11 +42,12 @@ var (
 		pin to a specific revision and abort if it is rolled over by another revision,
 		use --revision=N where N is the revision you need to watch for.`)
 
-	status_example = templates.Examples(`
+	statusExample = templates.Examples(`
 		# Watch the rollout status of a deployment
 		kubectl rollout status deployment/nginx`)
 )
 
+// NewCmdRolloutStatus creates the `status` subcommand.
 func NewCmdRolloutStatus(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
@@ -56,8 +57,8 @@ func NewCmdRolloutStatus(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status (TYPE NAME | TYPE/NAME) [flags]",
 		Short:   i18n.T("Show the status of the rollout"),
-		Long:    status_long,
-		Example: status_example,
+		Long:    statusLong,
+		Example: statusExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(RunStatus(f, cmd, out, args, options))
 		},
@@ -72,6 +73,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
+// RunStatus implements the actual command.
 func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string, options *resource.FilenameOptions) error {
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -31,8 +31,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// UndoOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
-// referencing the cmd.Flags()
+// UndoOptions holds command line options required to run the command.
 type UndoOptions struct {
 	resource.FilenameOptions
 
@@ -47,10 +46,10 @@ type UndoOptions struct {
 }
 
 var (
-	undo_long = templates.LongDesc(`
+	undoLong = templates.LongDesc(`
 		Rollback to a previous rollout.`)
 
-	undo_example = templates.Examples(`
+	undoExample = templates.Examples(`
 		# Rollback to the previous deployment
 		kubectl rollout undo deployment/abc
 
@@ -61,6 +60,7 @@ var (
 		kubectl rollout undo --dry-run=true deployment/abc`)
 )
 
+// NewCmdRolloutUndo creates the `undo` subcommand.
 func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &UndoOptions{}
 
@@ -70,15 +70,15 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "undo (TYPE NAME | TYPE/NAME) [flags]",
 		Short:   i18n.T("Undo a previous rollout"),
-		Long:    undo_long,
-		Example: undo_example,
+		Long:    undoLong,
+		Example: undoExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			allErrs := []error{}
-			err := options.CompleteUndo(f, cmd, out, args)
+			err := options.Complete(f, cmd, out, args)
 			if err != nil {
 				allErrs = append(allErrs, err)
 			}
-			err = options.RunUndo()
+			err = options.Run()
 			if err != nil {
 				allErrs = append(allErrs, err)
 			}
@@ -95,7 +95,8 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
+// Complete completes all the required options.
+func (o *UndoOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []string) error {
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(o.Filenames) {
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
@@ -138,7 +139,8 @@ func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io
 	return err
 }
 
-func (o *UndoOptions) RunUndo() error {
+// Run implements the actual command.
+func (o *UndoOptions) Run() error {
 	allErrs := []error{}
 	for ix, info := range o.Infos {
 		result, err := o.Rollbackers[ix].Rollback(info.Object, nil, o.ToRevision, o.DryRun)

--- a/pkg/kubectl/cmd/set/set.go
+++ b/pkg/kubectl/cmd/set/set.go
@@ -26,21 +26,22 @@ import (
 )
 
 var (
-	set_long = templates.LongDesc(`
+	setLong = templates.LongDesc(`
 		Configure application resources
 
 		These commands help you make changes to existing application resources.`)
 )
 
+// NewCmdSet creates the `set` subcommand.
 func NewCmdSet(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cobra.Command {
+
 	cmd := &cobra.Command{
 		Use:   "set SUBCOMMAND",
 		Short: i18n.T("Set specific features on objects"),
-		Long:  set_long,
+		Long:  setLong,
 		Run:   cmdutil.DefaultSubCommandRun(err),
 	}
 
-	// add subcommands
 	cmd.AddCommand(NewCmdImage(f, out, err))
 	cmd.AddCommand(NewCmdResources(f, out, err))
 	cmd.AddCommand(NewCmdSelector(f, out))

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -89,6 +89,7 @@ var (
 	  env | grep RAILS_ | kubectl set env -e - dc/registry`)
 )
 
+// EnvOptions holds command line options required to run the command.
 type EnvOptions struct {
 	Out io.Writer
 	Err io.Writer
@@ -140,7 +141,7 @@ func NewCmdEnv(f cmdutil.Factory, in io.Reader, out, errout io.Writer) *cobra.Co
 		Example: fmt.Sprintf(envExample),
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
-			cmdutil.CheckErr(options.RunEnv(f))
+			cmdutil.CheckErr(options.Run(f))
 		},
 	}
 	usage := "the resource to update the env"
@@ -176,6 +177,7 @@ func keyToEnvName(key string) string {
 	return strings.ToUpper(validEnvNameRegexp.ReplaceAllString(key, "_"))
 }
 
+// Complete completes all the required options.
 func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	resources, envArgs, ok := envutil.SplitEnvironmentFromResources(args)
 	if !ok {
@@ -213,8 +215,8 @@ func (o *EnvOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	return nil
 }
 
-// RunEnv contains all the necessary functionality for the OpenShift cli env command
-func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
+// Run contains all the necessary functionality for the OpenShift cli env command.
+func (o *EnvOptions) Run(f cmdutil.Factory) error {
 	kubeClient, err := f.ClientSet()
 	if err != nil {
 		return err
@@ -397,7 +399,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 	for _, patch := range patches {
 		info := patch.Info
 		if patch.Err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error: %s/%s %v\n", info.Mapping.Resource, info.Name, patch.Err))
+			allErrs = append(allErrs, fmt.Errorf("error: %s/%s %v", info.Mapping.Resource, info.Name, patch.Err))
 			continue
 		}
 
@@ -415,7 +417,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 
 		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch)
 		if err != nil {
-			allErrs = append(allErrs, fmt.Errorf("failed to patch env update to pod template: %v\n", err))
+			allErrs = append(allErrs, fmt.Errorf("failed to patch env update to pod template: %v", err))
 			continue
 		}
 		info.Refresh(obj, true)

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 	"testing"
 
+	"os"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
@@ -29,7 +31,6 @@ import (
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/printers"
-	"os"
 )
 
 func TestSetEnvLocal(t *testing.T) {
@@ -59,7 +60,7 @@ func TestSetEnvLocal(t *testing.T) {
 		Local: true}
 	err := opts.Complete(f, cmd, []string{"env=prod"})
 	if err == nil {
-		err = opts.RunEnv(f)
+		err = opts.Run(f)
 	}
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -36,14 +36,14 @@ import (
 )
 
 var (
-	resources_long = templates.LongDesc(`
+	resourcesLong = templates.LongDesc(`
 		Specify compute resource requirements (cpu, memory) for any resource that defines a pod template.  If a pod is successfully scheduled, it is guaranteed the amount of resource requested, but may burst up to its specified limits.
 
 		for each compute resource, if a limit is specified and a request is omitted, the request will default to the limit.
 
 		Possible resources include (case insensitive): %s.`)
 
-	resources_example = templates.Examples(`
+	resourcesExample = templates.Examples(`
 		# Set a deployments nginx container cpu limits to "200m" and memory to "512Mi"
 		kubectl set resources deployment nginx -c=nginx --limits=cpu=200m,memory=512Mi
 
@@ -57,8 +57,7 @@ var (
 		kubectl set resources -f path/to/file.yaml --limits=cpu=200m,memory=512Mi --local -o yaml`)
 )
 
-// ResourcesOptions is the start of the data required to perform the operation. As new fields are added, add them here instead of
-// referencing the cmd.Flags
+// ResourcesOptions holds command line options required to run the command.
 type ResourcesOptions struct {
 	resource.FilenameOptions
 
@@ -86,6 +85,7 @@ type ResourcesOptions struct {
 	Resources              []string
 }
 
+// NewCmdResources creates the `resources` subcommand.
 func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Command {
 	options := &ResourcesOptions{
 		Out: out,
@@ -100,8 +100,8 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 	cmd := &cobra.Command{
 		Use:     "resources (-f FILENAME | TYPE NAME)  ([--limits=LIMITS & --requests=REQUESTS]",
 		Short:   i18n.T("Update resource requests/limits on objects with pod templates"),
-		Long:    fmt.Sprintf(resources_long, strings.Join(resourceTypesWithPodTemplate, ", ")),
-		Example: resources_example,
+		Long:    fmt.Sprintf(resourcesLong, strings.Join(resourceTypesWithPodTemplate, ", ")),
+		Example: resourcesExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
 			cmdutil.CheckErr(options.Validate())
@@ -126,6 +126,7 @@ func NewCmdResources(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.
 	return cmd
 }
 
+// Complete completes all the required options.
 func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.Mapper, o.Typer = f.Object()
 	o.UpdatePodSpecForObject = f.UpdatePodSpecForObject
@@ -173,6 +174,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 	return nil
 }
 
+// Validate command options for sufficient information to run the command.
 func (o *ResourcesOptions) Validate() error {
 	var err error
 	if len(o.Limits) == 0 && len(o.Requests) == 0 {
@@ -187,6 +189,7 @@ func (o *ResourcesOptions) Validate() error {
 	return nil
 }
 
+// Run implements the actual command.
 func (o *ResourcesOptions) Run() error {
 	allErrs := []error{}
 	patches := CalculatePatches(o.Infos, o.Encoder, func(info *resource.Info) ([]byte, error) {
@@ -226,13 +229,13 @@ func (o *ResourcesOptions) Run() error {
 	for _, patch := range patches {
 		info := patch.Info
 		if patch.Err != nil {
-			allErrs = append(allErrs, fmt.Errorf("error: %s/%s %v\n", info.Mapping.Resource, info.Name, patch.Err))
+			allErrs = append(allErrs, fmt.Errorf("error: %s/%s %v", info.Mapping.Resource, info.Name, patch.Err))
 			continue
 		}
 
 		//no changes
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("info: %s %q was not changed\n", info.Mapping.Resource, info.Name))
+			allErrs = append(allErrs, fmt.Errorf("info: %s %q was not changed", info.Mapping.Resource, info.Name))
 			continue
 		}
 
@@ -242,7 +245,7 @@ func (o *ResourcesOptions) Run() error {
 
 		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch)
 		if err != nil {
-			allErrs = append(allErrs, fmt.Errorf("failed to patch limit update to pod template %v\n", err))
+			allErrs = append(allErrs, fmt.Errorf("failed to patch limit update to pod template %v", err))
 			continue
 		}
 		info.Refresh(obj, true)
@@ -251,7 +254,7 @@ func (o *ResourcesOptions) Run() error {
 		if o.Record || cmdutil.ContainsChangeCause(info) {
 			if err := cmdutil.RecordChangeCause(obj, o.ChangeCause); err == nil {
 				if obj, err = resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, false, obj); err != nil {
-					allErrs = append(allErrs, fmt.Errorf("changes to %s/%s can't be recorded: %v\n", info.Mapping.Resource, info.Name, err))
+					allErrs = append(allErrs, fmt.Errorf("changes to %s/%s can't be recorded: %v", info.Mapping.Resource, info.Name, err))
 				}
 			}
 		}

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -202,7 +202,7 @@ func (o *SelectorOptions) RunSelector() error {
 		if o.record || cmdutil.ContainsChangeCause(info) {
 			if err := cmdutil.RecordChangeCause(patched, o.changeCause); err == nil {
 				if patched, err = resource.NewHelper(info.Client, info.Mapping).Replace(info.Namespace, info.Name, false, patched); err != nil {
-					return fmt.Errorf("changes to %s/%s can't be recorded: %v\n", info.Mapping.Resource, info.Name, err)
+					return fmt.Errorf("changes to %s/%s can't be recorded: %v", info.Mapping.Resource, info.Name, err)
 				}
 			}
 		}

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -158,7 +158,7 @@ func (saConfig *serviceAccountConfig) Run() error {
 	for _, patch := range patches {
 		info := patch.Info
 		if patch.Err != nil {
-			patchErrs = append(patchErrs, fmt.Errorf("error: %s/%s %v\n", info.Mapping.Resource, info.Name, patch.Err))
+			patchErrs = append(patchErrs, fmt.Errorf("error: %s/%s %v", info.Mapping.Resource, info.Name, patch.Err))
 			continue
 		}
 		if saConfig.local || saConfig.dryRun {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently there are a number of entries in `hack/.golint_failures` that exclude linting. At least for the subcommands of `kubectl` this is unnecessary. We can lint these files.

This PR removes the entries in `hack/.golint_failures` and fixes all `golint` warnings for the newly linted files.

If comments were being updated for type/function identifiers then the identifiers were updated also to bring them into line with the rest of the code in `kubectl/cmd`. e.g `s/Configs/Options/g`

**Special notes for your reviewer**:

`kubectl/cmd/*` has a lot of functions that are similar (i.e Run/Validate/Complete). This PR attempts to start the way forward to uniform comments on these functions. If review deems the comments correct and sufficient then the rest of `kubectl/cmd` can be update with the same. If I could please get comment from reviewers if it is easier to review if I push more commits to this PR or if it is easier to do it as a separate PR when/if this one merges. Thanks.

This is code clean up only, does not change the program logic.

**Release note**:
```release-note
NONE
```

/sig cli
/kind cleanup