### PR TITLE
update the image of nfs-provisioner in external-storage

### DIFF
--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -550,7 +550,7 @@ var _ = SIGDescribe("Dynamic Provisioning", func() {
 				v1.BetaStorageClassAnnotation: className,
 			}
 
-			By("creating a claim with a external provisioning annotation")
+			By("creating a claim with an external provisioning annotation")
 			testDynamicProvisioning(test, c, claim, class)
 		})
 	})
@@ -830,7 +830,7 @@ func startExternalProvisioner(c clientset.Interface, ns string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "nfs-provisioner",
-					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.6",
+					Image: "quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8",
 					SecurityContext: &v1.SecurityContext{
 						Capabilities: &v1.Capabilities{
 							Add: []v1.Capability{"DAC_READ_SEARCH"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
https://github.com/kubernetes-incubator/external-storage/tree/master/nfs
in external-storage that the nfs-provisioner the image is v1.0.8
quay.io/kubernetes_incubator/nfs-provisioner:v1.0.8
so change it,thanks!
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
