### PR TITLE
Do deep copy instead of to and from JSON encoding

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -145,33 +145,13 @@ func (u *Unstructured) UnmarshalJSON(b []byte) error {
 	return err
 }
 
-func deepCopyJSON(x interface{}) interface{} {
-	switch x := x.(type) {
-	case map[string]interface{}:
-		clone := make(map[string]interface{}, len(x))
-		for k, v := range x {
-			clone[k] = deepCopyJSON(v)
-		}
-		return clone
-	case []interface{}:
-		clone := make([]interface{}, len(x))
-		for i := range x {
-			clone[i] = deepCopyJSON(x[i])
-		}
-		return clone
-	default:
-		// only non-pointer values (float64, int64, bool, string) are left. These can be copied by-value.
-		return x
-	}
-}
-
 func (in *Unstructured) DeepCopy() *Unstructured {
 	if in == nil {
 		return nil
 	}
 	out := new(Unstructured)
 	*out = *in
-	out.Object = deepCopyJSON(in.Object).(map[string]interface{})
+	out.Object = unstructured.DeepCopyJSON(in.Object)
 	return out
 }
 
@@ -181,7 +161,7 @@ func (in *UnstructuredList) DeepCopy() *UnstructuredList {
 	}
 	out := new(UnstructuredList)
 	*out = *in
-	out.Object = deepCopyJSON(in.Object).(map[string]interface{})
+	out.Object = unstructured.DeepCopyJSON(in.Object)
 	out.Items = make([]Unstructured, len(in.Items))
 	for i := range in.Items {
 		in.Items[i].DeepCopyInto(&out.Items[i])

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/testing/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/unstructured/testing/converter_test.go
@@ -21,6 +21,7 @@ limitations under the License.
 package testing
 
 import (
+	encodingjson "encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -462,6 +463,24 @@ func TestUnrecognized(t *testing.T) {
 			break
 		}
 	}
+}
+
+func TestDeepCopyJSON(t *testing.T) {
+	src := map[string]interface{}{
+		"a": nil,
+		"b": int64(123),
+		"c": map[string]interface{}{
+			"a": "b",
+		},
+		"d": []interface{}{
+			int64(1), int64(2),
+		},
+		"e": "estr",
+		"f": true,
+		"g": encodingjson.Number("123"),
+	}
+	deepCopy := conversionunstructured.DeepCopyJSON(src)
+	assert.Equal(t, src, deepCopy)
 }
 
 func TestFloatIntConversion(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Unstructured converter encodes to JSON and then parses the result into a new object. For `Unstructured` this can be avoided by directly doing a deep copy. It is an optimization.

**Special notes for your reviewer**:
#47889 is somewhat related.

**Release note**:
```release-note
NONE
```
/sig api-machinery
