### PR TITLE
bazel: Generate deb and rpms package with correct versions

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -80,7 +80,7 @@ genrule(
     cmd = """
 grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
     | awk '{print $$2}' \
-    | sed -e 's/^v//' -e 's/[\+-]/_/g' \
+    | sed -e 's/^v//' -Ee 's/-([a-z]+)/~\\1/' -e 's/-/+/g' \
     >$@
 """,
     stamp = 1,

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -89,6 +89,7 @@ pkg_tar(
 k8s_deb(
     name = "cloud-controller-manager",
     description = "Kubernetes Cloud Controller Manager",
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
@@ -96,21 +97,25 @@ k8s_deb(
     description = """Kubernetes Command Line Tool
 The Kubernetes command line tool for interacting with the Kubernetes API.
 """,
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
     name = "kube-apiserver",
     description = "Kubernetes API Server",
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
     name = "kube-controller-manager",
     description = "Kubernetes Controller Manager",
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
     name = "kube-scheduler",
     description = "Kubernetes Scheduler",
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
@@ -120,6 +125,7 @@ k8s_deb(
         "iproute2",
     ],
     description = "Kubernetes Service Proxy",
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
@@ -137,6 +143,7 @@ k8s_deb(
     description = """Kubernetes Node Agent
 The node agent of Kubernetes, the container cluster manager
 """,
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
@@ -148,6 +155,7 @@ k8s_deb(
     description = """Kubernetes Cluster Bootstrapping Tool
 The Kubernetes command line tool for bootstrapping a Kubernetes cluster.
 """,
+    version_file = "//build:os_package_version",
 )
 
 k8s_deb(
@@ -155,6 +163,7 @@ k8s_deb(
     description = """Kubernetes Packaging of CNI
 The Container Networking Interface tools for provisioning container networks.
 """,
+    version_file = "//build:os_package_version",
 )
 
 filegroup(

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -7,9 +7,9 @@ http_archive(
 
 http_archive(
     name = "io_kubernetes_build",
-    sha256 = "5da78568ffb9a323410c701618c23da8c93f4bf4aea76eee41ac244dbd8c8f95",
-    strip_prefix = "repo-infra-4eaf9e671bbb549fb4ec292cf251f921d7ef80ac",
-    urls = ["https://github.com/kubernetes/repo-infra/archive/4eaf9e671bbb549fb4ec292cf251f921d7ef80ac.tar.gz"],
+    sha256 = "ca8fa1ee0928220d77fcaa6bcf40a26c57800c024e21b08c8dd9cc8fbf910236",
+    strip_prefix = "repo-infra-0aafaab9e158d3628804242c6a9c4dd3eb8bce1f",
+    urls = ["https://github.com/kubernetes/repo-infra/archive/0aafaab9e158d3628804242c6a9c4dd3eb8bce1f.tar.gz"],
 )
 
 ETCD_VERSION = "3.0.17"

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -4,6 +4,7 @@ load("@bazel_tools//tools/build_defs/pkg:rpm.bzl", "pkg_rpm")
 
 pkg_rpm(
     name = "kubectl",
+    architecture = "x86_64",
     changelog = "//:CHANGELOG.md",
     data = [
         "//cmd/kubectl",
@@ -14,6 +15,7 @@ pkg_rpm(
 
 pkg_rpm(
     name = "kubelet",
+    architecture = "x86_64",
     changelog = "//:CHANGELOG.md",
     data = [
         "kubelet.service",
@@ -25,6 +27,7 @@ pkg_rpm(
 
 pkg_rpm(
     name = "kubeadm",
+    architecture = "x86_64",
     changelog = "//:CHANGELOG.md",
     data = [
         "10-kubeadm.conf",
@@ -36,6 +39,7 @@ pkg_rpm(
 
 pkg_rpm(
     name = "kubernetes-cni",
+    architecture = "x86_64",
     changelog = "//:CHANGELOG.md",
     data = [
         "@kubernetes_cni//file",


### PR DESCRIPTION
**What this PR does / why we need it**: Currently deb packages generated by bazel build have hardcoded version which does not correspond to actual content. This PR allows to set versions for debian packages similar to rpms.
Another issue that currently versions have underscores in the version field which is not acceptable by many of packaging guidelines. After this PR it will generate versions like:

```
1.6.9
1.7.0~alpha.1
1.7.0~beta.0
1.7.0~rc.1
1.7.0
1.7.1~beta.0
1.7.1
1.7.6~beta.0
1.8.0~alpha.0
1.8.0~alpha.3.602+5f8adc0c042843
1.8.0~alpha.3.601+e3210c6ccf77dd+dirty
```
This allows to sort versions correctly both in DPKG and RPM.
(Fedora packaging guidelines don't like ~, but rpm in Fedora, CentOS and OpenSuSE properly support it).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Depends on kubernetes/repo-infra#38, don't merge yet.

**Release note**:
```release-note
NONE
```
