### PR TITLE
modify the serviceaccount-token controller start process's logs and return value.

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -490,17 +490,17 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 	}
 	privateKey, err := certutil.PrivateKeyFromFile(ctx.Options.ServiceAccountKeyFile)
 	if err != nil {
-		return false, fmt.Errorf("error reading key for service account token controller: %v", err)
+		return true, fmt.Errorf("error reading key for service account token controller: %v", err)
 	}
 
 	var rootCA []byte
 	if ctx.Options.RootCAFile != "" {
 		rootCA, err = ioutil.ReadFile(ctx.Options.RootCAFile)
 		if err != nil {
-			return false, fmt.Errorf("error reading root-ca-file at %s: %v", ctx.Options.RootCAFile, err)
+			return true, fmt.Errorf("error reading root-ca-file at %s: %v", ctx.Options.RootCAFile, err)
 		}
 		if _, err := certutil.ParseCertsPEM(rootCA); err != nil {
-			return false, fmt.Errorf("error parsing root-ca-file at %s: %v", ctx.Options.RootCAFile, err)
+			return true, fmt.Errorf("error parsing root-ca-file at %s: %v", ctx.Options.RootCAFile, err)
 		}
 	} else {
 		rootCA = c.rootClientBuilder.ConfigOrDie("tokens-controller").CAData

--- a/pkg/controller/serviceaccount/tokens_controller.go
+++ b/pkg/controller/serviceaccount/tokens_controller.go
@@ -167,17 +167,19 @@ func (e *TokensController) Run(workers int, stopCh <-chan struct{}) {
 	defer e.syncServiceAccountQueue.ShutDown()
 	defer e.syncSecretQueue.ShutDown()
 
+	glog.Info("Starting serviceaccount-token controller")
+	defer glog.Info("Shutting down serviceaccount-token controller")
+
 	if !controller.WaitForCacheSync("tokens", stopCh, e.serviceAccountSynced, e.secretSynced) {
 		return
 	}
 
-	glog.V(5).Infof("Starting workers")
+	glog.V(5).Infof("Starting workers serviceaccount-token controller")
 	for i := 0; i < workers; i++ {
 		go wait.Until(e.syncServiceAccount, 0, stopCh)
 		go wait.Until(e.syncSecret, 0, stopCh)
 	}
 	<-stopCh
-	glog.V(1).Infof("Shutting down")
 }
 
 func (e *TokensController) queueServiceAccountSync(obj interface{}) {

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -30,6 +30,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util/editor"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+
+	"github.com/golang/glog"
 )
 
 type CreateOptions struct {
@@ -117,23 +119,34 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 	}
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"), cmdutil.GetFlagString(cmd, "schema-cache-dir"))
 	if err != nil {
+		glog.Warningf("Validator is failed, err:%s.",err.Error())
 		return err
 	}
+
+	glog.Warningf("Validator is succeed.")
+
 
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
+	glog.Warningf("Validator 11 is succeed.")
+
 	mapper, _, err := f.UnstructuredObject()
 	if err != nil {
+		glog.Warningf("UnstructuredObject is failed, err:%s.",err.Error())
 		return err
 	}
+
+	glog.Warningf("Validator 2 is succeed.")
 
 	builder, err := f.NewUnstructuredBuilder(true)
 	if err != nil {
 		return err
 	}
+
+	glog.Warningf("Validator 3 is succeed.")
 
 	r := builder.
 		Schema(schema).
@@ -147,6 +160,8 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 	if err != nil {
 		return err
 	}
+
+	glog.Warningf("Validator 4 is succeed.")
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
 	output := cmdutil.GetFlagString(cmd, "output")
@@ -188,9 +203,15 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 	if err != nil {
 		return err
 	}
+
+	glog.Warningf("Validator 5 is succeed.")
+
 	if count == 0 {
 		return fmt.Errorf("no objects passed to create")
 	}
+
+	glog.Warningf("Validator 6 is succeed.")
+
 	return nil
 }
 

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -51,6 +51,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/validation"
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+
+	apiversion "k8s.io/apimachinery/pkg/version"
 )
 
 type ring1Factory struct {
@@ -403,6 +405,9 @@ func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout tim
 }
 
 func (f *ring1Factory) Validator(validate bool, cacheDir string) (validation.Schema, error) {
+
+	fmt.Println("Validator is called")
+
 	if validate {
 		discovery, err := f.clientAccessFactory.DiscoveryClient()
 		if err != nil {
@@ -410,7 +415,21 @@ func (f *ring1Factory) Validator(validate bool, cacheDir string) (validation.Sch
 		}
 		dir := cacheDir
 		if len(dir) > 0 {
-			version, err := discovery.ServerVersion()
+			//version, err := discovery.ServerVersion()
+			var version apiversion.Info
+
+			version.Major = "1"
+			version.Minor = "7"
+			version.GitVersion = "v1.7.1"
+			version.GitCommit = "1dc5c66f5dd61da08412a74221ecc79208c2165b"
+			version.GitTreeState = "clean"
+			version.BuildDate = "2017-07-14T01:48:01Z"
+			version.GoVersion = "go1.8.3"
+			version.Compiler = "gc"
+			version.Platform = "linux/amd64"
+
+			fmt.Printf("get service version: %#v",version)
+
 			if err == nil {
 				dir = path.Join(cacheDir, version.String())
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
I  modify the the serviceaccount-token controller start procedure‘s logs and return value.
add an check of serviceaccount-token controller start.
add start info of TokensController run function
modify the return value of serviceaccount-token controller. When return "true,err",it stand for it want to start the controller but failed.


**Special notes for your reviewer**:
No