### PR TITLE
outputs `<none>` for colums not found

### DIFF
--- a/pkg/printers/customcolumn.go
+++ b/pkg/printers/customcolumn.go
@@ -176,7 +176,7 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 	}
 	parsers := make([]*jsonpath.JSONPath, len(s.Columns))
 	for ix := range s.Columns {
-		parsers[ix] = jsonpath.New(fmt.Sprintf("column%d", ix))
+		parsers[ix] = jsonpath.New(fmt.Sprintf("column%d", ix)).AllowMissingKeys(true)
 		if err := parsers[ix].Parse(s.Columns[ix].FieldSpec); err != nil {
 			return err
 		}
@@ -226,10 +226,10 @@ func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jso
 		if err != nil {
 			return err
 		}
-		if len(values) == 0 || len(values[0]) == 0 {
-			fmt.Fprintf(out, "<none>\t")
-		}
 		valueStrings := []string{}
+		if len(values) == 0 || len(values[0]) == 0 {
+			valueStrings = append(valueStrings, "<none>")
+		}
 		for arrIx := range values {
 			for valIx := range values[arrIx] {
 				valueStrings = append(valueStrings, fmt.Sprintf("%v", values[arrIx][valIx].Interface()))

--- a/pkg/printers/customcolumn_test.go
+++ b/pkg/printers/customcolumn_test.go
@@ -286,6 +286,26 @@ bar
 foo       baz
 `,
 		},
+		{
+			columns: []printers.Column{
+				{
+					Header:    "NAME",
+					FieldSpec: "{.metadata.name}",
+				},
+				{
+					Header:    "API_VERSION",
+					FieldSpec: "{.apiVersion}",
+				},
+				{
+					Header:    "NOT_FOUND",
+					FieldSpec: "{.notFound}",
+				},
+			},
+			obj: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}, TypeMeta: metav1.TypeMeta{APIVersion: "baz"}},
+			expectedOutput: `NAME      API_VERSION   NOT_FOUND
+foo       baz           <none>
+`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

outputs `<none>` for columns specified by `-o custom-columns` but not found in object

currently kubectl outputs an error of "xxx is not found" when a column is not in the returned json (omitted because of empty value or no such field in the object type at all). This PR suppress this error but outputs `<none>` at that field. This makes it convenient to output the objects details, especially when getting objects of different type in one command.

example:
```
$ kubectl get deploy,rs,po -o custom-columns=NAMESPACE:.metadata.namespace,NAME:.metadata.name,REPLICAS:.status.replicas
NAMESPACE   NAME                      REPLICAS
default     deck                      1
default     deck-433074128            1
default     deck-433074128-vxcg9      <none>
```

**Special notes for your reviewer**:

**Release note**:

```release-note
outputs `<none>` for columns specified by `-o custom-columns` but not found in object
```


@kubernetes/kubectl-reviewers 