### PR TITLE
Deviceplugin checkpoint

### DIFF
--- a/pkg/kubelet/deviceplugin/types.go
+++ b/pkg/kubelet/deviceplugin/types.go
@@ -29,6 +29,7 @@ type MonitorCallback func(resourceName string, added, updated, deleted []*plugin
 type Manager interface {
 	// Start starts the gRPC Registration service.
 	Start() error
+
 	// Devices is the map of devices that have registered themselves
 	// against the manager.
 	// The map key is the ResourceName of the device plugins.
@@ -40,6 +41,9 @@ type Manager interface {
 
 	// Stop stops the manager.
 	Stop() error
+
+	// Returns checkpoint file path.
+	CheckpointFile() string
 }
 
 // TODO: evaluate whether we need these error definitions.


### PR DESCRIPTION
**What this PR does / why we need it**:
Extends on top of PR 51209 to checkpoint device to pod allocation information on Kubelet to recover from Kubelet restarts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
