### PR TITLE
pkg/controller/node: fix node controller panic

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -370,6 +370,7 @@ func NewNodeController(
 	}
 
 	if nc.runTaintManager {
+		nc.taintManager = scheduler.NewNoExecuteTaintManager(kubeClient)
 		nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 			AddFunc: util.CreateAddNodeHandler(func(node *v1.Node) error {
 				nc.taintManager.NodeUpdated(nil, node)
@@ -384,7 +385,6 @@ func NewNodeController(
 				return nil
 			}),
 		})
-		nc.taintManager = scheduler.NewNoExecuteTaintManager(kubeClient)
 	}
 
 	nc.nodeLister = nodeInformer.Lister()


### PR DESCRIPTION
Was consistently hitting this panic when trying to use local-up-cluster.sh

```
I0829 16:40:07.059520     679 node_controller.go:471] Starting node controller
I0829 16:40:07.059532     679 controller_utils.go:1021] Waiting for caches to sync for node controller
E0829 16:40:07.059558     679 runtime.go:66] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:72
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:65
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51
/usr/local/go/src/runtime/asm_amd64.s:509
/usr/local/go/src/runtime/panic.go:491
/usr/local/go/src/runtime/panic.go:63
/usr/local/go/src/runtime/signal_unix.go:367
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/scheduler/taint_controller.go:287
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/node_controller.go:375
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/util/controller_utils.go:297
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/controller.go:195
<autogenerated>:1
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:545
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:381
/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71
/usr/local/go/src/runtime/asm_amd64.s:2337
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x48 pc=0x301c83d]

goroutine 1160 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:58 +0x111
panic(0x3f27d20, 0x946b540)
	/usr/local/go/src/runtime/panic.go:491 +0x283
k8s.io/kubernetes/pkg/controller/node/scheduler.(*NoExecuteTaintManager).NodeUpdated(0x0, 0x0, 0xc420480000)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/scheduler/taint_controller.go:287 +0x1ad
k8s.io/kubernetes/pkg/controller/node.NewNodeController.func8(0xc420480000, 0x46e6e80, 0xc4208d9340)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/node_controller.go:375 +0x44
k8s.io/kubernetes/pkg/controller/node/util.CreateAddNodeHandler.func1(0x46e6e80, 0xc4208d9340)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/controller/node/util/controller_utils.go:297 +0x89
k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnAdd(0xc421f5f460, 0xc421f5f480, 0xc421f5f4a0, 0x46e6e80, 0xc4208d9340)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/controller.go:195 +0x49
k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.(*ResourceEventHandlerFuncs).OnAdd(0xc420b4bd00, 0x46e6e80, 0xc4208d9340)
	<autogenerated>:1 +0x62
k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.(*processorListener).run(0xc420ee6960)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:545 +0x272
k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.(*processorListener).(k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache.run)-fm()
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/tools/cache/shared_informer.go:381 +0x2a
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc4202d1cc8, 0xc421f5f4b0)
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x4f
created by k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/home/eric/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:69 +0x62
```

Since the handler is being added to a live informer it looks like it can actually try to do something before being assigned. Might be due to my dinky laptop, but it seems like a good fix.

```release-note
NONE
```

cc @kubernetes/sig-node-pr-reviews 