### PR TITLE
Fixed integer overflow when matching PVPVC claims

### DIFF
--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -805,6 +805,7 @@ var (
 	classExternal                string = "external"
 	classUnknownInternal         string = "unknown-internal"
 	classUnsupportedMountOptions string = "unsupported-mountoptions"
+	classLarge                   string = "large"
 )
 
 // wrapTestWithPluginCalls returns a testCall that:


### PR DESCRIPTION
Fixes #49911

Fixed integer overflow when matching PVPVC claims. Added test to guard this behavior.