### PR TITLE
Depend on //cluster/lib instead of :all-srcs.

### DIFF
--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -51,26 +51,26 @@ pkg_tar(
 sh_test(
     name = "common_test",
     srcs = ["common.sh"],
-    data = [
-        ":all-srcs",
+    deps = [
+        "//cluster/lib",
+        "//hack/lib",
     ],
-    deps = ["//hack/lib"],
 )
 
 sh_test(
     name = "clientbin_test",
     srcs = ["clientbin.sh"],
-    data = [
-        ":all-srcs",
+    deps = [
+        "//cluster/lib",
+        "//hack/lib",
     ],
-    deps = ["//hack/lib"],
 )
 
 sh_test(
     name = "kube-util_test",
     srcs = ["kube-util.sh"],
-    data = [
-        ":all-srcs",
+    deps = [
+        "//cluster/lib",
+        "//hack/lib",
     ],
-    deps = ["//hack/lib"],
 )


### PR DESCRIPTION
Cleanup after #51649

Bug: #51642

```release-note
NONE
```

/assign @ixdy
/assign @roberthbailey 