### PR TITLE
Code clean up for rolling_updater.go

### DIFF
--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -387,7 +387,7 @@ func findNewName(args []string, oldRc *api.ReplicationController) string {
 		return args[1]
 	}
 	if oldRc != nil {
-		newName, _ := kubectl.GetNextControllerAnnotation(oldRc)
+		newName, _ := kubectl.NextControllerAnnotation(oldRc)
 		return newName
 	}
 	return ""

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -672,8 +672,8 @@ func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	return nil
 }
 
-// GetNextControllerAnnotation gets the annotation for the next RC.
-func GetNextControllerAnnotation(rc *api.ReplicationController) (string, bool) {
+// NextControllerAnnotation gets the annotation for the next RC.
+func NextControllerAnnotation(rc *api.ReplicationController) (string, bool) {
 	res, found := rc.Annotations[nextControllerAnnotation]
 	return res, found
 }

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -540,6 +540,8 @@ func (r *RollingUpdater) cleanupWithClients(oldRc, newRc *api.ReplicationControl
 	}
 }
 
+// Rename renames a ReplicationController. First deletes RC and its orphaned pods
+// then creates an RC with the newName.
 func Rename(c coreclient.ReplicationControllersGetter, rc *api.ReplicationController, newName string) error {
 	oldName := rc.Name
 	rc.Name = newName
@@ -568,6 +570,7 @@ func Rename(c coreclient.ReplicationControllersGetter, rc *api.ReplicationContro
 	return err
 }
 
+// LoadExistingNextReplicationController gets the next RC for namespace and newName.
 func LoadExistingNextReplicationController(c coreclient.ReplicationControllersGetter, namespace, newName string) (*api.ReplicationController, error) {
 	if len(newName) == 0 {
 		return nil, nil
@@ -579,6 +582,7 @@ func LoadExistingNextReplicationController(c coreclient.ReplicationControllersGe
 	return newRc, err
 }
 
+// NewControllerConfig is the configuration for a new RC.
 type NewControllerConfig struct {
 	Namespace        string
 	OldName, NewName string
@@ -588,6 +592,8 @@ type NewControllerConfig struct {
 	PullPolicy       api.PullPolicy
 }
 
+// CreateNewControllerFromCurrentController creates a new RC from an existing RC
+// with the new configuration in cfg.
 func CreateNewControllerFromCurrentController(rcClient coreclient.ReplicationControllersGetter, codec runtime.Codec, cfg *NewControllerConfig) (*api.ReplicationController, error) {
 	containerIndex := 0
 	// load the old RC into the "new" RC
@@ -641,6 +647,7 @@ func CreateNewControllerFromCurrentController(rcClient coreclient.ReplicationCon
 	return newRc, nil
 }
 
+// AbortRollingUpdate aborts a rolling update.
 func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	// Swap the controllers
 	tmp := c.OldRc
@@ -665,11 +672,13 @@ func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	return nil
 }
 
+// GetNextControllerAnnotation gets the annotation for the next RC.
 func GetNextControllerAnnotation(rc *api.ReplicationController) (string, bool) {
 	res, found := rc.Annotations[nextControllerAnnotation]
 	return res, found
 }
 
+// SetNextControllerAnnotation sets the annotation for the next RC.
 func SetNextControllerAnnotation(rc *api.ReplicationController, name string) {
 	if rc.Annotations == nil {
 		rc.Annotations = map[string]string{}
@@ -677,6 +686,7 @@ func SetNextControllerAnnotation(rc *api.ReplicationController, name string) {
 	rc.Annotations[nextControllerAnnotation] = name
 }
 
+// UpdateExistingReplicationController updates an existing RC.
 func UpdateExistingReplicationController(rcClient coreclient.ReplicationControllersGetter, podClient coreclient.PodsGetter, oldRc *api.ReplicationController, namespace, newName, deploymentKey, deploymentValue string, out io.Writer) (*api.ReplicationController, error) {
 	if _, found := oldRc.Spec.Selector[deploymentKey]; !found {
 		SetNextControllerAnnotation(oldRc, newName)
@@ -691,6 +701,7 @@ func UpdateExistingReplicationController(rcClient coreclient.ReplicationControll
 	return updateRcWithRetries(rcClient, namespace, oldRc, applyUpdate)
 }
 
+// AddDeploymentKeyToReplicationController adds a deployment key to an RC.
 func AddDeploymentKeyToReplicationController(oldRc *api.ReplicationController, rcClient coreclient.ReplicationControllersGetter, podClient coreclient.PodsGetter, deploymentKey, deploymentValue, namespace string, out io.Writer) (*api.ReplicationController, error) {
 	var err error
 	// First, update the template label.  This ensures that any newly created pods will have the new label
@@ -822,6 +833,7 @@ func updatePodWithRetries(podClient coreclient.PodsGetter, namespace string, pod
 	return pod, err
 }
 
+// FindSourceController finds an existing RC with annotation for source ID namespace/name.
 func FindSourceController(r coreclient.ReplicationControllersGetter, namespace, name string) (*api.ReplicationController, error) {
 	list, err := r.ReplicationControllers(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -84,7 +84,7 @@ func newRc(replicas int, desired int) *api.ReplicationController {
 		Name:      "foo-v2",
 		Annotations: map[string]string{
 			desiredReplicasAnnotation: fmt.Sprintf("%d", desired),
-			sourceIdAnnotation:        "foo-v1:7764ae47-9092-11e4-8393-42010af018ff",
+			sourceIDAnnotation:        "foo-v1:7764ae47-9092-11e4-8393-42010af018ff",
 		},
 	}
 	return rc
@@ -809,7 +809,7 @@ Scaling foo-v2 up to 2
 				rc.Status.Replicas = rc.Spec.Replicas
 				return rc, nil
 			},
-			getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+			getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 				// Simulate a create vs. update of an existing controller.
 				return test.newRc, test.newRcExists, nil
 			},
@@ -861,7 +861,7 @@ func TestUpdate_progressTimeout(t *testing.T) {
 			// Do nothing.
 			return rc, nil
 		},
-		getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+		getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 			return newRc, false, nil
 		},
 		cleanup: func(oldRc, newRc *api.ReplicationController, config *RollingUpdaterConfig) error {
@@ -905,7 +905,7 @@ func TestUpdate_assignOriginalAnnotation(t *testing.T) {
 		scaleAndWait: func(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error) {
 			return rc, nil
 		},
-		getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+		getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 			return newRc, false, nil
 		},
 		cleanup: func(oldRc, newRc *api.ReplicationController, config *RollingUpdaterConfig) error {
@@ -1234,7 +1234,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "foo",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "bar:1234",
+				sourceIDAnnotation: "bar:1234",
 			},
 		},
 	}
@@ -1243,7 +1243,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "bar",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "foo:12345",
+				sourceIDAnnotation: "foo:12345",
 			},
 		},
 	}
@@ -1252,7 +1252,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "baz",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "baz:45667",
+				sourceIDAnnotation: "baz:45667",
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits a number of warnings about missing documentation strings. `golint` also warns for usage of `Id` instead of `ID` in identifier names.

This PR does three things. All are trivial code clean up, if separate PR's are preferred please comment as such.

1. Change `Id` to `ID`
2. Add missing documentation strings to functions and types.
3. Remove the `Get` from the function name of a 'getter' function in line with Go coding standards.

**Special notes for your reviewer**:

PR contains three commits. Will squash or split into separate PR's as required.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup