### PR TITLE
kubectl: Fix golint warnings for generate.go

### DIFF
--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -51,6 +51,7 @@ type StructuredGenerator interface {
 	StructuredGenerate() (runtime.Object, error)
 }
 
+// IsZero returns true if i is nil or the zero value for its type.
 func IsZero(i interface{}) bool {
 	if i == nil {
 		return true
@@ -98,7 +99,7 @@ func AnnotateFlags(cmd *cobra.Command, generators map[string]Generator) {
 	}
 }
 
-//  EnsureFlagsValid ensures that no invalid flags are being used against a generator.
+// EnsureFlagsValid ensures that no invalid flags are being used against a generator.
 func EnsureFlagsValid(cmd *cobra.Command, generators map[string]Generator, generatorInUse string) error {
 	AnnotateFlags(cmd, generators)
 
@@ -136,6 +137,7 @@ func MakeParams(cmd *cobra.Command, params []GeneratorParam) map[string]interfac
 	return result
 }
 
+// MakeProtocols flattens protocols map into form "key1/val1,key2/val2, ..."
 func MakeProtocols(protocols map[string]string) string {
 	out := []string{}
 	for key, value := range protocols {
@@ -144,6 +146,8 @@ func MakeProtocols(protocols map[string]string) string {
 	return strings.Join(out, ",")
 }
 
+// ParseProtocols builds a map out of protocols.
+// protocols is of form "port1/protocol1,port2/protocol2, ..."
 func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	protocolsString, isString := protocols.(string)
 	if !isString {
@@ -170,6 +174,7 @@ func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	return portProtocolMap, nil
 }
 
+// MakeLabels flattens labels map into form "key1=val1,key2=val2, ..."
 func MakeLabels(labels map[string]string) string {
 	out := []string{}
 	for key, value := range labels {
@@ -202,10 +207,11 @@ func ParseLabels(labelSpec interface{}) (map[string]string, error) {
 	return labels, nil
 }
 
+// GetBool returns the boolean value represented by the string in params map for key.
+// If key is not in map, returns defValue.
 func GetBool(params map[string]string, key string, defValue bool) (bool, error) {
 	if val, found := params[key]; !found {
 		return defValue, nil
-	} else {
-		return strconv.ParseBool(val)
 	}
+	return strconv.ParseBool(val)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

`golint` emits the following warnings:
```
generate.go:54:1: exported function IsZero should have comment or be unexported
generate.go:101:1: comment on exported function EnsureFlagsValid should be of the form "EnsureFlagsValid ..."
generate.go:139:1: exported function MakeProtocols should have comment or be unexported
generate.go:147:1: exported function ParseProtocols should have comment or be unexported
generate.go:173:1: exported function MakeLabels should have comment or be unexported
generate.go:205:1: exported function GetBool should have comment or be unexported
generate.go:208:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
```
This PR fixes/adds function documentation. Also fixes indentation of statement after return.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
