### PR TITLE
Update the label manifest with new do-not-merge labels

### DIFF
--- a/labels.yaml
+++ b/labels.yaml
@@ -162,6 +162,16 @@ labels:
   color: bfe5bf
 - name: do-not-merge
   color: e11d21
+- name: do-not-merge/work-in-progress
+  color: e11d21
+- name: do-not-merge/hold
+  color: e11d21
+- name: do-not-merge/cherry-pick-not-approved
+  color: e11d21
+- name: do-not-merge/release-note-label-needed
+  color: e11d21
+- name: do-not-merge/blocked-paths
+  color: e11d21
 - name: flake-has-meta
   color: fbca04
 - name: for-new-contributors


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

https://github.com/kubernetes/kubernetes/issues/51735
(issue added by fejta)

```release-note
NONE
```

/cc @bgrant0607 @fejta 
/assign @grodrigues3 @spxtr 