### PR TITLE
apiextensions: add maximum for validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -57,6 +57,7 @@ func convertJSONSchemaProps(in *apiextensions.JSONSchemaProps, out *spec.Schema)
 	}
 	out.Format = in.Format
 	out.Title = in.Title
+	out.Maximum = in.Maximum
 	out.ExclusiveMaximum = in.ExclusiveMaximum
 	out.Minimum = in.Minimum
 	out.ExclusiveMinimum = in.ExclusiveMinimum


### PR DESCRIPTION
Missed the `Maximum` field for validation. Adding it now.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @sttts 
