### PR TITLE
Allow custom client verbs to be generated using client-gen

### DIFF
--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/deployment.go
@@ -42,6 +42,9 @@ type DeploymentInterface interface {
 	List(opts v1.ListOptions) (*v1beta1.DeploymentList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error)
+	GetScale(deploymentName string, options v1.GetOptions) (*v1beta1.Scale, error)
+	UpdateScale(deploymentName string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
+
 	DeploymentExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the deployment, and returns the corresponding v1beta1.Scale object, and an error if there is any.
+func (c *deployments) GetScale(deploymentName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *deployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -136,3 +136,25 @@ func (c *FakeDeployments) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*v1beta1.Deployment), err
 }
+
+// GetScale takes name of the deployment, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeDeployments) GetScale(deploymentName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(deploymentsResource, c.ns, "scale", deploymentName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeDeployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -136,3 +136,25 @@ func (c *FakeReplicaSets) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*v1beta1.ReplicaSet), err
 }
+
+// GetScale takes name of the replicaSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeReplicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(replicasetsResource, c.ns, "scale", replicaSetName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeReplicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
+++ b/federation/client/clientset_generated/federation_clientset/typed/extensions/v1beta1/replicaset.go
@@ -42,6 +42,9 @@ type ReplicaSetInterface interface {
 	List(opts v1.ListOptions) (*v1beta1.ReplicaSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ReplicaSet, err error)
+	GetScale(replicaSetName string, options v1.GetOptions) (*v1beta1.Scale, error)
+	UpdateScale(replicaSetName string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
+
 	ReplicaSetExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the replicaSet, and returns the corresponding v1beta1.Scale object, and an error if there is any.
+func (c *replicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *replicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2607,6 +2607,8 @@ type ReplicationControllerCondition struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/extensions.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/extensions.Scale,result=k8s.io/kubernetes/pkg/apis/extensions.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationController represents the configuration of a replication controller.

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -23,6 +23,8 @@ import (
 )
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/extensions.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/extensions.Scale,result=k8s.io/kubernetes/pkg/apis/extensions.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StatefulSet represents a set of pods with consistent identities.

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -166,6 +166,8 @@ type ThirdPartyResourceData struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Deployment struct {
@@ -751,6 +753,8 @@ type IngressBackend struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicaSet represents the configuration of a replica set.

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/BUILD
@@ -16,6 +16,7 @@ go_library(
     ],
     deps = [
         "//pkg/apis/apps:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/scheme:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/BUILD
@@ -15,6 +15,7 @@ go_library(
     ],
     deps = [
         "//pkg/apis/apps:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/apps/internalversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/fake/fake_statefulset.go
@@ -24,6 +24,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // FakeStatefulSets implements StatefulSetInterface
@@ -135,4 +136,26 @@ func (c *FakeStatefulSets) Patch(name string, pt types.PatchType, data []byte, s
 		return nil, err
 	}
 	return obj.(*apps.StatefulSet), err
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeStatefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(statefulsetsResource, c.ns, "scale", statefulSetName), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeStatefulSets) UpdateScale(statefulSetName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "scale", c.ns, scale), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/apps/internalversion/statefulset.go
@@ -22,6 +22,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 	apps "k8s.io/kubernetes/pkg/apis/apps"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 	scheme "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/scheme"
 )
 
@@ -42,6 +43,9 @@ type StatefulSetInterface interface {
 	List(opts v1.ListOptions) (*apps.StatefulSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *apps.StatefulSet, err error)
+	GetScale(statefulSetName string, options v1.GetOptions) (*extensions.Scale, error)
+	UpdateScale(statefulSetName string, scale *extensions.Scale) (*extensions.Scale, error)
+
 	StatefulSetExpansion
 }
 
@@ -166,6 +170,34 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding extensions.Scale object, and an error if there is any.
+func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *statefulSets) UpdateScale(statefulSetName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/ref:go_default_library",
         "//pkg/api/v1:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/scheme:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/BUILD
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/BUILD
@@ -34,6 +34,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/apis/extensions:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_replicationcontroller.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/core/internalversion/fake/fake_replicationcontroller.go
@@ -24,6 +24,7 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 	api "k8s.io/kubernetes/pkg/api"
+	extensions "k8s.io/kubernetes/pkg/apis/extensions"
 )
 
 // FakeReplicationControllers implements ReplicationControllerInterface
@@ -135,4 +136,26 @@ func (c *FakeReplicationControllers) Patch(name string, pt types.PatchType, data
 		return nil, err
 	}
 	return obj.(*api.ReplicationController), err
+}
+
+// GetScale takes name of the replicationController, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeReplicationControllers) GetScale(replicationControllerName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(replicationcontrollersResource, c.ns, "scale", replicationControllerName), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeReplicationControllers) UpdateScale(replicationControllerName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "scale", c.ns, scale), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
 }

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/deployment.go
@@ -42,6 +42,9 @@ type DeploymentInterface interface {
 	List(opts v1.ListOptions) (*extensions.DeploymentList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *extensions.Deployment, err error)
+	GetScale(deploymentName string, options v1.GetOptions) (*extensions.Scale, error)
+	UpdateScale(deploymentName string, scale *extensions.Scale) (*extensions.Scale, error)
+
 	DeploymentExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the deployment, and returns the corresponding extensions.Scale object, and an error if there is any.
+func (c *deployments) GetScale(deploymentName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *deployments) UpdateScale(deploymentName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_deployment.go
@@ -136,3 +136,25 @@ func (c *FakeDeployments) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*extensions.Deployment), err
 }
+
+// GetScale takes name of the deployment, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeDeployments) GetScale(deploymentName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(deploymentsResource, c.ns, "scale", deploymentName), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeDeployments) UpdateScale(deploymentName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "scale", c.ns, scale), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/fake/fake_replicaset.go
@@ -136,3 +136,25 @@ func (c *FakeReplicaSets) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*extensions.ReplicaSet), err
 }
