### PR TITLE
update scheduler to return structured errors instead of process exit

### DIFF
--- a/plugin/cmd/kube-scheduler/app/BUILD
+++ b/plugin/cmd/kube-scheduler/app/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
The scheduler Run method returns an error that is properly handled at higher levels.  Instead of existing the process, we should return the error and handle it at higher level logic to allow testing of error conditions and composition of commands.  The changes are relatively minor.

@sjenning @aveshagarwal 