### PR TITLE
Skip job adoption test in cronjob controller in newer clusters

### DIFF
--- a/test/e2e/cronjob.go
+++ b/test/e2e/cronjob.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/job"
 	"k8s.io/kubernetes/pkg/kubectl"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -47,6 +48,7 @@ const (
 var (
 	CronJobGroupVersionResource      = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "cronjobs"}
 	ScheduledJobGroupVersionResource = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}
+	removedScheduledJobsVersion      = utilversion.MustParseSemantic("v1.8.0")
 )
 
 var _ = framework.KubeDescribe("CronJob", func() {
@@ -63,6 +65,7 @@ var _ = framework.KubeDescribe("CronJob", func() {
 
 	// multiple jobs running at once
 	It("should schedule multiple jobs concurrently", func() {
+		framework.SkipUnlessServerVersionLT(removedScheduledJobsVersion, f.ClientSet.Discovery())
 		By("Creating a cronjob")
 		cronJob := newTestCronJob("concurrent", "*/1 * * * ?", batchv2alpha1.AllowConcurrent,
 			sleepCommand, nil)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -428,6 +428,16 @@ func SkipUnlessServerVersionGTE(v *utilversion.Version, c discovery.ServerVersio
 	}
 }
 
+func SkipUnlessServerVersionLT(v *utilversion.Version, c discovery.ServerVersionInterface) {
+	gte, err := ServerVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		Skipf("Not supported for server versions starting from %q", v)
+	}
+}
+
 func SkipIfMissingResource(clientPool dynamic.ClientPool, gvr schema.GroupVersionResource, namespace string) {
 	dynamicClient, err := clientPool.ClientForGroupVersionResource(gvr)
 	if err != nil {


### PR DESCRIPTION
This will skip `[k8s.io] CronJob should adopt Jobs it owns that don't have ControllerRef yet`, which was removed in https://github.com/kubernetes/kubernetes/pull/47469 in k8s 1.8. ptal

@mbohlool if you have an issue please link it here. 