### PR TITLE
Add configurable scheduler in scheduler_perf

### DIFF
--- a/plugin/cmd/kube-scheduler/app/configurator.go
+++ b/plugin/cmd/kube-scheduler/app/configurator.go
@@ -104,14 +104,14 @@ func CreateScheduler(
 	)
 
 	// Rebuild the configurator with a default Create(...) method.
-	configurator = &schedulerConfigurator{
+	configurator = NewschedulerConfigurator(
 		configurator,
 		s.PolicyConfigFile,
 		s.AlgorithmProvider,
 		s.PolicyConfigMapName,
 		s.PolicyConfigMapNamespace,
 		s.UseLegacyPolicyConfig,
-	}
+	)
 
 	return scheduler.NewFromConfigurator(configurator, func(cfg *scheduler.Config) {
 		cfg.Recorder = recorder
@@ -127,6 +127,24 @@ type schedulerConfigurator struct {
 	policyConfigMap          string
 	policyConfigMapNamespace string
 	useLegacyPolicyConfig    bool
+}
+
+func NewschedulerConfigurator(
+	configurator scheduler.Configurator,
+	policyConfigFile string,
+	algorithmProvider string,
+	policyConfigMapName string,
+	policyConfigMapNamespace string,
+	useLegacyPolicyConfig bool,
+) *schedulerConfigurator {
+	return &schedulerConfigurator{
+		configurator,
+		policyConfigFile,
+		algorithmProvider,
+		policyConfigMapName,
+		policyConfigMapNamespace,
+		useLegacyPolicyConfig,
+	}
 }
 
 // getSchedulerPolicyConfig finds and decodes scheduler's policy config. If no

--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
+        "//plugin/cmd/kube-scheduler/app:go_default_library",
         "//plugin/pkg/scheduler:go_default_library",
         "//plugin/pkg/scheduler/algorithmprovider:go_default_library",
         "//plugin/pkg/scheduler/factory:go_default_library",

--- a/test/integration/scheduler_perf/README.md
+++ b/test/integration/scheduler_perf/README.md
@@ -39,6 +39,50 @@ cd test/integration/scheduler_perf
 ./test-performance.sh
 ```
 
+Configure Scheduler
+------
+
+The scheduling policy in this Scheduler Performance Test is also configurable.
+
+Be default, `kube-scheduler` will always use default algorithm provider regardless of `config/scheduler-config.json` is present or not.
+
+You can specify you want to use customized scheduler by set `DEFAULT_PROVIDER` to `false`:
+
+```shell
+export DEFAULT_PROVIDER=false
+
+make generated_files
+
+cd test/integration/scheduler_perf
+./test-performance.sh
+```
+
+In this case, `kube-scheduler` will use predicates and priorities specified in `config/scheduler-config.json`.
+
+Also, the performance tests will configure nodes and pods based on the contents in the configure file.
+
+For example, I only want to enable `MatchNodeSelector` predicate during the performance test:
+
+```json
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+  {"name" : "MatchNodeSelector"}
+  ],
+"priorities" : [
+  {"name" : "LeastRequestedPriority", "weight" : 1},
+  {"name" : "BalancedResourceAllocation", "weight" : 1},
+  {"name" : "ServiceSpreadingPriority", "weight" : 1},
+  {"name" : "EqualPriority", "weight" : 1}
+  ],
+"hardPodAffinitySymmetricWeight" : 10
+}
+```
+Done!
+
+The test case will configure corresponding `NodeAffinity` to make sure this predicate is respected during test process.
+
 
 <!-- BEGIN MUNGE: GENERATED_ANALYTICS -->
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/test/component/scheduler/perf/README.md?pixel)]()

--- a/test/integration/scheduler_perf/config/scheduler-config.json
+++ b/test/integration/scheduler_perf/config/scheduler-config.json
@@ -1,0 +1,19 @@
+{
+"kind" : "Policy",
+"apiVersion" : "v1",
+"predicates" : [
+  {"name" : "PodFitsHostPorts"},
+  {"name" : "PodFitsResources"},
+  {"name" : "NoDiskConflict"},
+  {"name" : "NoVolumeZoneConflict"},
+  {"name" : "MatchNodeSelector"},
+  {"name" : "HostName"}
+  ],
+"priorities" : [
+  {"name" : "LeastRequestedPriority", "weight" : 1},
+  {"name" : "BalancedResourceAllocation", "weight" : 1},
+  {"name" : "ServiceSpreadingPriority", "weight" : 1},
+  {"name" : "EqualPriority", "weight" : 1}
+  ],
+"hardPodAffinitySymmetricWeight" : 10
+}

--- a/test/integration/scheduler_perf/scheduler_perf_types.go
+++ b/test/integration/scheduler_perf/scheduler_perf_types.go
@@ -18,14 +18,6 @@ package benchmark
 
 // High Level Configuration for all predicates and priorities.
 type schedulerPerfConfig struct {
-	NodeCount    int // The number of nodes which will be seeded with metadata to match predicates and have non-trivial priority rankings.
-	PodCount     int // The number of pods which will be seeded with metadata to match predicates and have non-trivial priority rankings.
-	NodeAffinity *nodeAffinity
-	// TODO: Other predicates and priorities to be added here.
-}
-
-// nodeAffinity priority configuration details.
-type nodeAffinity struct {
-	nodeAffinityKey string // Node Selection Key.
-	LabelCount      int    // number of labels to be added to each node or pod.
+	NodeCount int // The number of nodes which will be seeded with metadata to match predicates and have non-trivial priority rankings.
+	PodCount  int // The number of pods which will be seeded with metadata to match predicates and have non-trivial priority rankings.
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Make scheduler configurable from given json file in scheduler_perf

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

This is the part 1 of #49723

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
