### PR TITLE
Use etcd2 with CoreOs

### DIFF
--- a/cluster/libvirt-coreos/user_data_master.yml
+++ b/cluster/libvirt-coreos/user_data_master.yml
@@ -23,6 +23,7 @@ coreos:
         --insecure-bind-address=0.0.0.0 \
         --insecure-port=8080 \
         --etcd-servers=http://127.0.0.1:2379 \
+        --storage-backend=etcd2 \
         --kubelet-port=10250 \
         --v=4 \
         --service-cluster-ip-range=${SERVICE_CLUSTER_IP_RANGE}


### PR DESCRIPTION
Default image used in libvirt-coreos deployment is shipped with etcd2.
When we try use newer version of k8s where etcd3 is used by default
kube-apiserver crashes. Please see #43634 and coreos/coreos-kubernetes#871

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Users who follows https://kubernetes.io/docs/getting-started-guides/libvirt-coreos are not able to finish deployment due the constantly restarting kube-apiserver. This service in newer version of k8s is using by default etcd3 but CoreOs is shipped with etcd2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
