### PR TITLE
do not update init containers status if terminated

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1329,10 +1329,17 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 			Image: container.Image,
 			State: defaultWaitingState,
 		}
-		// Apply some values from the old statuses as the default values.
-		if oldStatus, found := oldStatuses[container.Name]; found {
-			status.RestartCount = oldStatus.RestartCount
-			status.LastTerminationState = oldStatus.LastTerminationState
+		oldStatus, found := oldStatuses[container.Name]
+		if found {
+			if isInitContainer && oldStatus.State.Terminated != nil {
+				// Do not update status on terminated init containers as
+				// they be removed at any time.
+				status = &oldStatus
+			} else {
+				// Apply some values from the old statuses as the default values.
+				status.RestartCount = oldStatus.RestartCount
+				status.LastTerminationState = oldStatus.LastTerminationState
+			}
 		}
 		statuses[container.Name] = status
 	}


### PR DESCRIPTION
fixes #29972 #41580

This fixes an issue where, if a completed init container is removed while the pod or subsequent init containers are still running, the status for that init container will be reset to `Waiting` with `PodInitializing`.  

This can manifest in a number of ways.

If the init container is removed why the main pod containers are running, the status will be reset with no functional problem but the status will be reported incorrectly in `kubectl get pod` for example

If the init container is removed why a subsequent init container is running, the init container will be **re-executed** leading to all manner of badness.

@derekwaynecarr @bparees