### PR TITLE
Fix InstanceTypeByProviderID for Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_instances.go
+++ b/pkg/cloudprovider/providers/azure/azure_instances.go
@@ -145,7 +145,7 @@ func (az *Cloud) InstanceTypeByProviderID(providerID string) (string, error) {
 		return "", err
 	}
 
-	return az.InstanceID(name)
+	return az.InstanceType(name)
 }
 
 // InstanceType returns the type of the specified instance.


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix change in #46940, should return InstanceType in function InstanceTypeByProviderID

Otherwise:
```
I0830 05:01:08.497989   15347 node_controller.go:328] Adding node label from cloud provider: beta.kubernetes.io/instance-type=/subscriptions/{id}/resourceGroups/{id}/providers/Microsoft.Compute/virtualMachines/k8s-agentpool1
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```
NONE
```

@brendandburns @realfake 
