### PR TITLE
Fix format specifiers in Azure cloud provider

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -285,7 +285,7 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		az.operationPollRateLimiter = flowcontrol.NewTokenBucketRateLimiter(
 			az.CloudProviderRateLimitQPS,
 			az.CloudProviderRateLimitBucket)
-		glog.V(2).Infof("Azure cloudprovider using rate limit config: QPS=%d, bucket=%d",
+		glog.V(2).Infof("Azure cloudprovider using rate limit config: QPS=%g, bucket=%d",
 			az.CloudProviderRateLimitQPS,
 			az.CloudProviderRateLimitBucket)
 	} else {

--- a/pkg/cloudprovider/providers/azure/azure_backoff.go
+++ b/pkg/cloudprovider/providers/azure/azure_backoff.go
@@ -157,11 +157,11 @@ func (az *Cloud) DeleteLBWithRetry(lbName string) error {
 func (az *Cloud) CreateOrUpdateRouteTableWithRetry(routeTable network.RouteTable) error {
 	return wait.ExponentialBackoff(az.resourceRequestBackoff, func() (bool, error) {
 		az.operationPollRateLimiter.Accept()
-		glog.V(10).Infof("RouteTablesClient.CreateOrUpdate(%s): start", routeTable)
+		glog.V(10).Infof("RouteTablesClient.CreateOrUpdate(%s): start", *routeTable.Name)
 		respChan, errChan := az.RouteTablesClient.CreateOrUpdate(az.ResourceGroup, az.RouteTableName, routeTable, nil)
 		resp := <-respChan
 		err := <-errChan
-		glog.V(10).Infof("RouteTablesClient.CreateOrUpdate(%s): end", routeTable)
+		glog.V(10).Infof("RouteTablesClient.CreateOrUpdate(%s): end", *routeTable.Name)
 		return processRetryResponse(resp.Response, err)
 	})
 }

--- a/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
@@ -184,7 +184,7 @@ func (c *BlobDiskController) createVHDBlobDisk(blobClient azstorage.BlobStorageC
 
 	tags := make(map[string]string)
 	tags["createdby"] = "k8sAzureDataDisk"
-	glog.V(4).Infof("azureDisk - creating page blob %name in container %s account %s", vhdName, containerName, accountName)
+	glog.V(4).Infof("azureDisk - creating page blob %s in container %s account %s", vhdName, containerName, accountName)
 
 	blob := container.GetBlobReference(vhdName)
 	blob.Properties.ContentLength = vhdSize
@@ -626,7 +626,7 @@ func (c *BlobDiskController) createStorageAccount(storageAccountName string, sto
 		// SA Accounts takes time to be provisioned
 		// so if this account was just created allow it sometime
 		// before polling
-		glog.V(2).Infof("azureDisk - storage account %s was just created, allowing time before polling status")
+		glog.V(2).Infof("azureDisk - storage account %s was just created, allowing time before polling status", storageAccountName)
 		time.Sleep(25 * time.Second) // as observed 25 is the average time for SA to be provisioned
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Fixes invalid/mismatched format specifiers in Azure cloud provider logging statements (`glog...Infof(...)`) that would cause information to be lost in logging output, as flagged by `go vet`.

**Which issue this PR fixes**: None

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
