### PR TITLE
allow disabling the scheduler port

### DIFF
--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -93,7 +93,9 @@ func Run(s *options.SchedulerServer) error {
 		return fmt.Errorf("error creating scheduler: %v", err)
 	}
 
-	go startHTTP(s)
+	if s.Port != -1 {
+		go startHTTP(s)
+	}
 
 	stop := make(chan struct{})
 	defer close(stop)


### PR DESCRIPTION
Unlike the `kube-apiserver`, the scheduler can function without exposing a status port.  This provides the option to disable it by explicitly passing a `-1`.  This does not change default behavior.

@aveshagarwal 