### PR TITLE
[WIP] Add unit tests to smoke test OpenAPI delegation

### DIFF
--- a/cmd/kube-apiserver/app/testing/BUILD
+++ b/cmd/kube-apiserver/app/testing/BUILD
@@ -12,6 +12,7 @@ go_test(
         "openapi_test.go",
         "server_test.go",
     ],
+    importpath = "k8s.io/kubernetes/cmd/kube-apiserver/app/testing",
     library = ":go_default_library",
     deps = [
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",

--- a/cmd/kube-apiserver/app/testing/BUILD
+++ b/cmd/kube-apiserver/app/testing/BUILD
@@ -16,6 +16,7 @@ go_test(
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -28,6 +29,7 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/util/feature/testing:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
     ],
 )
 

--- a/cmd/kube-apiserver/app/testing/BUILD
+++ b/cmd/kube-apiserver/app/testing/BUILD
@@ -8,8 +8,10 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["server_test.go"],
-    importpath = "k8s.io/kubernetes/cmd/kube-apiserver/app/testing",
+    srcs = [
+        "openapi_test.go",
+        "server_test.go",
+    ],
     library = ":go_default_library",
     deps = [
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",

--- a/cmd/kube-apiserver/app/testing/openapi_test.go
+++ b/cmd/kube-apiserver/app/testing/openapi_test.go
@@ -1,0 +1,99 @@
+// +build !race
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// We disable the race detector here because we cross a 5 minute test
+// time out threshold on CI systems; after 5 minutes the tests are
+// deemed to have failed.
+//
+// A `make test` will use -race whereas `make bazel-test` will not. We
+// want this test executed at least once and the simplest way is to
+// ensure that this test is not executed when -race is in effect.
+
+package testing
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
+)
+
+// TestOpenAPIDelegationChainPlumbing is a smoke test that checks for
+// the existence of some representative paths from the
+// apiextensions-server and the kube-aggregator server, both part of
+// the delegation chain in kube-apiserver.
+func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
+	config, tearDown := StartTestServerOrDie(t)
+	defer tearDown()
+
+	kubeclient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	result := kubeclient.RESTClient().Get().AbsPath("/swagger.json").Do()
+	status := 0
+	result.StatusCode(&status)
+	if status != 200 {
+		t.Fatalf("GET /swagger.json failed: expected status=%d, got=%d", 200, status)
+	}
+
+	raw, err := result.Raw()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	type openAPISchema struct {
+		Paths map[string]interface{} `json:"paths"`
+	}
+
+	var doc openAPISchema
+	err = json.Unmarshal(raw, &doc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	matchedExtension := false
+	extensionsPrefix := "/apis/" + apiextensions.GroupName
+
+	matchedRegistration := false
+	registrationPrefix := "/apis/" + apiregistration.GroupName
+
+	for path := range doc.Paths {
+		if strings.HasPrefix(path, extensionsPrefix) {
+			matchedExtension = true
+		}
+		if strings.HasPrefix(path, registrationPrefix) {
+			matchedRegistration = true
+		}
+		if matchedExtension && matchedRegistration {
+			return
+		}
+	}
+
+	if !matchedExtension {
+		t.Errorf("missing path: %q", extensionsPrefix)
+	}
+
+	if !matchedRegistration {
+		t.Errorf("missing path: %q", registrationPrefix)
+	}
+}

--- a/cmd/kube-apiserver/app/testing/openapi_test.go
+++ b/cmd/kube-apiserver/app/testing/openapi_test.go
@@ -97,7 +97,3 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 		t.Errorf("missing path: %q", registrationPrefix)
 	}
 }
-
-func TestBazelFails(t *testing.T) {
-	t.Error("expecting this to fail")
-}

--- a/cmd/kube-apiserver/app/testing/openapi_test.go
+++ b/cmd/kube-apiserver/app/testing/openapi_test.go
@@ -97,3 +97,7 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 		t.Errorf("missing path: %q", registrationPrefix)
 	}
 }
+
+func TestBazelFails(t *testing.T) {
+	t.Error("expecting this to fail")
+}

--- a/cmd/kube-apiserver/app/testing/server_test.go
+++ b/cmd/kube-apiserver/app/testing/server_test.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,6 +40,7 @@ import (
 	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 )
 
 func TestRun(t *testing.T) {
@@ -388,4 +391,66 @@ func crdExistsInDiscovery(client apiextensionsclientset.Interface, crd *apiexten
 		}
 	}
 	return false, nil
+}
+
+// TestOpenAPIDelegationChainPlumbing is a smoke test that checks for
+// the existence of some representative paths from the
+// apiextensions-server and the kube-aggregator server, both part of
+// the delegation chain in kube-apiserver.
+func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
+	config, tearDown := StartTestServerOrDie(t)
+	defer tearDown()
+
+	kubeclient, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	result := kubeclient.RESTClient().Get().AbsPath("/swagger.json").Do()
+	status := 0
+	result.StatusCode(&status)
+	if status != 200 {
+		t.Fatalf("GET /swagger.json failed: expected status=%d, got=%d", 200, status)
+	}
+
+	raw, err := result.Raw()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	type openAPISchema struct {
+		Paths map[string]interface{} `json:"paths"`
+	}
+
+	var doc openAPISchema
+	err = json.Unmarshal(raw, &doc)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal: %v", err)
+	}
+
+	matchedExtension := false
+	extensionsPrefix := "/apis/" + apiextensions.GroupName
+
+	matchedRegistration := false
+	registrationPrefix := "/apis/" + apiregistration.GroupName
+
+	for path := range doc.Paths {
+		if strings.HasPrefix(path, extensionsPrefix) {
+			matchedExtension = true
+		}
+		if strings.HasPrefix(path, registrationPrefix) {
+			matchedRegistration = true
+		}
+		if matchedExtension && matchedRegistration {
+			return
+		}
+	}
+
+	if !matchedExtension {
+		t.Errorf("missing path: %q", extensionsPrefix)
+	}
+
+	if !matchedRegistration {
+		t.Errorf("missing path: %q", registrationPrefix)
+	}
 }

--- a/cmd/kube-apiserver/app/testing/server_test.go
+++ b/cmd/kube-apiserver/app/testing/server_test.go
@@ -19,7 +19,6 @@ package testing
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	appsv1beta1 "k8s.io/api/apps/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -40,7 +38,6 @@ import (
 	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 )
 
 func TestRun(t *testing.T) {
@@ -391,66 +388,4 @@ func crdExistsInDiscovery(client apiextensionsclientset.Interface, crd *apiexten
 		}
 	}
 	return false, nil
-}
-
-// TestOpenAPIDelegationChainPlumbing is a smoke test that checks for
-// the existence of some representative paths from the
-// apiextensions-server and the kube-aggregator server, both part of
-// the delegation chain in kube-apiserver.
-func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
-	config, tearDown := StartTestServerOrDie(t)
-	defer tearDown()
-
-	kubeclient, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	result := kubeclient.RESTClient().Get().AbsPath("/swagger.json").Do()
-	status := 0
-	result.StatusCode(&status)
-	if status != 200 {
-		t.Fatalf("GET /swagger.json failed: expected status=%d, got=%d", 200, status)
-	}
-
-	raw, err := result.Raw()
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
-	}
-
-	type openAPISchema struct {
-		Paths map[string]interface{} `json:"paths"`
-	}
-
-	var doc openAPISchema
-	err = json.Unmarshal(raw, &doc)
-	if err != nil {
-		t.Fatalf("Failed to unmarshal: %v", err)
-	}
-
-	matchedExtension := false
-	extensionsPrefix := "/apis/" + apiextensions.GroupName
-
-	matchedRegistration := false
-	registrationPrefix := "/apis/" + apiregistration.GroupName
-
-	for path := range doc.Paths {
-		if strings.HasPrefix(path, extensionsPrefix) {
-			matchedExtension = true
-		}
-		if strings.HasPrefix(path, registrationPrefix) {
-			matchedRegistration = true
-		}
-		if matchedExtension && matchedRegistration {
-			return
-		}
-	}
-
-	if !matchedExtension {
-		t.Errorf("missing path: %q", extensionsPrefix)
-	}
-
-	if !matchedRegistration {
-		t.Errorf("missing path: %q", registrationPrefix)
-	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Add a smoke test that checks for the existence of some representative
paths from the apiextensions-server and the kube-aggregator server,
both part of the delegation chain in kube-apiserver.

And although the /api/openapi/swagger.json has the whole spec in it
and it is checked in, it is no guarantee that nothing is broken. This test
is a smoke test to help ensure we don't break OpenAPI delegation.
It's explicit, the checked in json file is not.

**Which issue this PR fixes**: 

Validates at test time #50011

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```