### PR TITLE
Version metadata-proxy configmap so rolling updates are triggered when configmap is updated

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy-configmap.yaml
@@ -1,7 +1,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: metadata-proxy-config
+  name: metadata-proxy-config-v0.1
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -49,4 +49,4 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: metadata-proxy-config
+          name: metadata-proxy-config-v0.1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Version configmap so rolling updates are triggered when configmap is updated.  Without this, a master restart won't trigger the running nginx pods' configs to change.

Replaces https://github.com/kubernetes/kubernetes/pull/51730 and https://github.com/kubernetes/contrib/pull/2739.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
