### PR TITLE
Update sys spec to support docker 1.11-1.13 and overlay2.

### DIFF
--- a/test/e2e_node/system/docker_validator_test.go
+++ b/test/e2e_node/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.(9|1[0-2])\..*`}, // Requires 1.9+
+		Version:     []string{`1\.1[1-3]\..*`}, // Requires 1.11+
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -38,24 +38,28 @@ func TestValidateDockerInfo(t *testing.T) {
 	}{
 		{
 			info: types.Info{Driver: "driver_1", ServerVersion: "1.10.1"},
+			err:  true,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "bad_driver", ServerVersion: "1.11.1"},
+			err:  true,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_1", ServerVersion: "1.11.1"},
 			err:  false,
 			warn: false,
 		},
 		{
-			info: types.Info{Driver: "bad_driver", ServerVersion: "1.9.1"},
-			err:  true,
+			info: types.Info{Driver: "driver_2", ServerVersion: "1.12.1"},
+			err:  false,
 			warn: false,
 		},
-		{
-			info: types.Info{Driver: "driver_2", ServerVersion: "1.8.1"},
-			err:  true,
-			warn: false,
-		},
-		// TODO remove/change warn value  once sig-node supports 1.13
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "1.13.1"},
 			err:  false,
-			warn: true,
+			warn: false,
 		},
 		// TODO remove/change warn value once sig-node supports 17.03-0-ce
 		{

--- a/test/e2e_node/system/types.go
+++ b/test/e2e_node/system/types.go
@@ -159,9 +159,8 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version: []string{`1\.(9|1[0-2])\..*`}, // Requires 1.9+
-			// TODO(random-liu): Validate overlay2.
-			GraphDriver: []string{"aufs", "overlay", "devicemapper"},
+			Version:     []string{`1\.1[1-3]\..*`}, // Requires 1.11+
+			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper"},
 		},
 	},
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/32536.

Update docker spec to:
1) Support overlay2;
2) Support docker version 1.11-1.13.

@dchen1107 @yguo0905 @luxas 
/cc @kubernetes/sig-node-pr-reviews 

```release-note
Kubernetes 1.8 supports docker version 1.11.x, 1.12.x and 1.13.x. And also supports overlay2.
```