### PR TITLE
Update godep-licenses script to work on darwin

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -141,7 +141,7 @@ echo "= Kubernetes licensed under: ="
 echo
 cat ${LICENSE_ROOT}/LICENSE
 echo
-echo "= LICENSE $(cat ${LICENSE_ROOT}/LICENSE | md5sum)"
+echo "= LICENSE $(cat ${LICENSE_ROOT}/LICENSE | md5sum | awk '{print $1}')"
 echo "================================================================================"
 ) > ${TMP_LICENSE_FILE}
 
@@ -180,7 +180,7 @@ __EOF__
   cat "${file}"
 
   echo
-  echo "= ${file} $(cat ${file} | md5sum)"
+  echo "= ${file} $(cat ${file} | md5sum | awk '{print $1}')"
   echo "================================================================================"
   echo
 done >> ${TMP_LICENSE_FILE}


### PR DESCRIPTION
**What this PR does / why we need it**:
When reviewing #51766, noticed that the godep licenses script has slightly different output on darwin (using the BSD md5sum) and linux (using the GNU md5sum).

This adds an awk trim to ensure that the output is the same on both platforms.

**Release note**:
```release-note
NONE
```
