### PR TITLE
Create cmd/util/resources.go

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -107,7 +107,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/apply_edit_last_applied.go
+++ b/pkg/kubectl/cmd/apply_edit_last_applied.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
@@ -72,7 +71,7 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, out, errOut io.Writer) *cobra
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -49,7 +49,7 @@ func NewCmdAutoscale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
 	validArgs := []string{"deployment", "replicaset", "replicationcontroller"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "autoscale (-f FILENAME | TYPE NAME | TYPE/NAME) [--min=MINPODS] --max=MAXPODS [--cpu-percent=CPU] [flags]",

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -196,8 +196,8 @@ __custom_func() {
 }
 `
 
-	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
-	// and add a short forms entry in expandResourceShortcut() when appropriate.
+	// If you add a resource to this list, please also take a look at util/resources.go
+	// and add a short forms entry in resourceTab when appropriate.
 	// TODO: This should be populated using the discovery information from apiserver.
 	validResources = `Valid resource types include:
 

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -123,7 +123,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -77,7 +76,7 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	// TODO: this should come from the factory, and may need to be loaded from the server, and so is probably
 	//   going to have to be removed
 	validArgs := printersinternal.DescribableResources()
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",

--- a/pkg/kubectl/cmd/edit.go
+++ b/pkg/kubectl/cmd/edit.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
@@ -83,7 +82,7 @@ func NewCmdEdit(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -79,7 +79,7 @@ func NewCmdExposeService(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	resources := regexp.MustCompile(`\s*,`).Split(exposeResources, -1)
 	for _, r := range resources {
 		validArgs = append(validArgs, strings.Fields(r)[0])
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -109,7 +109,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{
@@ -500,7 +500,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				if resourceName == "" {
 					resourceName = mapping.Resource
 				}
-				if alias, ok := kubectl.ResourceShortFormFor(mapping.Resource); ok {
+				if alias, ok := cmdutil.ResourceShortFormFor(mapping.Resource); ok {
 					resourceName = alias
 				} else if resourceName == "" {
 					resourceName = "none"

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/validation"
 
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -105,7 +104,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -88,7 +87,7 @@ func NewCmdPatch(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmdutil.CheckErr(err)
 	if p != nil {
 		validArgs = p.HandledResources()
-		argAliases = kubectl.ResourceAliases(validArgs)
+		argAliases = cmdutil.ResourceAliases(validArgs)
 	}
 
 	cmd := &cobra.Command{

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -45,7 +44,7 @@ func NewCmdRolloutHistory(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "history (TYPE NAME | TYPE/NAME) [flags]",

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/set"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -67,7 +66,7 @@ func NewCmdRolloutPause(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &PauseConfig{}
 
 	validArgs := []string{"deployment"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "pause RESOURCE",

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/set"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -65,7 +64,7 @@ func NewCmdRolloutResume(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &ResumeConfig{}
 
 	validArgs := []string{"deployment"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "resume RESOURCE",

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -21,7 +21,6 @@ import (
 	"io"
 
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -51,7 +50,7 @@ func NewCmdRolloutStatus(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "status (TYPE NAME | TYPE/NAME) [flags]",

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -65,7 +65,7 @@ func NewCmdRolloutUndo(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &UndoOptions{}
 
 	validArgs := []string{"deployment", "daemonset", "statefulset"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "undo (TYPE NAME | TYPE/NAME) [flags]",

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -61,7 +61,7 @@ func NewCmdScale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &resource.FilenameOptions{}
 
 	validArgs := []string{"deployment", "replicaset", "replicationcontroller", "job", "statefulset"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "scale [--resource-version=version] [--current-replicas=count] --replicas=COUNT (-f FILENAME | TYPE NAME)",

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/validation"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -81,7 +80,7 @@ func NewCmdTaint(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	options := &TaintOptions{}
 
 	validArgs := []string{"node"}
-	argAliases := kubectl.ResourceAliases(validArgs)
+	argAliases := cmdutil.ResourceAliases(validArgs)
 
 	cmd := &cobra.Command{
 		Use:     "taint NODE NAME KEY_1=VAL_1:TAINT_EFFECT_1 ... KEY_N=VAL_N:TAINT_EFFECT_N",
@@ -189,7 +188,7 @@ func (o TaintOptions) validateFlags() error {
 // Validate checks to the TaintOptions to see if there is sufficient information run the command.
 func (o TaintOptions) Validate() error {
 	resourceType := strings.ToLower(o.resources[0])
-	validResources, isValidResource := append(kubectl.ResourceAliases([]string{"node"}), "node"), false
+	validResources, isValidResource := append(cmdutil.ResourceAliases([]string{"node"}), "node"), false
 	for _, validResource := range validResources {
 		if resourceType == validResource {
 			isValidResource = true

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -15,6 +15,7 @@ go_library(
         "factory_object_mapping.go",
         "helpers.go",
         "printing.go",
+        "resources.go",
         "shortcut_restmapper.go",
     ],
     visibility = [

--- a/pkg/kubectl/cmd/util/resources.go
+++ b/pkg/kubectl/cmd/util/resources.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// resourceForms holds resource long and short form (name and alias).
+type resourceForms struct {
+	ShortForm schema.GroupResource
+	LongForm  schema.GroupResource
+}
+
+//
+// TODO(tcharding): Move validResources string out of `kubectl/cmd.go` to here.
+// This will mean there is a single point of knowledge (SPOK).
+//
+
+// resourceTab is a static list of resources that have short forms (aliases).
+var resourceTab = []resourceForms{
+	// Note that the list is ordered by group.
+	{
+		ShortForm: schema.GroupResource{Resource: "cm"},
+		LongForm:  schema.GroupResource{Resource: "configmaps"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "cs"},
+		LongForm:  schema.GroupResource{Resource: "componentstatuses"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ep"},
+		LongForm:  schema.GroupResource{Resource: "endpoints"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ev"},
+		LongForm:  schema.GroupResource{Resource: "events"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "limits"},
+		LongForm:  schema.GroupResource{Resource: "limitranges"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "no"},
+		LongForm:  schema.GroupResource{Resource: "nodes"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "ns"},
+		LongForm:  schema.GroupResource{Resource: "namespaces"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "po"},
+		LongForm:  schema.GroupResource{Resource: "pods"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "pvc"},
+		LongForm:  schema.GroupResource{Resource: "persistentvolumeclaims"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "pv"},
+		LongForm:  schema.GroupResource{Resource: "persistentvolumes"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "quota"},
+		LongForm:  schema.GroupResource{Resource: "resourcequotas"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "rc"},
+		LongForm:  schema.GroupResource{Resource: "replicationcontrollers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "rs"},
+		LongForm:  schema.GroupResource{Resource: "replicasets"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "sa"},
+		LongForm:  schema.GroupResource{Resource: "serviceaccounts"},
+	},
+	{
+		ShortForm: schema.GroupResource{Resource: "svc"},
+		LongForm:  schema.GroupResource{Resource: "services"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "autoscaling", Resource: "hpa"},
+		LongForm:  schema.GroupResource{Group: "autoscaling", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "certificates.k8s.io", Resource: "csr"},
+		LongForm:  schema.GroupResource{Group: "certificates.k8s.io", Resource: "certificatesigningrequests"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "deploy"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "deployments"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "ds"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "daemonsets"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "hpa"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "horizontalpodautoscalers"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "ing"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "ingresses"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "netpol"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "networkpolicies"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "extensions", Resource: "psp"},
+		LongForm:  schema.GroupResource{Group: "extensions", Resource: "podSecurityPolicies"},
+	},
+	{
+		ShortForm: schema.GroupResource{Group: "policy", Resource: "pdb"},
+		LongForm:  schema.GroupResource{Group: "policy", Resource: "poddisruptionbudgets"},
+	},
+}
+
+// ResourceShortFormFor looks for a short form of resource given name.
+// TODO: Change the signature of this function so that it can
+// make use of ResourceShortcuts.
+func ResourceShortFormFor(longForm string) (string, bool) {
+
+	// Search resource table for matching longForm.
+	for _, r := range resourceTab {
+		if r.LongForm.Resource == longForm {
+			return r.ShortForm.Resource, true
+		}
+	}
+	return "", false
+}
+
+// ResourceAliases returns the resource shortcuts and plural forms for the given resources.
+func ResourceAliases(rs []string) []string {
+	as := make([]string, 0, len(rs))
+	plurals := make(map[string]struct{}, len(rs))
+	for _, r := range rs {
+		var plural string
+		switch {
+		case r == "endpoints":
+			plural = r // exception. "endpoint" does not exist. Why?
+		case strings.HasSuffix(r, "y"):
+			plural = r[0:len(r)-1] + "ies"
+		case strings.HasSuffix(r, "s"):
+			plural = r + "es"
+		default:
+			plural = r + "s"
+		}
+		as = append(as, plural)
+
+		plurals[plural] = struct{}{}
+	}
+
+	for _, item := range resourceTab {
+		if _, found := plurals[item.LongForm.Resource]; found {
+			as = append(as, item.ShortForm.Resource)
+		}
+	}
+	return as
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Functions `ResourceShortFormFor()` and `ResourceAliases()` are used solely
within the `kubectl/cmd` package. They should be a part of the `kubectl/cmd/util`
package instead of the `kubectl` package.

This PR moves utility functions to a newly created file
`kubectl/cmd/util/resources.go` and updates all function call sites.

**Special notes for your reviewer**:

`resource` is an overloaded term. PR uses term `resourceForms` for structure containing `longForm` and `ShortFrom` names (which are in turn GV strings). Open to suggestions for better identifiers.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
