### PR TITLE
Skip system container cgroup stats if undefined

### DIFF
--- a/pkg/kubelet/server/stats/summary.go
+++ b/pkg/kubelet/server/stats/summary.go
@@ -83,6 +83,10 @@ func (sp *summaryProviderImpl) Get() (*statsapi.Summary, error) {
 		statsapi.SystemContainerMisc:    nodeConfig.SystemCgroupsName,
 	}
 	for sys, name := range systemContainers {
+		// skip if cgroup name is undefined (not all system containers are required)
+		if name == "" {
+			continue
+		}
 		s, _, err := sp.provider.GetCgroupStats(name)
 		if err != nil {
 			glog.Errorf("Failed to get system container stats for %q: %v", name, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
the kubelet /stats/summary endpoint tried to look up cgroup stats for containers that are not required.  this polluted logs with messages about not finding stats for "" container.  this pr skips cgroup stats if the cgroup name is not specified (they are optional anyway)

**Special notes for your reviewer**:
i think this was a regression from recent refactor.

**Release note**:
```release-note
NONE
```
