### PR TITLE
Fix splitProviderID for Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -779,7 +779,7 @@ func TestSplitProviderID(t *testing.T) {
 	}{
 		{
 			providerID: CloudProviderName + ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
-			name:       "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
+			name:       "k8s-agent-AAAAAAAA-0",
 			fail:       false,
 		},
 		{

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -46,7 +46,7 @@ const (
 	securityRuleIDTemplate      = "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/networkSecurityGroups/%s/securityRules/%s"
 )
 
-var providerIDRE = regexp.MustCompile(`^` + CloudProviderName + `://(.+)$`)
+var providerIDRE = regexp.MustCompile(`^` + CloudProviderName + `://(?:.*)/Microsoft.Compute/virtualMachines/(.+)$`)
 
 // returns the full identifier of a machine
 func (az *Cloud) getMachineID(machineName string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
#46940 add 'splitProviderID' for Azure to get node name from provider, but it captures the resource id instead of node name.

Functions such as NodeAddresses are accepting node names:
https://github.com/kubernetes/kubernetes/blob/84d9778f225cdf8046774d56d47b1e264e47499f/pkg/cloudprovider/providers/azure/azure_instances.go#L32

With current implementation, it takes in a resource ID, and will result in following error
```
E0830 04:15:09.877143   10427 azure_instances.go:63] error: az.NodeAddresses, az.getIPForMachine(/subscriptions/{id}/resourceGroups/{id}/providers/Microsoft.Compute/virtualMachines/k8s-master-0), err=instance not found
```

This fix makes is return node names instead.


**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
`NONE`


@brendandburns  @realfake @wlan0 