### PR TITLE
fix kubectl cp command error

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -195,6 +195,8 @@ func makeTar(filepath string, writer io.Writer) error {
 	// TODO: use compression here?
 	tarWriter := tar.NewWriter(writer)
 	defer tarWriter.Close()
+
+	filepath = path.Clean(filepath)
 	return recursiveTar(path.Dir(filepath), path.Base(filepath), tarWriter)
 }
 

--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -104,6 +104,7 @@ func TestTarUntar(t *testing.T) {
 		t.Errorf("unexpected error: %v | %v", err, err2)
 		t.FailNow()
 	}
+	dir = dir + "/"
 	defer func() {
 		if err := os.RemoveAll(dir); err != nil {
 			t.Errorf("Unexpected error cleaning up: %v", err)


### PR DESCRIPTION
fix kubectl cp command error.

modified:   pkg/kubectl/cmd/cp.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
fix kubectl cp error.
it happens when copy directory to pod and the directory path ends with '/'.
for example:
kubectl cp /tmp/test/ test-pod:/tmp/test/
it will fail with 
error: stat /tmp/test/test: no such file or directory

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
