### PR TITLE
test/e2e/auth: fix audit log test format parsing

### DIFF
--- a/test/e2e/auth/BUILD
+++ b/test/e2e/auth/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/51556

```release-note
NONE
```

cc @CaoShuFeng

Still need to figure out how to run this test locally.
