### PR TITLE
removing non-existed fields in KubeControllerManagerConfiguration

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -166,9 +166,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 	fs.DurationVar(&s.HorizontalPodAutoscalerDownscaleForbiddenWindow.Duration, "horizontal-pod-autoscaler-downscale-delay", s.HorizontalPodAutoscalerDownscaleForbiddenWindow.Duration, "The period since last downscale, before another downscale can be performed in horizontal pod autoscaler.")
 	fs.DurationVar(&s.DeploymentControllerSyncPeriod.Duration, "deployment-controller-sync-period", s.DeploymentControllerSyncPeriod.Duration, "Period for syncing the deployments.")
 	fs.DurationVar(&s.PodEvictionTimeout.Duration, "pod-eviction-timeout", s.PodEvictionTimeout.Duration, "The grace period for deleting pods on failed nodes.")
-	fs.Float32Var(&s.DeletingPodsQps, "deleting-pods-qps", 0.1, "Number of nodes per second on which pods are deleted in case of node failure.")
 	fs.MarkDeprecated("deleting-pods-qps", "This flag is currently no-op and will be deleted.")
-	fs.Int32Var(&s.DeletingPodsBurst, "deleting-pods-burst", 0, "Number of nodes on which pods are bursty deleted in case of node failure. For more details look into RateLimiter.")
 	fs.MarkDeprecated("deleting-pods-burst", "This flag is currently no-op and will be deleted.")
 	fs.Int32Var(&s.RegisterRetryCount, "register-retry-count", s.RegisterRetryCount, ""+
 		"The number of retries for initial node registration.  Retry interval equals node-sync-period.")

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -22,32 +22,32 @@ import (
 
 // ClientConnectionConfiguration contains details for constructing a client.
 type ClientConnectionConfiguration struct {
-	// kubeConfigFile is the path to a kubeconfig file.
+	// KubeConfigFile is the path to a kubeconfig file.
 	KubeConfigFile string
-	// acceptContentTypes defines the Accept header sent by clients when connecting to a server, overriding the
-	// default value of 'application/json'. This field will control all connections to the server used by a particular
-	// client.
+	// AcceptContentTypes defines the Accept header sent by clients when connecting
+	// to a server, overriding the default value of 'application/json'. This field
+	// will control all connections to the server used by a particular client.
 	AcceptContentTypes string
-	// contentType is the content type used when sending data to the server from this client.
+	// ContentType is the content type used when sending data to the server from this client.
 	ContentType string
-	// qps controls the number of queries per second allowed for this connection.
+	// QPS controls the number of queries per second allowed for this connection.
 	QPS float32
-	// burst allows extra queries to accumulate when a client is exceeding its rate.
+	// Burst allows extra queries to accumulate when a client is exceeding its rate.
 	Burst int
 }
 
 // KubeProxyIPTablesConfiguration contains iptables-related configuration
 // details for the Kubernetes proxy server.
 type KubeProxyIPTablesConfiguration struct {
-	// masqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
+	// MasqueradeBit is the bit of the iptables fwmark space to use for SNAT if using
 	// the pure iptables proxy mode. Values must be within the range [0, 31].
 	MasqueradeBit *int32
-	// masqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
+	// MasqueradeAll tells kube-proxy to SNAT everything if using the pure iptables proxy mode.
 	MasqueradeAll bool
-	// syncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
+	// SyncPeriod is the period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').  Must be greater than 0.
 	SyncPeriod metav1.Duration
-	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
+	// MinSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
 	MinSyncPeriod metav1.Duration
 }
@@ -55,32 +55,32 @@ type KubeProxyIPTablesConfiguration struct {
 // KubeProxyIPVSConfiguration contains ipvs-related configuration
 // details for the Kubernetes proxy server.
 type KubeProxyIPVSConfiguration struct {
-	// syncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
-	// '2h22m').  Must be greater than 0.
+	// SyncPeriod is the period that ipvs rules are refreshed (e.g. '5s', '1m',
+	// '2h22m'). Must be greater than 0.
 	SyncPeriod metav1.Duration
-	// minSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
+	// MinSyncPeriod is the minimum period that ipvs rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
 	MinSyncPeriod metav1.Duration
-	// ipvs scheduler
+	// Scheduler is the ipvs scheduler.
 	Scheduler string
 }
 
 // KubeProxyConntrackConfiguration contains conntrack settings for
 // the Kubernetes proxy server.
 type KubeProxyConntrackConfiguration struct {
-	// max is the maximum number of NAT connections to track (0 to
-	// leave as-is).  This takes precedence over conntrackMaxPerCore and conntrackMin.
+	// Max is the maximum number of NAT connections to track (0 to
+	// leave as-is). This takes precedence over conntrackMaxPerCore and conntrackMin.
 	Max int32
-	// maxPerCore is the maximum number of NAT connections to track
+	// MaxPerCore is the maximum number of NAT connections to track
 	// per CPU core (0 to leave the limit as-is and ignore conntrackMin).
 	MaxPerCore int32
-	// min is the minimum value of connect-tracking records to allocate,
+	// Min is the minimum value of connect-tracking records to allocate,
 	// regardless of conntrackMaxPerCore (set conntrackMaxPerCore=0 to leave the limit as-is).
 	Min int32
-	// tcpEstablishedTimeout is how long an idle TCP connection will be kept open
-	// (e.g. '2s').  Must be greater than 0.
+	// TCPEstablishedTimeout is how long an idle TCP connection will be kept open
+	// (e.g. '2s'). Must be greater than 0.
 	TCPEstablishedTimeout metav1.Duration
-	// tcpCloseWaitTimeout is how long an idle conntrack entry
+	// TCPCloseWaitTimeout is how long an idle conntrack entry
 	// in CLOSE_WAIT state will remain in the conntrack
 	// table. (e.g. '60s'). Must be greater than 0 to set.
 	TCPCloseWaitTimeout metav1.Duration
@@ -93,7 +93,7 @@ type KubeProxyConntrackConfiguration struct {
 type KubeProxyConfiguration struct {
 	metav1.TypeMeta
 
-	// featureGates is a comma-separated list of key=value pairs that control
+	// FeatureGates is a comma-separated list of key=value pairs that control
 	// which alpha/beta features are enabled.
 	//
 	// TODO this really should be a map but that requires refactoring all
@@ -102,49 +102,50 @@ type KubeProxyConfiguration struct {
 	// pairs.
 	FeatureGates string
 
-	// bindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
+	// BindAddress is the IP address for the proxy server to serve on (set to 0.0.0.0
 	// for all interfaces)
 	BindAddress string
-	// healthzBindAddress is the IP address and port for the health check server to serve on,
+	// HealthzBindAddress is the IP address and port for the health check server to serve on,
 	// defaulting to 0.0.0.0:10256
 	HealthzBindAddress string
-	// metricsBindAddress is the IP address and port for the metrics server to serve on,
+	// MetricsBindAddress is the IP address and port for the metrics server to serve on,
 	// defaulting to 127.0.0.1:10249 (set to 0.0.0.0 for all interfaces)
 	MetricsBindAddress string
-	// enableProfiling enables profiling via web interface on /debug/pprof handler.
+	// EnableProfiling enables profiling via web interface on /debug/pprof handler.
 	// Profiling handlers will be handled by metrics server.
 	EnableProfiling bool
-	// clusterCIDR is the CIDR range of the pods in the cluster. It is used to
+	// ClusterCIDR is the CIDR range of the pods in the cluster. It is used to
 	// bridge traffic coming from outside of the cluster. If not provided,
 	// no off-cluster bridging will be performed.
 	ClusterCIDR string
-	// hostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
+	// HostnameOverride, if non-empty, will be used as the identity instead of the actual hostname.
 	HostnameOverride string
-	// clientConnection specifies the kubeconfig file and client connection settings for the proxy
-	// server to use when communicating with the apiserver.
+	// ClientConnection specifies the kubeconfig file and client connection settings for
+	// the proxy server to use when communicating with the apiserver.
 	ClientConnection ClientConnectionConfiguration
-	// iptables contains iptables-related configuration options.
+	// IPTables contains iptables-related configuration options.
 	IPTables KubeProxyIPTablesConfiguration
-	// ipvs contains ipvs-related configuration options.
+	// IPVS contains ipvs-related configuration options.
 	IPVS KubeProxyIPVSConfiguration
-	// oomScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
+	// OOMScoreAdj is the oom-score-adj value for kube-proxy process. Values must be within
 	// the range [-1000, 1000]
 	OOMScoreAdj *int32
-	// mode specifies which proxy mode to use.
+	// Mode specifies which proxy mode to use.
 	Mode ProxyMode
-	// portRange is the range of host ports (beginPort-endPort, inclusive) that may be consumed
-	// in order to proxy service traffic. If unspecified (0-0) then ports will be randomly chosen.
+	// PortRange is the range of host ports (beginPort-endPort, inclusive) that may
+	// be consumed in order to proxy service traffic. If unspecified (0-0) then ports
+	// will be randomly chosen.
 	PortRange string
-	// resourceContainer is the absolute name of the resource-only container to create and run
+	// ResourceContainer is the absolute name of the resource-only container to create and run
 	// the Kube-proxy in (Default: /kube-proxy).
 	ResourceContainer string
-	// udpIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
+	// UDPIdleTimeout is how long an idle UDP connection will be kept open (e.g. '250ms', '2s').
 	// Must be greater than 0. Only applicable for proxyMode=userspace.
 	UDPIdleTimeout metav1.Duration
-	// conntrack contains conntrack-related configuration options.
+	// Conntrack contains conntrack-related configuration options.
 	Conntrack KubeProxyConntrackConfiguration
-	// configSyncPeriod is how often configuration from the apiserver is refreshed. Must be greater
-	// than 0.
+	// ConfigSyncPeriod is how often configuration from the apiserver is refreshed. Must
+	// be greater than 0.
 	ConfigSyncPeriod metav1.Duration
 }
 
@@ -165,25 +166,25 @@ const (
 type KubeSchedulerConfiguration struct {
 	metav1.TypeMeta
 
-	// port is the port that the scheduler's http service runs on.
+	// Port is the port that the scheduler's http service runs on.
 	Port int32
-	// address is the IP address to serve on.
+	// Address is the IP address to serve on.
 	Address string
-	// algorithmProvider is the scheduling algorithm provider to use.
+	// AlgorithmProvider is the scheduling algorithm provider to use.
 	AlgorithmProvider string
-	// policyConfigFile is the filepath to the scheduler policy configuration.
+	// PolicyConfigFile is the filepath to the scheduler policy configuration.
 	PolicyConfigFile string
-	// enableProfiling enables profiling via web interface.
+	// EnableProfiling enables profiling via web interface.
 	EnableProfiling bool
-	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
+	// EnableContentionProfiling enables lock contention profiling, if enableProfiling is true.
 	EnableContentionProfiling bool
-	// contentType is contentType of requests sent to apiserver.
+	// ContentType is the content type of requests sent to apiserver.
 	ContentType string
-	// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
+	// KubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
 	KubeAPIQPS float32
-	// kubeAPIBurst is the QPS burst to use while talking with kubernetes apiserver.
+	// KubeAPIBurst is the QPS burst to use while talking with kubernetes apiserver.
 	KubeAPIBurst int32
-	// schedulerName is name of the scheduler, used to select which pods
+	// SchedulerName is name of the scheduler, used to select which pods
 	// will be processed by this scheduler, based on pod's "spec.SchedulerName".
 	SchedulerName string
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
@@ -193,7 +194,7 @@ type KubeSchedulerConfiguration struct {
 	// Indicate the "all topologies" set for empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.
 	// DEPRECATED: This is no longer used.
 	FailureDomains string
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection LeaderElectionConfiguration
 	// LockObjectNamespace defines the namespace of the lock object
 	LockObjectNamespace string
@@ -217,35 +218,35 @@ type KubeSchedulerConfiguration struct {
 // LeaderElectionConfiguration defines the configuration of leader election
 // clients for components that can run with leader election enabled.
 type LeaderElectionConfiguration struct {
-	// leaderElect enables a leader election client to gain leadership
+	// LeaderElect enables a leader election client to gain leadership
 	// before executing the main loop. Enable this when running replicated
 	// components for high availability.
 	LeaderElect bool
-	// leaseDuration is the duration that non-leader candidates will wait
+	// LeaseDuration is the duration that non-leader candidates will wait
 	// after observing a leadership renewal until attempting to acquire
 	// leadership of a led but unrenewed leader slot. This is effectively the
 	// maximum duration that a leader can be stopped before it is replaced
 	// by another candidate. This is only applicable if leader election is
 	// enabled.
 	LeaseDuration metav1.Duration
-	// renewDeadline is the interval between attempts by the acting master to
+	// RenewDeadline is the interval between attempts by the acting master to
 	// renew a leadership slot before it stops leading. This must be less
 	// than or equal to the lease duration. This is only applicable if leader
 	// election is enabled.
 	RenewDeadline metav1.Duration
-	// retryPeriod is the duration the clients should wait between attempting
+	// RetryPeriod is the duration the clients should wait between attempting
 	// acquisition and renewal of a leadership. This is only applicable if
 	// leader election is enabled.
 	RetryPeriod metav1.Duration
-	// resourceLock indicates the resource object type that will be used to lock
+	// ResourceLock indicates the resource object type that will be used to lock
 	// during leader election cycles.
 	ResourceLock string
 }
 
 type GroupResource struct {
-	// group is the group portion of the GroupResource.
+	// Group is the group portion of the GroupResource.
 	Group string
-	// resource is the resource portion of the GroupResource.
+	// Resource is the resource portion of the GroupResource.
 	Resource string
 }
 
@@ -261,135 +262,127 @@ type KubeControllerManagerConfiguration struct {
 	// first item for a particular name wins
 	Controllers []string
 
-	// port is the port that the controller-manager's http service runs on.
+	// Port is the port that the controller-manager's http service runs on.
 	Port int32
-	// address is the IP address to serve on (set to 0.0.0.0 for all interfaces).
+	// Port is the IP address to serve on (set to 0.0.0.0 for all interfaces).
 	Address string
-	// useServiceAccountCredentials indicates whether controllers should be run with
+	// UseServiceAccountCredentials indicates whether controllers should be run with
 	// individual service account credentials.
 	UseServiceAccountCredentials bool
-	// cloudProvider is the provider for cloud services.
+	// CloudProvider is the provider for cloud services.
 	CloudProvider string
-	// cloudConfigFile is the path to the cloud provider configuration file.
+	// CloudConfigFile is the path to the cloud provider configuration file.
 	CloudConfigFile string
-	// run with untagged cloud instances
+	// AllowUntaggedCloud runs with untagged cloud instances
 	AllowUntaggedCloud bool
-	// concurrentEndpointSyncs is the number of endpoint syncing operations
+	// ConcurrentEndpointSyncs is the number of endpoint syncing operations
 	// that will be done concurrently. Larger number = faster endpoint updating,
 	// but more CPU (and network) load.
 	ConcurrentEndpointSyncs int32
-	// concurrentRSSyncs is the number of replica sets that are  allowed to sync
+	// ConcurrentRSSyncs is the number of replica sets that are  allowed to sync
 	// concurrently. Larger number = more responsive replica  management, but more
 	// CPU (and network) load.
 	ConcurrentRSSyncs int32
-	// concurrentRCSyncs is the number of replication controllers that are
+	// ConcurrentRCSyncs is the number of replication controllers that are
 	// allowed to sync concurrently. Larger number = more responsive replica
 	// management, but more CPU (and network) load.
 	ConcurrentRCSyncs int32
-	// concurrentServiceSyncs is the number of services that are
+	// ConcurrentServiceSyncs is the number of services that are
 	// allowed to sync concurrently. Larger number = more responsive service
 	// management, but more CPU (and network) load.
 	ConcurrentServiceSyncs int32
-	// concurrentResourceQuotaSyncs is the number of resource quotas that are
+	// ConcurrentResourceQuotaSyncs is the number of resource quotas that are
 	// allowed to sync concurrently. Larger number = more responsive quota
 	// management, but more CPU (and network) load.
 	ConcurrentResourceQuotaSyncs int32
-	// concurrentDeploymentSyncs is the number of deployment objects that are
+	// ConcurrentDeploymentSyncs is the number of deployment objects that are
 	// allowed to sync concurrently. Larger number = more responsive deployments,
 	// but more CPU (and network) load.
 	ConcurrentDeploymentSyncs int32
-	// concurrentDaemonSetSyncs is the number of daemonset objects that are
+	// ConcurrentDaemonSetSyncs is the number of daemonset objects that are
 	// allowed to sync concurrently. Larger number = more responsive daemonset,
 	// but more CPU (and network) load.
 	ConcurrentDaemonSetSyncs int32
-	// concurrentJobSyncs is the number of job objects that are
+	// ConcurrentJobSyncs is the number of job objects that are
 	// allowed to sync concurrently. Larger number = more responsive jobs,
 	// but more CPU (and network) load.
 	ConcurrentJobSyncs int32
-	// concurrentNamespaceSyncs is the number of namespace objects that are
+	// ConcurrentNamespaceSyncs is the number of namespace objects that are
 	// allowed to sync concurrently.
 	ConcurrentNamespaceSyncs int32
-	// concurrentSATokenSyncs is the number of service account token syncing operations
+	// ConcurrentSATokenSyncs is the number of service account token syncing operations
 	// that will be done concurrently.
 	ConcurrentSATokenSyncs int32
-	// lookupCacheSizeForRC is the size of lookup cache for replication controllers.
-	// Larger number = more responsive replica management, but more MEM load.
-	// serviceSyncPeriod is the period for syncing services with their external
+	// ServiceSyncPeriod is the period for syncing services with their external
 	// load balancers.
 	ServiceSyncPeriod metav1.Duration
-	// nodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
+	// NodeSyncPeriod is the period for syncing nodes from cloudprovider. Longer
 	// periods will result in fewer calls to cloud provider, but may delay addition
 	// of new nodes to cluster.
 	NodeSyncPeriod metav1.Duration
-	// routeReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..
+	// RouteReconciliationPeriod is the period for reconciling routes created for Nodes by cloud provider..
 	RouteReconciliationPeriod metav1.Duration
-	// resourceQuotaSyncPeriod is the period for syncing quota usage status
+	// ResourceQuotaSyncPeriod is the period for syncing quota usage status
 	// in the system.
 	ResourceQuotaSyncPeriod metav1.Duration
-	// namespaceSyncPeriod is the period for syncing namespace life-cycle
+	// NamespaceSyncPeriod is the period for syncing namespace life-cycle
 	// updates.
 	NamespaceSyncPeriod metav1.Duration
-	// pvClaimBinderSyncPeriod is the period for syncing persistent volumes
+	// PVClaimBinderSyncPeriod is the period for syncing persistent volumes
 	// and persistent volume claims.
 	PVClaimBinderSyncPeriod metav1.Duration
-	// minResyncPeriod is the resync period in reflectors; will be random between
-	// minResyncPeriod and 2*minResyncPeriod.
+	// MinResyncPeriod is the resync period in reflectors; will be random between
+	// MinResyncPeriod and 2*MinResyncPeriod.
 	MinResyncPeriod metav1.Duration
-	// terminatedPodGCThreshold is the number of terminated pods that can exist
+	// TerminatedPodGCThreshold is the number of terminated pods that can exist
 	// before the terminated pod garbage collector starts deleting terminated pods.
 	// If <= 0, the terminated pod garbage collector is disabled.
 	TerminatedPodGCThreshold int32
-	// horizontalPodAutoscalerSyncPeriod is the period for syncing the number of
+	// HorizontalPodAutoscalerSyncPeriod is the period for syncing the number of
 	// pods in horizontal pod autoscaler.
 	HorizontalPodAutoscalerSyncPeriod metav1.Duration
-	// horizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.
+	// HorizontalPodAutoscalerUpscaleForbiddenWindow is a period after which next upscale allowed.
 	HorizontalPodAutoscalerUpscaleForbiddenWindow metav1.Duration
-	// horizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.
+	// HorizontalPodAutoscalerDownscaleForbiddenWindow is a period after which next downscale allowed.
 	HorizontalPodAutoscalerDownscaleForbiddenWindow metav1.Duration
-	// deploymentControllerSyncPeriod is the period for syncing the deployments.
+	// DeploymentControllerSyncPeriod is the period for syncing the deployments.
 	DeploymentControllerSyncPeriod metav1.Duration
-	// podEvictionTimeout is the grace period for deleting pods on failed nodes.
+	// PodEvictionTimeout is the grace period for deleting pods on failed nodes.
 	PodEvictionTimeout metav1.Duration
-	// DEPRECATED: deletingPodsQps is the number of nodes per second on which pods are deleted in
-	// case of node failure.
-	DeletingPodsQps float32
-	// DEPRECATED: deletingPodsBurst is the number of nodes on which pods are bursty deleted in
-	// case of node failure. For more details look into RateLimiter.
-	DeletingPodsBurst int32
-	// nodeMontiorGracePeriod is the amount of time which we allow a running node to be
+	// NodeMonitorGracePeriod is the amount of time which we allow a running node to be
 	// unresponsive before marking it unhealthy. Must be N times more than kubelet's
 	// nodeStatusUpdateFrequency, where N means number of retries allowed for kubelet
 	// to post node status.
 	NodeMonitorGracePeriod metav1.Duration
-	// registerRetryCount is the number of retries for initial node registration.
+	// RegisterRetryCount is the number of retries for initial node registration.
 	// Retry interval equals node-sync-period.
 	RegisterRetryCount int32
-	// nodeStartupGracePeriod is the amount of time which we allow starting a node to
+	// NodeStartupGracePeriod is the amount of time which we allow starting a node to
 	// be unresponsive before marking it unhealthy.
 	NodeStartupGracePeriod metav1.Duration
-	// nodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
+	// NodeMonitorPeriod is the period for syncing NodeStatus in NodeController.
 	NodeMonitorPeriod metav1.Duration
-	// serviceAccountKeyFile is the filename containing a PEM-encoded private RSA key
+	// ServiceAccountKeyFile is the filename containing a PEM-encoded private RSA key
 	// used to sign service account tokens.
 	ServiceAccountKeyFile string
-	// clusterSigningCertFile is the filename containing a PEM-encoded
+	// ClusterSigningCertFile is the filename containing a PEM-encoded
 	// X509 CA certificate used to issue cluster-scoped certificates
 	ClusterSigningCertFile string
-	// clusterSigningCertFile is the filename containing a PEM-encoded
+	// ClusterSigningKeyFile is the filename containing a PEM-encoded
 	// RSA or ECDSA private key used to issue cluster-scoped certificates
 	ClusterSigningKeyFile string
-	// clusterSigningDuration is the length of duration signed certificates
+	// ClusterSigningDuration is the length of duration signed certificates
 	// will be given.
 	ClusterSigningDuration metav1.Duration
-	// enableProfiling enables profiling via web interface host:port/debug/pprof/
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/
 	EnableProfiling bool
-	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
+	// EnableContentionProfiling enables lock contention profiling, if enableProfiling is true.
 	EnableContentionProfiling bool
-	// clusterName is the instance prefix for the cluster.
+	// ClusterName is the instance prefix for the cluster.
 	ClusterName string
-	// clusterCIDR is CIDR Range for Pods in cluster.
+	// ClusterCIDR is CIDR Range for Pods in cluster.
 	ClusterCIDR string
-	// serviceCIDR is CIDR Range for Services in cluster.
+	// ServiceCIDR is CIDR Range for Services in cluster.
 	ServiceCIDR string
 	// NodeCIDRMaskSize is the mask size for node cidr in cluster.
 	NodeCIDRMaskSize int32
@@ -398,45 +391,54 @@ type KubeControllerManagerConfiguration struct {
 	AllocateNodeCIDRs bool
 	// CIDRAllocatorType determines what kind of pod CIDR allocator will be used.
 	CIDRAllocatorType string
-	// configureCloudRoutes enables CIDRs allocated with allocateNodeCIDRs
+	// ConfigureCloudRoutes enables CIDRs allocated with AllocateNodeCIDRs
 	// to be configured on the cloud provider.
 	ConfigureCloudRoutes bool
-	// rootCAFile is the root certificate authority will be included in service
+	// RootCAFile is the root certificate authority will be included in service
 	// account's token secret. This must be a valid PEM-encoded CA bundle.
 	RootCAFile string
-	// contentType is contentType of requests sent to apiserver.
+	// ContentType is the content type of requests sent to apiserver.
 	ContentType string
-	// kubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
+	// KubeAPIQPS is the QPS to use while talking with kubernetes apiserver.
 	KubeAPIQPS float32
-	// kubeAPIBurst is the burst to use while talking with kubernetes apiserver.
+	// KubeAPIBurst is the burst to use while talking with kubernetes apiserver.
 	KubeAPIBurst int32
-	// leaderElection defines the configuration of leader election client.
+	// LeaderElection defines the configuration of leader election client.
 	LeaderElection LeaderElectionConfiguration
-	// volumeConfiguration holds configuration for volume related features.
+	// VolumeConfiguration holds configuration for volume related features.
 	VolumeConfiguration VolumeConfiguration
-	// How long to wait between starting controller managers
+	// ControllerStartInterval defines the time interval to wait between starting
+	// controller managers.
 	ControllerStartInterval metav1.Duration
-	// enables the generic garbage collector. MUST be synced with the
-	// corresponding flag of the kube-apiserver. WARNING: the generic garbage
+	// EnableGarbageCollector enables the generic garbage collector. MUST be synced
+	// with the corresponding flag of the kube-apiserver. WARNING: the generic garbage
 	// collector is an alpha feature.
 	EnableGarbageCollector bool
-	// concurrentGCSyncs is the number of garbage collector workers that are
+	// ConcurrentGCSyncs is the number of garbage collector workers that are
 	// allowed to sync concurrently.
 	ConcurrentGCSyncs int32
-	// gcIgnoredResources is the list of GroupResources that garbage collection should ignore.
+	// GCIgnoredResources is the list of GroupResources that garbage collection should ignore.
 	GCIgnoredResources []GroupResource
-	// nodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy
+	// NodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is healthy
 	NodeEvictionRate float32
-	// secondaryNodeEvictionRate is the number of nodes per second on which pods are deleted in case of node failure when a zone is unhealthy
+	// SecondaryNodeEvictionRate is the number of nodes per second on which pods are
+	// deleted in case of node failure when a zone is unhealthy. Zone refers to entire
+	// cluster in non-multizone clusters. SecondaryNodeEvictionRate is implicitly
+	// overridden to 0 if the cluster size is smaller than LargeClusterSizeThreshold.
 	SecondaryNodeEvictionRate float32
-	// secondaryNodeEvictionRate is implicitly overridden to 0 for clusters smaller than or equal to largeClusterSizeThreshold
+	// LargeClusterSizeThreshold defines number of nodes from which NodeController treats
+	// the cluster as large for the eviction logic purposes. SecondaryNodeEvictionRate is
+	// implicitly overridden to 0 for clusters LargeClusterSizeThreshold size or smaller.
 	LargeClusterSizeThreshold int32
-	// Zone is treated as unhealthy in nodeEvictionRate and secondaryNodeEvictionRate when at least
-	// unhealthyZoneThreshold (no less than 3) of Nodes in the zone are NotReady
+	// UnhealthyZoneThreshold defines fraction of Nodes in a zone which needs to be not
+	// Ready for zone to be treated as unhealthy. Zone is treated as unhealthy in
+	// NodeEvictionRate and SecondaryNodeEvictionRate when at least UnhealthyZoneThreshold
+	// (no less than 3) of Nodes in the zone are NotReady.
 	UnhealthyZoneThreshold float32
-	// Reconciler runs a periodic loop to reconcile the desired state of the with
-	// the actual state of the world by triggering attach detach operations.
-	// This flag enables or disables reconcile.  Is false by default, and thus enabled.
+	// DisableAttachDetachReconcilerSync is a flag which enables or disables reconcile.
+	// It is false by default, and thus enabled. Reconciler runs a periodic loop to
+	// reconcile the desired state of the with the actual state of the world by triggering
+	// attach detach operations.
 	DisableAttachDetachReconcilerSync bool
 	// ReconcilerSyncLoopPeriod is the amount of time the reconciler sync states loop
 	// wait between successive executions. Is set to 5 sec by default.
@@ -456,45 +458,46 @@ type KubeControllerManagerConfiguration struct {
 // are then passed to the appropriate plugin. The ControllerManager binary is the only part
 // of the code which knows what plugins are supported and which flags correspond to each plugin.
 type VolumeConfiguration struct {
-	// enableHostPathProvisioning enables HostPath PV provisioning when running without a
+	// EnableHostPathProvisioning enables HostPath PV provisioning when running without a
 	// cloud provider. This allows testing and development of provisioning features. HostPath
 	// provisioning is not supported in any way, won't work in a multi-node cluster, and
 	// should not be used for anything other than testing or development.
 	EnableHostPathProvisioning bool
-	// enableDynamicProvisioning enables the provisioning of volumes when running within an environment
-	// that supports dynamic provisioning. Defaults to true.
+	// EnableDynamicProvisioning enables the provisioning of volumes when running within
+	// an environment that supports dynamic provisioning. Defaults to true.
 	EnableDynamicProvisioning bool
-	// persistentVolumeRecyclerConfiguration holds configuration for persistent volume plugins.
+	// PersistentVolumeRecyclerConfiguration holds configuration for persistent volume
+	// plugins.
 	PersistentVolumeRecyclerConfiguration PersistentVolumeRecyclerConfiguration
-	// volumePluginDir is the full path of the directory in which the flex
+	// FlexVolumePluginDir is the full path of the directory in which the flex
 	// volume plugin should search for additional third party volume plugins
 	FlexVolumePluginDir string
 }
 
 type PersistentVolumeRecyclerConfiguration struct {
-	// maximumRetry is number of retries the PV recycler will execute on failure to recycle
+	// MaximumRetry is number of retries the PV recycler will execute on failure to recycle
 	// PV.
 	MaximumRetry int32
-	// minimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
+	// MinimumTimeoutNFS is the minimum ActiveDeadlineSeconds to use for an NFS Recycler
 	// pod.
 	MinimumTimeoutNFS int32
-	// podTemplateFilePathNFS is the file path to a pod definition used as a template for
+	// PodTemplateFilePathNFS is the file path to a pod definition used as a template for
 	// NFS persistent volume recycling
 	PodTemplateFilePathNFS string
-	// incrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
+	// IncrementTimeoutNFS is the increment of time added per Gi to ActiveDeadlineSeconds
 	// for an NFS scrubber pod.
 	IncrementTimeoutNFS int32
-	// podTemplateFilePathHostPath is the file path to a pod definition used as a template for
+	// PodTemplateFilePathHostPath is the file path to a pod definition used as a template for
 	// HostPath persistent volume recycling. This is for development and testing only and
 	// will not work in a multi-node cluster.
 	PodTemplateFilePathHostPath string
-	// minimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
-	// Recycler pod.  This is for development and testing only and will not work in a multi-node
-	// cluster.
+	// MinimumTimeoutHostPath is the minimum ActiveDeadlineSeconds to use for a HostPath
+	// Recycler pod.  This is for development and testing only and will not work in a
+	// multi-node cluster.
 	MinimumTimeoutHostPath int32
-	// incrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
-	// for a HostPath scrubber pod.  This is for development and testing only and will not work
-	// in a multi-node cluster.
+	// IncrementTimeoutHostPath is the increment of time added per Gi to ActiveDeadlineSeconds
+	// for a HostPath scrubber pod.  This is for development and testing only and will not
+	// work in a multi-node cluster.
 	IncrementTimeoutHostPath int32
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
The field `lookupCacheSizeForRC` no longer exists in `KubeControllerManagerConfiguration`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`
