### PR TITLE
Add fallback function 'detect-project' in skeleton util

### DIFF
--- a/cluster/skeleton/util.sh
+++ b/cluster/skeleton/util.sh
@@ -93,3 +93,7 @@ function test-teardown {
 function prepare-e2e {
 	echo "Skeleton Provider: prepare-e2e not implemented" 1>&2
 }
+
+function detect-project {
+	echo "Skeleton Provider: detect-project not implemented" 1>&2
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

detect-project is not implemented by default:
When use ./hack/ginkgo-e2e.sh to run e2e test with custom providers, it will prompt
```
log-dump.sh: line 70: detect-project: command not found
```
And script exits with code 127.

**Which issue this PR fixes**

**Special notes for your reviewer**:

**Release note**:
`NONE`

@shyamjvs
