### PR TITLE
kubectl: Remove ending punctuation from error strings

### DIFF
--- a/pkg/kubectl/secret_for_tls.go
+++ b/pkg/kubectl/secret_for_tls.go
@@ -128,10 +128,10 @@ func (s SecretForTLSGeneratorV1) validate() error {
 	// if no key/cert is given. The only requiredment is that we either get both
 	// or none. See test/e2e/ingress_utils for self signed cert generation.
 	if len(s.Key) == 0 {
-		return fmt.Errorf("key must be specified.")
+		return fmt.Errorf("key must be specified")
 	}
 	if len(s.Cert) == 0 {
-		return fmt.Errorf("certificate must be specified.")
+		return fmt.Errorf("certificate must be specified")
 	}
 	if _, err := tls.LoadX509KeyPair(s.Cert, s.Key); err != nil {
 		return fmt.Errorf("failed to load key pair %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits 2 warnings of type:

`error strings should not end with punctuation`

Remove punctuation from end of error strings.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup