### PR TITLE
kubectl: Move utility functions to util package

### DIFF
--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -14,7 +14,6 @@ go_test(
         "delete_test.go",
         "env_file_test.go",
         "generate_test.go",
-        "kubectl_test.go",
         "namespace_test.go",
         "quota_test.go",
         "resource_filter_test.go",

--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/kubectl/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/hash"
 )
 
@@ -169,7 +170,7 @@ func (s ConfigMapGeneratorV1) validate() error {
 // information into the provided configMap.
 func handleConfigMapFromLiteralSources(configMap *api.ConfigMap, literalSources []string) error {
 	for _, literalSource := range literalSources {
-		keyName, value, err := parseLiteralSource(literalSource)
+		keyName, value, err := util.ParseLiteralSource(literalSource)
 		if err != nil {
 			return err
 		}
@@ -185,7 +186,7 @@ func handleConfigMapFromLiteralSources(configMap *api.ConfigMap, literalSources 
 // into the provided configMap
 func handleConfigMapFromFileSources(configMap *api.ConfigMap, fileSources []string) error {
 	for _, fileSource := range fileSources {
-		keyName, filePath, err := parseFileSource(fileSource)
+		keyName, filePath, err := util.ParseFileSource(fileSource)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -18,16 +18,9 @@ limitations under the License.
 package kubectl
 
 import (
-	"errors"
-	"fmt"
-	"path"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
-)
-
-const (
-	kubectlAnnotationPrefix = "kubectl.kubernetes.io/"
 )
 
 type NamespaceInfo struct {
@@ -187,45 +180,4 @@ func ResourceAliases(rs []string) []string {
 		}
 	}
 	return as
-}
-
-// parseFileSource parses the source given. Acceptable formats include:
-//
-// 1.  source-path: the basename will become the key name
-// 2.  source-name=source-path: the source-name will become the key name and source-path is the path to the key file
-//
-// Key names cannot include '='.
-func parseFileSource(source string) (keyName, filePath string, err error) {
-	numSeparators := strings.Count(source, "=")
-	switch {
-	case numSeparators == 0:
-		return path.Base(source), source, nil
-	case numSeparators == 1 && strings.HasPrefix(source, "="):
-		return "", "", fmt.Errorf("key name for file path %v missing.", strings.TrimPrefix(source, "="))
-	case numSeparators == 1 && strings.HasSuffix(source, "="):
-		return "", "", fmt.Errorf("file path for key name %v missing.", strings.TrimSuffix(source, "="))
-	case numSeparators > 1:
-		return "", "", errors.New("Key names or file paths cannot contain '='.")
-	default:
-		components := strings.Split(source, "=")
-		return components[0], components[1], nil
-	}
-}
-
-// parseLiteralSource parses the source key=val pair into its component pieces.
-// This functionality is distinguished from strings.SplitN(source, "=", 2) since
-// it returns an error in the case of empty keys, values, or a missing equals
-// sign.
-func parseLiteralSource(source string) (keyName, value string, err error) {
-	// leading equal is invalid
-	if strings.Index(source, "=") == 0 {
-		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
-	}
-	// split after the first equal (so values can have the = character)
-	items := strings.SplitN(source, "=", 2)
-	if len(items) != 2 {
-		return "", "", fmt.Errorf("invalid literal source %v, expected key=value", source)
-	}
-
-	return items[0], items[1], nil
 }

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -42,6 +42,7 @@ import (
 )
 
 const (
+	kubectlAnnotationPrefix    = "kubectl.kubernetes.io/"
 	sourceIdAnnotation         = kubectlAnnotationPrefix + "update-source-id"
 	desiredReplicasAnnotation  = kubectlAnnotationPrefix + "desired-replicas"
 	originalReplicasAnnotation = kubectlAnnotationPrefix + "original-replicas"

--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/kubectl/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/hash"
 )
 
@@ -173,7 +174,7 @@ func (s SecretGeneratorV1) validate() error {
 // handleFromLiteralSources adds the specified literal source information into the provided secret
 func handleFromLiteralSources(secret *api.Secret, literalSources []string) error {
 	for _, literalSource := range literalSources {
-		keyName, value, err := parseLiteralSource(literalSource)
+		keyName, value, err := util.ParseLiteralSource(literalSource)
 		if err != nil {
 			return err
 		}
@@ -187,7 +188,7 @@ func handleFromLiteralSources(secret *api.Secret, literalSources []string) error
 // handleFromFileSources adds the specified file source information into the provided secret
 func handleFromFileSources(secret *api.Secret, fileSources []string) error {
 	for _, fileSource := range fileSources {
-		keyName, filePath, err := parseFileSource(fileSource)
+		keyName, filePath, err := util.ParseFileSource(fileSource)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/util/BUILD
+++ b/pkg/kubectl/util/BUILD
@@ -1,6 +1,7 @@
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -42,4 +43,10 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//build/visible_to:pkg_kubectl_util_CONSUMERS"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    library = ":go_default_library",
 )

--- a/pkg/kubectl/util/util_test.go
+++ b/pkg/kubectl/util/util_test.go
@@ -14,11 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package util
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestParseFileSource(t *testing.T) {
 	cases := []struct {
@@ -91,7 +89,7 @@ func TestParseFileSource(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		key, filepath, err := parseFileSource(tc.input)
+		key, filepath, err := ParseFileSource(tc.input)
 		if err != nil {
 			if tc.err {
 				continue
@@ -173,7 +171,7 @@ func TestParseLiteralSource(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		key, value, err := parseLiteralSource(tc.input)
+		key, value, err := ParseLiteralSource(tc.input)
 		if err != nil {
 			if tc.err {
 				continue


### PR DESCRIPTION
**What this PR does / why we need it**:

`parseFileSource()` and `parseLiteralSource()` are utility functions.
We have a package already for utility functions, `kubectl/util/`.

Move utility functions to `kubectl/util`, capitalize function names to
export from package.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
