### PR TITLE
validate the alpha.kubernetes.io/nvidia-gpu type for ResourceQuota

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -7573,7 +7573,7 @@ func validatePodResourceName(resourceName core.ResourceName, fldPath *field.Path
 func ValidateResourceQuotaResourceName(value core.ResourceName, fldPath *field.Path) field.ErrorList {
 	allErrs := validateResourceName(value, fldPath)
 
-	if len(strings.Split(string(value), "/")) == 1 {
+	if len(strings.Split(string(value), "/")) == 1 || strings.Contains(strings.ToLower(string(value)), "kubernetes.io/") {
 		if !helper.IsStandardQuotaResourceName(value) {
 			return append(allErrs, field.Invalid(fldPath, value, isInvalidQuotaResource))
 		}


### PR DESCRIPTION
As #46639 shows, although the ResourceQuota does not support the `alpha.kubernetes.io/nvidia-gpu` type,  but it create success! This PR will validate it, pop-up error message. As the following:

```command
root@slave2:/home/zhangjian/testK8s# kubectl create -f resourcequota.yaml 
The ResourceQuota "quota" is invalid: 
* spec.hard[limits.alpha.kubernetes.io/nvidia-gpu]: Invalid value: "limits.alpha.kubernetes.io/nvidia-gpu": must be a standard resource for quota
* spec.hard[requests.alpha.kubernetes.io/nvidia-gpu]: Invalid value: "requests.alpha.kubernetes.io/nvidia-gpu": must be a standard resource for quota
```
the content of resourcequota.yaml:
```yaml
ind: ResourceQuota
metadata:
  name: quota
  namespace: default
spec:
  hard:
    requests.cpu: "12"
    requests.memory: 8Gi
    requests.alpha.kubernetes.io/nvidia-gpu: "1"
    limits.cpu: "12"
    limits.memory: 8Gi
    limits.alpha.kubernetes.io/nvidia-gpu: "1"
    configmaps: "100"
    services: "100"
    secrets: "100"
```