### PR TITLE
Revert to using isolated PID namespaces in Docker

### DIFF
--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -108,6 +108,7 @@ func NewContainerRuntimeOptions() *ContainerRuntimeOptions {
 		DockerEndpoint:            dockerEndpoint,
 		DockershimRootDirectory:   "/var/lib/dockershim",
 		DockerExecHandlerName:     "native",
+		DockerDisableSharedPID:    true,
 		PodSandboxImage:           defaultPodSandboxImage,
 		ImagePullProgressDeadline: metav1.Duration{Duration: 1 * time.Minute},
 		RktAPIEndpoint:            defaultRktAPIServiceEndpoint,

--- a/test/e2e_node/docker_test.go
+++ b/test/e2e_node/docker_test.go
@@ -40,11 +40,11 @@ var _ = framework.KubeDescribe("Docker features [Feature:Docker]", func() {
 		It("processes in different containers of the same pod should be able to see each other", func() {
 			// TODO(yguo0905): Change this test to run unless the runtime is
 			// Docker and its version is <1.13.
-			By("Check whether shared PID namespace is enabled.")
-			isEnabled, err := isSharedPIDNamespaceEnabled()
+			By("Check whether shared PID namespace is supported.")
+			isEnabled, err := isSharedPIDNamespaceSupported()
 			framework.ExpectNoError(err)
 			if !isEnabled {
-				framework.Skipf("Skipped because shared PID namespace is not enabled.")
+				framework.Skipf("Skipped because shared PID namespace is not supported by this docker version.")
 			}
 
 			By("Create a pod with two containers.")

--- a/test/e2e_node/docker_util.go
+++ b/test/e2e_node/docker_util.go
@@ -43,9 +43,9 @@ func getDockerAPIVersion() (semver.Version, error) {
 	return semver.MustParse(version.APIVersion + ".0"), nil
 }
 
-// isSharedPIDNamespaceEnabled returns true if the Docker version is 1.13.1+
+// isSharedPIDNamespaceSupported returns true if the Docker version is 1.13.1+
 // (API version 1.26+), and false otherwise.
-func isSharedPIDNamespaceEnabled() (bool, error) {
+func isSharedPIDNamespaceSupported() (bool, error) {
 	version, err := getDockerAPIVersion()
 	if err != nil {
 		return false, err

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -155,6 +155,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--serialize-image-pulls", "false",
 		"--pod-manifest-path", manifestPath,
 		"--file-check-frequency", "10s", // Check file frequently so tests won't wait too long
+		"--docker-disable-shared-pid=false",
 		// Assign a fixed CIDR to the node because there is no node controller.
 		//
 		// Note: this MUST be in sync with with the IP in


### PR DESCRIPTION
**What this PR does / why we need it**: Reverts to the previous docker default of using isolated PID namespaces for containers in a pod. There exist container images that expect always to be PID 1 which we want to support unmodified in 1.8.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #48937

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Sharing a PID namespace between containers in a pod is disabled by default in 1.8. To enable for a node, use the --docker-disable-shared-pid=false kubelet flag. Note that PID namespace sharing requires docker >= 1.13.1.
```
