### PR TITLE
Fix function doc string clearing golint warning

### DIFF
--- a/pkg/kubectl/apply.go
+++ b/pkg/kubectl/apply.go
@@ -174,8 +174,8 @@ func CreateApplyAnnotation(info *resource.Info, codec runtime.Encoder) error {
 	return SetOriginalConfiguration(info, modified)
 }
 
-// Create the annotation used by kubectl apply only when createAnnotation is true
-// Otherwise, only update the annotation when it already exists
+// CreateOrUpdateAnnotation creates the annotation used by kubectl apply if createAnnotation is true.
+// Otherwise, only update the annotation when it already exists.
 func CreateOrUpdateAnnotation(createAnnotation bool, info *resource.Info, codec runtime.Encoder) error {
 	if createAnnotation {
 		return CreateApplyAnnotation(info, codec)


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits warning
```
apply.go:177:1: comment on exported function CreateOrUpdateAnnotation should be of the form "CreateOrUpdateAnnotation ...
```

This PR fixes the document string in line with `golint` suggestion.

**Release note**:
```release-note
NONE
```
/sig cli
/kind cleanup
