### PR TITLE
Minor fixes to validation test

### DIFF
--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -5552,8 +5552,8 @@ func TestValidatePodUpdate(t *testing.T) {
 	)
 
 	tests := []struct {
-		a    api.Pod
-		b    api.Pod
+		new  api.Pod
+		old  api.Pod
 		err  string
 		test string
 	}{
@@ -5635,6 +5635,35 @@ func TestValidatePodUpdate(t *testing.T) {
 				},
 			},
 			"may not add or remove containers",
+			"less containers",
+		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "foo:V1",
+						},
+						{
+							Image: "bar:V2",
+						},
+					},
+				},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec: api.PodSpec{
+					Containers: []api.Container{
+						{
+							Image: "foo:V2",
+						},
+					},
+				},
+			},
+			"may not add or remove containers",
 			"more containers",
 		},
 		{
@@ -5676,7 +5705,19 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec:       api.PodSpec{Containers: []api.Container{{Image: "foo:V1"}}},
 			},
 			"",
-			"deletion timestamp filled out",
+			"deletion timestamp removed",
+		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", DeletionTimestamp: &now},
+				Spec:       api.PodSpec{Containers: []api.Container{{Image: "foo:V1"}}},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Containers: []api.Container{{Image: "foo:V1"}}},
+			},
+			"metadata.deletionTimestamp",
+			"deletion timestamp added",
 		},
 		{
 			api.Pod{
@@ -5688,7 +5729,7 @@ func TestValidatePodUpdate(t *testing.T) {
 				Spec:       api.PodSpec{Containers: []api.Container{{Image: "foo:V1"}}},
 			},
 			"metadata.deletionGracePeriodSeconds",
-			"deletion grace period seconds cleared",
+			"deletion grace period seconds changed",
 		},
 		{
 			api.Pod{
@@ -6144,13 +6185,13 @@ func TestValidatePodUpdate(t *testing.T) {
 			api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.MirrorPodAnnotationKey: ""}}, Spec: api.PodSpec{NodeName: "foo"}},
 			api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.PodSpec{NodeName: "foo"}},
 			"metadata.annotations[kubernetes.io/config.mirror]",
-			"removed mirror pod annotation",
+			"added mirror pod annotation",
 		},
 		{
 			api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, Spec: api.PodSpec{NodeName: "foo"}},
 			api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.MirrorPodAnnotationKey: ""}}, Spec: api.PodSpec{NodeName: "foo"}},
 			"metadata.annotations[kubernetes.io/config.mirror]",
-			"added mirror pod annotation",
+			"removed mirror pod annotation",
 		},
 		{
 			api.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Annotations: map[string]string{api.MirrorPodAnnotationKey: "foo"}}, Spec: api.PodSpec{NodeName: "foo"}},
@@ -6205,16 +6246,16 @@ func TestValidatePodUpdate(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.a.ObjectMeta.ResourceVersion = "1"
-		test.b.ObjectMeta.ResourceVersion = "1"
-		errs := ValidatePodUpdate(&test.a, &test.b)
+		test.new.ObjectMeta.ResourceVersion = "1"
+		test.old.ObjectMeta.ResourceVersion = "1"
+		errs := ValidatePodUpdate(&test.new, &test.old)
 		if test.err == "" {
 			if len(errs) != 0 {
-				t.Errorf("unexpected invalid: %s (%+v)\nA: %+v\nB: %+v", test.test, errs, test.a, test.b)
+				t.Errorf("unexpected invalid: %s (%+v)\nA: %+v\nB: %+v", test.test, errs, test.new, test.old)
 			}
 		} else {
 			if len(errs) == 0 {
-				t.Errorf("unexpected valid: %s\nA: %+v\nB: %+v", test.test, test.a, test.b)
+				t.Errorf("unexpected valid: %s\nA: %+v\nB: %+v", test.test, test.new, test.old)
 			} else if actualErr := errs.ToAggregate().Error(); !strings.Contains(actualErr, test.err) {
 				t.Errorf("unexpected error message: %s\nExpected error: %s\nActual error: %s", test.test, test.err, actualErr)
 			}


### PR DESCRIPTION
Some test cases confuse the new object with the old object. This PR fixed that. Also added a test to verify that deletionTimestamp cannot be added (via the REST endpoints).