### PR TITLE
Fix pointer receivers handling in unstructured converter

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
@@ -3,17 +3,6 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
-    "go_test",
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["converter_test.go"],
-    library = ":go_default_library",
-    deps = [
-        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
-    ],
 )
 
 go_library(
@@ -40,6 +29,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/testing:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/testing/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/testing/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["converter_test.go"],
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/conversion/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes unstructured converter to properly handle types that have `MarshalJSON()` implemented with a pointer receiver. In particular the converter now can roundtrip `*Unstructured` type.

**Which issue this PR fixes**:
Fixes #47889. Similar to #43346.

**Special notes for your reviewer**:
Without the fix the tests are failing:
```console
make test WHAT=./vendor/k8s.io/apimachinery/pkg/conversion/unstructured

Running tests for APIVersion: v1,admissionregistration.k8s.io/v1alpha1,admission.k8s.io/v1alpha1,apps/v1beta1,apps/v1beta2,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v1beta1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1beta1,storage.k8s.io/v1,,federation/v1beta1
+++ [0829 16:39:36] Running tests without code coverage
--- FAIL: TestCustomToUnstructured (0.00s)
    --- FAIL: TestCustomToUnstructured/false (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: bool(false)
                        actual: map[string]interface {}(map[string]interface {}{"data":"ZmFsc2U="})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/[1] (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: []interface {}([]interface {}{1})
                        actual: map[string]interface {}(map[string]interface {}{"data":"WzFd"})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/true (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: bool(true)
                        actual: map[string]interface {}(map[string]interface {}{"data":"dHJ1ZQ=="})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/0 (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: int64(0)
                        actual: map[string]interface {}(map[string]interface {}{"data":"MA=="})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/null (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: <nil>(<nil>)
                        actual: map[string]interface {}(map[string]interface {}{"data":"bnVsbA=="})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/[] (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: []interface {}([]interface {}{})
                        actual: map[string]interface {}(map[string]interface {}{"data":"W10="})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/{"a":1} (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: map[string]interface {}{"a":1}
                        actual: map[string]interface {}{"data":"eyJhIjoxfQ=="}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,3 +1,3 @@
                         (map[string]interface {}) (len=1) {
                        - (string) (len=1) "a": (int64) 1
                        + (string) (len=4) "data": (string) (len=12) "eyJhIjoxfQ=="
                         }
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/0.0 (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: float64(0)
                        actual: map[string]interface {}(map[string]interface {}{"data":"MC4w"})
        Messages:       customPointer1
    --- FAIL: TestCustomToUnstructured/{} (0.00s)
        Error Trace:    converter_test.go:500
        Error:          Not equal:
                        expected: map[string]interface {}{}
                        actual: map[string]interface {}{"data":"e30="}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,2 +1,3 @@
                        -(map[string]interface {}) {
                        +(map[string]interface {}) (len=1) {
                        + (string) (len=4) "data": (string) (len=4) "e30="
                         }
        Messages:       customPointer1
--- FAIL: TestCustomToUnstructuredTopLevel (0.00s)
    --- FAIL: TestCustomToUnstructuredTopLevel/1 (0.00s)
        Error Trace:    converter_test.go:519
        Error:          Not equal:
                        expected: map[string]interface {}{"a":1}
                        actual: map[string]interface {}{"data":"eyJhIjoxfQ=="}

                        Diff:
                        --- Expected
                        +++ Actual
                        @@ -1,3 +1,3 @@
                         (map[string]interface {}) (len=1) {
                        - (string) (len=1) "a": (int64) 1
                        + (string) (len=4) "data": (string) (len=12) "eyJhIjoxfQ=="
                         }
FAIL
FAIL    k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/conversion/unstructured    0.047s
make: *** [test] Error 1
```

```console
make test WHAT=./vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

Running tests for APIVersion: v1,admissionregistration.k8s.io/v1alpha1,admission.k8s.io/v1alpha1,apps/v1beta1,apps/v1beta2,authentication.k8s.io/v1,authentication.k8s.io/v1beta1,authorization.k8s.io/v1,authorization.k8s.io/v1beta1,autoscaling/v1,autoscaling/v2alpha1,batch/v1,batch/v1beta1,batch/v2alpha1,certificates.k8s.io/v1beta1,extensions/v1beta1,imagepolicy.k8s.io/v1alpha1,networking.k8s.io/v1,policy/v1beta1,rbac.authorization.k8s.io/v1,rbac.authorization.k8s.io/v1beta1,rbac.authorization.k8s.io/v1alpha1,scheduling.k8s.io/v1alpha1,settings.k8s.io/v1alpha1,storage.k8s.io/v1beta1,storage.k8s.io/v1,,federation/v1beta1
+++ [0829 16:40:38] Running tests without code coverage
--- FAIL: TestConversionRoundtrip (0.00s)
    unstructured_test.go:111: FromUnstructured failed: Object 'Kind' is missing in '{"object":{"apiVersion":"v1","kind":"Foo","metadata":{"name":"foo1"}}}'
FAIL
FAIL    k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured  0.046s
make: *** [test] Error 1
```

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery