### PR TITLE
Fix golint warnings for kubectl/autoscale.go

### DIFF
--- a/pkg/kubectl/autoscale.go
+++ b/pkg/kubectl/autoscale.go
@@ -59,7 +59,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	if !found || len(name) == 0 {
 		name, found = params["default-name"]
 		if !found || len(name) == 0 {
-			return nil, fmt.Errorf("'name' is a required parameter.")
+			return nil, fmt.Errorf("'name' is a required parameter")
 		}
 	}
 	minString, found := params["min"]
@@ -72,7 +72,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 	maxString, found := params["max"]
 	if !found {
-		return nil, fmt.Errorf("'max' is a required parameter.")
+		return nil, fmt.Errorf("'max' is a required parameter")
 	}
 	max, err := strconv.Atoi(maxString)
 	if err != nil {
@@ -80,7 +80,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 
 	if min > max {
-		return nil, fmt.Errorf("'max' must be greater than or equal to 'min'.")
+		return nil, fmt.Errorf("'max' must be greater than or equal to 'min'")
 	}
 
 	cpuString, found := params["cpu-percent"]

--- a/pkg/kubectl/autoscale.go
+++ b/pkg/kubectl/autoscale.go
@@ -26,8 +26,10 @@ import (
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
+// HorizontalPodAutoscalerV1 implements the Generate interface.
 type HorizontalPodAutoscalerV1 struct{}
 
+// ParamNames returns the list of parameters that this generator uses.
 func (HorizontalPodAutoscalerV1) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"default-name", true},
@@ -41,6 +43,7 @@ func (HorizontalPodAutoscalerV1) ParamNames() []GeneratorParam {
 	}
 }
 
+// Generate creates an API object given a set of parameters.
 func (HorizontalPodAutoscalerV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
 	return generateHPA(genericParams)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits the following warnings:
```
autoscale.go:29:6: exported type HorizontalPodAutoscalerV1 should have comment or be unexported
autoscale.go:31:1: exported method HorizontalPodAutoscalerV1.ParamNames should have comment or be unexported
autoscale.go:44:1: exported method HorizontalPodAutoscalerV1.Generate should have comment or be unexported
autoscale.go:62:27: error strings should not end with punctuation
autoscale.go:75:26: error strings should not end with punctuation
autoscale.go:83:26: error strings should not end with punctuation
```

This PR removes punctuation from error strings and adds function/type documentation. 

**Release note**:
```release-note
NONE
```
/sig cli
/kind cleanup