### PR TITLE
Add `ReclaimPolicy` field to `kubectl describe storageclass` output.

### DIFF
--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -3111,6 +3111,9 @@ func describeStorageClass(sc *storage.StorageClass, events *api.EventList) (stri
 		w.Write(LEVEL_0, "Annotations:\t%s\n", labels.FormatLabels(sc.Annotations))
 		w.Write(LEVEL_0, "Provisioner:\t%s\n", sc.Provisioner)
 		w.Write(LEVEL_0, "Parameters:\t%s\n", labels.FormatLabels(sc.Parameters))
+		if sc.ReclaimPolicy != nil {
+			w.Write(LEVEL_0, "ReclaimPolicy:\t%s\n", *sc.ReclaimPolicy)
+		}
 		if events != nil {
 			DescribeEvents(events, w)
 		}

--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -819,6 +819,7 @@ func TestDescribeCluster(t *testing.T) {
 }
 
 func TestDescribeStorageClass(t *testing.T) {
+	reclaimPolicy := api.PersistentVolumeReclaimRetain
 	f := fake.NewSimpleClientset(&storage.StorageClass{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -832,6 +833,7 @@ func TestDescribeStorageClass(t *testing.T) {
 			"param1": "value1",
 			"param2": "value2",
 		},
+		ReclaimPolicy: &reclaimPolicy,
 	})
 	s := StorageClassDescriber{f}
 	out, err := s.Describe("", "foo", printers.DescriberSettings{ShowEvents: true})


### PR DESCRIPTION
Add `ReclaimPolicy` field to `kubectl describe storageclass` output.

PR https://github.com/kubernetes/kubernetes/pull/47987 added `ReclaimPolicy` field to StorageClass.

**Release note**:
```release-note
None
```