### PR TITLE
metricsutil: Remove HeapsterMetricsClient constructor

### DIFF
--- a/pkg/kubectl/cmd/top_node.go
+++ b/pkg/kubectl/cmd/top_node.go
@@ -123,7 +123,13 @@ func (o *TopNodeOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		return err
 	}
 	o.NodeClient = clientset.Core()
-	o.Client = metricsutil.NewHeapsterMetricsClient(clientset.Core(), o.HeapsterOptions.Namespace, o.HeapsterOptions.Scheme, o.HeapsterOptions.Service, o.HeapsterOptions.Port)
+	o.Client = &metricsutil.HeapsterMetricsClient{
+		SVCClient:         clientset.Core(),
+		HeapsterNamespace: o.HeapsterOptions.Namespace,
+		HeapsterScheme:    o.HeapsterOptions.Scheme,
+		HeapsterService:   o.HeapsterOptions.Service,
+		HeapsterPort:      o.HeapsterOptions.Port,
+	}
 	o.Printer = metricsutil.NewTopCmdPrinter(out)
 	return nil
 }

--- a/pkg/kubectl/cmd/top_pod.go
+++ b/pkg/kubectl/cmd/top_pod.go
@@ -119,7 +119,13 @@ func (o *TopPodOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 		return err
 	}
 	o.PodClient = clientset.Core()
-	o.Client = metricsutil.NewHeapsterMetricsClient(clientset.Core(), o.HeapsterOptions.Namespace, o.HeapsterOptions.Scheme, o.HeapsterOptions.Service, o.HeapsterOptions.Port)
+	o.Client = &metricsutil.HeapsterMetricsClient{
+		SVCClient:         clientset.Core(),
+		HeapsterNamespace: o.HeapsterOptions.Namespace,
+		HeapsterScheme:    o.HeapsterOptions.Scheme,
+		HeapsterService:   o.HeapsterOptions.Service,
+		HeapsterPort:      o.HeapsterOptions.Port,
+	}
 	o.Printer = metricsutil.NewTopCmdPrinter(out)
 	return nil
 }

--- a/pkg/kubectl/metricsutil/metrics_client.go
+++ b/pkg/kubectl/metricsutil/metrics_client.go
@@ -53,18 +53,14 @@ type HeapsterMetricsClient struct {
 	HeapsterPort      string
 }
 
-func NewHeapsterMetricsClient(svcClient coreclient.ServicesGetter, namespace, scheme, service, port string) *HeapsterMetricsClient {
+func DefaultHeapsterMetricsClient(svcClient coreclient.ServicesGetter) *HeapsterMetricsClient {
 	return &HeapsterMetricsClient{
 		SVCClient:         svcClient,
-		HeapsterNamespace: namespace,
-		HeapsterScheme:    scheme,
-		HeapsterService:   service,
-		HeapsterPort:      port,
+		HeapsterNamespace: DefaultHeapsterNamespace,
+		HeapsterScheme:    DefaultHeapsterScheme,
+		HeapsterService:   DefaultHeapsterService,
+		HeapsterPort:      DefaultHeapsterPort,
 	}
-}
-
-func DefaultHeapsterMetricsClient(svcClient coreclient.ServicesGetter) *HeapsterMetricsClient {
-	return NewHeapsterMetricsClient(svcClient, DefaultHeapsterNamespace, DefaultHeapsterScheme, DefaultHeapsterService, DefaultHeapsterPort)
 }
 
 func podMetricsUrl(namespace string, name string) (string, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `metrics_client.go` provides a constructor for a `HeapsterMetricsClient`
object. The constructor simply returns the address of a struct literal. Having this
constructor adds nothing to the code base since the same can be achieved by simply
using a struct literal.

The constructor makes creation worse because it burdens the reader (and writer) with
remembering the order of the parameters. It also makes the code more bug prone since
4 of the 5 parameters are strings and the compiler will not catch a miss-ordering.

Remove the constructor and use a struct literal. Utilize name based struct literals
improving readability and reducing the risk of miss-ordering the struct members.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup