### PR TITLE
GCE: E2E test - supplied static IP for internal LBs

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -3111,4 +3111,5 @@ function ssh-to-node() {
 # Perform preparations required to run e2e tests
 function prepare-e2e() {
   detect-project
+  detect-subnetworks
 }

--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -157,6 +157,7 @@ export PATH=$(dirname "${e2e_test}"):"${PATH}"
   --node-instance-group="${NODE_INSTANCE_GROUP:-}" \
   --prefix="${KUBE_GCE_INSTANCE_PREFIX:-e2e}" \
   --network="${KUBE_GCE_NETWORK:-${KUBE_GKE_NETWORK:-e2e}}" \
+  --subnetwork="${SUBNETWORK:-}" \
   --node-tag="${NODE_TAG:-}" \
   --master-tag="${MASTER_TAG:-}" \
   --cluster-monitoring-mode="${KUBE_ENABLE_CLUSTER_MONITORING:-standalone}" \

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -81,8 +81,8 @@ func setupProviderConfig() error {
 			Region:             region,
 			Zone:               zone,
 			ManagedZones:       managedZones,
-			NetworkName:        "", // TODO: Change this to use framework.TestContext.CloudConfig.Network?
-			SubnetworkName:     "",
+			NetworkName:        framework.TestContext.CloudConfig.Network,
+			SubnetworkName:     framework.TestContext.CloudConfig.Subnetwork,
 			NodeTags:           nil,
 			NodeInstancePrefix: "",
 			TokenSource:        nil,

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -184,6 +184,7 @@ type CloudConfig struct {
 	ClusterIPRange    string
 	ClusterTag        string
 	Network           string
+	Subnetwork        string
 	ConfigFile        string // for azure and openstack
 	NodeTag           string
 	MasterTag         string
@@ -267,6 +268,7 @@ func RegisterClusterFlags() {
 	flag.StringVar(&cloudConfig.Cluster, "gke-cluster", "", "GKE name of cluster being used, if applicable")
 	flag.StringVar(&cloudConfig.NodeInstanceGroup, "node-instance-group", "", "Name of the managed instance group for nodes. Valid only for gce, gke or aws. If there is more than one group: comma separated list of groups.")
 	flag.StringVar(&cloudConfig.Network, "network", "e2e", "The cloud provider network for this e2e cluster.")
+	flag.StringVar(&cloudConfig.Subnetwork, "subnetwork", "", "The cloud provider subnetwork for this e2e cluster.")
 	flag.IntVar(&cloudConfig.NumNodes, "num-nodes", -1, "Number of nodes in the cluster")
 	flag.StringVar(&cloudConfig.ClusterIPRange, "cluster-ip-range", "10.64.0.0/14", "A CIDR notation IP range from which to assign IPs in the cluster.")
 	flag.StringVar(&cloudConfig.NodeTag, "node-tag", "", "Network tags used on node instances. Valid only for gce, gke")


### PR DESCRIPTION
ILB test will now reserve an RFC 1918 address within the subnetwork and set the `loadBalancerIP` field of the K8s service. The test will know the service controller successfully syncs after the loadbalancer's external IP updates to said address.

**Release note**:
```release-note
NONE
```