+
+// GetScale takes name of the replicaSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeReplicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(replicasetsResource, c.ns, "scale", replicaSetName), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeReplicaSets) UpdateScale(replicaSetName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "scale", c.ns, scale), &extensions.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*extensions.Scale), err
+}

--- a/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
+++ b/pkg/client/clientset_generated/internalclientset/typed/extensions/internalversion/replicaset.go
@@ -42,6 +42,9 @@ type ReplicaSetInterface interface {
 	List(opts v1.ListOptions) (*extensions.ReplicaSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *extensions.ReplicaSet, err error)
+	GetScale(replicaSetName string, options v1.GetOptions) (*extensions.Scale, error)
+	UpdateScale(replicaSetName string, scale *extensions.Scale) (*extensions.Scale, error)
+
 	ReplicaSetExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the replicaSet, and returns the corresponding extensions.Scale object, and an error if there is any.
+func (c *replicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *replicaSets) UpdateScale(replicaSetName string, scale *extensions.Scale) (result *extensions.Scale, err error) {
+	result = &extensions.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -77,6 +77,8 @@ type Scale struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // StatefulSet represents a set of pods with consistent identities.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2951,6 +2951,8 @@ type ReplicationControllerCondition struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/extensions/v1beta1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/extensions/v1beta1.Scale,result=k8s.io/api/extensions/v1beta1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicationController represents the configuration of a replication controller.

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -158,6 +158,8 @@ type ThirdPartyResourceData struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Deployment enables declarative updates for Pods and ReplicaSets.
@@ -764,6 +766,8 @@ type IngressBackend struct {
 }
 
 // +genclient
+// +genclient:method=GetScale,verb=get,subresource=scale,result=Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ReplicaSet represents the configuration of a ReplicaSet.

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
@@ -136,3 +136,25 @@ func (c *FakeStatefulSets) Patch(name string, pt types.PatchType, data []byte, s
 	}
 	return obj.(*v1beta2.StatefulSet), err
 }
+
+// GetScale takes name of the statefulSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeStatefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *v1beta2.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(statefulsetsResource, c.ns, "scale", statefulSetName), &v1beta2.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeStatefulSets) UpdateScale(statefulSetName string, scale *v1beta2.Scale) (result *v1beta2.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(statefulsetsResource, "scale", c.ns, scale), &v1beta2.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta2.Scale), err
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -42,6 +42,9 @@ type StatefulSetInterface interface {
 	List(opts v1.ListOptions) (*v1beta2.StatefulSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta2.StatefulSet, err error)
+	GetScale(statefulSetName string, options v1.GetOptions) (*v1beta2.Scale, error)
+	UpdateScale(statefulSetName string, scale *v1beta2.Scale) (*v1beta2.Scale, error)
+
 	StatefulSetExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the statefulSet, and returns the corresponding v1beta2.Scale object, and an error if there is any.
+func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (result *v1beta2.Scale, err error) {
+	result = &v1beta2.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *statefulSets) UpdateScale(statefulSetName string, scale *v1beta2.Scale) (result *v1beta2.Scale, err error) {
+	result = &v1beta2.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("statefulsets").
+		Name(statefulSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/BUILD
@@ -35,6 +35,7 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/BUILD
@@ -34,6 +34,7 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -18,6 +18,7 @@ package fake
 
 import (
 	core_v1 "k8s.io/api/core/v1"
+	v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -135,4 +136,26 @@ func (c *FakeReplicationControllers) Patch(name string, pt types.PatchType, data
 		return nil, err
 	}
 	return obj.(*core_v1.ReplicationController), err
+}
+
+// GetScale takes name of the replicationController, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeReplicationControllers) GetScale(replicationControllerName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(replicationcontrollersResource, c.ns, "scale", replicationControllerName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeReplicationControllers) UpdateScale(replicationControllerName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicationcontrollersResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -42,6 +42,9 @@ type DeploymentInterface interface {
 	List(opts v1.ListOptions) (*v1beta1.DeploymentList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.Deployment, err error)
+	GetScale(deploymentName string, options v1.GetOptions) (*v1beta1.Scale, error)
+	UpdateScale(deploymentName string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
+
 	DeploymentExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the deployment, and returns the corresponding v1beta1.Scale object, and an error if there is any.
+func (c *deployments) GetScale(deploymentName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *deployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("deployments").
+		Name(deploymentName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -136,3 +136,25 @@ func (c *FakeDeployments) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*v1beta1.Deployment), err
 }
+
+// GetScale takes name of the deployment, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeDeployments) GetScale(deploymentName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(deploymentsResource, c.ns, "scale", deploymentName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeDeployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(deploymentsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -136,3 +136,25 @@ func (c *FakeReplicaSets) Patch(name string, pt types.PatchType, data []byte, su
 	}
 	return obj.(*v1beta1.ReplicaSet), err
 }
+
+// GetScale takes name of the replicaSet, and returns the corresponding scale object, and an error if there is any.
+func (c *FakeReplicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewGetSubresourceAction(replicasetsResource, c.ns, "scale", replicaSetName), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}
+
+// UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *FakeReplicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	obj, err := c.Fake.
+		Invokes(testing.NewUpdateSubresourceAction(replicasetsResource, "scale", c.ns, scale), &v1beta1.Scale{})
+
+	if obj == nil {
+		return nil, err
+	}
+	return obj.(*v1beta1.Scale), err
+}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -42,6 +42,9 @@ type ReplicaSetInterface interface {
 	List(opts v1.ListOptions) (*v1beta1.ReplicaSetList, error)
 	Watch(opts v1.ListOptions) (watch.Interface, error)
 	Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1beta1.ReplicaSet, err error)
+	GetScale(replicaSetName string, options v1.GetOptions) (*v1beta1.Scale, error)
+	UpdateScale(replicaSetName string, scale *v1beta1.Scale) (*v1beta1.Scale, error)
+
 	ReplicaSetExpansion
 }
 
@@ -166,6 +169,34 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
+		Do().
+		Into(result)
+	return
+}
+
+// GetScale takes name of the replicaSet, and returns the corresponding v1beta1.Scale object, and an error if there is any.
+func (c *replicaSets) GetScale(replicaSetName string, options v1.GetOptions) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Get().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		VersionedParams(&options, scheme.ParameterCodec).
+		Do().
+		Into(result)
+	return
+}
+
+// UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
+func (c *replicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (result *v1beta1.Scale, err error) {
+	result = &v1beta1.Scale{}
+	err = c.client.Put().
+		Namespace(c.ns).
+		Resource("replicasets").
+		Name(replicaSetName).
+		SubResource("scale").
+		Body(scale).
 		Do().
 		Into(result)
 	return

--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -47,6 +47,17 @@ func NewGetAction(resource schema.GroupVersionResource, namespace, name string) 
 	return action
 }
 
+func NewGetSubresourceAction(resource schema.GroupVersionResource, namespace, subresource, name string) GetActionImpl {
+	action := GetActionImpl{}
+	action.Verb = "get"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Name = name
+
+	return action
+}
+
 func NewRootListAction(resource schema.GroupVersionResource, kind schema.GroupVersionKind, opts interface{}) ListActionImpl {
 	action := ListActionImpl{}
 	action.Verb = "list"
@@ -70,6 +81,20 @@ func NewListAction(resource schema.GroupVersionResource, kind schema.GroupVersio
 	return action
 }
 
+func NewListSubresourceAction(resource schema.GroupVersionResource, name, subresource string, kind schema.GroupVersionKind, namespace string, opts interface{}) ListActionImpl {
+	action := ListActionImpl{}
+	action.Verb = "list"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Kind = kind
+	action.Namespace = namespace
+	action.Name = name
+	labelSelector, fieldSelector, _ := ExtractFromListOptions(opts)
+	action.ListRestrictions = ListRestrictions{labelSelector, fieldSelector}
+
+	return action
+}
+
 func NewRootCreateAction(resource schema.GroupVersionResource, object runtime.Object) CreateActionImpl {
 	action := CreateActionImpl{}
 	action.Verb = "create"
@@ -84,6 +109,18 @@ func NewCreateAction(resource schema.GroupVersionResource, namespace string, obj
 	action.Verb = "create"
 	action.Resource = resource
 	action.Namespace = namespace
+	action.Object = object
+
+	return action
+}
+
+func NewCreateSubresourceAction(resource schema.GroupVersionResource, name, subresource string, namespace string, object runtime.Object) CreateActionImpl {
+	action := CreateActionImpl{}
+	action.Verb = "create"
+	action.Resource = resource
+	action.Subresource = subresource
+	action.Namespace = namespace
+	action.Name = name
 	action.Object = object
 
 	return action
@@ -389,6 +426,7 @@ func (a GetActionImpl) GetName() string {
 type ListActionImpl struct {
 	ActionImpl
 	Kind             schema.GroupVersionKind
+	Name             string
 	ListRestrictions ListRestrictions
 }
 
@@ -402,6 +440,7 @@ func (a ListActionImpl) GetListRestrictions() ListRestrictions {
 
 type CreateActionImpl struct {
 	ActionImpl
+	Name   string
 	Object runtime.Object
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
@@ -32,6 +32,7 @@ var supportedTags = []string{
 	"genclient:skipVerbs",
 	"genclient:noStatus",
 	"genclient:readonly",
+	"genclient:method",
 }
 
 // SupportedVerbs is a list of supported verbs for +onlyVerbs and +skipVerbs.
@@ -54,6 +55,96 @@ var ReadonlyVerbs = []string{
 	"watch",
 }
 
+// genClientPrefix is the default prefix for all genclient tags.
+const genClientPrefix = "genclient:"
+
+// unsupportedExtensionVerbs is a list of verbs we don't support generating
+// extension client functions for.
+var unsupportedExtensionVerbs = []string{
+	"updateStatus",
+	"deleteCollection",
+	"watch",
+	"delete",
+}
+
+// inputTypeSupportedVerbs is a list of verb types that supports overriding the
+// input argument type.
+var inputTypeSupportedVerbs = []string{
+	"create",
+	"update",
+}
+
+// resultTypeSupportedVerbs is a list of verb types that supports overriding the
+// resulting type.
+var resultTypeSupportedVerbs = []string{
+	"create",
+	"update",
+	"get",
+	"list",
+	"patch",
+}
+
+// Extensions allows to extend the default set of client verbs
+// (CRUD+watch+patch+list+deleteCollection) for a given type with custom defined
+// verbs. Custom verbs can have custom input and result types and also allow to
+// use a sub-resource in a request instead of top-level resource type.
+//
+// Example:
+//
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
+//
+// type ReplicaSet struct { ... }
+//
+// The 'method=UpdateScale' is the name of the client function.
+// The 'verb=update' here means the client function will use 'PUT' action.
+// The 'subresource=scale' means we will use SubResource template to generate this client function.
+// The 'input' is the input type used for creation (function argument).
+// The 'result' (not needed in this case) is the result type returned from the
+// client function.
+//
+type extension struct {
+	// VerbName is the name of the custom verb (Scale, Instantiate, etc..)
+	VerbName string
+	// VerbType is the type of the verb (only verbs from SupportedVerbs are
+	// supported)
+	VerbType string
+	// SubResourcePath defines a path to a sub-resource to use in the request.
+	// (optional)
+	SubResourcePath string
+	// InputTypeOverride overrides the input parameter type for the verb. By
+	// default the original type is used. Overriding the input type only works for
+	// "create" and "update" verb types. The given type must exists in the same
+	// package as the original type.
+	// (optional)
+	InputTypeOverride string
+	// ResultTypeOverride overrides the resulting object type for the verb. By
+	// default the original type is used. Overriding the result type works.
+	// (optional)
+	ResultTypeOverride string
+}
+
+// IsSubresource indicates if this extension should generate the sub-resource.
+func (e *extension) IsSubresource() bool {
+	return len(e.SubResourcePath) > 0
+}
+
+// HasVerb checks if the extension matches the given verb.
+func (e *extension) HasVerb(verb string) bool {
+	return e.VerbType == verb
+}
+
+// Input returns the input override package path and the type.
+func (e *extension) Input() (string, string) {
+	parts := strings.Split(e.InputTypeOverride, ".")
+	return parts[len(parts)-1], strings.Join(parts[0:len(parts)-1], ".")
+}
+
+// Result returns the result override package path and the type.
+func (e *extension) Result() (string, string) {
+	parts := strings.Split(e.ResultTypeOverride, ".")
+	return parts[len(parts)-1], strings.Join(parts[0:len(parts)-1], ".")
+}
+
 // Tags represents a genclient configuration for a single type.
 type Tags struct {
 	// +genclient
@@ -67,6 +158,8 @@ type Tags struct {
 	// +genclient:skipVerbs=get,update
 	// +genclient:onlyVerbs=create,delete
 	SkipVerbs []string
+	// +genclient:method=UpdateScale,verb=update,subresource=scale,input=Scale,result=Scale
+	Extensions []extension
 }
 
 // HasVerb returns true if we should include the given verb in final client interface and
@@ -103,25 +196,25 @@ func ParseClientGenTags(lines []string) (Tags, error) {
 	if len(value) > 0 && len(value[0]) > 0 {
 		return ret, fmt.Errorf("+genclient=%s is invalid, use //+genclient if you want to generate client or omit it when you want to disable generation", value)
 	}
-	_, ret.NonNamespaced = values["genclient:nonNamespaced"]
+	_, ret.NonNamespaced = values[genClientPrefix+"nonNamespaced"]
 	// Check the old format and error when used
 	if value := values["nonNamespaced"]; len(value) > 0 && len(value[0]) > 0 {
 		return ret, fmt.Errorf("+nonNamespaced=%s is invalid, use //+genclient:nonNamespaced instead", value[0])
 	}
-	_, ret.NoVerbs = values["genclient:noVerbs"]
-	_, ret.NoStatus = values["genclient:noStatus"]
+	_, ret.NoVerbs = values[genClientPrefix+"noVerbs"]
+	_, ret.NoStatus = values[genClientPrefix+"noStatus"]
 	onlyVerbs := []string{}
-	if _, isReadonly := values["genclient:readonly"]; isReadonly {
+	if _, isReadonly := values[genClientPrefix+"readonly"]; isReadonly {
 		onlyVerbs = ReadonlyVerbs
 	}
 	// Check the old format and error when used
 	if value := values["readonly"]; len(value) > 0 && len(value[0]) > 0 {
 		return ret, fmt.Errorf("+readonly=%s is invalid, use //+genclient:readonly instead", value[0])
 	}
-	if v, exists := values["genclient:skipVerbs"]; exists {
+	if v, exists := values[genClientPrefix+"skipVerbs"]; exists {
 		ret.SkipVerbs = strings.Split(v[0], ",")
 	}
-	if v, exists := values["genclient:onlyVerbs"]; exists || len(onlyVerbs) > 0 {
+	if v, exists := values[genClientPrefix+"onlyVerbs"]; exists || len(onlyVerbs) > 0 {
 		if len(v) > 0 {
 			onlyVerbs = append(onlyVerbs, strings.Split(v[0], ",")...)
 		}
@@ -146,7 +239,92 @@ func ParseClientGenTags(lines []string) (Tags, error) {
 		}
 		ret.SkipVerbs = skipVerbs
 	}
+	var err error
+	if ret.Extensions, err = parseClientExtensions(values); err != nil {
+		return ret, err
+	}
 	return ret, validateClientGenTags(values)
+}
+
+func parseClientExtensions(tags map[string][]string) ([]extension, error) {
+	var ret []extension
+	for name, values := range tags {
+		if !strings.HasPrefix(name, genClientPrefix+"method") {
+			continue
+		}
+		for _, value := range values {
+			// the value comes in this form: "Foo,verb=create"
+			ext := extension{}
+			parts := strings.Split(value, ",")
+			if len(parts) == 0 {
+				return nil, fmt.Errorf("invalid of empty extension verb name: %q", value)
+			}
+			// The first part represents the name of the extension
+			ext.VerbName = parts[0]
+			if len(ext.VerbName) == 0 {
+				return nil, fmt.Errorf("must specify a verb name (// +genclient:method=Foo,verb=create)")
+			}
+			// Parse rest of the arguments
+			params := parts[1:]
+			for _, p := range params {
+				parts := strings.Split(p, "=")
+				if len(parts) != 2 {
+					return nil, fmt.Errorf("invalid extension tag specification %q", p)
+				}
+				key, val := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+				if len(val) == 0 {
+					return nil, fmt.Errorf("empty value of %q for %q extension", key, ext.VerbName)
+				}
+				switch key {
+				case "verb":
+					ext.VerbType = val
+				case "subresource":
+					ext.SubResourcePath = val
+				case "input":
+					ext.InputTypeOverride = val
+				case "result":
+					ext.ResultTypeOverride = val
+				default:
+					return nil, fmt.Errorf("unknown extension configuration key %q", key)
+				}
+			}
+			// Validate resulting extension configuration
+			if len(ext.VerbType) == 0 {
+				return nil, fmt.Errorf("verb type must be specified (use '// +genclient:method=%s,verb=create')", ext.VerbName)
+			}
+			if len(ext.ResultTypeOverride) > 0 {
+				supported := false
+				for _, v := range resultTypeSupportedVerbs {
+					if ext.VerbType == v {
+						supported = true
+						break
+					}
+				}
+				if !supported {
+					return nil, fmt.Errorf("%s: result type is not supported for %q verbs (supported verbs: %#v)", ext.VerbName, ext.VerbType, resultTypeSupportedVerbs)
+				}
+			}
+			if len(ext.InputTypeOverride) > 0 {
+				supported := false
+				for _, v := range inputTypeSupportedVerbs {
+					if ext.VerbType == v {
+						supported = true
+						break
+					}
+				}
+				if !supported {
+					return nil, fmt.Errorf("%s: input type is not supported for %q verbs (supported verbs: %#v)", ext.VerbName, ext.VerbType, inputTypeSupportedVerbs)
+				}
+			}
+			for _, t := range unsupportedExtensionVerbs {
+				if ext.VerbType == t {
+					return nil, fmt.Errorf("verb %q is not supported by extension generator", ext.VerbType)
+				}
+			}
+			ret = append(ret, ext)
+		}
+	}
+	return ret, nil
 }
 
 // validateTags validates that only supported genclient tags were provided.
@@ -155,7 +333,7 @@ func validateClientGenTags(values map[string][]string) error {
 		delete(values, k)
 	}
 	for key := range values {
-		if strings.HasPrefix(key, "genclient") {
+		if strings.HasPrefix(key, strings.TrimSuffix(genClientPrefix, ":")) {
 			return errors.New("unknown tag detected: " + key)
 		}
 	}


### PR DESCRIPTION
This change will allow to define custom verbs for resources using the following new tag:

```
// +genclient:method=Foo,verb=create,subresource=foo,input=Bar,output=k8s.io/pkg/api.Blah
```

This will generate client method `Foo(bar *Bar) (*api.Blah, error)` (format depends on the particular verb type)

With this change we can add `UpdateScale()` and `GetScale()` into all scalable resources. Note that intention of this PR is not to fix the Scale(), but that is used as an example of this new capability.
Additionally this will also allow us to get rid of `// +genclient:noStatus` and fix guessing of the "updateStatus" subresource presence based on the existence of '.Status' field.
Basically you will have to add following into all types you want to generate `UpdateStatus()` for:

```
// +genclient:method=UpdateStatus,verb=update,subresource=status
```

This allows further extension of the client without writing an expansion (which proved to be pain to maintain and copy...). Also allows to customize native CRUD methods if needed (input/output types).

```release-note
NONE
```