### PR TITLE
Switch audit output to v1beta1

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit_test.go
@@ -389,7 +389,7 @@ func TestAuditLegacy(t *testing.T) {
 		},
 	} {
 		var buf bytes.Buffer
-		backend := pluginlog.NewBackend(&buf, pluginlog.FormatLegacy)
+		backend := pluginlog.NewBackend(&buf, pluginlog.FormatLegacy, auditv1beta1.SchemeGroupVersion)
 		policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse)
 		handler := WithAudit(http.HandlerFunc(test.handler), &fakeRequestContextMapper{
 			user: &user.DefaultInfo{Name: "admin"},
@@ -859,7 +859,7 @@ func TestAuditJson(t *testing.T) {
 		},
 	} {
 		var buf bytes.Buffer
-		backend := pluginlog.NewBackend(&buf, pluginlog.FormatJson)
+		backend := pluginlog.NewBackend(&buf, pluginlog.FormatJson, auditv1beta1.SchemeGroupVersion)
 		policyChecker := policy.FakeChecker(auditinternal.LevelRequestResponse)
 		handler := WithAudit(http.HandlerFunc(test.handler), &fakeRequestContextMapper{
 			user: &user.DefaultInfo{Name: "admin"},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -51,7 +51,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit/policy:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/authenticatorfactory:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -25,8 +25,7 @@ import (
 	"github.com/spf13/pflag"
 	"gopkg.in/natefinch/lumberjack.v2"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	auditv1alpha1 "k8s.io/apiserver/pkg/apis/audit/v1alpha1"
+	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
 	"k8s.io/apiserver/pkg/audit"
 	"k8s.io/apiserver/pkg/audit/policy"
 	"k8s.io/apiserver/pkg/features"
@@ -214,7 +213,7 @@ func (o *AuditLogOptions) getWriter() io.Writer {
 
 func (o *AuditLogOptions) advancedApplyTo(c *server.Config) error {
 	if w := o.getWriter(); w != nil {
-		c.AuditBackend = appendBackend(c.AuditBackend, pluginlog.NewBackend(w, o.Format))
+		c.AuditBackend = appendBackend(c.AuditBackend, pluginlog.NewBackend(w, o.Format, auditv1beta1.SchemeGroupVersion))
 	}
 	return nil
 }
@@ -239,8 +238,7 @@ func (o *AuditWebhookOptions) applyTo(c *server.Config) error {
 		return nil
 	}
 
-	// TODO: switch to beta
-	webhook, err := pluginwebhook.NewBackend(o.ConfigFile, o.Mode, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	webhook, err := pluginwebhook.NewBackend(o.ConfigFile, o.Mode, auditv1beta1.SchemeGroupVersion)
 	if err != nil {
 		return fmt.Errorf("initializing audit webhook: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/BUILD
@@ -10,8 +10,8 @@ go_library(
     srcs = ["backend.go"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
-	auditv1beta1 "k8s.io/apiserver/pkg/apis/audit/v1beta1"
 	"k8s.io/apiserver/pkg/audit"
 )
 
@@ -41,16 +41,18 @@ var AllowedFormats = []string{
 }
 
 type backend struct {
-	out    io.Writer
-	format string
+	out          io.Writer
+	format       string
+	groupVersion schema.GroupVersion
 }
 
 var _ audit.Backend = &backend{}
 
-func NewBackend(out io.Writer, format string) *backend {
+func NewBackend(out io.Writer, format string, groupVersion schema.GroupVersion) audit.Backend {
 	return &backend{
-		out:    out,
-		format: format,
+		out:          out,
+		format:       format,
+		groupVersion: groupVersion,
 	}
 }
 
@@ -66,8 +68,7 @@ func (b *backend) logEvent(ev *auditinternal.Event) {
 	case FormatLegacy:
 		line = audit.EventString(ev) + "\n"
 	case FormatJson:
-		// TODO(audit): figure out a general way to let the client choose their preferred version
-		bs, err := runtime.Encode(audit.Codecs.LegacyCodec(auditv1beta1.SchemeGroupVersion), ev)
+		bs, err := runtime.Encode(audit.Codecs.LegacyCodec(b.groupVersion), ev)
 		if err != nil {
 			audit.HandlePluginError("log", err, ev)
 			return

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
@@ -69,12 +69,12 @@ const pluginName = "webhook"
 // NewBackend returns an audit backend that sends events over HTTP to an external service.
 // The mode indicates the caching behavior of the webhook. Either blocking (ModeBlocking)
 // or buffered with batch POSTs (ModeBatch).
-func NewBackend(kubeConfigFile string, mode string, groupVersions []schema.GroupVersion) (audit.Backend, error) {
+func NewBackend(kubeConfigFile string, mode string, groupVersion schema.GroupVersion) (audit.Backend, error) {
 	switch mode {
 	case ModeBatch:
-		return newBatchWebhook(kubeConfigFile, groupVersions)
+		return newBatchWebhook(kubeConfigFile, groupVersion)
 	case ModeBlocking:
-		return newBlockingWebhook(kubeConfigFile, groupVersions)
+		return newBlockingWebhook(kubeConfigFile, groupVersion)
 	default:
 		return nil, fmt.Errorf("webhook mode %q is not in list of known modes (%s)",
 			mode, strings.Join(AllowedModes, ","))
@@ -99,12 +99,12 @@ func init() {
 	install.Install(groupFactoryRegistry, registry, audit.Scheme)
 }
 
-func loadWebhook(configFile string, groupVersions []schema.GroupVersion) (*webhook.GenericWebhook, error) {
-	return webhook.NewGenericWebhook(registry, audit.Codecs, configFile, groupVersions, 0)
+func loadWebhook(configFile string, groupVersion schema.GroupVersion) (*webhook.GenericWebhook, error) {
+	return webhook.NewGenericWebhook(registry, audit.Codecs, configFile, []schema.GroupVersion{groupVersion}, 0)
 }
 
-func newBlockingWebhook(configFile string, groupVersions []schema.GroupVersion) (*blockingBackend, error) {
-	w, err := loadWebhook(configFile, groupVersions)
+func newBlockingWebhook(configFile string, groupVersion schema.GroupVersion) (*blockingBackend, error) {
+	w, err := loadWebhook(configFile, groupVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -139,8 +139,8 @@ func (b *blockingBackend) processEvents(ev ...*auditinternal.Event) error {
 	return b.w.RestClient.Post().Body(&list).Do().Error()
 }
 
-func newBatchWebhook(configFile string, groupVersions []schema.GroupVersion) (*batchBackend, error) {
-	w, err := loadWebhook(configFile, groupVersions)
+func newBatchWebhook(configFile string, groupVersion schema.GroupVersion) (*batchBackend, error) {
+	w, err := loadWebhook(configFile, groupVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_v1alpha1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook_v1alpha1_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	auditv1alpha1 "k8s.io/apiserver/pkg/apis/audit/v1alpha1"
 )
@@ -45,7 +44,7 @@ func TestBatchWebhookMaxEventsV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 
 	backend.ProcessEvents(events...)
 
@@ -77,7 +76,7 @@ func TestBatchWebhookStopChV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 	backend.ProcessEvents(events...)
 
 	stopCh := make(chan struct{})
@@ -103,7 +102,7 @@ func TestBatchWebhookProcessEventsAfterStopV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 	stopCh := make(chan struct{})
 
 	backend.Run(stopCh)
@@ -128,7 +127,7 @@ func TestBatchWebhookShutdownV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 	backend.ProcessEvents(events...)
 
 	go func() {
@@ -172,7 +171,7 @@ func TestBatchWebhookEmptyBufferV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 
 	stopCh := make(chan struct{})
 	timer := make(chan time.Time, 1)
@@ -205,7 +204,7 @@ func TestBatchBufferFullV1Alpha1(t *testing.T) {
 	}))
 	defer s.Close()
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 
 	// Make sure this doesn't block.
 	backend.ProcessEvents(events...)
@@ -243,7 +242,7 @@ func TestBatchRunV1Alpha1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 
 	// Test the Run codepath. E.g. that the spawned goroutines behave correctly.
 	backend.Run(stopCh)
@@ -281,7 +280,7 @@ func TestBatchConcurrentRequestsV1Alpha1(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	backend := newTestBatchWebhook(t, s.URL, []schema.GroupVersion{auditv1alpha1.SchemeGroupVersion})
+	backend := newTestBatchWebhook(t, s.URL, auditv1alpha1.SchemeGroupVersion)
 	backend.Run(stopCh)
 
 	backend.ProcessEvents(events...)


### PR DESCRIPTION
This PR adds two switches to pick preferred version for webhook and log backends, and it switches to use `audit.k8s.io/v1beta1` as default for both.

@sttts @crassirostris ptal

**Release note**:
```release-note
Switch to audit.k8s.io/v1beta1 in audit.
```
