### PR TITLE
kubectl: Print type instead of variable

### DIFF
--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -147,7 +147,7 @@ func MakeProtocols(protocols map[string]string) string {
 func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	protocolsString, isString := protocols.(string)
 	if !isString {
-		return nil, fmt.Errorf("expected string, found %v", protocols)
+		return nil, fmt.Errorf("expected string, found %T", protocols)
 	}
 	if len(protocolsString) == 0 {
 		return nil, fmt.Errorf("no protocols passed")


### PR DESCRIPTION
**What this PR does / why we need it**:

Function `ParseProtocols()` accepts an interface parameter. If the parameter is not of type `string` an error is returned. Currently the error string contains the contents of the interface argument. It would be more informative if we returned the type instead. This would also mitigate the risk of large error out with an interface of unknown size.

/sig cli