### PR TITLE
CRI: Move pullable logic from dockershim to kubelet.

### DIFF
--- a/pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
+++ b/pkg/kubelet/apis/cri/v1alpha1/runtime/api.pb.go
@@ -2081,8 +2081,10 @@ type ContainerStatus struct {
 	ExitCode int32 `protobuf:"varint,7,opt,name=exit_code,json=exitCode,proto3" json:"exit_code,omitempty"`
 	// Spec of the image.
 	Image *ImageSpec `protobuf:"bytes,8,opt,name=image" json:"image,omitempty"`
-	// Reference to the image in use. For most runtimes, this should be an
-	// image ID
+	// Reference to the image in use. This should be a user readable image
+	// reference. Kubelet will provide it for user to consume.
+	// TODO(random-liu): Define another field for the readable image reference,
+	// and keep image id here.
 	ImageRef string `protobuf:"bytes,9,opt,name=image_ref,json=imageRef,proto3" json:"image_ref,omitempty"`
 	// Brief CamelCase string explaining why container is in its current state.
 	Reason string `protobuf:"bytes,10,opt,name=reason,proto3" json:"reason,omitempty"`

--- a/pkg/kubelet/apis/cri/v1alpha1/runtime/api.proto
+++ b/pkg/kubelet/apis/cri/v1alpha1/runtime/api.proto
@@ -754,8 +754,10 @@ message ContainerStatus {
     int32 exit_code = 7;
     // Spec of the image.
     ImageSpec image = 8;
-    // Reference to the image in use. For most runtimes, this should be an
-    // image ID
+    // Reference to the image in use. This should be a user readable image
+    // reference. Kubelet will provide it for user to consume.
+    // TODO(random-liu): Define another field for the readable image reference,
+    // and keep image id here.
     string image_ref = 9;
     // Brief CamelCase string explaining why container is in its current state.
     string reason = 10;


### PR DESCRIPTION
Move pullable related logic from dockershim to kubelet.

Currently, dockershim returns `docker://imageID` if repo digest doesn't exist; returns `docker-pullable://repodigest` if repo digest exists.

And kubelet populate this to `ContainerStatus.ImageID`. We also have a node e2e test for this https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/image_id_test.go.

However, I don't think runtime should care about this. At least, I don't think we want to do this in cri-containerd.

Runtime should just return it's imageID and repo digests. It's kubelet's responsibility to decide which one to use, and how to decorate it.

This PR moves the logic into kubelet, and there shouldn't be regression, because we still keep `docker://` and `docker-pullable://` for docker and other runtime.

@feiskyer @yujuhong @mrunalp 
/cc @kubernetes/sig-node-pr-reviews 