### PR TITLE
Fix execution of kube-addons

### DIFF
--- a/cluster/libvirt-coreos/config-default.sh
+++ b/cluster/libvirt-coreos/config-default.sh
@@ -67,7 +67,7 @@ ENABLE_DNS_HORIZONTAL_AUTOSCALER="${KUBE_ENABLE_DNS_HORIZONTAL_AUTOSCALER:-false
 #Generate dns files
 sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-controller.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-controller.yaml"
 sed -f "${KUBE_ROOT}/cluster/addons/dns/transforms2sed.sed" < "${KUBE_ROOT}/cluster/addons/dns/kubedns-svc.yaml.base" | sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-svc.yaml"
-cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-sa.yaml" "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-sa.yaml"
+sed -f "${KUBE_ROOT}/cluster/libvirt-coreos/forShellEval.sed"  < "${KUBE_ROOT}/cluster/addons/dns/kubedns-sa.yaml" > "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-sa.yaml"
 cp "${KUBE_ROOT}/cluster/addons/dns/kubedns-cm.yaml" "${KUBE_ROOT}/cluster/libvirt-coreos/kubedns-cm.yaml"
 
 

--- a/cluster/libvirt-coreos/util.sh
+++ b/cluster/libvirt-coreos/util.sh
@@ -216,7 +216,6 @@ function initialize-pool {
 
   mkdir -p "$POOL_PATH/kubernetes/addons"
   if [[ "$ENABLE_CLUSTER_DNS" == "true" ]]; then
-      render-template "$ROOT/namespace.yaml" > "$POOL_PATH/kubernetes/addons/namespace.yaml"
       render-template "$ROOT/kubedns-svc.yaml" > "$POOL_PATH/kubernetes/addons/kubedns-svc.yaml"
       render-template "$ROOT/kubedns-controller.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-controller.yaml"
       render-template "$ROOT/kubedns-sa.yaml"  > "$POOL_PATH/kubernetes/addons/kubedns-sa.yaml"


### PR DESCRIPTION
kube-addons service exits with error due to two problems:

- quotes in ServiceAccount definition are not properly escaped
- namespace "kube-system" already exists

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR resolves two problems visible during kube-addons service start:
```
Error from server (BadRequest): error when creating "/opt/kubernetes/addons/kubedns-sa.yaml": ServiceAccount in version "v1" cannot be handled as a ServiceAccount: [pos 144]: json: expect char '"' but got char 't'
```

and

```
Error from server (AlreadyExists): error when creating "/opt/kubernetes/addons/namespace.yaml": namespaces "kube-system" already exists
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```