### PR TITLE
kubectl: Remove ending punctuation from error strings (secret.go)

### DIFF
--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -202,7 +202,7 @@ func handleFromFileSources(secret *api.Secret, fileSources []string) error {
 		}
 		if info.IsDir() {
 			if strings.Contains(fileSource, "=") {
-				return fmt.Errorf("cannot give a key name for a directory path.")
+				return fmt.Errorf("cannot give a key name for a directory path")
 			}
 			fileList, err := ioutil.ReadDir(filePath)
 			if err != nil {
@@ -262,7 +262,7 @@ func addKeyFromLiteralToSecret(secret *api.Secret, keyName string, data []byte) 
 	}
 
 	if _, entryExists := secret.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, secret.Data)
+		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v", keyName, secret.Data)
 	}
 	secret.Data[keyName] = data
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits 2 warnings of type:

`error strings should not end with punctuation`

Remove punctuation from end of error strings.
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
