### PR TITLE
Remove trailing punctuation from error strings

### DIFF
--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -179,7 +179,7 @@ func handleConfigMapFromFileSources(configMap *api.ConfigMap, fileSources []stri
 		}
 		if info.IsDir() {
 			if strings.Contains(fileSource, "=") {
-				return fmt.Errorf("cannot give a key name for a directory path.")
+				return fmt.Errorf("cannot give a key name for a directory path")
 			}
 			fileList, err := ioutil.ReadDir(filePath)
 			if err != nil {
@@ -244,7 +244,7 @@ func addKeyFromLiteralToConfigMap(configMap *api.ConfigMap, keyName, data string
 		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))
 	}
 	if _, entryExists := configMap.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, configMap.Data)
+		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v", keyName, configMap.Data)
 	}
 	configMap.Data[keyName] = data
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits the following warnings
```
configmap.go:182:23: error strings should not end with punctuation
configmap.go:247:21: error strings should not end with punctuation
```

This PR removes the trailing punctuation from error strings.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup