### PR TITLE
Do not mutate original UnstructuredList even temporarily to avoid data races

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = ["unstructured_test.go"],
     library = ":go_default_library",
+    deps = ["//vendor/github.com/stretchr/testify/assert:go_default_library"],
 )
 
 go_library(

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -702,9 +702,12 @@ func (unstructuredJSONScheme) Encode(obj runtime.Object, w io.Writer) error {
 		for _, i := range t.Items {
 			items = append(items, i.Object)
 		}
-		t.Object["items"] = items
-		defer func() { delete(t.Object, "items") }()
-		return json.NewEncoder(w).Encode(t.Object)
+		listObj := make(map[string]interface{}, len(t.Object)+1)
+		for k, v := range t.Object { // Make a shallow copy
+			listObj[k] = v
+		}
+		listObj["items"] = items
+		return json.NewEncoder(w).Encode(listObj)
 	case *runtime.Unknown:
 		// TODO: Unstructured needs to deal with ContentType.
 		_, err := w.Write(t.Raw)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -16,7 +16,31 @@ limitations under the License.
 
 package unstructured
 
-import "testing"
+import (
+	"io/ioutil"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestCodecOfUnstructuredList tests that there are no data races in Encode().
+// i.e. that it does not mutate the object being encoded.
+func TestCodecOfUnstructuredList(t *testing.T) {
+	var wg sync.WaitGroup
+	concurrency := 10
+	list := UnstructuredList{
+		Object: map[string]interface{}{},
+	}
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func() {
+			defer wg.Done()
+			assert.NoError(t, UnstructuredJSONScheme.Encode(&list, ioutil.Discard))
+		}()
+	}
+	wg.Wait()
+}
 
 func TestUnstructuredList(t *testing.T) {
 	list := &UnstructuredList{


### PR DESCRIPTION
**What this PR does / why we need it**:
See #51521.

**Which issue this PR fixes**:
Fixes #51521.

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery
