### PR TITLE
Delete the federation namespace from fcp instead of individual objects

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -74,17 +74,16 @@ function cleanup-federation-api-objects {
   set +o errexit
 
   echo "Cleaning Federation control plane objects"
-  # Delete all resources with the federated-cluster label.
-  $host_kubectl delete pods,svc,rc,deployment,secret -lapp=federated-cluster
-
-  # Delete all PVs bound to PVCs in FEDERATION_NAMESPACE
-  pvs=$($host_kubectl get pvc --namespace=${FEDERATION_NAMESPACE} -o jsonpath='{.items[*].spec.volumeName}')
-  while $host_kubectl delete pv ${pvs} >/dev/null 2>&1; do
-    sleep 2
+  kube::log::status "Removing namespace \"${FEDERATION_NAMESPACE}\" from \"${FEDERATION_KUBE_CONTEXT}\""
+  # Try deleting until the namespace is completely gone.
+  while $host_kubectl --context="${FEDERATION_KUBE_CONTEXT}" delete namespace "${FEDERATION_NAMESPACE}" >/dev/null 2>&1; do
+    # It is usually slower to remove a namespace because it involves
+    # performing a cascading deletion of all the resources in the
+    # namespace. So we sleep a little longer than other resources
+    # before retrying
+    sleep 5
   done
-
-  # Delete all resources in FEDERATION_NAMESPACE.
-  $host_kubectl delete pvc,pods,svc,rc,deployment,secret --namespace=${FEDERATION_NAMESPACE} --all
+  kube::log::status "Removed namespace \"${FEDERATION_NAMESPACE}\" from \"${FEDERATION_KUBE_CONTEXT}\""
 
   # This is a big hammer. We get rid of federation-system namespace from
   # all the clusters


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR simplifies cleanup by deleting the entire namespace instead of individual objects.
This PR is linked to https://github.com/kubernetes/kubernetes/issues/50543. This may not solve the issue but instead to try an alternative.

**Release note**:
```release-note
Delete the federation namespace from control plane instead of individual objects
```

/assign @madhusudancs 