### PR TITLE
[Paused until 1.9] Let DefaultStorageClass admission plugin handle updates

### DIFF
--- a/plugin/pkg/admission/storageclass/setdefault/admission.go
+++ b/plugin/pkg/admission/storageclass/setdefault/admission.go
@@ -32,6 +32,7 @@ import (
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	storagelisters "k8s.io/kubernetes/pkg/client/listers/storage/internalversion"
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+	"k8s.io/kubernetes/pkg/kubeapiserver/admission/util"
 )
 
 const (
@@ -95,6 +96,15 @@ func (c *claimDefaulterPlugin) Admit(a admission.Attributes) error {
 	pvc, ok := a.GetObject().(*api.PersistentVolumeClaim)
 	// if we can't convert then we don't handle this object so just return
 	if !ok {
+		return nil
+	}
+
+	updateInitialized, err := util.IsUpdatingInitializedObject(a)
+	if err != nil {
+		return err
+	}
+	if updateInitialized {
+		// spec of an initialized pvc is immutable
 		return nil
 	}
 

--- a/plugin/pkg/admission/storageclass/setdefault/admission_test.go
+++ b/plugin/pkg/admission/storageclass/setdefault/admission_test.go
@@ -233,5 +233,43 @@ func TestAdmission(t *testing.T) {
 		if test.expectedClassName == "" && class != "" {
 			t.Errorf("Test %q: expected class name %q, got %q", test.name, test.expectedClassName, class)
 		}
+
+		// should handle update of uninitialized pvc exactly the same, disregard of the old pvc.
+		clone, err = api.Scheme.DeepCopy(test.claim)
+		if err != nil {
+			t.Fatalf("Cannot clone claim: %v", err)
+		}
+		uninitializedPVC := clone.(*api.PersistentVolumeClaim)
+		uninitializedPVC.Initializers = &metav1.Initializers{Pending: []metav1.Initializer{{Name: "init"}}}
+		attrs = admission.NewAttributesRecord(
+			claim,            // new object
+			uninitializedPVC, // old object
+			api.Kind("PersistentVolumeClaim").WithVersion("version"),
+			claim.Namespace,
+			claim.Name,
+			api.Resource("persistentvolumeclaims").WithVersion("version"),
+			"", // subresource
+			admission.Update,
+			nil, // userInfo
+		)
+		err = ctrl.Admit(attrs)
+		glog.Infof("Got %v", err)
+		if err != nil && !test.expectError {
+			t.Errorf("Test %q: unexpected error received: %v", test.name, err)
+		}
+		if err == nil && test.expectError {
+			t.Errorf("Test %q: expected error and no error recevied", test.name)
+		}
+
+		class = ""
+		if claim.Spec.StorageClassName != nil {
+			class = *claim.Spec.StorageClassName
+		}
+		if test.expectedClassName != "" && test.expectedClassName != class {
+			t.Errorf("Test %q: expected class name %q, got %q", test.name, test.expectedClassName, class)
+		}
+		if test.expectedClassName == "" && class != "" {
+			t.Errorf("Test %q: expected class name %q, got %q", test.name, test.expectedClassName, class)
+		}
 	}
 }


### PR DESCRIPTION
 of uninitialized object.

Please don't review before #50344 is merged.

Follow up https://github.com/kubernetes/kubernetes/pull/50344

