### PR TITLE
Allow metadata firewall & proxy on in GCE, off by default

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -745,6 +745,16 @@ EOF
 ENABLE_CUSTOM_METRICS: $(yaml-quote ${ENABLE_CUSTOM_METRICS})
 EOF
   fi
+  if [ -n "${ENABLE_METADATA_PROXY:-}" ]; then
+    cat >>$file <<EOF
+ENABLE_METADATA_PROXY: $(yaml-quote ${ENABLE_METADATA_PROXY})
+EOF
+  fi
+  if [ -n "${KUBE_FIREWALL_METADATA_SERVER:-}" ]; then
+    cat >>$file <<EOF
+KUBE_FIREWALL_METADATA_SERVER: $(yaml-quote ${KUBE_FIREWALL_METADATA_SERVER})
+EOF
+  fi
   if [ -n "${FEATURE_GATES:-}" ]; then
     cat >>$file <<EOF
 FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -140,9 +140,11 @@ if [[ ${NETWORK_POLICY_PROVIDER:-} == "calico" ]]; then
 	NODE_LABELS="${NODE_LABELS},projectcalico.org/ds-ready=true"
 fi
 
-# Turn the simple metadata proxy on by default.
-ENABLE_METADATA_PROXY="${ENABLE_METADATA_PROXY:-simple}"
-if [[ ${ENABLE_METADATA_PROXY} != "false" ]]; then
+# Currently, ENABLE_METADATA_PROXY supports only "simple".  In the future, we
+# may add other options.
+ENABLE_METADATA_PROXY="${ENABLE_METADATA_PROXY:-}"
+# Apply the right node label if metadata proxy is on.
+if [[ ${ENABLE_METADATA_PROXY:-} == "simple" ]]; then
         NODE_LABELS="${NODE_LABELS},beta.kubernetes.io/metadata-proxy-ready=true"
 fi
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -194,9 +194,8 @@ if [[ ${NETWORK_POLICY_PROVIDER:-} == "calico" ]]; then
 	NODE_LABELS="$NODE_LABELS,projectcalico.org/ds-ready=true"
 fi
 
-# Turn the simple metadata proxy on by default.
-ENABLE_METADATA_PROXY="${ENABLE_METADATA_PROXY:-simple}"
-if [[ ${ENABLE_METADATA_PROXY} != "false" ]]; then
+# Apply the right node label if metadata proxy is on.
+if [[ ${ENABLE_METADATA_PROXY:-} == "simple" ]]; then
         NODE_LABELS="${NODE_LABELS},beta.kubernetes.io/metadata-proxy-ready=true"
 fi
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Add necessary variables in kube-env to allow a user to turn on metadata firewall and proxy for K8s on GCE.

Ref #8867.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
GCE users can enable the metadata firewall and metadata proxy with KUBE_FIREWALL_METADATA_SERVER and ENABLE_METADATA_PROXY, respectively.
```
