### PR TITLE
rbd: default image format to v2 instead of deprecated v1

### DIFF
--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -291,7 +291,7 @@ func (r *rbdVolumeProvisioner) Provision() (*v1.PersistentVolume, error) {
 	adminSecretNamespace := rbdDefaultAdminSecretNamespace
 	secretName := ""
 	secret := ""
-	imageFormat := rbdImageFormat1
+	imageFormat := rbdImageFormat2
 	fstype := ""
 
 	for k, v := range r.options.Parameters {


### PR DESCRIPTION
**What this PR does / why we need it**:
Image format v1 has been deprecated since the Infernalis release of
Ceph over two years ago.

**Release note**:
```StorageClass Ceph RBD now defaults to using the v2 image format ```
