### PR TITLE
Remove type names from `extensions/v1beta1`

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -70632,16 +70632,16 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.AllowedHostPath": {
-    "description": "defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+    "description": "Defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
     "properties": {
      "pathPrefix": {
-      "description": "is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
+      "description": "Is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSet": {
-    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -70673,7 +70673,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "Collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -70707,7 +70707,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "Specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -70742,7 +70742,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "Represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -70810,7 +70810,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Deployment": {
-    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -70842,7 +70842,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "Describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -70875,7 +70875,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "List of Deployments.",
     "required": [
      "items"
     ],
@@ -70885,7 +70885,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is the list of Deployments.",
+      "description": "List of Deployments.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Deployment"
@@ -70909,7 +70909,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentRollback": {
-    "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DEPRECATED. Stores the information required to rollback a deployment.",
     "required": [
      "name",
      "rollbackTo"
@@ -70932,7 +70932,7 @@
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollbackConfig"
      },
      "updatedAnnotations": {
-      "description": "The annotations to be updated to a deployment",
+      "description": "The annotations to be updated to a deployment.",
       "type": "object",
       "additionalProperties": {
        "type": "string"
@@ -70948,7 +70948,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "Specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -70991,13 +70991,13 @@
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStrategy"
      },
      "template": {
-      "description": "Template describes the pods that will be created.",
+      "description": "Describes the pods that will be created.",
       "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "Most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -71046,7 +71046,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "Describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -71059,39 +71059,39 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions": {
-    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "Defines the strategy type and options used to create the strategy.",
     "properties": {
      "ranges": {
-      "description": "Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
+      "description": "The allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
       }
      },
      "rule": {
-      "description": "Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
+      "description": "The strategy that will dictate what FSGroup is used in the SecurityContext.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressPath": {
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
     "required": [
      "backend"
     ],
     "properties": {
      "backend": {
-      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
+      "description": "Defines the referenced service endpoint to which the traffic will be forwarded to.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressBackend"
      },
      "path": {
-      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+      "description": "An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue": {
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "List of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
     "required": [
      "paths"
     ],
@@ -71106,55 +71106,55 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.HostPortRange": {
-    "description": "Host Port Range defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+    "description": "Defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
     "required": [
      "min",
      "max"
     ],
     "properties": {
      "max": {
-      "description": "max is the end of the range, inclusive.",
+      "description": "The end of the range, inclusive.",
       "type": "integer",
       "format": "int32"
      },
      "min": {
-      "description": "min is the start of the range, inclusive.",
+      "description": "The start of the range, inclusive.",
       "type": "integer",
       "format": "int32"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.IDRange": {
-    "description": "ID Range provides a min/max of an allowed range of IDs.",
+    "description": "Provides a min/max of an allowed range of IDs.",
     "required": [
      "min",
      "max"
     ],
     "properties": {
      "max": {
-      "description": "Max is the end of the range, inclusive.",
+      "description": "The end of the range, inclusive.",
       "type": "integer",
       "format": "int64"
      },
      "min": {
-      "description": "Min is the start of the range, inclusive.",
+      "description": "The start of the range, inclusive.",
       "type": "integer",
       "format": "int64"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.IPBlock": {
-    "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+    "description": "Describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
     "required": [
      "cidr"
     ],
     "properties": {
      "cidr": {
-      "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
+      "description": "String representing the IP Block Valid examples are \"192.168.1.1/24\"",
       "type": "string"
      },
      "except": {
-      "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+      "description": "Slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
       "type": "array",
       "items": {
        "type": "string"
@@ -71163,7 +71163,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Ingress": {
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71178,11 +71178,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressSpec"
      },
      "status": {
-      "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressStatus"
      }
     },
@@ -71195,7 +71195,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.IngressBackend": {
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "Describes all endpoints for a given service and port.",
     "required": [
      "serviceName",
      "servicePort"
@@ -71212,7 +71212,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressList": {
-    "description": "IngressList is a collection of Ingress.",
+    "description": "Collection of Ingress.",
     "required": [
      "items"
     ],
@@ -71222,7 +71222,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is the list of Ingress.",
+      "description": "List of Ingress.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Ingress"
@@ -71246,10 +71246,10 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.IngressRule": {
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
     "properties": {
      "host": {
-      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+      "description": "The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
       "type": "string"
      },
      "http": {
@@ -71258,7 +71258,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressSpec": {
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "Describes the Ingress the user wishes to exist.",
     "properties": {
      "backend": {
       "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
@@ -71281,32 +71281,32 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressStatus": {
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "The current state of the Ingress.",
     "properties": {
      "loadBalancer": {
-      "description": "LoadBalancer contains the current status of the load-balancer.",
+      "description": "Contains the current status of the load-balancer.",
       "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressTLS": {
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "Describes the transport layer security associated with an Ingress.",
     "properties": {
      "hosts": {
-      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+      "description": "List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
       "type": "array",
       "items": {
        "type": "string"
       }
      },
      "secretName": {
-      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+      "description": "Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicy": {
-    "description": "NetworkPolicy describes what network traffic is allowed for a set of Pods",
+    "description": "Describes what network traffic is allowed for a set of Pods",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71353,7 +71353,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule": {
-    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "description": "Matches traffic if and only if the traffic matches both ports AND from.",
     "properties": {
      "from": {
       "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
@@ -71372,7 +71372,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyList": {
-    "description": "Network Policy List is a list of NetworkPolicy objects.",
+    "description": "List of NetworkPolicy objects.",
     "required": [
      "items"
     ],
@@ -71382,7 +71382,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is a list of schema objects.",
+      "description": "List of schema objects.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.NetworkPolicy"
@@ -71408,7 +71408,7 @@
    "io.k8s.api.extensions.v1beta1.NetworkPolicyPeer": {
     "properties": {
      "ipBlock": {
-      "description": "IPBlock defines policy on a particular IPBlock",
+      "description": "Defines policy on a particular IPBlock",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IPBlock"
      },
      "namespaceSelector": {
@@ -71466,7 +71466,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicy": {
-    "description": "Pod Security Policy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+    "description": "Governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71481,7 +71481,7 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "spec defines the policy enforced.",
+      "description": "Defines the policy enforced.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec"
      }
     },
@@ -71494,7 +71494,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicyList": {
-    "description": "Pod Security Policy List is a list of PodSecurityPolicy objects.",
+    "description": "List of PodSecurityPolicy objects.",
     "required": [
      "items"
     ],
@@ -71504,7 +71504,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is a list of schema objects.",
+      "description": "List of schema objects.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.PodSecurityPolicy"
@@ -71528,7 +71528,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec": {
-    "description": "Pod Security Policy Spec defines the policy enforced.",
+    "description": "Defines the policy enforced.",
     "required": [
      "seLinux",
      "runAsUser",
@@ -71537,86 +71537,86 @@
     ],
     "properties": {
      "allowPrivilegeEscalation": {
-      "description": "AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
+      "description": "Determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
       "type": "boolean"
      },
      "allowedCapabilities": {
-      "description": "AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.",
+      "description": "List of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.",
       "type": "array",
       "items": {
        "type": "string"
       }
      },
      "allowedHostPaths": {
-      "description": "is a white list of allowed host paths. Empty indicates that all host paths may be used.",
+      "description": "Is a white list of allowed host paths. Empty indicates that all host paths may be used.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.AllowedHostPath"
       }
      },
      "defaultAddCapabilities": {
-      "description": "DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
+      "description": "Default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
       "type": "array",
       "items": {
        "type": "string"
       }
      },
      "defaultAllowPrivilegeEscalation": {
-      "description": "DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.",
+      "description": "Controls the default setting for whether a process can gain more privileges than its parent process.",
       "type": "boolean"
      },
      "fsGroup": {
-      "description": "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.",
+      "description": "The strategy that will dictate what fs group is used by the SecurityContext.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions"
      },
      "hostIPC": {
-      "description": "hostIPC determines if the policy allows the use of HostIPC in the pod spec.",
+      "description": "Determines if the policy allows the use of HostIPC in the pod spec.",
       "type": "boolean"
      },
      "hostNetwork": {
-      "description": "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
+      "description": "Determines if the policy allows the use of HostNetwork in the pod spec.",
       "type": "boolean"
      },
      "hostPID": {
-      "description": "hostPID determines if the policy allows the use of HostPID in the pod spec.",
+      "description": "Determines if the policy allows the use of HostPID in the pod spec.",
       "type": "boolean"
      },
      "hostPorts": {
-      "description": "hostPorts determines which host port ranges are allowed to be exposed.",
+      "description": "Determines which host port ranges are allowed to be exposed.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.HostPortRange"
       }
      },
      "privileged": {
-      "description": "privileged determines if a pod can request to be run as privileged.",
+      "description": "Determines if a pod can request to be run as privileged.",
       "type": "boolean"
      },
      "readOnlyRootFilesystem": {
-      "description": "ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+      "description": "When set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
       "type": "boolean"
      },
      "requiredDropCapabilities": {
-      "description": "RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+      "description": "Capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
       "type": "array",
       "items": {
        "type": "string"
       }
      },
      "runAsUser": {
-      "description": "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.",
+      "description": "The strategy that will dictate the allowable RunAsUser values that may be set.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions"
      },
      "seLinux": {
-      "description": "seLinux is the strategy that will dictate the allowable labels that may be set.",
+      "description": "The strategy that will dictate the allowable labels that may be set.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions"
      },
      "supplementalGroups": {
-      "description": "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.",
+      "description": "The strategy that will dictate what supplemental groups are used by the SecurityContext.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions"
      },
      "volumes": {
-      "description": "volumes is a white list of allowed volume plugins.  Empty indicates that all plugins may be used.",
+      "description": "A white list of allowed volume plugins.  Empty indicates that all plugins may be used.",
       "type": "array",
       "items": {
        "type": "string"
@@ -71625,7 +71625,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
-    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71640,11 +71640,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetSpec"
      },
      "status": {
-      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetStatus"
      }
     },
@@ -71657,7 +71657,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "Describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -71686,7 +71686,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "Collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -71720,7 +71720,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "Specification of a ReplicaSet.",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -71728,22 +71728,22 @@
       "format": "int32"
      },
      "replicas": {
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+      "description": "Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
       "type": "integer",
       "format": "int32"
      },
      "selector": {
-      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+      "description": "A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      },
      "template": {
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
+      "description": "The object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
       "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "Represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -71768,7 +71768,7 @@
       "format": "int32"
      },
      "observedGeneration": {
-      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+      "description": "Reflects the generation of the most recently observed ReplicaSet.",
       "type": "integer",
       "format": "int64"
      },
@@ -71778,7 +71778,7 @@
       "format": "int32"
      },
      "replicas": {
-      "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+      "description": "The most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
       "type": "integer",
       "format": "int32"
      }
@@ -71817,32 +71817,32 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions": {
-    "description": "Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.",
+    "description": "Defines the strategy type and any options used to create the strategy.",
     "required": [
      "rule"
     ],
     "properties": {
      "ranges": {
-      "description": "Ranges are the allowed ranges of uids that may be used.",
+      "description": "Allowed ranges of uids that may be used.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
       }
      },
      "rule": {
-      "description": "Rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
+      "description": "Strategy that will dictate the allowable RunAsUser values that may be set.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions": {
-    "description": "SELinux  Strategy Options defines the strategy type and any options used to create the strategy.",
+    "description": "Defines the strategy type and any options used to create the strategy.",
     "required": [
      "rule"
     ],
     "properties": {
      "rule": {
-      "description": "type is the strategy that will dictate the allowable labels that may be set.",
+      "description": "The strategy that will dictate the allowable labels that may be set.",
       "type": "string"
      },
      "seLinuxOptions": {
@@ -71852,7 +71852,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Scale": {
-    "description": "represents a scaling request for a resource.",
+    "description": "Represents a scaling request for a resource.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71867,11 +71867,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
+      "description": "Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleSpec"
      },
      "status": {
-      "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
+      "description": "Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleStatus"
      }
     },
@@ -71884,7 +71884,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ScaleSpec": {
-    "description": "describes the attributes of a scale subresource",
+    "description": "Describes the attributes of a scale subresource.",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -71894,41 +71894,41 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ScaleStatus": {
-    "description": "represents the current status of a scale subresource.",
+    "description": "Represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
     "properties": {
      "replicas": {
-      "description": "actual number of observed instances of the scaled object.",
+      "description": "Actual number of observed instances of the scaled object.",
       "type": "integer",
       "format": "int32"
      },
      "selector": {
-      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "description": "Label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors.",
       "type": "object",
       "additionalProperties": {
        "type": "string"
       }
      },
      "targetSelector": {
-      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+      "description": "Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions": {
-    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "Defines the strategy type and options used to create the strategy.",
     "properties": {
      "ranges": {
-      "description": "Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
+      "description": "The allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IDRange"
       }
      },
      "rule": {
-      "description": "Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
+      "description": "The strategy that will dictate what supplemental groups is used in the SecurityContext.",
       "type": "string"
      }
     }

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -6850,7 +6850,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "Collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -6896,7 +6896,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7160,7 +7160,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "Specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -9246,7 +9246,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "Represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -9372,7 +9372,7 @@
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "List of Deployments.",
     "required": [
      "items"
     ],
@@ -9394,13 +9394,13 @@
       "items": {
        "$ref": "v1beta1.Deployment"
       },
-      "description": "Items is the list of Deployments."
+      "description": "List of Deployments."
      }
     }
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9426,7 +9426,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "Specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -9442,7 +9442,7 @@
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template describes the pods that will be created."
+      "description": "Describes the pods that will be created."
      },
      "strategy": {
       "$ref": "v1beta1.DeploymentStrategy",
@@ -9475,7 +9475,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "Describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -9514,7 +9514,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "Most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -9562,7 +9562,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "Describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -9596,7 +9596,7 @@
    },
    "v1beta1.DeploymentRollback": {
     "id": "v1beta1.DeploymentRollback",
-    "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DEPRECATED. Stores the information required to rollback a deployment.",
     "required": [
      "name",
      "rollbackTo"
@@ -9616,7 +9616,7 @@
      },
      "updatedAnnotations": {
       "type": "object",
-      "description": "The annotations to be updated to a deployment"
+      "description": "The annotations to be updated to a deployment."
      },
      "rollbackTo": {
       "$ref": "v1beta1.RollbackConfig",
@@ -9626,7 +9626,7 @@
    },
    "v1beta1.Scale": {
     "id": "v1beta1.Scale",
-    "description": "represents a scaling request for a resource.",
+    "description": "Represents a scaling request for a resource.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9642,17 +9642,17 @@
      },
      "spec": {
       "$ref": "v1beta1.ScaleSpec",
-      "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+      "description": "Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
      },
      "status": {
       "$ref": "v1beta1.ScaleStatus",
-      "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
+      "description": "Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
      }
     }
    },
    "v1beta1.ScaleSpec": {
     "id": "v1beta1.ScaleSpec",
-    "description": "describes the attributes of a scale subresource",
+    "description": "Describes the attributes of a scale subresource.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -9663,7 +9663,7 @@
    },
    "v1beta1.ScaleStatus": {
     "id": "v1beta1.ScaleStatus",
-    "description": "represents the current status of a scale subresource.",
+    "description": "Represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
@@ -9671,21 +9671,21 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "actual number of observed instances of the scaled object."
+      "description": "Actual number of observed instances of the scaled object."
      },
      "selector": {
       "type": "object",
-      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+      "description": "Label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors."
      },
      "targetSelector": {
       "type": "string",
-      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+      "description": "Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
      }
     }
    },
    "v1beta1.IngressList": {
     "id": "v1beta1.IngressList",
-    "description": "IngressList is a collection of Ingress.",
+    "description": "Collection of Ingress.",
     "required": [
      "items"
     ],
@@ -9707,13 +9707,13 @@
       "items": {
        "$ref": "v1beta1.Ingress"
       },
-      "description": "Items is the list of Ingress."
+      "description": "List of Ingress."
      }
     }
    },
    "v1beta1.Ingress": {
     "id": "v1beta1.Ingress",
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
     "properties": {
      "kind": {
       "type": "string",
@@ -9729,17 +9729,17 @@
      },
      "spec": {
       "$ref": "v1beta1.IngressSpec",
-      "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.IngressStatus",
-      "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      }
     }
    },
    "v1beta1.IngressSpec": {
     "id": "v1beta1.IngressSpec",
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "Describes the Ingress the user wishes to exist.",
     "properties": {
      "backend": {
       "$ref": "v1beta1.IngressBackend",
@@ -9763,7 +9763,7 @@
    },
    "v1beta1.IngressBackend": {
     "id": "v1beta1.IngressBackend",
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "Describes all endpoints for a given service and port.",
     "required": [
      "serviceName",
      "servicePort"
@@ -9781,28 +9781,28 @@
    },
    "v1beta1.IngressTLS": {
     "id": "v1beta1.IngressTLS",
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "Describes the transport layer security associated with an Ingress.",
     "properties": {
      "hosts": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
+      "description": "List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
      },
      "secretName": {
       "type": "string",
-      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+      "description": "Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
      }
     }
    },
    "v1beta1.IngressRule": {
     "id": "v1beta1.IngressRule",
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
     "properties": {
      "host": {
       "type": "string",
-      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
+      "description": "The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
      },
      "http": {
       "$ref": "v1beta1.HTTPIngressRuleValue"
@@ -9811,7 +9811,7 @@
    },
    "v1beta1.HTTPIngressRuleValue": {
     "id": "v1beta1.HTTPIngressRuleValue",
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "List of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
     "required": [
      "paths"
     ],
@@ -9827,28 +9827,28 @@
    },
    "v1beta1.HTTPIngressPath": {
     "id": "v1beta1.HTTPIngressPath",
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
     "required": [
      "backend"
     ],
     "properties": {
      "path": {
       "type": "string",
-      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
+      "description": "An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
      },
      "backend": {
       "$ref": "v1beta1.IngressBackend",
-      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+      "description": "Defines the referenced service endpoint to which the traffic will be forwarded to."
      }
     }
    },
    "v1beta1.IngressStatus": {
     "id": "v1beta1.IngressStatus",
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "The current state of the Ingress.",
     "properties": {
      "loadBalancer": {
       "$ref": "v1.LoadBalancerStatus",
-      "description": "LoadBalancer contains the current status of the load-balancer."
+      "description": "Contains the current status of the load-balancer."
      }
     }
    },
@@ -9881,7 +9881,7 @@
    },
    "v1beta1.NetworkPolicyList": {
     "id": "v1beta1.NetworkPolicyList",
-    "description": "Network Policy List is a list of NetworkPolicy objects.",
+    "description": "List of NetworkPolicy objects.",
     "required": [
      "items"
     ],
@@ -9903,13 +9903,13 @@
       "items": {
        "$ref": "v1beta1.NetworkPolicy"
       },
-      "description": "Items is a list of schema objects."
+      "description": "List of schema objects."
      }
     }
    },
    "v1beta1.NetworkPolicy": {
     "id": "v1beta1.NetworkPolicy",
-    "description": "NetworkPolicy describes what network traffic is allowed for a set of Pods",
+    "description": "Describes what network traffic is allowed for a set of Pods",
     "properties": {
      "kind": {
       "type": "string",
@@ -9964,7 +9964,7 @@
    },
    "v1beta1.NetworkPolicyIngressRule": {
     "id": "v1beta1.NetworkPolicyIngressRule",
-    "description": "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "description": "Matches traffic if and only if the traffic matches both ports AND from.",
     "properties": {
      "ports": {
       "type": "array",
@@ -10012,27 +10012,27 @@
      },
      "ipBlock": {
       "$ref": "v1beta1.IPBlock",
-      "description": "IPBlock defines policy on a particular IPBlock"
+      "description": "Defines policy on a particular IPBlock"
      }
     }
    },
    "v1beta1.IPBlock": {
     "id": "v1beta1.IPBlock",
-    "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+    "description": "Describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
     "required": [
      "cidr"
     ],
     "properties": {
      "cidr": {
       "type": "string",
-      "description": "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\""
+      "description": "String representing the IP Block Valid examples are \"192.168.1.1/24\""
      },
      "except": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range"
+      "description": "Slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range"
      }
     }
    },
@@ -10062,7 +10062,7 @@
    },
    "v1beta1.PodSecurityPolicyList": {
     "id": "v1beta1.PodSecurityPolicyList",
-    "description": "Pod Security Policy List is a list of PodSecurityPolicy objects.",
+    "description": "List of PodSecurityPolicy objects.",
     "required": [
      "items"
     ],
@@ -10084,13 +10084,13 @@
       "items": {
        "$ref": "v1beta1.PodSecurityPolicy"
       },
-      "description": "Items is a list of schema objects."
+      "description": "List of schema objects."
      }
     }
    },
    "v1beta1.PodSecurityPolicy": {
     "id": "v1beta1.PodSecurityPolicy",
-    "description": "Pod Security Policy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+    "description": "Governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
     "properties": {
      "kind": {
       "type": "string",
@@ -10106,13 +10106,13 @@
      },
      "spec": {
       "$ref": "v1beta1.PodSecurityPolicySpec",
-      "description": "spec defines the policy enforced."
+      "description": "Defines the policy enforced."
      }
     }
    },
    "v1beta1.PodSecurityPolicySpec": {
     "id": "v1beta1.PodSecurityPolicySpec",
-    "description": "Pod Security Policy Spec defines the policy enforced.",
+    "description": "Defines the policy enforced.",
     "required": [
      "seLinux",
      "runAsUser",
@@ -10122,89 +10122,89 @@
     "properties": {
      "privileged": {
       "type": "boolean",
-      "description": "privileged determines if a pod can request to be run as privileged."
+      "description": "Determines if a pod can request to be run as privileged."
      },
      "defaultAddCapabilities": {
       "type": "array",
       "items": {
        "$ref": "v1.Capability"
       },
-      "description": "DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities."
+      "description": "Default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities."
      },
      "requiredDropCapabilities": {
       "type": "array",
       "items": {
        "$ref": "v1.Capability"
       },
-      "description": "RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added."
+      "description": "Capabilities that will be dropped from the container.  These are required to be dropped and cannot be added."
      },
      "allowedCapabilities": {
       "type": "array",
       "items": {
        "$ref": "v1.Capability"
       },
-      "description": "AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities."
+      "description": "List of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities."
      },
      "volumes": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.FSType"
       },
-      "description": "volumes is a white list of allowed volume plugins.  Empty indicates that all plugins may be used."
+      "description": "A white list of allowed volume plugins.  Empty indicates that all plugins may be used."
      },
      "hostNetwork": {
       "type": "boolean",
-      "description": "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec."
+      "description": "Determines if the policy allows the use of HostNetwork in the pod spec."
      },
      "hostPorts": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.HostPortRange"
       },
-      "description": "hostPorts determines which host port ranges are allowed to be exposed."
+      "description": "Determines which host port ranges are allowed to be exposed."
      },
      "hostPID": {
       "type": "boolean",
-      "description": "hostPID determines if the policy allows the use of HostPID in the pod spec."
+      "description": "Determines if the policy allows the use of HostPID in the pod spec."
      },
      "hostIPC": {
       "type": "boolean",
-      "description": "hostIPC determines if the policy allows the use of HostIPC in the pod spec."
+      "description": "Determines if the policy allows the use of HostIPC in the pod spec."
      },
      "seLinux": {
       "$ref": "v1beta1.SELinuxStrategyOptions",
-      "description": "seLinux is the strategy that will dictate the allowable labels that may be set."
+      "description": "The strategy that will dictate the allowable labels that may be set."
      },
      "runAsUser": {
       "$ref": "v1beta1.RunAsUserStrategyOptions",
-      "description": "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set."
+      "description": "The strategy that will dictate the allowable RunAsUser values that may be set."
      },
      "supplementalGroups": {
       "$ref": "v1beta1.SupplementalGroupsStrategyOptions",
-      "description": "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext."
+      "description": "The strategy that will dictate what supplemental groups are used by the SecurityContext."
      },
      "fsGroup": {
       "$ref": "v1beta1.FSGroupStrategyOptions",
-      "description": "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext."
+      "description": "The strategy that will dictate what fs group is used by the SecurityContext."
      },
      "readOnlyRootFilesystem": {
       "type": "boolean",
-      "description": "ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to."
+      "description": "When set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to."
      },
      "defaultAllowPrivilegeEscalation": {
       "type": "boolean",
-      "description": "DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process."
+      "description": "Controls the default setting for whether a process can gain more privileges than its parent process."
      },
      "allowPrivilegeEscalation": {
       "type": "boolean",
-      "description": "AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true."
+      "description": "Determines if a pod can request to allow privilege escalation. If unspecified, defaults to true."
      },
      "allowedHostPaths": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.AllowedHostPath"
       },
-      "description": "is a white list of allowed host paths. Empty indicates that all host paths may be used."
+      "description": "Is a white list of allowed host paths. Empty indicates that all host paths may be used."
      }
     }
    },
@@ -10214,7 +10214,7 @@
    },
    "v1beta1.HostPortRange": {
     "id": "v1beta1.HostPortRange",
-    "description": "Host Port Range defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+    "description": "Defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
     "required": [
      "min",
      "max"
@@ -10223,25 +10223,25 @@
      "min": {
       "type": "integer",
       "format": "int32",
-      "description": "min is the start of the range, inclusive."
+      "description": "The start of the range, inclusive."
      },
      "max": {
       "type": "integer",
       "format": "int32",
-      "description": "max is the end of the range, inclusive."
+      "description": "The end of the range, inclusive."
      }
     }
    },
    "v1beta1.SELinuxStrategyOptions": {
     "id": "v1beta1.SELinuxStrategyOptions",
-    "description": "SELinux  Strategy Options defines the strategy type and any options used to create the strategy.",
+    "description": "Defines the strategy type and any options used to create the strategy.",
     "required": [
      "rule"
     ],
     "properties": {
      "rule": {
       "type": "string",
-      "description": "type is the strategy that will dictate the allowable labels that may be set."
+      "description": "The strategy that will dictate the allowable labels that may be set."
      },
      "seLinuxOptions": {
       "$ref": "v1.SELinuxOptions",
@@ -10251,27 +10251,27 @@
    },
    "v1beta1.RunAsUserStrategyOptions": {
     "id": "v1beta1.RunAsUserStrategyOptions",
-    "description": "Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.",
+    "description": "Defines the strategy type and any options used to create the strategy.",
     "required": [
      "rule"
     ],
     "properties": {
      "rule": {
       "type": "string",
-      "description": "Rule is the strategy that will dictate the allowable RunAsUser values that may be set."
+      "description": "Strategy that will dictate the allowable RunAsUser values that may be set."
      },
      "ranges": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.IDRange"
       },
-      "description": "Ranges are the allowed ranges of uids that may be used."
+      "description": "Allowed ranges of uids that may be used."
      }
     }
    },
    "v1beta1.IDRange": {
     "id": "v1beta1.IDRange",
-    "description": "ID Range provides a min/max of an allowed range of IDs.",
+    "description": "Provides a min/max of an allowed range of IDs.",
     "required": [
      "min",
      "max"
@@ -10280,62 +10280,62 @@
      "min": {
       "type": "integer",
       "format": "int64",
-      "description": "Min is the start of the range, inclusive."
+      "description": "The start of the range, inclusive."
      },
      "max": {
       "type": "integer",
       "format": "int64",
-      "description": "Max is the end of the range, inclusive."
+      "description": "The end of the range, inclusive."
      }
     }
    },
    "v1beta1.SupplementalGroupsStrategyOptions": {
     "id": "v1beta1.SupplementalGroupsStrategyOptions",
-    "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "Defines the strategy type and options used to create the strategy.",
     "properties": {
      "rule": {
       "type": "string",
-      "description": "Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext."
+      "description": "The strategy that will dictate what supplemental groups is used in the SecurityContext."
      },
      "ranges": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.IDRange"
       },
-      "description": "Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end."
+      "description": "The allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end."
      }
     }
    },
    "v1beta1.FSGroupStrategyOptions": {
     "id": "v1beta1.FSGroupStrategyOptions",
-    "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+    "description": "Defines the strategy type and options used to create the strategy.",
     "properties": {
      "rule": {
       "type": "string",
-      "description": "Rule is the strategy that will dictate what FSGroup is used in the SecurityContext."
+      "description": "The strategy that will dictate what FSGroup is used in the SecurityContext."
      },
      "ranges": {
       "type": "array",
       "items": {
        "$ref": "v1beta1.IDRange"
       },
-      "description": "Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end."
+      "description": "The allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end."
      }
     }
    },
    "v1beta1.AllowedHostPath": {
     "id": "v1beta1.AllowedHostPath",
-    "description": "defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+    "description": "Defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
     "properties": {
      "pathPrefix": {
       "type": "string",
-      "description": "is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`"
+      "description": "Is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`"
      }
     }
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "Collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -10363,7 +10363,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.",
     "properties": {
      "kind": {
       "type": "string",
@@ -10379,22 +10379,22 @@
      },
      "spec": {
       "$ref": "v1beta1.ReplicaSetSpec",
-      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.ReplicaSetStatus",
-      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      }
     }
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "Specification of a ReplicaSet.",
     "properties": {
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
+      "description": "Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
      },
      "minReadySeconds": {
       "type": "integer",
@@ -10403,17 +10403,17 @@
      },
      "selector": {
       "$ref": "v1.LabelSelector",
-      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+      "description": "A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+      "description": "The object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
      }
     }
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "Represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -10421,7 +10421,7 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
+      "description": "The most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
      },
      "fullyLabeledReplicas": {
       "type": "integer",
@@ -10441,7 +10441,7 @@
      "observedGeneration": {
       "type": "integer",
       "format": "int64",
-      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+      "description": "Reflects the generation of the most recently observed ReplicaSet."
      },
      "conditions": {
       "type": "array",
@@ -10454,7 +10454,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "Describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -421,7 +421,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_allowedhostpath">v1beta1.AllowedHostPath</h3>
 <div class="paragraph">
-<p>defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.</p>
+<p>Defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -443,7 +443,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">pathPrefix</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">is the path prefix that the host volume must match. It does not support <code>*</code>. Trailing slashes are trimmed when validating the path prefix with a host path.<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Is the path prefix that the host volume must match. It does not support <code>*</code>. Trailing slashes are trimmed when validating the path prefix with a host path.<br>
 <br>
 Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> and <code>/foo/bar</code> <code>/foo</code> would not allow <code>/food</code> or <code>/etc/foo</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
@@ -457,7 +457,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</h3>
 <div class="paragraph">
-<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>Most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -643,7 +643,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetstatus">v1beta1.DaemonSetStatus</h3>
 <div class="paragraph">
-<p>DaemonSetStatus represents the current status of a daemon set.</p>
+<p>Represents the current status of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -897,7 +897,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_ingressspec">v1beta1.IngressSpec</h3>
 <div class="paragraph">
-<p>IngressSpec describes the Ingress the user wishes to exist.</p>
+<p>Describes the Ingress the user wishes to exist.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1086,7 +1086,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_ingressbackend">v1beta1.IngressBackend</h3>
 <div class="paragraph">
-<p>IngressBackend describes all endpoints for a given service and port.</p>
+<p>Describes all endpoints for a given service and port.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1127,7 +1127,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_replicasetlist">v1beta1.ReplicaSetList</h3>
 <div class="paragraph">
-<p>ReplicaSetList is a collection of ReplicaSets.</p>
+<p>Collection of ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1251,7 +1251,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_ingressstatus">v1beta1.IngressStatus</h3>
 <div class="paragraph">
-<p>IngressStatus describe the current state of the Ingress.</p>
+<p>The current state of the Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1273,7 +1273,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">loadBalancer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">LoadBalancer contains the current status of the load-balancer.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Contains the current status of the load-balancer.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_loadbalancerstatus">v1.LoadBalancerStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1326,7 +1326,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_replicasetcondition">v1beta1.ReplicaSetCondition</h3>
 <div class="paragraph">
-<p>ReplicaSetCondition describes the state of a replica set at a certain point.</p>
+<p>Describes the state of a replica set at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1388,7 +1388,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_networkpolicylist">v1beta1.NetworkPolicyList</h3>
 <div class="paragraph">
-<p>Network Policy List is a list of NetworkPolicy objects.</p>
+<p>List of NetworkPolicy objects.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1431,7 +1431,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of schema objects.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of schema objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_networkpolicy">v1beta1.NetworkPolicy</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1501,7 +1501,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicylist">v1beta1.PodSecurityPolicyList</h3>
 <div class="paragraph">
-<p>Pod Security Policy List is a list of PodSecurityPolicy objects.</p>
+<p>List of PodSecurityPolicy objects.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1544,7 +1544,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of schema objects.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of schema objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_podsecuritypolicy">v1beta1.PodSecurityPolicy</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1597,7 +1597,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_fsgroupstrategyoptions">v1beta1.FSGroupStrategyOptions</h3>
 <div class="paragraph">
-<p>FSGroupStrategyOptions defines the strategy type and options used to create the strategy.</p>
+<p>Defines the strategy type and options used to create the strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1619,14 +1619,14 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rule</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate what FSGroup is used in the SecurityContext.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ranges</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_idrange">v1beta1.IDRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1638,7 +1638,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <div class="sect2">
 <h3 id="_v1beta1_httpingressrulevalue">v1beta1.HTTPIngressRuleValue</h3>
 <div class="paragraph">
-<p>HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: <a href="http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;">http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;</a> &#8594; backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last <em>/</em> and before the first <em>?</em> or <em>#</em>.</p>
+<p>List of http selectors pointing to backends. In the example: <a href="http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;">http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;</a> &#8594; backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last <em>/</em> and before the first <em>?</em> or <em>#</em>.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2243,7 +2243,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</h3>
 <div class="paragraph">
-<p>ReplicaSetSpec is the specification of a ReplicaSet.</p>
+<p>Specification of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2265,7 +2265,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2279,14 +2279,14 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The object that describes the pod that will be created if insufficient replicas are detected. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2298,7 +2298,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deployment">v1beta1.Deployment</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2360,7 +2360,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetspec">v1beta1.DaemonSetSpec</h3>
 <div class="paragraph">
-<p>DaemonSetSpec is the specification of a daemon set.</p>
+<p>Specification of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2585,7 +2585,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_ingresslist">v1beta1.IngressList</h3>
 <div class="paragraph">
-<p>IngressList is a collection of Ingress.</p>
+<p>Collection of Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2628,7 +2628,7 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Ingress.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of Ingress.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingress">v1beta1.Ingress</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2681,7 +2681,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_scalespec">v1beta1.ScaleSpec</h3>
 <div class="paragraph">
-<p>describes the attributes of a scale subresource</p>
+<p>Describes the attributes of a scale subresource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2982,7 +2982,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_selinuxstrategyoptions">v1beta1.SELinuxStrategyOptions</h3>
 <div class="paragraph">
-<p>SELinux  Strategy Options defines the strategy type and any options used to create the strategy.</p>
+<p>Defines the strategy type and any options used to create the strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3004,7 +3004,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rule</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">type is the strategy that will dictate the allowable labels that may be set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate the allowable labels that may be set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3023,7 +3023,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_runasuserstrategyoptions">v1beta1.RunAsUserStrategyOptions</h3>
 <div class="paragraph">
-<p>Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.</p>
+<p>Defines the strategy type and any options used to create the strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3045,14 +3045,14 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rule</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rule is the strategy that will dictate the allowable RunAsUser values that may be set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Strategy that will dictate the allowable RunAsUser values that may be set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ranges</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ranges are the allowed ranges of uids that may be used.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Allowed ranges of uids that may be used.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_idrange">v1beta1.IDRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3273,7 +3273,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_ipblock">v1beta1.IPBlock</h3>
 <div class="paragraph">
-<p>IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec&#8217;s podSelector. The except entry describes CIDRs that should not be included within this rule.</p>
+<p>Describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods matched by a NetworkPolicySpec&#8217;s podSelector. The except entry describes CIDRs that should not be included within this rule.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3295,14 +3295,14 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">cidr</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24"</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">String representing the IP Block Valid examples are "192.168.1.1/24"</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">except</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" Except values will be rejected if they are outside the CIDR range</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3355,7 +3355,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_supplementalgroupsstrategyoptions">v1beta1.SupplementalGroupsStrategyOptions</h3>
 <div class="paragraph">
-<p>SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.</p>
+<p>Defines the strategy type and options used to create the strategy.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3377,14 +3377,14 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rule</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate what supplemental groups is used in the SecurityContext.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ranges</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_idrange">v1beta1.IDRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3675,7 +3675,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetlist">v1beta1.DaemonSetList</h3>
 <div class="paragraph">
-<p>DaemonSetList is a collection of daemon sets.</p>
+<p>Collection of daemon sets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4173,7 +4173,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deploymentspec">v1beta1.DeploymentSpec</h3>
 <div class="paragraph">
-<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>Specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4209,7 +4209,7 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template describes the pods that will be created.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Describes the pods that will be created.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4311,7 +4311,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicy">v1beta1.PodSecurityPolicy</h3>
 <div class="paragraph">
-<p>Pod Security Policy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.</p>
+<p>Governs the ability to make requests that affect the Security Context that will be applied to a pod and container.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4354,7 +4354,7 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">spec defines the policy enforced.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the policy enforced.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_podsecuritypolicyspec">v1beta1.PodSecurityPolicySpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4888,7 +4888,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_ingresstls">v1beta1.IngressTLS</h3>
 <div class="paragraph">
-<p>IngressTLS describes the transport layer security associated with an Ingress.</p>
+<p>Describes the transport layer security associated with an Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4910,14 +4910,14 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hosts</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4981,7 +4981,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_scale">v1beta1.Scale</h3>
 <div class="paragraph">
-<p>represents a scaling request for a resource.</p>
+<p>Represents a scaling request for a resource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5024,14 +5024,14 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">defines the behavior of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the behavior of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalespec">v1beta1.ScaleSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current status of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current status of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalestatus">v1beta1.ScaleStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5315,7 +5315,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_networkpolicy">v1beta1.NetworkPolicy</h3>
 <div class="paragraph">
-<p>NetworkPolicy describes what network traffic is allowed for a set of Pods</p>
+<p>Describes what network traffic is allowed for a set of Pods</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5502,7 +5502,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_scalestatus">v1beta1.ScaleStatus</h3>
 <div class="paragraph">
-<p>represents the current status of a scale subresource.</p>
+<p>Represents the current status of a scale subresource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5524,21 +5524,21 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">actual number of observed instances of the scaled object.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Actual number of observed instances of the scaled object.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label query over pods that should match the replicas count. More info: <a href="http://kubernetes.io/docs/user-guide/labels#label-selectors">http://kubernetes.io/docs/user-guide/labels#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Label query over pods that should match the replicas count. More info: <a href="http://kubernetes.io/docs/user-guide/labels#label-selectors">http://kubernetes.io/docs/user-guide/labels#label-selectors</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">object</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">targetSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5650,7 +5650,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentlist">v1beta1.DeploymentList</h3>
 <div class="paragraph">
-<p>DeploymentList is a list of Deployments.</p>
+<p>List of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5693,7 +5693,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Deployments.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of Deployments.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_deployment">v1beta1.Deployment</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5705,7 +5705,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</h3>
 <div class="paragraph">
-<p>DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.</p>
+<p>DEPRECATED. Stores the information required to rollback a deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5748,7 +5748,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">updatedAnnotations</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The annotations to be updated to a deployment</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The annotations to be updated to a deployment.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">object</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5915,7 +5915,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstrategy">v1beta1.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>Describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5997,7 +5997,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_ingressrule">v1beta1.IngressRule</h3>
 <div class="paragraph">
-<p>IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.</p>
+<p>Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6019,7 +6019,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">host</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the<br>
 	  IP in the Spec of the parent Ingress.<br>
 2. The <code>:</code> delimiter is not respected because ports are not allowed.<br>
 	  Currently the port of an Ingress is implicitly :80 for http and<br>
@@ -6076,7 +6076,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">ipBlock</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">IPBlock defines policy on a particular IPBlock</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines policy on a particular IPBlock</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ipblock">v1beta1.IPBlock</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6484,7 +6484,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_networkpolicyingressrule">v1beta1.NetworkPolicyIngressRule</h3>
 <div class="paragraph">
-<p>This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.</p>
+<p>Matches traffic if and only if the traffic matches both ports AND from.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6594,7 +6594,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</h3>
 <div class="paragraph">
-<p>ReplicaSetStatus represents the current status of a ReplicaSet.</p>
+<p>Represents the current status of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6616,7 +6616,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the most recently oberved number of replicas. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The most recently oberved number of replicas. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6644,7 +6644,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">observedGeneration</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ObservedGeneration reflects the generation of the most recently observed ReplicaSet.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reflects the generation of the most recently observed ReplicaSet.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6801,7 +6801,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicaset">v1beta1.ReplicaSet</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.</p>
+<p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6844,14 +6844,14 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the specification of the desired behavior of the ReplicaSet. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the specification of the desired behavior of the ReplicaSet. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6996,7 +6996,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_daemonset">v1beta1.DaemonSet</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.</p>
+<p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7306,7 +7306,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_hostportrange">v1beta1.HostPortRange</h3>
 <div class="paragraph">
-<p>Host Port Range defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.</p>
+<p>Defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7328,14 +7328,14 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">min</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">min is the start of the range, inclusive.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The start of the range, inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">max</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">max is the end of the range, inclusive.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The end of the range, inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7682,7 +7682,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_podsecuritypolicyspec">v1beta1.PodSecurityPolicySpec</h3>
 <div class="paragraph">
-<p>Pod Security Policy Spec defines the policy enforced.</p>
+<p>Defines the policy enforced.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7704,119 +7704,119 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">privileged</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">privileged determines if a pod can request to be run as privileged.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines if a pod can request to be run as privileged.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">defaultAddCapabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capability">v1.Capability</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">requiredDropCapabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capability">v1.Capability</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">allowedCapabilities</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author&#8217;s discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author&#8217;s discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_capability">v1.Capability</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">volumes</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">volumes is a white list of allowed volume plugins.  Empty indicates that all plugins may be used.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A white list of allowed volume plugins.  Empty indicates that all plugins may be used.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_fstype">v1beta1.FSType</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostNetwork</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines if the policy allows the use of HostNetwork in the pod spec.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPorts</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hostPorts determines which host port ranges are allowed to be exposed.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines which host port ranges are allowed to be exposed.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_hostportrange">v1beta1.HostPortRange</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostPID</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hostPID determines if the policy allows the use of HostPID in the pod spec.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines if the policy allows the use of HostPID in the pod spec.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hostIPC</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">hostIPC determines if the policy allows the use of HostIPC in the pod spec.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines if the policy allows the use of HostIPC in the pod spec.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">seLinux</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">seLinux is the strategy that will dictate the allowable labels that may be set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate the allowable labels that may be set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_selinuxstrategyoptions">v1beta1.SELinuxStrategyOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">runAsUser</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate the allowable RunAsUser values that may be set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_runasuserstrategyoptions">v1beta1.RunAsUserStrategyOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">supplementalGroups</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate what supplemental groups are used by the SecurityContext.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_supplementalgroupsstrategyoptions">v1beta1.SupplementalGroupsStrategyOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fsGroup</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The strategy that will dictate what fs group is used by the SecurityContext.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_fsgroupstrategyoptions">v1beta1.FSGroupStrategyOptions</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">readOnlyRootFilesystem</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">When set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">defaultAllowPrivilegeEscalation</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Controls the default setting for whether a process can gain more privileges than its parent process.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">allowPrivilegeEscalation</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">boolean</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">allowedHostPaths</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">is a white list of allowed host paths. Empty indicates that all host paths may be used.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Is a white list of allowed host paths. Empty indicates that all host paths may be used.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_allowedhostpath">v1beta1.AllowedHostPath</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7828,7 +7828,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_deploymentcondition">v1beta1.DeploymentCondition</h3>
 <div class="paragraph">
-<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>Describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -8089,7 +8089,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_idrange">v1beta1.IDRange</h3>
 <div class="paragraph">
-<p>ID Range provides a min/max of an allowed range of IDs.</p>
+<p>Provides a min/max of an allowed range of IDs.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -8111,14 +8111,14 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">min</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Min is the start of the range, inclusive.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The start of the range, inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">max</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Max is the end of the range, inclusive.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The end of the range, inclusive.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -8178,7 +8178,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_httpingresspath">v1beta1.HTTPIngressPath</h3>
 <div class="paragraph">
-<p>HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.</p>
+<p>Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -8200,14 +8200,14 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a <em>/</em>. If unspecified, the path defaults to a catch all sending traffic to the backend.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a <em>/</em>. If unspecified, the path defaults to a catch all sending traffic to the backend.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">backend</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Backend defines the referenced service endpoint to which the traffic will be forwarded to.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the referenced service endpoint to which the traffic will be forwarded to.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressbackend">v1beta1.IngressBackend</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -8219,7 +8219,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_ingress">v1beta1.Ingress</h3>
 <div class="paragraph">
-<p>Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.</p>
+<p>Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -8262,14 +8262,14 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is the desired state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Desired state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressspec">v1beta1.IngressSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the current state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressstatus">v1beta1.IngressStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -13209,7 +13209,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSet": {
-    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -13241,7 +13241,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "Collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -13275,7 +13275,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "Specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -13310,7 +13310,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "Represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -13378,7 +13378,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Deployment": {
-    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -13410,7 +13410,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "Describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -13443,7 +13443,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentList": {
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "List of Deployments.",
     "required": [
      "items"
     ],
@@ -13453,7 +13453,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is the list of Deployments.",
+      "description": "List of Deployments.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Deployment"
@@ -13477,7 +13477,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentRollback": {
-    "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DEPRECATED. Stores the information required to rollback a deployment.",
     "required": [
      "name",
      "rollbackTo"
@@ -13500,7 +13500,7 @@
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.RollbackConfig"
      },
      "updatedAnnotations": {
-      "description": "The annotations to be updated to a deployment",
+      "description": "The annotations to be updated to a deployment.",
       "type": "object",
       "additionalProperties": {
        "type": "string"
@@ -13516,7 +13516,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "Specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -13559,13 +13559,13 @@
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.DeploymentStrategy"
      },
      "template": {
-      "description": "Template describes the pods that will be created.",
+      "description": "Describes the pods that will be created.",
       "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "Most recently observed status of the Deployment.",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -13614,7 +13614,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "Describes how to replace existing pods with new ones.",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -13627,23 +13627,23 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressPath": {
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
     "required": [
      "backend"
     ],
     "properties": {
      "backend": {
-      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
+      "description": "Defines the referenced service endpoint to which the traffic will be forwarded to.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressBackend"
      },
      "path": {
-      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+      "description": "An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue": {
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "List of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
     "required": [
      "paths"
     ],
@@ -13658,7 +13658,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Ingress": {
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -13673,11 +13673,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressSpec"
      },
      "status": {
-      "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.IngressStatus"
      }
     },
@@ -13690,7 +13690,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.IngressBackend": {
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "Describes all endpoints for a given service and port.",
     "required": [
      "serviceName",
      "servicePort"
@@ -13707,7 +13707,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressList": {
-    "description": "IngressList is a collection of Ingress.",
+    "description": "Collection of Ingress.",
     "required": [
      "items"
     ],
@@ -13717,7 +13717,7 @@
       "type": "string"
      },
      "items": {
-      "description": "Items is the list of Ingress.",
+      "description": "List of Ingress.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.Ingress"
@@ -13741,10 +13741,10 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.IngressRule": {
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
     "properties": {
      "host": {
-      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+      "description": "The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
       "type": "string"
      },
      "http": {
@@ -13753,7 +13753,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressSpec": {
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "Describes the Ingress the user wishes to exist.",
     "properties": {
      "backend": {
       "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
@@ -13776,32 +13776,32 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressStatus": {
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "The current state of the Ingress.",
     "properties": {
      "loadBalancer": {
-      "description": "LoadBalancer contains the current status of the load-balancer.",
+      "description": "Contains the current status of the load-balancer.",
       "$ref": "#/definitions/io.k8s.api.core.v1.LoadBalancerStatus"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.IngressTLS": {
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "Describes the transport layer security associated with an Ingress.",
     "properties": {
      "hosts": {
-      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+      "description": "List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
       "type": "array",
       "items": {
        "type": "string"
       }
      },
      "secretName": {
-      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+      "description": "Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
       "type": "string"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
-    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -13816,11 +13816,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetSpec"
      },
      "status": {
-      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+      "description": "Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ReplicaSetStatus"
      }
     },
@@ -13833,7 +13833,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "Describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"
@@ -13862,7 +13862,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "Collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -13896,7 +13896,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "Specification of a ReplicaSet.",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -13904,22 +13904,22 @@
       "format": "int32"
      },
      "replicas": {
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+      "description": "Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
       "type": "integer",
       "format": "int32"
      },
      "selector": {
-      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+      "description": "A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector"
      },
      "template": {
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
+      "description": "The object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
       "$ref": "#/definitions/io.k8s.api.core.v1.PodTemplateSpec"
      }
     }
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "Represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -13944,7 +13944,7 @@
       "format": "int32"
      },
      "observedGeneration": {
-      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+      "description": "Reflects the generation of the most recently observed ReplicaSet.",
       "type": "integer",
       "format": "int64"
      },
@@ -13954,7 +13954,7 @@
       "format": "int32"
      },
      "replicas": {
-      "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+      "description": "The most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
       "type": "integer",
       "format": "int32"
      }
@@ -13993,7 +13993,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.Scale": {
-    "description": "represents a scaling request for a resource.",
+    "description": "Represents a scaling request for a resource.",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -14008,11 +14008,11 @@
       "$ref": "#/definitions/io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"
      },
      "spec": {
-      "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
+      "description": "Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleSpec"
      },
      "status": {
-      "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
+      "description": "Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
       "$ref": "#/definitions/io.k8s.api.extensions.v1beta1.ScaleStatus"
      }
     },
@@ -14025,7 +14025,7 @@
     ]
    },
    "io.k8s.api.extensions.v1beta1.ScaleSpec": {
-    "description": "describes the attributes of a scale subresource",
+    "description": "Describes the attributes of a scale subresource.",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -14035,25 +14035,25 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.ScaleStatus": {
-    "description": "represents the current status of a scale subresource.",
+    "description": "Represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
     "properties": {
      "replicas": {
-      "description": "actual number of observed instances of the scaled object.",
+      "description": "Actual number of observed instances of the scaled object.",
       "type": "integer",
       "format": "int32"
      },
      "selector": {
-      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
+      "description": "Label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors.",
       "type": "object",
       "additionalProperties": {
        "type": "string"
       }
      },
      "targetSelector": {
-      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+      "description": "Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
       "type": "string"
      }
     }

--- a/federation/apis/swagger-spec/extensions_v1beta1.json
+++ b/federation/apis/swagger-spec/extensions_v1beta1.json
@@ -5014,7 +5014,7 @@
   "models": {
    "v1beta1.DaemonSetList": {
     "id": "v1beta1.DaemonSetList",
-    "description": "DaemonSetList is a collection of daemon sets.",
+    "description": "Collection of daemon sets.",
     "required": [
      "items"
     ],
@@ -5060,7 +5060,7 @@
    },
    "v1beta1.DaemonSet": {
     "id": "v1beta1.DaemonSet",
-    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.",
     "properties": {
      "kind": {
       "type": "string",
@@ -5324,7 +5324,7 @@
    },
    "v1beta1.DaemonSetSpec": {
     "id": "v1beta1.DaemonSetSpec",
-    "description": "DaemonSetSpec is the specification of a daemon set.",
+    "description": "Specification of a daemon set.",
     "required": [
      "template"
     ],
@@ -7410,7 +7410,7 @@
    },
    "v1beta1.DaemonSetStatus": {
     "id": "v1beta1.DaemonSetStatus",
-    "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "description": "Represents the current status of a daemon set.",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -7536,7 +7536,7 @@
    },
    "v1beta1.DeploymentList": {
     "id": "v1beta1.DeploymentList",
-    "description": "DeploymentList is a list of Deployments.",
+    "description": "List of Deployments.",
     "required": [
      "items"
     ],
@@ -7558,13 +7558,13 @@
       "items": {
        "$ref": "v1beta1.Deployment"
       },
-      "description": "Items is the list of Deployments."
+      "description": "List of Deployments."
      }
     }
    },
    "v1beta1.Deployment": {
     "id": "v1beta1.Deployment",
-    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7590,7 +7590,7 @@
    },
    "v1beta1.DeploymentSpec": {
     "id": "v1beta1.DeploymentSpec",
-    "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "description": "Specification of the desired behavior of the Deployment.",
     "required": [
      "template"
     ],
@@ -7606,7 +7606,7 @@
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template describes the pods that will be created."
+      "description": "Describes the pods that will be created."
      },
      "strategy": {
       "$ref": "v1beta1.DeploymentStrategy",
@@ -7639,7 +7639,7 @@
    },
    "v1beta1.DeploymentStrategy": {
     "id": "v1beta1.DeploymentStrategy",
-    "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "description": "Describes how to replace existing pods with new ones.",
     "properties": {
      "type": {
       "type": "string",
@@ -7678,7 +7678,7 @@
    },
    "v1beta1.DeploymentStatus": {
     "id": "v1beta1.DeploymentStatus",
-    "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "description": "Most recently observed status of the Deployment.",
     "properties": {
      "observedGeneration": {
       "type": "integer",
@@ -7726,7 +7726,7 @@
    },
    "v1beta1.DeploymentCondition": {
     "id": "v1beta1.DeploymentCondition",
-    "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "description": "Describes the state of a deployment at a certain point.",
     "required": [
      "type",
      "status"
@@ -7760,7 +7760,7 @@
    },
    "v1beta1.DeploymentRollback": {
     "id": "v1beta1.DeploymentRollback",
-    "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "description": "DEPRECATED. Stores the information required to rollback a deployment.",
     "required": [
      "name",
      "rollbackTo"
@@ -7780,7 +7780,7 @@
      },
      "updatedAnnotations": {
       "type": "object",
-      "description": "The annotations to be updated to a deployment"
+      "description": "The annotations to be updated to a deployment."
      },
      "rollbackTo": {
       "$ref": "v1beta1.RollbackConfig",
@@ -7790,7 +7790,7 @@
    },
    "v1beta1.Scale": {
     "id": "v1beta1.Scale",
-    "description": "represents a scaling request for a resource.",
+    "description": "Represents a scaling request for a resource.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7806,17 +7806,17 @@
      },
      "spec": {
       "$ref": "v1beta1.ScaleSpec",
-      "description": "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
+      "description": "Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status."
      },
      "status": {
       "$ref": "v1beta1.ScaleStatus",
-      "description": "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
+      "description": "Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only."
      }
     }
    },
    "v1beta1.ScaleSpec": {
     "id": "v1beta1.ScaleSpec",
-    "description": "describes the attributes of a scale subresource",
+    "description": "Describes the attributes of a scale subresource.",
     "properties": {
      "replicas": {
       "type": "integer",
@@ -7827,7 +7827,7 @@
    },
    "v1beta1.ScaleStatus": {
     "id": "v1beta1.ScaleStatus",
-    "description": "represents the current status of a scale subresource.",
+    "description": "Represents the current status of a scale subresource.",
     "required": [
      "replicas"
     ],
@@ -7835,21 +7835,21 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "actual number of observed instances of the scaled object."
+      "description": "Actual number of observed instances of the scaled object."
      },
      "selector": {
       "type": "object",
-      "description": "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors"
+      "description": "Label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors."
      },
      "targetSelector": {
       "type": "string",
-      "description": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+      "description": "Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
      }
     }
    },
    "v1beta1.IngressList": {
     "id": "v1beta1.IngressList",
-    "description": "IngressList is a collection of Ingress.",
+    "description": "Collection of Ingress.",
     "required": [
      "items"
     ],
@@ -7871,13 +7871,13 @@
       "items": {
        "$ref": "v1beta1.Ingress"
       },
-      "description": "Items is the list of Ingress."
+      "description": "List of Ingress."
      }
     }
    },
    "v1beta1.Ingress": {
     "id": "v1beta1.Ingress",
-    "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "description": "Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
     "properties": {
      "kind": {
       "type": "string",
@@ -7893,17 +7893,17 @@
      },
      "spec": {
       "$ref": "v1beta1.IngressSpec",
-      "description": "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.IngressStatus",
-      "description": "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      }
     }
    },
    "v1beta1.IngressSpec": {
     "id": "v1beta1.IngressSpec",
-    "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "description": "Describes the Ingress the user wishes to exist.",
     "properties": {
      "backend": {
       "$ref": "v1beta1.IngressBackend",
@@ -7927,7 +7927,7 @@
    },
    "v1beta1.IngressBackend": {
     "id": "v1beta1.IngressBackend",
-    "description": "IngressBackend describes all endpoints for a given service and port.",
+    "description": "Describes all endpoints for a given service and port.",
     "required": [
      "serviceName",
      "servicePort"
@@ -7945,28 +7945,28 @@
    },
    "v1beta1.IngressTLS": {
     "id": "v1beta1.IngressTLS",
-    "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "description": "Describes the transport layer security associated with an Ingress.",
     "properties": {
      "hosts": {
       "type": "array",
       "items": {
        "type": "string"
       },
-      "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
+      "description": "List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified."
      },
      "secretName": {
       "type": "string",
-      "description": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
+      "description": "Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing."
      }
     }
    },
    "v1beta1.IngressRule": {
     "id": "v1beta1.IngressRule",
-    "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "description": "Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
     "properties": {
      "host": {
       "type": "string",
-      "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
+      "description": "The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue."
      },
      "http": {
       "$ref": "v1beta1.HTTPIngressRuleValue"
@@ -7975,7 +7975,7 @@
    },
    "v1beta1.HTTPIngressRuleValue": {
     "id": "v1beta1.HTTPIngressRuleValue",
-    "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "description": "List of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
     "required": [
      "paths"
     ],
@@ -7991,28 +7991,28 @@
    },
    "v1beta1.HTTPIngressPath": {
     "id": "v1beta1.HTTPIngressPath",
-    "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "description": "Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
     "required": [
      "backend"
     ],
     "properties": {
      "path": {
       "type": "string",
-      "description": "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
+      "description": "An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend."
      },
      "backend": {
       "$ref": "v1beta1.IngressBackend",
-      "description": "Backend defines the referenced service endpoint to which the traffic will be forwarded to."
+      "description": "Defines the referenced service endpoint to which the traffic will be forwarded to."
      }
     }
    },
    "v1beta1.IngressStatus": {
     "id": "v1beta1.IngressStatus",
-    "description": "IngressStatus describe the current state of the Ingress.",
+    "description": "The current state of the Ingress.",
     "properties": {
      "loadBalancer": {
       "$ref": "v1.LoadBalancerStatus",
-      "description": "LoadBalancer contains the current status of the load-balancer."
+      "description": "Contains the current status of the load-balancer."
      }
     }
    },
@@ -8045,7 +8045,7 @@
    },
    "v1beta1.ReplicaSetList": {
     "id": "v1beta1.ReplicaSetList",
-    "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "description": "Collection of ReplicaSets.",
     "required": [
      "items"
     ],
@@ -8073,7 +8073,7 @@
    },
    "v1beta1.ReplicaSet": {
     "id": "v1beta1.ReplicaSet",
-    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.",
     "properties": {
      "kind": {
       "type": "string",
@@ -8089,22 +8089,22 @@
      },
      "spec": {
       "$ref": "v1beta1.ReplicaSetSpec",
-      "description": "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      },
      "status": {
       "$ref": "v1beta1.ReplicaSetStatus",
-      "description": "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
+      "description": "Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status"
      }
     }
    },
    "v1beta1.ReplicaSetSpec": {
     "id": "v1beta1.ReplicaSetSpec",
-    "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "description": "Specification of a ReplicaSet.",
     "properties": {
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
+      "description": "Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
      },
      "minReadySeconds": {
       "type": "integer",
@@ -8113,17 +8113,17 @@
      },
      "selector": {
       "$ref": "v1.LabelSelector",
-      "description": "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
+      "description": "A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors"
      },
      "template": {
       "$ref": "v1.PodTemplateSpec",
-      "description": "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
+      "description": "The object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template"
      }
     }
    },
    "v1beta1.ReplicaSetStatus": {
     "id": "v1beta1.ReplicaSetStatus",
-    "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "description": "Represents the current status of a ReplicaSet.",
     "required": [
      "replicas"
     ],
@@ -8131,7 +8131,7 @@
      "replicas": {
       "type": "integer",
       "format": "int32",
-      "description": "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
+      "description": "The most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller"
      },
      "fullyLabeledReplicas": {
       "type": "integer",
@@ -8151,7 +8151,7 @@
      "observedGeneration": {
       "type": "integer",
       "format": "int64",
-      "description": "ObservedGeneration reflects the generation of the most recently observed ReplicaSet."
+      "description": "Reflects the generation of the most recently observed ReplicaSet."
      },
      "conditions": {
       "type": "array",
@@ -8164,7 +8164,7 @@
    },
    "v1beta1.ReplicaSetCondition": {
     "id": "v1beta1.ReplicaSetCondition",
-    "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "description": "Describes the state of a replica set at a certain point.",
     "required": [
      "type",
      "status"

--- a/federation/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/federation/docs/api-reference/extensions/v1beta1/definitions.html
@@ -409,7 +409,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstatus">v1beta1.DeploymentStatus</h3>
 <div class="paragraph">
-<p>DeploymentStatus is the most recently observed status of the Deployment.</p>
+<p>Most recently observed status of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -595,7 +595,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetstatus">v1beta1.DaemonSetStatus</h3>
 <div class="paragraph">
-<p>DaemonSetStatus represents the current status of a daemon set.</p>
+<p>Represents the current status of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -849,7 +849,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_ingressspec">v1beta1.IngressSpec</h3>
 <div class="paragraph">
-<p>IngressSpec describes the Ingress the user wishes to exist.</p>
+<p>Describes the Ingress the user wishes to exist.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1038,7 +1038,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_ingressbackend">v1beta1.IngressBackend</h3>
 <div class="paragraph">
-<p>IngressBackend describes all endpoints for a given service and port.</p>
+<p>Describes all endpoints for a given service and port.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1079,7 +1079,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetlist">v1beta1.ReplicaSetList</h3>
 <div class="paragraph">
-<p>ReplicaSetList is a collection of ReplicaSets.</p>
+<p>Collection of ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1203,7 +1203,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_ingressstatus">v1beta1.IngressStatus</h3>
 <div class="paragraph">
-<p>IngressStatus describe the current state of the Ingress.</p>
+<p>The current state of the Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1225,7 +1225,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">loadBalancer</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">LoadBalancer contains the current status of the load-balancer.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Contains the current status of the load-balancer.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_loadbalancerstatus">v1.LoadBalancerStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -1278,7 +1278,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_replicasetcondition">v1beta1.ReplicaSetCondition</h3>
 <div class="paragraph">
-<p>ReplicaSetCondition describes the state of a replica set at a certain point.</p>
+<p>Describes the state of a replica set at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -1439,7 +1439,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <div class="sect2">
 <h3 id="_v1beta1_httpingressrulevalue">v1beta1.HTTPIngressRuleValue</h3>
 <div class="paragraph">
-<p>HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: <a href="http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;">http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;</a> &#8594; backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last <em>/</em> and before the first <em>?</em> or <em>#</em>.</p>
+<p>List of http selectors pointing to backends. In the example: <a href="http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;">http://&lt;host&gt;/&lt;path&gt;?&lt;searchpart&gt;</a> &#8594; backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last <em>/</em> and before the first <em>?</em> or <em>#</em>.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2044,7 +2044,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</h3>
 <div class="paragraph">
-<p>ReplicaSetSpec is the specification of a ReplicaSet.</p>
+<p>Specification of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2066,7 +2066,7 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2080,14 +2080,14 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_labelselector">v1.LabelSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The object that describes the pod that will be created if insufficient replicas are detected. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2099,7 +2099,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deployment">v1beta1.Deployment</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.</p>
+<p>DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2161,7 +2161,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetspec">v1beta1.DaemonSetSpec</h3>
 <div class="paragraph">
-<p>DaemonSetSpec is the specification of a daemon set.</p>
+<p>Specification of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2386,7 +2386,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_ingresslist">v1beta1.IngressList</h3>
 <div class="paragraph">
-<p>IngressList is a collection of Ingress.</p>
+<p>Collection of Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -2429,7 +2429,7 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Ingress.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of Ingress.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingress">v1beta1.Ingress</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -2482,7 +2482,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_scalespec">v1beta1.ScaleSpec</h3>
 <div class="paragraph">
-<p>describes the attributes of a scale subresource</p>
+<p>Describes the attributes of a scale subresource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3312,7 +3312,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_daemonsetlist">v1beta1.DaemonSetList</h3>
 <div class="paragraph">
-<p>DaemonSetList is a collection of daemon sets.</p>
+<p>Collection of daemon sets.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3810,7 +3810,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_deploymentspec">v1beta1.DeploymentSpec</h3>
 <div class="paragraph">
-<p>DeploymentSpec is the specification of the desired behavior of the Deployment.</p>
+<p>Specification of the desired behavior of the Deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -3846,7 +3846,7 @@ When an object is created, the system will populate this list with the current s
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">template</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Template describes the pods that will be created.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Describes the pods that will be created.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_podtemplatespec">v1.PodTemplateSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4470,7 +4470,7 @@ When an object is created, the system will populate this list with the current s
 <div class="sect2">
 <h3 id="_v1beta1_ingresstls">v1beta1.IngressTLS</h3>
 <div class="paragraph">
-<p>IngressTLS describes the transport layer security associated with an Ingress.</p>
+<p>Describes the transport layer security associated with an Ingress.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4492,14 +4492,14 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">hosts</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">secretName</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the "Host" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4563,7 +4563,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_scale">v1beta1.Scale</h3>
 <div class="paragraph">
-<p>represents a scaling request for a resource.</p>
+<p>Represents a scaling request for a resource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -4606,14 +4606,14 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">defines the behavior of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the behavior of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalespec">v1beta1.ScaleSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">current status of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current status of the scale. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a>. Read-only.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_scalestatus">v1beta1.ScaleStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5025,7 +5025,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_scalestatus">v1beta1.ScaleStatus</h3>
 <div class="paragraph">
-<p>represents the current status of a scale subresource.</p>
+<p>Represents the current status of a scale subresource.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5047,21 +5047,21 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">actual number of observed instances of the scaled object.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Actual number of observed instances of the scaled object.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">selector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label query over pods that should match the replicas count. More info: <a href="http://kubernetes.io/docs/user-guide/labels#label-selectors">http://kubernetes.io/docs/user-guide/labels#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Label query over pods that should match the replicas count. More info: <a href="http://kubernetes.io/docs/user-guide/labels#label-selectors">http://kubernetes.io/docs/user-guide/labels#label-selectors</a>.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">object</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">targetSelector</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: <a href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors">https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5121,7 +5121,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentlist">v1beta1.DeploymentList</h3>
 <div class="paragraph">
-<p>DeploymentList is a list of Deployments.</p>
+<p>List of Deployments.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5164,7 +5164,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is the list of Deployments.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">List of Deployments.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_deployment">v1beta1.Deployment</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5176,7 +5176,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentrollback">v1beta1.DeploymentRollback</h3>
 <div class="paragraph">
-<p>DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.</p>
+<p>DEPRECATED. Stores the information required to rollback a deployment.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5219,7 +5219,7 @@ Examples:<br>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">updatedAnnotations</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">The annotations to be updated to a deployment</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The annotations to be updated to a deployment.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">object</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -5386,7 +5386,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_deploymentstrategy">v1beta1.DeploymentStrategy</h3>
 <div class="paragraph">
-<p>DeploymentStrategy describes how to replace existing pods with new ones.</p>
+<p>Describes how to replace existing pods with new ones.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5468,7 +5468,7 @@ Examples:<br>
 <div class="sect2">
 <h3 id="_v1beta1_ingressrule">v1beta1.IngressRule</h3>
 <div class="paragraph">
-<p>IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.</p>
+<p>Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -5490,7 +5490,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">host</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the<br>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the "host" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the<br>
 	  IP in the Spec of the parent Ingress.<br>
 2. The <code>:</code> delimiter is not respected because ports are not allowed.<br>
 	  Currently the port of an Ingress is implicitly :80 for http and<br>
@@ -5979,7 +5979,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</h3>
 <div class="paragraph">
-<p>ReplicaSetStatus represents the current status of a ReplicaSet.</p>
+<p>Represents the current status of a ReplicaSet.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6001,7 +6001,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">replicas</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Replicas is the most recently oberved number of replicas. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">The most recently oberved number of replicas. More info: <a href="https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller">https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6029,7 +6029,7 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">observedGeneration</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">ObservedGeneration reflects the generation of the most recently observed ReplicaSet.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Reflects the generation of the most recently observed ReplicaSet.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int64)</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6186,7 +6186,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_replicaset">v1beta1.ReplicaSet</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.</p>
+<p>DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6229,14 +6229,14 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec defines the specification of the desired behavior of the ReplicaSet. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the specification of the desired behavior of the ReplicaSet. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_replicasetspec">v1beta1.ReplicaSetSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_replicasetstatus">v1beta1.ReplicaSetStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -6340,7 +6340,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_daemonset">v1beta1.DaemonSet</h3>
 <div class="paragraph">
-<p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.</p>
+<p>DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -6943,7 +6943,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_deploymentcondition">v1beta1.DeploymentCondition</h3>
 <div class="paragraph">
-<p>DeploymentCondition describes the state of a deployment at a certain point.</p>
+<p>Describes the state of a deployment at a certain point.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7252,7 +7252,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_httpingresspath">v1beta1.HTTPIngressPath</h3>
 <div class="paragraph">
-<p>HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.</p>
+<p>Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7274,14 +7274,14 @@ Both these may change in the future. Incoming requests are matched against the h
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a <em>/</em>. If unspecified, the path defaults to a catch all sending traffic to the backend.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional "path" part of a URL as defined by RFC 3986. Paths must begin with a <em>/</em>. If unspecified, the path defaults to a catch all sending traffic to the backend.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">backend</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Backend defines the referenced service endpoint to which the traffic will be forwarded to.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Defines the referenced service endpoint to which the traffic will be forwarded to.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressbackend">v1beta1.IngressBackend</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -7293,7 +7293,7 @@ Both these may change in the future. Incoming requests are matched against the h
 <div class="sect2">
 <h3 id="_v1beta1_ingress">v1beta1.Ingress</h3>
 <div class="paragraph">
-<p>Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.</p>
+<p>Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.</p>
 </div>
 <table class="tableblock frame-all grid-all" style="width:100%; ">
 <colgroup>
@@ -7336,14 +7336,14 @@ Both these may change in the future. Incoming requests are matched against the h
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">spec</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Spec is the desired state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Desired state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressspec">v1beta1.IngressSpec</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">status</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Status is the current state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Current state of the Ingress. More info: <a href="https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status">https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status</a></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_ingressstatus">v1beta1.IngressStatus</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/extensions/v1beta1/generated.proto
@@ -34,15 +34,15 @@ option go_package = "v1beta1";
 
 // An APIVersion represents a single concrete version of an object model.
 message APIVersion {
-  // Name of this version (e.g. 'v1').
+  // Version (e.g. 'v1').
   // +optional
   optional string name = 1;
 }
 
-// defines the host volume conditions that will be enabled by a policy
+// Defines the host volume conditions that will be enabled by a policy
 // for pods to use. It requires the path prefix to be defined.
 message AllowedHostPath {
-  // is the path prefix that the host volume must match.
+  // Is the path prefix that the host volume must match.
   // It does not support `*`.
   // Trailing slashes are trimmed when validating the path prefix with a host path.
   // 
@@ -79,7 +79,7 @@ message CustomMetricTargetList {
 
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
 // more information.
-// DaemonSet represents the configuration of a daemon set.
+// Represents the configuration of a daemon set.
 message DaemonSet {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -100,7 +100,7 @@ message DaemonSet {
   optional DaemonSetStatus status = 3;
 }
 
-// DaemonSetList is a collection of daemon sets.
+// Collection of daemon sets.
 message DaemonSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -111,7 +111,7 @@ message DaemonSetList {
   repeated DaemonSet items = 2;
 }
 
-// DaemonSetSpec is the specification of a daemon set.
+// Specification of a daemon set.
 message DaemonSetSpec {
   // A label query over pods that are managed by the daemon set.
   // Must match in order to be controlled.
@@ -151,7 +151,7 @@ message DaemonSetSpec {
   optional int32 revisionHistoryLimit = 6;
 }
 
-// DaemonSetStatus represents the current status of a daemon set.
+// Represents the current status of a daemon set.
 message DaemonSetStatus {
   // The number of nodes that are running at least 1
   // daemon pod and are supposed to run the daemon pod.
@@ -215,8 +215,7 @@ message DaemonSetUpdateStrategy {
 }
 
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
-// more information.
-// Deployment enables declarative updates for Pods and ReplicaSets.
+// more information. It enables declarative updates for Pods and ReplicaSets.
 message Deployment {
   // Standard object metadata.
   // +optional
@@ -231,7 +230,7 @@ message Deployment {
   optional DeploymentStatus status = 3;
 }
 
-// DeploymentCondition describes the state of a deployment at a certain point.
+// Describes the state of a deployment at a certain point.
 message DeploymentCondition {
   // Type of deployment condition.
   optional string type = 1;
@@ -252,23 +251,23 @@ message DeploymentCondition {
   optional string message = 5;
 }
 
-// DeploymentList is a list of Deployments.
+// List of Deployments.
 message DeploymentList {
   // Standard list metadata.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is the list of Deployments.
+  // List of Deployments.
   repeated Deployment items = 2;
 }
 
 // DEPRECATED.
-// DeploymentRollback stores the information required to rollback a deployment.
+// Stores the information required to rollback a deployment.
 message DeploymentRollback {
   // Required: This must match the Name of a deployment.
   optional string name = 1;
 
-  // The annotations to be updated to a deployment
+  // The annotations to be updated to a deployment.
   // +optional
   map<string, string> updatedAnnotations = 2;
 
@@ -276,7 +275,7 @@ message DeploymentRollback {
   optional RollbackConfig rollbackTo = 3;
 }
 
-// DeploymentSpec is the specification of the desired behavior of the Deployment.
+// Specification of the desired behavior of the Deployment.
 message DeploymentSpec {
   // Number of desired pods. This is a pointer to distinguish between explicit
   // zero and not specified. Defaults to 1.
@@ -288,7 +287,7 @@ message DeploymentSpec {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
-  // Template describes the pods that will be created.
+  // Describes the pods that will be created.
   optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
 
   // The deployment strategy to use to replace existing pods with new ones.
@@ -327,7 +326,7 @@ message DeploymentSpec {
   optional int32 progressDeadlineSeconds = 9;
 }
 
-// DeploymentStatus is the most recently observed status of the Deployment.
+// Most recently observed status of the Deployment.
 message DeploymentStatus {
   // The generation observed by the deployment controller.
   // +optional
@@ -367,7 +366,7 @@ message DeploymentStatus {
   optional int32 collisionCount = 8;
 }
 
-// DeploymentStrategy describes how to replace existing pods with new ones.
+// Describes how to replace existing pods with new ones.
 message DeploymentStrategy {
   // Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
   // +optional
@@ -382,22 +381,22 @@ message DeploymentStrategy {
   optional RollingUpdateDeployment rollingUpdate = 2;
 }
 
-// FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+// Defines the strategy type and options used to create the strategy.
 message FSGroupStrategyOptions {
-  // Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+  // The strategy that will dictate what FSGroup is used in the SecurityContext.
   // +optional
   optional string rule = 1;
 
-  // Ranges are the allowed ranges of fs groups.  If you would like to force a single
+  // The allowed ranges of fs groups.  If you would like to force a single
   // fs group then supply a single range with the same start and end.
   // +optional
   repeated IDRange ranges = 2;
 }
 
-// HTTPIngressPath associates a path regex with a backend. Incoming urls matching
+// Associates a path regex with a backend. Incoming urls matching
 // the path are forwarded to the backend.
 message HTTPIngressPath {
-  // Path is an extended POSIX regex as defined by IEEE Std 1003.1,
+  // An extended POSIX regex as defined by IEEE Std 1003.1,
   // (i.e this follows the egrep/unix syntax, not the perl syntax)
   // matched against the path of an incoming request. Currently it can
   // contain characters disallowed from the conventional "path"
@@ -407,12 +406,12 @@ message HTTPIngressPath {
   // +optional
   optional string path = 1;
 
-  // Backend defines the referenced service endpoint to which the traffic
+  // Defines the referenced service endpoint to which the traffic
   // will be forwarded to.
   optional IngressBackend backend = 2;
 }
 
-// HTTPIngressRuleValue is a list of http selectors pointing to backends.
+// List of http selectors pointing to backends.
 // In the example: http://<host>/<path>?<searchpart> -> backend where
 // where parts of the url correspond to RFC 3986, this resource will be used
 // to match against everything after the last '/' and before the first '?'
@@ -422,41 +421,41 @@ message HTTPIngressRuleValue {
   repeated HTTPIngressPath paths = 1;
 }
 
-// Host Port Range defines a range of host ports that will be enabled by a policy
+// Defines a range of host ports that will be enabled by a policy
 // for pods to use.  It requires both the start and end to be defined.
 message HostPortRange {
-  // min is the start of the range, inclusive.
+  // The start of the range, inclusive.
   optional int32 min = 1;
 
-  // max is the end of the range, inclusive.
+  // The end of the range, inclusive.
   optional int32 max = 2;
 }
 
-// ID Range provides a min/max of an allowed range of IDs.
+// Provides a min/max of an allowed range of IDs.
 message IDRange {
-  // Min is the start of the range, inclusive.
+  // The start of the range, inclusive.
   optional int64 min = 1;
 
-  // Max is the end of the range, inclusive.
+  // The end of the range, inclusive.
   optional int64 max = 2;
 }
 
-// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods
+// Describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods
 // matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should
 // not be included within this rule.
 message IPBlock {
-  // CIDR is a string representing the IP Block
+  // String representing the IP Block
   // Valid examples are "192.168.1.1/24"
   optional string cidr = 1;
 
-  // Except is a slice of CIDRs that should not be included within an IP Block
+  // Slice of CIDRs that should not be included within an IP Block
   // Valid examples are "192.168.1.1/24"
   // Except values will be rejected if they are outside the CIDR range
   // +optional
   repeated string except = 2;
 }
 
-// Ingress is a collection of rules that allow inbound connections to reach the
+// Collection of rules that allow inbound connections to reach the
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
@@ -466,18 +465,18 @@ message Ingress {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Spec is the desired state of the Ingress.
+  // Desired state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
   // +optional
   optional IngressSpec spec = 2;
 
-  // Status is the current state of the Ingress.
+  // Current state of the Ingress.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
   // +optional
   optional IngressStatus status = 3;
 }
 
-// IngressBackend describes all endpoints for a given service and port.
+// Describes all endpoints for a given service and port.
 message IngressBackend {
   // Specifies the name of the referenced service.
   optional string serviceName = 1;
@@ -486,22 +485,22 @@ message IngressBackend {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString servicePort = 2;
 }
 
-// IngressList is a collection of Ingress.
+// Collection of Ingress.
 message IngressList {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is the list of Ingress.
+  // List of Ingress.
   repeated Ingress items = 2;
 }
 
-// IngressRule represents the rules mapping the paths under a specified host to
+// Represents the rules mapping the paths under a specified host to
 // the related backend services. Incoming requests are first evaluated for a host
 // match, then routed to the backend associated with the matching IngressRuleValue.
 message IngressRule {
-  // Host is the fully qualified domain name of a network host, as defined
+  // The fully qualified domain name of a network host, as defined
   // by RFC 3986. Note the following deviations from the "host" part of the
   // URI as defined in the RFC:
   // 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
@@ -516,7 +515,7 @@ message IngressRule {
   // +optional
   optional string host = 1;
 
-  // IngressRuleValue represents a rule to route requests for this IngressRule.
+  // Represents a rule to route requests for this IngressRule.
   // If unspecified, the rule defaults to a http catch-all. Whether that sends
   // just traffic matching the host to the default backend or all traffic to the
   // default backend, is left to the controller fulfilling the Ingress. Http is
@@ -525,7 +524,7 @@ message IngressRule {
   optional IngressRuleValue ingressRuleValue = 2;
 }
 
-// IngressRuleValue represents a rule to apply against incoming requests. If the
+// Represents a rule to apply against incoming requests. If the
 // rule is satisfied, the request is routed to the specified backend. Currently
 // mixing different types of rules in a single Ingress is disallowed, so exactly
 // one of the following must be set.
@@ -534,7 +533,7 @@ message IngressRuleValue {
   optional HTTPIngressRuleValue http = 1;
 }
 
-// IngressSpec describes the Ingress the user wishes to exist.
+// Describes the Ingress the user wishes to exist.
 message IngressSpec {
   // A default backend capable of servicing requests that don't match any
   // rule. At least one of 'backend' or 'rules' must be specified. This field
@@ -557,23 +556,23 @@ message IngressSpec {
   repeated IngressRule rules = 3;
 }
 
-// IngressStatus describe the current state of the Ingress.
+// The current state of the Ingress.
 message IngressStatus {
-  // LoadBalancer contains the current status of the load-balancer.
+  // Contains the current status of the load-balancer.
   // +optional
   optional k8s.io.api.core.v1.LoadBalancerStatus loadBalancer = 1;
 }
 
-// IngressTLS describes the transport layer security associated with an Ingress.
+// Describes the transport layer security associated with an Ingress.
 message IngressTLS {
-  // Hosts are a list of hosts included in the TLS certificate. The values in
+  // List of hosts included in the TLS certificate. The values in
   // this list must match the name/s used in the tlsSecret. Defaults to the
   // wildcard host setting for the loadbalancer controller fulfilling this
   // Ingress, if left unspecified.
   // +optional
   repeated string hosts = 1;
 
-  // SecretName is the name of the secret used to terminate SSL traffic on 443.
+  // Name of the secret used to terminate SSL traffic on 443.
   // Field is left optional to allow SSL routing based on SNI hostname alone.
   // If the SNI host in a listener conflicts with the "Host" header field used
   // by an IngressRule, the SNI host is used for termination and value of the
@@ -582,7 +581,7 @@ message IngressTLS {
   optional string secretName = 2;
 }
 
-// NetworkPolicy describes what network traffic is allowed for a set of Pods
+// Describes what network traffic is allowed for a set of Pods
 message NetworkPolicy {
   // Standard object's metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
@@ -615,7 +614,7 @@ message NetworkPolicyEgressRule {
   repeated NetworkPolicyPeer to = 2;
 }
 
-// This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.
+// Matches traffic if and only if the traffic matches both ports AND from.
 message NetworkPolicyIngressRule {
   // List of ports which should be made accessible on the pods selected for this rule.
   // Each item in this list is combined using a logical OR.
@@ -634,14 +633,14 @@ message NetworkPolicyIngressRule {
   repeated NetworkPolicyPeer from = 2;
 }
 
-// Network Policy List is a list of NetworkPolicy objects.
+// List of NetworkPolicy objects.
 message NetworkPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is a list of schema objects.
+  // List of schema objects.
   repeated NetworkPolicy items = 2;
 }
 
@@ -659,7 +658,7 @@ message NetworkPolicyPeer {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector namespaceSelector = 2;
 
-  // IPBlock defines policy on a particular IPBlock
+  // Defines policy on a particular IPBlock
   // +optional
   optional IPBlock ipBlock = 3;
 }
@@ -721,7 +720,7 @@ message NetworkPolicySpec {
   repeated string policyTypes = 4;
 }
 
-// Pod Security Policy governs the ability to make requests that affect the Security Context
+// Governs the ability to make requests that affect the Security Context
 // that will be applied to a pod and container.
 message PodSecurityPolicy {
   // Standard object's metadata.
@@ -729,79 +728,79 @@ message PodSecurityPolicy {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // spec defines the policy enforced.
+  // Defines the policy enforced.
   // +optional
   optional PodSecurityPolicySpec spec = 2;
 }
 
-// Pod Security Policy List is a list of PodSecurityPolicy objects.
+// List of PodSecurityPolicy objects.
 message PodSecurityPolicyList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is a list of schema objects.
+  // List of schema objects.
   repeated PodSecurityPolicy items = 2;
 }
 
-// Pod Security Policy Spec defines the policy enforced.
+// Defines the policy enforced.
 message PodSecurityPolicySpec {
-  // privileged determines if a pod can request to be run as privileged.
+  // Determines if a pod can request to be run as privileged.
   // +optional
   optional bool privileged = 1;
 
-  // DefaultAddCapabilities is the default set of capabilities that will be added to the container
+  // Default set of capabilities that will be added to the container
   // unless the pod spec specifically drops the capability.  You may not list a capabiility in both
   // DefaultAddCapabilities and RequiredDropCapabilities.
   // +optional
   repeated string defaultAddCapabilities = 2;
 
-  // RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
+  // Capabilities that will be dropped from the container.  These
   // are required to be dropped and cannot be added.
   // +optional
   repeated string requiredDropCapabilities = 3;
 
-  // AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+  // List of capabilities that can be requested to add to the container.
   // Capabilities in this field may be added at the pod author's discretion.
   // You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
   // +optional
   repeated string allowedCapabilities = 4;
 
-  // volumes is a white list of allowed volume plugins.  Empty indicates that all plugins
+  // A white list of allowed volume plugins.  Empty indicates that all plugins
   // may be used.
   // +optional
   repeated string volumes = 5;
 
-  // hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+  // Determines if the policy allows the use of HostNetwork in the pod spec.
   // +optional
   optional bool hostNetwork = 6;
 
-  // hostPorts determines which host port ranges are allowed to be exposed.
+  // Determines which host port ranges are allowed to be exposed.
   // +optional
   repeated HostPortRange hostPorts = 7;
 
-  // hostPID determines if the policy allows the use of HostPID in the pod spec.
+  // Determines if the policy allows the use of HostPID in the pod spec.
   // +optional
   optional bool hostPID = 8;
 
-  // hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+  // Determines if the policy allows the use of HostIPC in the pod spec.
   // +optional
   optional bool hostIPC = 9;
 
-  // seLinux is the strategy that will dictate the allowable labels that may be set.
+  // The strategy that will dictate the allowable labels that may be set.
   optional SELinuxStrategyOptions seLinux = 10;
 
-  // runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+  // The strategy that will dictate the allowable RunAsUser values that may be set.
   optional RunAsUserStrategyOptions runAsUser = 11;
 
-  // SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+  // The strategy that will dictate what supplemental groups are used by the SecurityContext.
   optional SupplementalGroupsStrategyOptions supplementalGroups = 12;
 
-  // FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+  // The strategy that will dictate what fs group is used by the SecurityContext.
   optional FSGroupStrategyOptions fsGroup = 13;
 
-  // ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file
+  // When set to true will force containers to run with a read only root file
   // system.  If the container specifically requests to run with a non-read only root file system
   // the PSP should deny the pod.
   // If set to false the container may run with a read only root file system if it wishes but it
@@ -809,24 +808,24 @@ message PodSecurityPolicySpec {
   // +optional
   optional bool readOnlyRootFilesystem = 14;
 
-  // DefaultAllowPrivilegeEscalation controls the default setting for whether a
+  // Controls the default setting for whether a
   // process can gain more privileges than its parent process.
   // +optional
   optional bool defaultAllowPrivilegeEscalation = 15;
 
-  // AllowPrivilegeEscalation determines if a pod can request to allow
+  // Determines if a pod can request to allow
   // privilege escalation. If unspecified, defaults to true.
   // +optional
   optional bool allowPrivilegeEscalation = 16;
 
-  // is a white list of allowed host paths. Empty indicates that all host paths may be used.
+  // Is a white list of allowed host paths. Empty indicates that all host paths may be used.
   // +optional
   repeated AllowedHostPath allowedHostPaths = 17;
 }
 
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for
 // more information.
-// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// Ensures that a specified number of pod replicas are running at any given time.
 message ReplicaSet {
   // If the Labels of a ReplicaSet are empty, they are defaulted to
   // be the same as the Pod(s) that the ReplicaSet manages.
@@ -834,12 +833,12 @@ message ReplicaSet {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Spec defines the specification of the desired behavior of the ReplicaSet.
+  // Defines the specification of the desired behavior of the ReplicaSet.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
   // +optional
   optional ReplicaSetSpec spec = 2;
 
-  // Status is the most recently observed status of the ReplicaSet.
+  // Is the most recently observed status of the ReplicaSet.
   // This data may be out of date by some window of time.
   // Populated by the system.
   // Read-only.
@@ -848,7 +847,7 @@ message ReplicaSet {
   optional ReplicaSetStatus status = 3;
 }
 
-// ReplicaSetCondition describes the state of a replica set at a certain point.
+// Describes the state of a replica set at a certain point.
 message ReplicaSetCondition {
   // Type of replica set condition.
   optional string type = 1;
@@ -869,7 +868,7 @@ message ReplicaSetCondition {
   optional string message = 5;
 }
 
-// ReplicaSetList is a collection of ReplicaSets.
+// Collection of ReplicaSets.
 message ReplicaSetList {
   // Standard list metadata.
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds
@@ -881,9 +880,9 @@ message ReplicaSetList {
   repeated ReplicaSet items = 2;
 }
 
-// ReplicaSetSpec is the specification of a ReplicaSet.
+// Specification of a ReplicaSet.
 message ReplicaSetSpec {
-  // Replicas is the number of desired replicas.
+  // Number of desired replicas.
   // This is a pointer to distinguish between explicit zero and unspecified.
   // Defaults to 1.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
@@ -896,23 +895,23 @@ message ReplicaSetSpec {
   // +optional
   optional int32 minReadySeconds = 4;
 
-  // Selector is a label query over pods that should match the replica count.
+  // A label query over pods that should match the replica count.
   // If the selector is empty, it is defaulted to the labels present on the pod template.
   // Label keys and values that must match in order to be controlled by this replica set.
   // More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
-  // Template is the object that describes the pod that will be created if
+  // The object that describes the pod that will be created if
   // insufficient replicas are detected.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
   // +optional
   optional k8s.io.api.core.v1.PodTemplateSpec template = 3;
 }
 
-// ReplicaSetStatus represents the current status of a ReplicaSet.
+// Represents the current status of a ReplicaSet.
 message ReplicaSetStatus {
-  // Replicas is the most recently oberved number of replicas.
+  // The most recently oberved number of replicas.
   // More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
   optional int32 replicas = 1;
 
@@ -928,7 +927,7 @@ message ReplicaSetStatus {
   // +optional
   optional int32 availableReplicas = 5;
 
-  // ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+  // Reflects the generation of the most recently observed ReplicaSet.
   // +optional
   optional int64 observedGeneration = 3;
 
@@ -939,7 +938,7 @@ message ReplicaSetStatus {
   repeated ReplicaSetCondition conditions = 6;
 }
 
-// Dummy definition
+// Dummy definition.
 message ReplicationControllerDummy {
 }
 
@@ -1000,19 +999,19 @@ message RollingUpdateDeployment {
   optional k8s.io.apimachinery.pkg.util.intstr.IntOrString maxSurge = 2;
 }
 
-// Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.
+// Defines the strategy type and any options used to create the strategy.
 message RunAsUserStrategyOptions {
-  // Rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+  // Strategy that will dictate the allowable RunAsUser values that may be set.
   optional string rule = 1;
 
-  // Ranges are the allowed ranges of uids that may be used.
+  // Allowed ranges of uids that may be used.
   // +optional
   repeated IDRange ranges = 2;
 }
 
-// SELinux  Strategy Options defines the strategy type and any options used to create the strategy.
+// Defines the strategy type and any options used to create the strategy.
 message SELinuxStrategyOptions {
-  // type is the strategy that will dictate the allowable labels that may be set.
+  // The strategy that will dictate the allowable labels that may be set.
   optional string rule = 1;
 
   // seLinuxOptions required to run as; required for MustRunAs
@@ -1021,38 +1020,39 @@ message SELinuxStrategyOptions {
   optional k8s.io.api.core.v1.SELinuxOptions seLinuxOptions = 2;
 }
 
-// represents a scaling request for a resource.
+// Represents a scaling request for a resource.
 message Scale {
   // Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
+  // Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
   // +optional
   optional ScaleSpec spec = 2;
 
-  // current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.
+  // Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.
   // +optional
   optional ScaleStatus status = 3;
 }
 
-// describes the attributes of a scale subresource
+// Describes the attributes of a scale subresource.
 message ScaleSpec {
   // desired number of instances for the scaled object.
   // +optional
   optional int32 replicas = 1;
 }
 
-// represents the current status of a scale subresource.
+// Represents the current status of a scale subresource.
 message ScaleStatus {
-  // actual number of observed instances of the scaled object.
+  // Actual number of observed instances of the scaled object.
   optional int32 replicas = 1;
 
-  // label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
+  // Label query over pods that should match the replicas count. More
+  // info: http://kubernetes.io/docs/user-guide/labels#label-selectors.
   // +optional
   map<string, string> selector = 2;
 
-  // label selector for pods that should match the replicas count. This is a serializated
+  // Label selector for pods that should match the replicas count. This is a serializated
   // version of both map-based and more expressive set-based selectors. This is done to
   // avoid introspection in the clients. The string will be in the same format as the
   // query-param syntax. If the target type only supports map-based selectors, both this
@@ -1062,30 +1062,30 @@ message ScaleStatus {
   optional string targetSelector = 3;
 }
 
-// SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+// Defines the strategy type and options used to create the strategy.
 message SupplementalGroupsStrategyOptions {
-  // Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+  // The strategy that will dictate what supplemental groups is used in the SecurityContext.
   // +optional
   optional string rule = 1;
 
-  // Ranges are the allowed ranges of supplemental groups.  If you would like to force a single
+  // The allowed ranges of supplemental groups.  If you would like to force a single
   // supplemental group then supply a single range with the same start and end.
   // +optional
   repeated IDRange ranges = 2;
 }
 
-// A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
+// A generic representation of a resource, it is used by add-ons and plugins to add new resource
 // types to the API.  It consists of one or more Versions of the api.
 message ThirdPartyResource {
-  // Standard object metadata
+  // Standard object metadata.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Description is the description of this object.
+  // Description of this object.
   // +optional
   optional string description = 2;
 
-  // Versions are versions for this third party object
+  // Versions for this third party object.
   // +optional
   repeated APIVersion versions = 3;
 }
@@ -1096,29 +1096,29 @@ message ThirdPartyResourceData {
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
-  // Data is the raw JSON data for this data.
+  // Raw JSON data for this data.
   // +optional
   optional bytes data = 2;
 }
 
-// ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.
+// List of ThirdPartyResourceData.
 message ThirdPartyResourceDataList {
   // Standard list metadata
   // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is the list of ThirdpartyResourceData.
+  // List of ThirdpartyResourceData.
   repeated ThirdPartyResourceData items = 2;
 }
 
-// ThirdPartyResourceList is a list of ThirdPartyResources.
+// List of ThirdPartyResources.
 message ThirdPartyResourceList {
   // Standard list metadata.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
-  // Items is the list of ThirdPartyResources.
+  // List of ThirdPartyResources.
   repeated ThirdPartyResource items = 2;
 }
 

--- a/staging/src/k8s.io/api/extensions/v1beta1/types.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types.go
@@ -24,23 +24,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// describes the attributes of a scale subresource
+// Describes the attributes of a scale subresource.
 type ScaleSpec struct {
 	// desired number of instances for the scaled object.
 	// +optional
 	Replicas int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 }
 
-// represents the current status of a scale subresource.
+// Represents the current status of a scale subresource.
 type ScaleStatus struct {
-	// actual number of observed instances of the scaled object.
+	// Actual number of observed instances of the scaled object.
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
-	// label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors
+	// Label query over pods that should match the replicas count. More
+	// info: http://kubernetes.io/docs/user-guide/labels#label-selectors.
 	// +optional
 	Selector map[string]string `json:"selector,omitempty" protobuf:"bytes,2,rep,name=selector"`
 
-	// label selector for pods that should match the replicas count. This is a serializated
+	// Label selector for pods that should match the replicas count. This is a serializated
 	// version of both map-based and more expressive set-based selectors. This is done to
 	// avoid introspection in the clients. The string will be in the same format as the
 	// query-param syntax. If the target type only supports map-based selectors, both this
@@ -54,25 +55,25 @@ type ScaleStatus struct {
 // +genclient:noVerbs
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// represents a scaling request for a resource.
+// Represents a scaling request for a resource.
 type Scale struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
+	// Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.
 	// +optional
 	Spec ScaleSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.
+	// Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.
 	// +optional
 	Status ScaleStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Dummy definition
+// Dummy definition.
 type ReplicationControllerDummy struct {
 	metav1.TypeMeta `json:",inline"`
 }
@@ -104,27 +105,27 @@ type CustomMetricCurrentStatusList struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource
+// A generic representation of a resource, it is used by add-ons and plugins to add new resource
 // types to the API.  It consists of one or more Versions of the api.
 type ThirdPartyResource struct {
 	metav1.TypeMeta `json:",inline"`
 
-	// Standard object metadata
+	// Standard object metadata.
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Description is the description of this object.
+	// Description of this object.
 	// +optional
 	Description string `json:"description,omitempty" protobuf:"bytes,2,opt,name=description"`
 
-	// Versions are versions for this third party object
+	// Versions for this third party object.
 	// +optional
 	Versions []APIVersion `json:"versions,omitempty" protobuf:"bytes,3,rep,name=versions"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ThirdPartyResourceList is a list of ThirdPartyResources.
+// List of ThirdPartyResources.
 type ThirdPartyResourceList struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -132,13 +133,13 @@ type ThirdPartyResourceList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is the list of ThirdPartyResources.
+	// List of ThirdPartyResources.
 	Items []ThirdPartyResource `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // An APIVersion represents a single concrete version of an object model.
 type APIVersion struct {
-	// Name of this version (e.g. 'v1').
+	// Version (e.g. 'v1').
 	// +optional
 	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
 }
@@ -152,7 +153,7 @@ type ThirdPartyResourceData struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Data is the raw JSON data for this data.
+	// Raw JSON data for this data.
 	// +optional
 	Data []byte `json:"data,omitempty" protobuf:"bytes,2,opt,name=data"`
 }
@@ -163,8 +164,7 @@ type ThirdPartyResourceData struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for
-// more information.
-// Deployment enables declarative updates for Pods and ReplicaSets.
+// more information. It enables declarative updates for Pods and ReplicaSets.
 type Deployment struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -180,7 +180,7 @@ type Deployment struct {
 	Status DeploymentStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
 
-// DeploymentSpec is the specification of the desired behavior of the Deployment.
+// Specification of the desired behavior of the Deployment.
 type DeploymentSpec struct {
 	// Number of desired pods. This is a pointer to distinguish between explicit
 	// zero and not specified. Defaults to 1.
@@ -192,7 +192,7 @@ type DeploymentSpec struct {
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
-	// Template describes the pods that will be created.
+	// Describes the pods that will be created.
 	Template v1.PodTemplateSpec `json:"template" protobuf:"bytes,3,opt,name=template"`
 
 	// The deployment strategy to use to replace existing pods with new ones.
@@ -234,12 +234,12 @@ type DeploymentSpec struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DEPRECATED.
-// DeploymentRollback stores the information required to rollback a deployment.
+// Stores the information required to rollback a deployment.
 type DeploymentRollback struct {
 	metav1.TypeMeta `json:",inline"`
 	// Required: This must match the Name of a deployment.
 	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	// The annotations to be updated to a deployment
+	// The annotations to be updated to a deployment.
 	// +optional
 	UpdatedAnnotations map[string]string `json:"updatedAnnotations,omitempty" protobuf:"bytes,2,rep,name=updatedAnnotations"`
 	// The config of this deployment rollback.
@@ -254,13 +254,13 @@ type RollbackConfig struct {
 }
 
 const (
-	// DefaultDeploymentUniqueLabelKey is the default key of the selector that is added
+	// Default key of the selector that is added
 	// to existing RCs (and label key that is added to its pods) to prevent the existing RCs
 	// to select new pods (and old pods being select by new RC).
 	DefaultDeploymentUniqueLabelKey string = "pod-template-hash"
 )
 
-// DeploymentStrategy describes how to replace existing pods with new ones.
+// Describes how to replace existing pods with new ones.
 type DeploymentStrategy struct {
 	// Type of deployment. Can be "Recreate" or "RollingUpdate". Default is RollingUpdate.
 	// +optional
@@ -315,7 +315,7 @@ type RollingUpdateDeployment struct {
 	MaxSurge *intstr.IntOrString `json:"maxSurge,omitempty" protobuf:"bytes,2,opt,name=maxSurge"`
 }
 
-// DeploymentStatus is the most recently observed status of the Deployment.
+// Most recently observed status of the Deployment.
 type DeploymentStatus struct {
 	// The generation observed by the deployment controller.
 	// +optional
@@ -372,7 +372,7 @@ const (
 	DeploymentReplicaFailure DeploymentConditionType = "ReplicaFailure"
 )
 
-// DeploymentCondition describes the state of a deployment at a certain point.
+// Describes the state of a deployment at a certain point.
 type DeploymentCondition struct {
 	// Type of deployment condition.
 	Type DeploymentConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=DeploymentConditionType"`
@@ -390,14 +390,14 @@ type DeploymentCondition struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DeploymentList is a list of Deployments.
+// List of Deployments.
 type DeploymentList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is the list of Deployments.
+	// List of Deployments.
 	Items []Deployment `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
@@ -446,7 +446,7 @@ type RollingUpdateDaemonSet struct {
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty" protobuf:"bytes,1,opt,name=maxUnavailable"`
 }
 
-// DaemonSetSpec is the specification of a daemon set.
+// Specification of a daemon set.
 type DaemonSetSpec struct {
 	// A label query over pods that are managed by the daemon set.
 	// Must match in order to be controlled.
@@ -486,7 +486,7 @@ type DaemonSetSpec struct {
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,6,opt,name=revisionHistoryLimit"`
 }
 
-// DaemonSetStatus represents the current status of a daemon set.
+// Represents the current status of a daemon set.
 type DaemonSetStatus struct {
 	// The number of nodes that are running at least 1
 	// daemon pod and are supposed to run the daemon pod.
@@ -539,7 +539,7 @@ type DaemonSetStatus struct {
 
 // DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for
 // more information.
-// DaemonSet represents the configuration of a daemon set.
+// Represents the configuration of a daemon set.
 type DaemonSet struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -563,12 +563,12 @@ type DaemonSet struct {
 
 const (
 	// DEPRECATED: DefaultDaemonSetUniqueLabelKey is used instead.
-	// DaemonSetTemplateGenerationKey is the key of the labels that is added
+	// the key of the labels that is added
 	// to daemon set pods to distinguish between old and new pod templates
 	// during DaemonSet template update.
 	DaemonSetTemplateGenerationKey string = "pod-template-generation"
 
-	// DefaultDaemonSetUniqueLabelKey is the default label key that is added
+	// The default label key that is added
 	// to existing DaemonSet pods to distinguish between old and new
 	// DaemonSet pods during DaemonSet template updates.
 	DefaultDaemonSetUniqueLabelKey = appsv1beta1.ControllerRevisionHashLabelKey
@@ -576,7 +576,7 @@ const (
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// DaemonSetList is a collection of daemon sets.
+// Collection of daemon sets.
 type DaemonSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -590,7 +590,7 @@ type DaemonSetList struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.
+// List of ThirdPartyResourceData.
 type ThirdPartyResourceDataList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata
@@ -598,14 +598,14 @@ type ThirdPartyResourceDataList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is the list of ThirdpartyResourceData.
+	// List of ThirdpartyResourceData.
 	Items []ThirdPartyResourceData `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Ingress is a collection of rules that allow inbound connections to reach the
+// Collection of rules that allow inbound connections to reach the
 // endpoints defined by a backend. An Ingress can be configured to give services
 // externally-reachable urls, load balance traffic, terminate SSL, offer name
 // based virtual hosting etc.
@@ -616,12 +616,12 @@ type Ingress struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Spec is the desired state of the Ingress.
+	// Desired state of the Ingress.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
 	// +optional
 	Spec IngressSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// Status is the current state of the Ingress.
+	// Current state of the Ingress.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
 	// +optional
 	Status IngressStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
@@ -629,7 +629,7 @@ type Ingress struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// IngressList is a collection of Ingress.
+// Collection of Ingress.
 type IngressList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -637,11 +637,11 @@ type IngressList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is the list of Ingress.
+	// List of Ingress.
 	Items []Ingress `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// IngressSpec describes the Ingress the user wishes to exist.
+// Describes the Ingress the user wishes to exist.
 type IngressSpec struct {
 	// A default backend capable of servicing requests that don't match any
 	// rule. At least one of 'backend' or 'rules' must be specified. This field
@@ -665,15 +665,15 @@ type IngressSpec struct {
 	// TODO: Add the ability to specify load-balancer IP through claims
 }
 
-// IngressTLS describes the transport layer security associated with an Ingress.
+// Describes the transport layer security associated with an Ingress.
 type IngressTLS struct {
-	// Hosts are a list of hosts included in the TLS certificate. The values in
+	// List of hosts included in the TLS certificate. The values in
 	// this list must match the name/s used in the tlsSecret. Defaults to the
 	// wildcard host setting for the loadbalancer controller fulfilling this
 	// Ingress, if left unspecified.
 	// +optional
 	Hosts []string `json:"hosts,omitempty" protobuf:"bytes,1,rep,name=hosts"`
-	// SecretName is the name of the secret used to terminate SSL traffic on 443.
+	// Name of the secret used to terminate SSL traffic on 443.
 	// Field is left optional to allow SSL routing based on SNI hostname alone.
 	// If the SNI host in a listener conflicts with the "Host" header field used
 	// by an IngressRule, the SNI host is used for termination and value of the
@@ -683,18 +683,18 @@ type IngressTLS struct {
 	// TODO: Consider specifying different modes of termination, protocols etc.
 }
 
-// IngressStatus describe the current state of the Ingress.
+// The current state of the Ingress.
 type IngressStatus struct {
-	// LoadBalancer contains the current status of the load-balancer.
+	// Contains the current status of the load-balancer.
 	// +optional
 	LoadBalancer v1.LoadBalancerStatus `json:"loadBalancer,omitempty" protobuf:"bytes,1,opt,name=loadBalancer"`
 }
 
-// IngressRule represents the rules mapping the paths under a specified host to
+// Represents the rules mapping the paths under a specified host to
 // the related backend services. Incoming requests are first evaluated for a host
 // match, then routed to the backend associated with the matching IngressRuleValue.
 type IngressRule struct {
-	// Host is the fully qualified domain name of a network host, as defined
+	// The fully qualified domain name of a network host, as defined
 	// by RFC 3986. Note the following deviations from the "host" part of the
 	// URI as defined in the RFC:
 	// 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the
@@ -708,7 +708,7 @@ type IngressRule struct {
 	// specified IngressRuleValue.
 	// +optional
 	Host string `json:"host,omitempty" protobuf:"bytes,1,opt,name=host"`
-	// IngressRuleValue represents a rule to route requests for this IngressRule.
+	// Represents a rule to route requests for this IngressRule.
 	// If unspecified, the rule defaults to a http catch-all. Whether that sends
 	// just traffic matching the host to the default backend or all traffic to the
 	// default backend, is left to the controller fulfilling the Ingress. Http is
@@ -717,7 +717,7 @@ type IngressRule struct {
 	IngressRuleValue `json:",inline,omitempty" protobuf:"bytes,2,opt,name=ingressRuleValue"`
 }
 
-// IngressRuleValue represents a rule to apply against incoming requests. If the
+// Represents a rule to apply against incoming requests. If the
 // rule is satisfied, the request is routed to the specified backend. Currently
 // mixing different types of rules in a single Ingress is disallowed, so exactly
 // one of the following must be set.
@@ -732,7 +732,7 @@ type IngressRuleValue struct {
 	HTTP *HTTPIngressRuleValue `json:"http,omitempty" protobuf:"bytes,1,opt,name=http"`
 }
 
-// HTTPIngressRuleValue is a list of http selectors pointing to backends.
+// List of http selectors pointing to backends.
 // In the example: http://<host>/<path>?<searchpart> -> backend where
 // where parts of the url correspond to RFC 3986, this resource will be used
 // to match against everything after the last '/' and before the first '?'
@@ -744,10 +744,10 @@ type HTTPIngressRuleValue struct {
 	// options usable by a loadbalancer, like http keep-alive.
 }
 
-// HTTPIngressPath associates a path regex with a backend. Incoming urls matching
+// Associates a path regex with a backend. Incoming urls matching
 // the path are forwarded to the backend.
 type HTTPIngressPath struct {
-	// Path is an extended POSIX regex as defined by IEEE Std 1003.1,
+	// An extended POSIX regex as defined by IEEE Std 1003.1,
 	// (i.e this follows the egrep/unix syntax, not the perl syntax)
 	// matched against the path of an incoming request. Currently it can
 	// contain characters disallowed from the conventional "path"
@@ -757,12 +757,12 @@ type HTTPIngressPath struct {
 	// +optional
 	Path string `json:"path,omitempty" protobuf:"bytes,1,opt,name=path"`
 
-	// Backend defines the referenced service endpoint to which the traffic
+	// Defines the referenced service endpoint to which the traffic
 	// will be forwarded to.
 	Backend IngressBackend `json:"backend" protobuf:"bytes,2,opt,name=backend"`
 }
 
-// IngressBackend describes all endpoints for a given service and port.
+// Describes all endpoints for a given service and port.
 type IngressBackend struct {
 	// Specifies the name of the referenced service.
 	ServiceName string `json:"serviceName" protobuf:"bytes,1,opt,name=serviceName"`
@@ -778,7 +778,7 @@ type IngressBackend struct {
 
 // DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for
 // more information.
-// ReplicaSet ensures that a specified number of pod replicas are running at any given time.
+// Ensures that a specified number of pod replicas are running at any given time.
 type ReplicaSet struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -788,12 +788,12 @@ type ReplicaSet struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Spec defines the specification of the desired behavior of the ReplicaSet.
+	// Defines the specification of the desired behavior of the ReplicaSet.
 	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
 	// +optional
 	Spec ReplicaSetSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	// Status is the most recently observed status of the ReplicaSet.
+	// Is the most recently observed status of the ReplicaSet.
 	// This data may be out of date by some window of time.
 	// Populated by the system.
 	// Read-only.
@@ -804,7 +804,7 @@ type ReplicaSet struct {
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// ReplicaSetList is a collection of ReplicaSets.
+// Collection of ReplicaSets.
 type ReplicaSetList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -817,9 +817,9 @@ type ReplicaSetList struct {
 	Items []ReplicaSet `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-// ReplicaSetSpec is the specification of a ReplicaSet.
+// Specification of a ReplicaSet.
 type ReplicaSetSpec struct {
-	// Replicas is the number of desired replicas.
+	// Number of desired replicas.
 	// This is a pointer to distinguish between explicit zero and unspecified.
 	// Defaults to 1.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
@@ -832,23 +832,23 @@ type ReplicaSetSpec struct {
 	// +optional
 	MinReadySeconds int32 `json:"minReadySeconds,omitempty" protobuf:"varint,4,opt,name=minReadySeconds"`
 
-	// Selector is a label query over pods that should match the replica count.
+	// A label query over pods that should match the replica count.
 	// If the selector is empty, it is defaulted to the labels present on the pod template.
 	// Label keys and values that must match in order to be controlled by this replica set.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty" protobuf:"bytes,2,opt,name=selector"`
 
-	// Template is the object that describes the pod that will be created if
+	// The object that describes the pod that will be created if
 	// insufficient replicas are detected.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template
 	// +optional
 	Template v1.PodTemplateSpec `json:"template,omitempty" protobuf:"bytes,3,opt,name=template"`
 }
 
-// ReplicaSetStatus represents the current status of a ReplicaSet.
+// Represents the current status of a ReplicaSet.
 type ReplicaSetStatus struct {
-	// Replicas is the most recently oberved number of replicas.
+	// The most recently oberved number of replicas.
 	// More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller
 	Replicas int32 `json:"replicas" protobuf:"varint,1,opt,name=replicas"`
 
@@ -864,7 +864,7 @@ type ReplicaSetStatus struct {
 	// +optional
 	AvailableReplicas int32 `json:"availableReplicas,omitempty" protobuf:"varint,5,opt,name=availableReplicas"`
 
-	// ObservedGeneration reflects the generation of the most recently observed ReplicaSet.
+	// Reflects the generation of the most recently observed ReplicaSet.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,3,opt,name=observedGeneration"`
 
@@ -879,13 +879,13 @@ type ReplicaSetConditionType string
 
 // These are valid conditions of a replica set.
 const (
-	// ReplicaSetReplicaFailure is added in a replica set when one of its pods fails to be created
+	// Added in a replica set when one of its pods fails to be created
 	// due to insufficient quota, limit ranges, pod security policy, node selectors, etc. or deleted
 	// due to kubelet being down or finalizers are failing.
 	ReplicaSetReplicaFailure ReplicaSetConditionType = "ReplicaFailure"
 )
 
-// ReplicaSetCondition describes the state of a replica set at a certain point.
+// Describes the state of a replica set at a certain point.
 type ReplicaSetCondition struct {
 	// Type of replica set condition.
 	Type ReplicaSetConditionType `json:"type" protobuf:"bytes,1,opt,name=type,casttype=ReplicaSetConditionType"`
@@ -906,7 +906,7 @@ type ReplicaSetCondition struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Pod Security Policy governs the ability to make requests that affect the Security Context
+// Governs the ability to make requests that affect the Security Context
 // that will be applied to a pod and container.
 type PodSecurityPolicy struct {
 	metav1.TypeMeta `json:",inline"`
@@ -915,78 +915,78 @@ type PodSecurityPolicy struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// spec defines the policy enforced.
+	// Defines the policy enforced.
 	// +optional
 	Spec PodSecurityPolicySpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
-// Pod Security Policy Spec defines the policy enforced.
+// Defines the policy enforced.
 type PodSecurityPolicySpec struct {
-	// privileged determines if a pod can request to be run as privileged.
+	// Determines if a pod can request to be run as privileged.
 	// +optional
 	Privileged bool `json:"privileged,omitempty" protobuf:"varint,1,opt,name=privileged"`
-	// DefaultAddCapabilities is the default set of capabilities that will be added to the container
+	// Default set of capabilities that will be added to the container
 	// unless the pod spec specifically drops the capability.  You may not list a capabiility in both
 	// DefaultAddCapabilities and RequiredDropCapabilities.
 	// +optional
 	DefaultAddCapabilities []v1.Capability `json:"defaultAddCapabilities,omitempty" protobuf:"bytes,2,rep,name=defaultAddCapabilities,casttype=k8s.io/api/core/v1.Capability"`
-	// RequiredDropCapabilities are the capabilities that will be dropped from the container.  These
+	// Capabilities that will be dropped from the container.  These
 	// are required to be dropped and cannot be added.
 	// +optional
 	RequiredDropCapabilities []v1.Capability `json:"requiredDropCapabilities,omitempty" protobuf:"bytes,3,rep,name=requiredDropCapabilities,casttype=k8s.io/api/core/v1.Capability"`
-	// AllowedCapabilities is a list of capabilities that can be requested to add to the container.
+	// List of capabilities that can be requested to add to the container.
 	// Capabilities in this field may be added at the pod author's discretion.
 	// You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.
 	// +optional
 	AllowedCapabilities []v1.Capability `json:"allowedCapabilities,omitempty" protobuf:"bytes,4,rep,name=allowedCapabilities,casttype=k8s.io/api/core/v1.Capability"`
-	// volumes is a white list of allowed volume plugins.  Empty indicates that all plugins
+	// A white list of allowed volume plugins.  Empty indicates that all plugins
 	// may be used.
 	// +optional
 	Volumes []FSType `json:"volumes,omitempty" protobuf:"bytes,5,rep,name=volumes,casttype=FSType"`
-	// hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.
+	// Determines if the policy allows the use of HostNetwork in the pod spec.
 	// +optional
 	HostNetwork bool `json:"hostNetwork,omitempty" protobuf:"varint,6,opt,name=hostNetwork"`
-	// hostPorts determines which host port ranges are allowed to be exposed.
+	// Determines which host port ranges are allowed to be exposed.
 	// +optional
 	HostPorts []HostPortRange `json:"hostPorts,omitempty" protobuf:"bytes,7,rep,name=hostPorts"`
-	// hostPID determines if the policy allows the use of HostPID in the pod spec.
+	// Determines if the policy allows the use of HostPID in the pod spec.
 	// +optional
 	HostPID bool `json:"hostPID,omitempty" protobuf:"varint,8,opt,name=hostPID"`
-	// hostIPC determines if the policy allows the use of HostIPC in the pod spec.
+	// Determines if the policy allows the use of HostIPC in the pod spec.
 	// +optional
 	HostIPC bool `json:"hostIPC,omitempty" protobuf:"varint,9,opt,name=hostIPC"`
-	// seLinux is the strategy that will dictate the allowable labels that may be set.
+	// The strategy that will dictate the allowable labels that may be set.
 	SELinux SELinuxStrategyOptions `json:"seLinux" protobuf:"bytes,10,opt,name=seLinux"`
-	// runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.
+	// The strategy that will dictate the allowable RunAsUser values that may be set.
 	RunAsUser RunAsUserStrategyOptions `json:"runAsUser" protobuf:"bytes,11,opt,name=runAsUser"`
-	// SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.
+	// The strategy that will dictate what supplemental groups are used by the SecurityContext.
 	SupplementalGroups SupplementalGroupsStrategyOptions `json:"supplementalGroups" protobuf:"bytes,12,opt,name=supplementalGroups"`
-	// FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.
+	// The strategy that will dictate what fs group is used by the SecurityContext.
 	FSGroup FSGroupStrategyOptions `json:"fsGroup" protobuf:"bytes,13,opt,name=fsGroup"`
-	// ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file
+	// When set to true will force containers to run with a read only root file
 	// system.  If the container specifically requests to run with a non-read only root file system
 	// the PSP should deny the pod.
 	// If set to false the container may run with a read only root file system if it wishes but it
 	// will not be forced to.
 	// +optional
 	ReadOnlyRootFilesystem bool `json:"readOnlyRootFilesystem,omitempty" protobuf:"varint,14,opt,name=readOnlyRootFilesystem"`
-	// DefaultAllowPrivilegeEscalation controls the default setting for whether a
+	// Controls the default setting for whether a
 	// process can gain more privileges than its parent process.
 	// +optional
 	DefaultAllowPrivilegeEscalation *bool `json:"defaultAllowPrivilegeEscalation,omitempty" protobuf:"varint,15,opt,name=defaultAllowPrivilegeEscalation"`
-	// AllowPrivilegeEscalation determines if a pod can request to allow
+	// Determines if a pod can request to allow
 	// privilege escalation. If unspecified, defaults to true.
 	// +optional
 	AllowPrivilegeEscalation *bool `json:"allowPrivilegeEscalation,omitempty" protobuf:"varint,16,opt,name=allowPrivilegeEscalation"`
-	// is a white list of allowed host paths. Empty indicates that all host paths may be used.
+	// Is a white list of allowed host paths. Empty indicates that all host paths may be used.
 	// +optional
 	AllowedHostPaths []AllowedHostPath `json:"allowedHostPaths,omitempty" protobuf:"bytes,17,rep,name=allowedHostPaths"`
 }
 
-// defines the host volume conditions that will be enabled by a policy
+// Defines the host volume conditions that will be enabled by a policy
 // for pods to use. It requires the path prefix to be defined.
 type AllowedHostPath struct {
-	// is the path prefix that the host volume must match.
+	// Is the path prefix that the host volume must match.
 	// It does not support `*`.
 	// Trailing slashes are trimmed when validating the path prefix with a host path.
 	//
@@ -996,7 +996,7 @@ type AllowedHostPath struct {
 	PathPrefix string `json:"pathPrefix,omitempty" protobuf:"bytes,1,rep,name=pathPrefix"`
 }
 
-// FS Type gives strong typing to different file systems that are used by volumes.
+// Gives strong typing to different file systems that are used by volumes.
 type FSType string
 
 var (
@@ -1024,18 +1024,18 @@ var (
 	All                   FSType = "*"
 )
 
-// Host Port Range defines a range of host ports that will be enabled by a policy
+// Defines a range of host ports that will be enabled by a policy
 // for pods to use.  It requires both the start and end to be defined.
 type HostPortRange struct {
-	// min is the start of the range, inclusive.
+	// The start of the range, inclusive.
 	Min int32 `json:"min" protobuf:"varint,1,opt,name=min"`
-	// max is the end of the range, inclusive.
+	// The end of the range, inclusive.
 	Max int32 `json:"max" protobuf:"varint,2,opt,name=max"`
 }
 
-// SELinux  Strategy Options defines the strategy type and any options used to create the strategy.
+// Defines the strategy type and any options used to create the strategy.
 type SELinuxStrategyOptions struct {
-	// type is the strategy that will dictate the allowable labels that may be set.
+	// The strategy that will dictate the allowable labels that may be set.
 	Rule SELinuxStrategy `json:"rule" protobuf:"bytes,1,opt,name=rule,casttype=SELinuxStrategy"`
 	// seLinuxOptions required to run as; required for MustRunAs
 	// More info: https://git.k8s.io/community/contributors/design-proposals/security_context.md
@@ -1043,94 +1043,94 @@ type SELinuxStrategyOptions struct {
 	SELinuxOptions *v1.SELinuxOptions `json:"seLinuxOptions,omitempty" protobuf:"bytes,2,opt,name=seLinuxOptions"`
 }
 
-// SELinuxStrategy denotes strategy types for generating SELinux options for a
+// Denotes strategy types for generating SELinux options for a
 // Security Context.
 type SELinuxStrategy string
 
 const (
-	// container must have SELinux labels of X applied.
+	// Container must have SELinux labels of X applied.
 	SELinuxStrategyMustRunAs SELinuxStrategy = "MustRunAs"
-	// container may make requests for any SELinux context labels.
+	// Container may make requests for any SELinux context labels.
 	SELinuxStrategyRunAsAny SELinuxStrategy = "RunAsAny"
 )
 
-// Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.
+// Defines the strategy type and any options used to create the strategy.
 type RunAsUserStrategyOptions struct {
-	// Rule is the strategy that will dictate the allowable RunAsUser values that may be set.
+	// Strategy that will dictate the allowable RunAsUser values that may be set.
 	Rule RunAsUserStrategy `json:"rule" protobuf:"bytes,1,opt,name=rule,casttype=RunAsUserStrategy"`
-	// Ranges are the allowed ranges of uids that may be used.
+	// Allowed ranges of uids that may be used.
 	// +optional
 	Ranges []IDRange `json:"ranges,omitempty" protobuf:"bytes,2,rep,name=ranges"`
 }
 
-// ID Range provides a min/max of an allowed range of IDs.
+// Provides a min/max of an allowed range of IDs.
 type IDRange struct {
-	// Min is the start of the range, inclusive.
+	// The start of the range, inclusive.
 	Min int64 `json:"min" protobuf:"varint,1,opt,name=min"`
-	// Max is the end of the range, inclusive.
+	// The end of the range, inclusive.
 	Max int64 `json:"max" protobuf:"varint,2,opt,name=max"`
 }
 
-// RunAsUserStrategy denotes strategy types for generating RunAsUser values for a
+// Denotes strategy types for generating RunAsUser values for a
 // Security Context.
 type RunAsUserStrategy string
 
 const (
-	// container must run as a particular uid.
+	// Container must run as a particular uid.
 	RunAsUserStrategyMustRunAs RunAsUserStrategy = "MustRunAs"
-	// container must run as a non-root uid
+	// Container must run as a non-root uid
 	RunAsUserStrategyMustRunAsNonRoot RunAsUserStrategy = "MustRunAsNonRoot"
-	// container may make requests for any uid.
+	// Container may make requests for any uid.
 	RunAsUserStrategyRunAsAny RunAsUserStrategy = "RunAsAny"
 )
 
-// FSGroupStrategyOptions defines the strategy type and options used to create the strategy.
+// Defines the strategy type and options used to create the strategy.
 type FSGroupStrategyOptions struct {
-	// Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.
+	// The strategy that will dictate what FSGroup is used in the SecurityContext.
 	// +optional
 	Rule FSGroupStrategyType `json:"rule,omitempty" protobuf:"bytes,1,opt,name=rule,casttype=FSGroupStrategyType"`
-	// Ranges are the allowed ranges of fs groups.  If you would like to force a single
+	// The allowed ranges of fs groups.  If you would like to force a single
 	// fs group then supply a single range with the same start and end.
 	// +optional
 	Ranges []IDRange `json:"ranges,omitempty" protobuf:"bytes,2,rep,name=ranges"`
 }
 
-// FSGroupStrategyType denotes strategy types for generating FSGroup values for a
+// Denotes strategy types for generating FSGroup values for a
 // SecurityContext
 type FSGroupStrategyType string
 
 const (
-	// container must have FSGroup of X applied.
+	// Container must have FSGroup of X applied.
 	FSGroupStrategyMustRunAs FSGroupStrategyType = "MustRunAs"
-	// container may make requests for any FSGroup labels.
+	// Container may make requests for any FSGroup labels.
 	FSGroupStrategyRunAsAny FSGroupStrategyType = "RunAsAny"
 )
 
-// SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.
+// Defines the strategy type and options used to create the strategy.
 type SupplementalGroupsStrategyOptions struct {
-	// Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.
+	// The strategy that will dictate what supplemental groups is used in the SecurityContext.
 	// +optional
 	Rule SupplementalGroupsStrategyType `json:"rule,omitempty" protobuf:"bytes,1,opt,name=rule,casttype=SupplementalGroupsStrategyType"`
-	// Ranges are the allowed ranges of supplemental groups.  If you would like to force a single
+	// The allowed ranges of supplemental groups.  If you would like to force a single
 	// supplemental group then supply a single range with the same start and end.
 	// +optional
 	Ranges []IDRange `json:"ranges,omitempty" protobuf:"bytes,2,rep,name=ranges"`
 }
 
-// SupplementalGroupsStrategyType denotes strategy types for determining valid supplemental
+// Denotes strategy types for determining valid supplemental
 // groups for a SecurityContext.
 type SupplementalGroupsStrategyType string
 
 const (
-	// container must run as a particular gid.
+	// Container must run as a particular gid.
 	SupplementalGroupsStrategyMustRunAs SupplementalGroupsStrategyType = "MustRunAs"
-	// container may make requests for any gid.
+	// Container may make requests for any gid.
 	SupplementalGroupsStrategyRunAsAny SupplementalGroupsStrategyType = "RunAsAny"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Pod Security Policy List is a list of PodSecurityPolicy objects.
+// List of PodSecurityPolicy objects.
 type PodSecurityPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -1138,13 +1138,13 @@ type PodSecurityPolicyList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is a list of schema objects.
+	// List of schema objects.
 	Items []PodSecurityPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// NetworkPolicy describes what network traffic is allowed for a set of Pods
+// Describes what network traffic is allowed for a set of Pods
 type NetworkPolicy struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object's metadata.
@@ -1210,7 +1210,7 @@ type NetworkPolicySpec struct {
 	PolicyTypes []PolicyType `json:"policyTypes,omitempty" protobuf:"bytes,4,rep,name=policyTypes,casttype=PolicyType"`
 }
 
-// This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.
+// Matches traffic if and only if the traffic matches both ports AND from.
 type NetworkPolicyIngressRule struct {
 	// List of ports which should be made accessible on the pods selected for this rule.
 	// Each item in this list is combined using a logical OR.
@@ -1265,14 +1265,14 @@ type NetworkPolicyPort struct {
 	Port *intstr.IntOrString `json:"port,omitempty" protobuf:"bytes,2,opt,name=port"`
 }
 
-// IPBlock describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods
+// Describes a particular CIDR (Ex. "192.168.1.1/24") that is allowed to the pods
 // matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should
 // not be included within this rule.
 type IPBlock struct {
-	// CIDR is a string representing the IP Block
+	// String representing the IP Block
 	// Valid examples are "192.168.1.1/24"
 	CIDR string `json:"cidr" protobuf:"bytes,1,name=cidr"`
-	// Except is a slice of CIDRs that should not be included within an IP Block
+	// Slice of CIDRs that should not be included within an IP Block
 	// Valid examples are "192.168.1.1/24"
 	// Except values will be rejected if they are outside the CIDR range
 	// +optional
@@ -1295,14 +1295,14 @@ type NetworkPolicyPeer struct {
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty" protobuf:"bytes,2,opt,name=namespaceSelector"`
 
-	// IPBlock defines policy on a particular IPBlock
+	// Defines policy on a particular IPBlock
 	// +optional
 	IPBlock *IPBlock `json:"ipBlock,omitempty" protobuf:"bytes,3,rep,name=ipBlock"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// Network Policy List is a list of NetworkPolicy objects.
+// List of NetworkPolicy objects.
 type NetworkPolicyList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
@@ -1310,6 +1310,6 @@ type NetworkPolicyList struct {
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
-	// Items is a list of schema objects.
+	// List of schema objects.
 	Items []NetworkPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }

--- a/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/types_swagger_doc_generated.go
@@ -29,7 +29,7 @@ package v1beta1
 // AUTO-GENERATED FUNCTIONS START HERE
 var map_APIVersion = map[string]string{
 	"":     "An APIVersion represents a single concrete version of an object model.",
-	"name": "Name of this version (e.g. 'v1').",
+	"name": "Version (e.g. 'v1').",
 }
 
 func (APIVersion) SwaggerDoc() map[string]string {
@@ -37,8 +37,8 @@ func (APIVersion) SwaggerDoc() map[string]string {
 }
 
 var map_AllowedHostPath = map[string]string{
-	"":           "defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
-	"pathPrefix": "is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
+	"":           "Defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+	"pathPrefix": "Is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
 }
 
 func (AllowedHostPath) SwaggerDoc() map[string]string {
@@ -65,7 +65,7 @@ func (CustomMetricTarget) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSet = map[string]string{
-	"":         "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+	"":         "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. Represents the configuration of a daemon set.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "The desired behavior of this daemon set. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 	"status":   "The current status of this daemon set. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
@@ -76,7 +76,7 @@ func (DaemonSet) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetList = map[string]string{
-	"":         "DaemonSetList is a collection of daemon sets.",
+	"":         "Collection of daemon sets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"items":    "A list of daemon sets.",
 }
@@ -86,7 +86,7 @@ func (DaemonSetList) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetSpec = map[string]string{
-	"":                     "DaemonSetSpec is the specification of a daemon set.",
+	"":                     "Specification of a daemon set.",
 	"selector":             "A label query over pods that are managed by the daemon set. Must match in order to be controlled. If empty, defaulted to labels on Pod template. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 	"template":             "An object that describes the pod that will be created. The DaemonSet will create exactly one copy of this pod on every node that matches the template's node selector (or on every node if no node selector is specified). More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
 	"updateStrategy":       "An update strategy to replace existing DaemonSet pods with new pods.",
@@ -100,7 +100,7 @@ func (DaemonSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DaemonSetStatus = map[string]string{
-	"": "DaemonSetStatus represents the current status of a daemon set.",
+	"": "Represents the current status of a daemon set.",
 	"currentNumberScheduled": "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"numberMisscheduled":     "The number of nodes that are running the daemon pod, but are not supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
 	"desiredNumberScheduled": "The total number of nodes that should be running the daemon pod (including nodes correctly running the daemon pod). More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/",
@@ -126,7 +126,7 @@ func (DaemonSetUpdateStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_Deployment = map[string]string{
-	"":         "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+	"":         "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. It enables declarative updates for Pods and ReplicaSets.",
 	"metadata": "Standard object metadata.",
 	"spec":     "Specification of the desired behavior of the Deployment.",
 	"status":   "Most recently observed status of the Deployment.",
@@ -137,7 +137,7 @@ func (Deployment) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentCondition = map[string]string{
-	"":                   "DeploymentCondition describes the state of a deployment at a certain point.",
+	"":                   "Describes the state of a deployment at a certain point.",
 	"type":               "Type of deployment condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastUpdateTime":     "The last time this condition was updated.",
@@ -151,9 +151,9 @@ func (DeploymentCondition) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentList = map[string]string{
-	"":         "DeploymentList is a list of Deployments.",
+	"":         "List of Deployments.",
 	"metadata": "Standard list metadata.",
-	"items":    "Items is the list of Deployments.",
+	"items":    "List of Deployments.",
 }
 
 func (DeploymentList) SwaggerDoc() map[string]string {
@@ -161,9 +161,9 @@ func (DeploymentList) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentRollback = map[string]string{
-	"":                   "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+	"":                   "DEPRECATED. Stores the information required to rollback a deployment.",
 	"name":               "Required: This must match the Name of a deployment.",
-	"updatedAnnotations": "The annotations to be updated to a deployment",
+	"updatedAnnotations": "The annotations to be updated to a deployment.",
 	"rollbackTo":         "The config of this deployment rollback.",
 }
 
@@ -172,10 +172,10 @@ func (DeploymentRollback) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentSpec = map[string]string{
-	"":                        "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+	"":                        "Specification of the desired behavior of the Deployment.",
 	"replicas":                "Number of desired pods. This is a pointer to distinguish between explicit zero and not specified. Defaults to 1.",
 	"selector":                "Label selector for pods. Existing ReplicaSets whose pods are selected by this will be the ones affected by this deployment.",
-	"template":                "Template describes the pods that will be created.",
+	"template":                "Describes the pods that will be created.",
 	"strategy":                "The deployment strategy to use to replace existing pods with new ones.",
 	"minReadySeconds":         "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
 	"revisionHistoryLimit":    "The number of old ReplicaSets to retain to allow rollback. This is a pointer to distinguish between explicit zero and not specified.",
@@ -189,7 +189,7 @@ func (DeploymentSpec) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStatus = map[string]string{
-	"":                    "DeploymentStatus is the most recently observed status of the Deployment.",
+	"":                    "Most recently observed status of the Deployment.",
 	"observedGeneration":  "The generation observed by the deployment controller.",
 	"replicas":            "Total number of non-terminated pods targeted by this deployment (their labels match the selector).",
 	"updatedReplicas":     "Total number of non-terminated pods targeted by this deployment that have the desired template spec.",
@@ -205,7 +205,7 @@ func (DeploymentStatus) SwaggerDoc() map[string]string {
 }
 
 var map_DeploymentStrategy = map[string]string{
-	"":              "DeploymentStrategy describes how to replace existing pods with new ones.",
+	"":              "Describes how to replace existing pods with new ones.",
 	"type":          "Type of deployment. Can be \"Recreate\" or \"RollingUpdate\". Default is RollingUpdate.",
 	"rollingUpdate": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
 }
@@ -215,9 +215,9 @@ func (DeploymentStrategy) SwaggerDoc() map[string]string {
 }
 
 var map_FSGroupStrategyOptions = map[string]string{
-	"":       "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
-	"rule":   "Rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
-	"ranges": "Ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
+	"":       "Defines the strategy type and options used to create the strategy.",
+	"rule":   "The strategy that will dictate what FSGroup is used in the SecurityContext.",
+	"ranges": "The allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end.",
 }
 
 func (FSGroupStrategyOptions) SwaggerDoc() map[string]string {
@@ -225,9 +225,9 @@ func (FSGroupStrategyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_HTTPIngressPath = map[string]string{
-	"":        "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
-	"path":    "Path is an extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
-	"backend": "Backend defines the referenced service endpoint to which the traffic will be forwarded to.",
+	"":        "Associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+	"path":    "An extended POSIX regex as defined by IEEE Std 1003.1, (i.e this follows the egrep/unix syntax, not the perl syntax) matched against the path of an incoming request. Currently it can contain characters disallowed from the conventional \"path\" part of a URL as defined by RFC 3986. Paths must begin with a '/'. If unspecified, the path defaults to a catch all sending traffic to the backend.",
+	"backend": "Defines the referenced service endpoint to which the traffic will be forwarded to.",
 }
 
 func (HTTPIngressPath) SwaggerDoc() map[string]string {
@@ -235,7 +235,7 @@ func (HTTPIngressPath) SwaggerDoc() map[string]string {
 }
 
 var map_HTTPIngressRuleValue = map[string]string{
-	"":      "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+	"":      "List of http selectors pointing to backends. In the example: http://<host>/<path>?<searchpart> -> backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
 	"paths": "A collection of paths that map requests to backends.",
 }
 
@@ -244,9 +244,9 @@ func (HTTPIngressRuleValue) SwaggerDoc() map[string]string {
 }
 
 var map_HostPortRange = map[string]string{
-	"":    "Host Port Range defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
-	"min": "min is the start of the range, inclusive.",
-	"max": "max is the end of the range, inclusive.",
+	"":    "Defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+	"min": "The start of the range, inclusive.",
+	"max": "The end of the range, inclusive.",
 }
 
 func (HostPortRange) SwaggerDoc() map[string]string {
@@ -254,9 +254,9 @@ func (HostPortRange) SwaggerDoc() map[string]string {
 }
 
 var map_IDRange = map[string]string{
-	"":    "ID Range provides a min/max of an allowed range of IDs.",
-	"min": "Min is the start of the range, inclusive.",
-	"max": "Max is the end of the range, inclusive.",
+	"":    "Provides a min/max of an allowed range of IDs.",
+	"min": "The start of the range, inclusive.",
+	"max": "The end of the range, inclusive.",
 }
 
 func (IDRange) SwaggerDoc() map[string]string {
@@ -264,9 +264,9 @@ func (IDRange) SwaggerDoc() map[string]string {
 }
 
 var map_IPBlock = map[string]string{
-	"":       "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
-	"cidr":   "CIDR is a string representing the IP Block Valid examples are \"192.168.1.1/24\"",
-	"except": "Except is a slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
+	"":       "Describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+	"cidr":   "String representing the IP Block Valid examples are \"192.168.1.1/24\"",
+	"except": "Slice of CIDRs that should not be included within an IP Block Valid examples are \"192.168.1.1/24\" Except values will be rejected if they are outside the CIDR range",
 }
 
 func (IPBlock) SwaggerDoc() map[string]string {
@@ -274,10 +274,10 @@ func (IPBlock) SwaggerDoc() map[string]string {
 }
 
 var map_Ingress = map[string]string{
-	"":         "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+	"":         "Collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"spec":     "Spec is the desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is the current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"spec":     "Desired state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"status":   "Current state of the Ingress. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 }
 
 func (Ingress) SwaggerDoc() map[string]string {
@@ -285,7 +285,7 @@ func (Ingress) SwaggerDoc() map[string]string {
 }
 
 var map_IngressBackend = map[string]string{
-	"":            "IngressBackend describes all endpoints for a given service and port.",
+	"":            "Describes all endpoints for a given service and port.",
 	"serviceName": "Specifies the name of the referenced service.",
 	"servicePort": "Specifies the port of the referenced service.",
 }
@@ -295,9 +295,9 @@ func (IngressBackend) SwaggerDoc() map[string]string {
 }
 
 var map_IngressList = map[string]string{
-	"":         "IngressList is a collection of Ingress.",
+	"":         "Collection of Ingress.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"items":    "Items is the list of Ingress.",
+	"items":    "List of Ingress.",
 }
 
 func (IngressList) SwaggerDoc() map[string]string {
@@ -305,8 +305,8 @@ func (IngressList) SwaggerDoc() map[string]string {
 }
 
 var map_IngressRule = map[string]string{
-	"":     "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
-	"host": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
+	"":     "Represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+	"host": "The fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
 }
 
 func (IngressRule) SwaggerDoc() map[string]string {
@@ -314,7 +314,7 @@ func (IngressRule) SwaggerDoc() map[string]string {
 }
 
 var map_IngressRuleValue = map[string]string{
-	"": "IngressRuleValue represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend. Currently mixing different types of rules in a single Ingress is disallowed, so exactly one of the following must be set.",
+	"": "Represents a rule to apply against incoming requests. If the rule is satisfied, the request is routed to the specified backend. Currently mixing different types of rules in a single Ingress is disallowed, so exactly one of the following must be set.",
 }
 
 func (IngressRuleValue) SwaggerDoc() map[string]string {
@@ -322,7 +322,7 @@ func (IngressRuleValue) SwaggerDoc() map[string]string {
 }
 
 var map_IngressSpec = map[string]string{
-	"":        "IngressSpec describes the Ingress the user wishes to exist.",
+	"":        "Describes the Ingress the user wishes to exist.",
 	"backend": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
 	"tls":     "TLS configuration. Currently the Ingress only supports a single TLS port, 443. If multiple members of this list specify different hosts, they will be multiplexed on the same port according to the hostname specified through the SNI TLS extension, if the ingress controller fulfilling the ingress supports SNI.",
 	"rules":   "A list of host rules used to configure the Ingress. If unspecified, or no rule matches, all traffic is sent to the default backend.",
@@ -333,8 +333,8 @@ func (IngressSpec) SwaggerDoc() map[string]string {
 }
 
 var map_IngressStatus = map[string]string{
-	"":             "IngressStatus describe the current state of the Ingress.",
-	"loadBalancer": "LoadBalancer contains the current status of the load-balancer.",
+	"":             "The current state of the Ingress.",
+	"loadBalancer": "Contains the current status of the load-balancer.",
 }
 
 func (IngressStatus) SwaggerDoc() map[string]string {
@@ -342,9 +342,9 @@ func (IngressStatus) SwaggerDoc() map[string]string {
 }
 
 var map_IngressTLS = map[string]string{
-	"":           "IngressTLS describes the transport layer security associated with an Ingress.",
-	"hosts":      "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
-	"secretName": "SecretName is the name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
+	"":           "Describes the transport layer security associated with an Ingress.",
+	"hosts":      "List of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
+	"secretName": "Name of the secret used to terminate SSL traffic on 443. Field is left optional to allow SSL routing based on SNI hostname alone. If the SNI host in a listener conflicts with the \"Host\" header field used by an IngressRule, the SNI host is used for termination and value of the Host header is used for routing.",
 }
 
 func (IngressTLS) SwaggerDoc() map[string]string {
@@ -352,7 +352,7 @@ func (IngressTLS) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkPolicy = map[string]string{
-	"":         "NetworkPolicy describes what network traffic is allowed for a set of Pods",
+	"":         "Describes what network traffic is allowed for a set of Pods",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
 	"spec":     "Specification of the desired behavior for this NetworkPolicy.",
 }
@@ -372,7 +372,7 @@ func (NetworkPolicyEgressRule) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkPolicyIngressRule = map[string]string{
-	"":      "This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+	"":      "Matches traffic if and only if the traffic matches both ports AND from.",
 	"ports": "List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
 	"from":  "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
 }
@@ -382,9 +382,9 @@ func (NetworkPolicyIngressRule) SwaggerDoc() map[string]string {
 }
 
 var map_NetworkPolicyList = map[string]string{
-	"":         "Network Policy List is a list of NetworkPolicy objects.",
+	"":         "List of NetworkPolicy objects.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"items":    "Items is a list of schema objects.",
+	"items":    "List of schema objects.",
 }
 
 func (NetworkPolicyList) SwaggerDoc() map[string]string {
@@ -394,7 +394,7 @@ func (NetworkPolicyList) SwaggerDoc() map[string]string {
 var map_NetworkPolicyPeer = map[string]string{
 	"podSelector":       "This is a label selector which selects Pods in this namespace. This field follows standard label selector semantics. If present but empty, this selector selects all pods in this namespace.",
 	"namespaceSelector": "Selects Namespaces using cluster scoped-labels.  This matches all pods in all namespaces selected by this label selector. This field follows standard label selector semantics. If present but empty, this selector selects all namespaces.",
-	"ipBlock":           "IPBlock defines policy on a particular IPBlock",
+	"ipBlock":           "Defines policy on a particular IPBlock",
 }
 
 func (NetworkPolicyPeer) SwaggerDoc() map[string]string {
@@ -422,9 +422,9 @@ func (NetworkPolicySpec) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicy = map[string]string{
-	"":         "Pod Security Policy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+	"":         "Governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
 	"metadata": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"spec":     "spec defines the policy enforced.",
+	"spec":     "Defines the policy enforced.",
 }
 
 func (PodSecurityPolicy) SwaggerDoc() map[string]string {
@@ -432,9 +432,9 @@ func (PodSecurityPolicy) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicyList = map[string]string{
-	"":         "Pod Security Policy List is a list of PodSecurityPolicy objects.",
+	"":         "List of PodSecurityPolicy objects.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"items":    "Items is a list of schema objects.",
+	"items":    "List of schema objects.",
 }
 
 func (PodSecurityPolicyList) SwaggerDoc() map[string]string {
@@ -442,24 +442,24 @@ func (PodSecurityPolicyList) SwaggerDoc() map[string]string {
 }
 
 var map_PodSecurityPolicySpec = map[string]string{
-	"":                                "Pod Security Policy Spec defines the policy enforced.",
-	"privileged":                      "privileged determines if a pod can request to be run as privileged.",
-	"defaultAddCapabilities":          "DefaultAddCapabilities is the default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
-	"requiredDropCapabilities":        "RequiredDropCapabilities are the capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
-	"allowedCapabilities":             "AllowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.",
-	"volumes":                         "volumes is a white list of allowed volume plugins.  Empty indicates that all plugins may be used.",
-	"hostNetwork":                     "hostNetwork determines if the policy allows the use of HostNetwork in the pod spec.",
-	"hostPorts":                       "hostPorts determines which host port ranges are allowed to be exposed.",
-	"hostPID":                         "hostPID determines if the policy allows the use of HostPID in the pod spec.",
-	"hostIPC":                         "hostIPC determines if the policy allows the use of HostIPC in the pod spec.",
-	"seLinux":                         "seLinux is the strategy that will dictate the allowable labels that may be set.",
-	"runAsUser":                       "runAsUser is the strategy that will dictate the allowable RunAsUser values that may be set.",
-	"supplementalGroups":              "SupplementalGroups is the strategy that will dictate what supplemental groups are used by the SecurityContext.",
-	"fsGroup":                         "FSGroup is the strategy that will dictate what fs group is used by the SecurityContext.",
-	"readOnlyRootFilesystem":          "ReadOnlyRootFilesystem when set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
-	"defaultAllowPrivilegeEscalation": "DefaultAllowPrivilegeEscalation controls the default setting for whether a process can gain more privileges than its parent process.",
-	"allowPrivilegeEscalation":        "AllowPrivilegeEscalation determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
-	"allowedHostPaths":                "is a white list of allowed host paths. Empty indicates that all host paths may be used.",
+	"":                                "Defines the policy enforced.",
+	"privileged":                      "Determines if a pod can request to be run as privileged.",
+	"defaultAddCapabilities":          "Default set of capabilities that will be added to the container unless the pod spec specifically drops the capability.  You may not list a capabiility in both DefaultAddCapabilities and RequiredDropCapabilities.",
+	"requiredDropCapabilities":        "Capabilities that will be dropped from the container.  These are required to be dropped and cannot be added.",
+	"allowedCapabilities":             "List of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both AllowedCapabilities and RequiredDropCapabilities.",
+	"volumes":                         "A white list of allowed volume plugins.  Empty indicates that all plugins may be used.",
+	"hostNetwork":                     "Determines if the policy allows the use of HostNetwork in the pod spec.",
+	"hostPorts":                       "Determines which host port ranges are allowed to be exposed.",
+	"hostPID":                         "Determines if the policy allows the use of HostPID in the pod spec.",
+	"hostIPC":                         "Determines if the policy allows the use of HostIPC in the pod spec.",
+	"seLinux":                         "The strategy that will dictate the allowable labels that may be set.",
+	"runAsUser":                       "The strategy that will dictate the allowable RunAsUser values that may be set.",
+	"supplementalGroups":              "The strategy that will dictate what supplemental groups are used by the SecurityContext.",
+	"fsGroup":                         "The strategy that will dictate what fs group is used by the SecurityContext.",
+	"readOnlyRootFilesystem":          "When set to true will force containers to run with a read only root file system.  If the container specifically requests to run with a non-read only root file system the PSP should deny the pod. If set to false the container may run with a read only root file system if it wishes but it will not be forced to.",
+	"defaultAllowPrivilegeEscalation": "Controls the default setting for whether a process can gain more privileges than its parent process.",
+	"allowPrivilegeEscalation":        "Determines if a pod can request to allow privilege escalation. If unspecified, defaults to true.",
+	"allowedHostPaths":                "Is a white list of allowed host paths. Empty indicates that all host paths may be used.",
 }
 
 func (PodSecurityPolicySpec) SwaggerDoc() map[string]string {
@@ -467,10 +467,10 @@ func (PodSecurityPolicySpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSet = map[string]string{
-	"":         "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+	"":         "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. Ensures that a specified number of pod replicas are running at any given time.",
 	"metadata": "If the Labels of a ReplicaSet are empty, they are defaulted to be the same as the Pod(s) that the ReplicaSet manages. Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"spec":     "Spec defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-	"status":   "Status is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"spec":     "Defines the specification of the desired behavior of the ReplicaSet. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"status":   "Is the most recently observed status of the ReplicaSet. This data may be out of date by some window of time. Populated by the system. Read-only. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
 }
 
 func (ReplicaSet) SwaggerDoc() map[string]string {
@@ -478,7 +478,7 @@ func (ReplicaSet) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetCondition = map[string]string{
-	"":                   "ReplicaSetCondition describes the state of a replica set at a certain point.",
+	"":                   "Describes the state of a replica set at a certain point.",
 	"type":               "Type of replica set condition.",
 	"status":             "Status of the condition, one of True, False, Unknown.",
 	"lastTransitionTime": "The last time the condition transitioned from one status to another.",
@@ -491,7 +491,7 @@ func (ReplicaSetCondition) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetList = map[string]string{
-	"":         "ReplicaSetList is a collection of ReplicaSets.",
+	"":         "Collection of ReplicaSets.",
 	"metadata": "Standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
 	"items":    "List of ReplicaSets. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller",
 }
@@ -501,11 +501,11 @@ func (ReplicaSetList) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetSpec = map[string]string{
-	"":                "ReplicaSetSpec is the specification of a ReplicaSet.",
-	"replicas":        "Replicas is the number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+	"":                "Specification of a ReplicaSet.",
+	"replicas":        "Number of desired replicas. This is a pointer to distinguish between explicit zero and unspecified. Defaults to 1. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"minReadySeconds": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
-	"selector":        "Selector is a label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
-	"template":        "Template is the object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
+	"selector":        "A label query over pods that should match the replica count. If the selector is empty, it is defaulted to the labels present on the pod template. Label keys and values that must match in order to be controlled by this replica set. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+	"template":        "The object that describes the pod that will be created if insufficient replicas are detected. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller#pod-template",
 }
 
 func (ReplicaSetSpec) SwaggerDoc() map[string]string {
@@ -513,12 +513,12 @@ func (ReplicaSetSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicaSetStatus = map[string]string{
-	"":                     "ReplicaSetStatus represents the current status of a ReplicaSet.",
-	"replicas":             "Replicas is the most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
+	"":                     "Represents the current status of a ReplicaSet.",
+	"replicas":             "The most recently oberved number of replicas. More info: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#what-is-a-replicationcontroller",
 	"fullyLabeledReplicas": "The number of pods that have labels matching the labels of the pod template of the replicaset.",
 	"readyReplicas":        "The number of ready replicas for this replica set.",
 	"availableReplicas":    "The number of available replicas (ready for at least minReadySeconds) for this replica set.",
-	"observedGeneration":   "ObservedGeneration reflects the generation of the most recently observed ReplicaSet.",
+	"observedGeneration":   "Reflects the generation of the most recently observed ReplicaSet.",
 	"conditions":           "Represents the latest available observations of a replica set's current state.",
 }
 
@@ -527,7 +527,7 @@ func (ReplicaSetStatus) SwaggerDoc() map[string]string {
 }
 
 var map_ReplicationControllerDummy = map[string]string{
-	"": "Dummy definition",
+	"": "Dummy definition.",
 }
 
 func (ReplicationControllerDummy) SwaggerDoc() map[string]string {
@@ -563,9 +563,9 @@ func (RollingUpdateDeployment) SwaggerDoc() map[string]string {
 }
 
 var map_RunAsUserStrategyOptions = map[string]string{
-	"":       "Run A sUser Strategy Options defines the strategy type and any options used to create the strategy.",
-	"rule":   "Rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
-	"ranges": "Ranges are the allowed ranges of uids that may be used.",
+	"":       "Defines the strategy type and any options used to create the strategy.",
+	"rule":   "Strategy that will dictate the allowable RunAsUser values that may be set.",
+	"ranges": "Allowed ranges of uids that may be used.",
 }
 
 func (RunAsUserStrategyOptions) SwaggerDoc() map[string]string {
@@ -573,8 +573,8 @@ func (RunAsUserStrategyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_SELinuxStrategyOptions = map[string]string{
-	"":               "SELinux  Strategy Options defines the strategy type and any options used to create the strategy.",
-	"rule":           "type is the strategy that will dictate the allowable labels that may be set.",
+	"":               "Defines the strategy type and any options used to create the strategy.",
+	"rule":           "The strategy that will dictate the allowable labels that may be set.",
 	"seLinuxOptions": "seLinuxOptions required to run as; required for MustRunAs More info: https://git.k8s.io/community/contributors/design-proposals/security_context.md",
 }
 
@@ -583,10 +583,10 @@ func (SELinuxStrategyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_Scale = map[string]string{
-	"":         "represents a scaling request for a resource.",
+	"":         "Represents a scaling request for a resource.",
 	"metadata": "Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata.",
-	"spec":     "defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
-	"status":   "current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
+	"spec":     "Defines the behavior of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.",
+	"status":   "Current status of the scale. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status. Read-only.",
 }
 
 func (Scale) SwaggerDoc() map[string]string {
@@ -594,7 +594,7 @@ func (Scale) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleSpec = map[string]string{
-	"":         "describes the attributes of a scale subresource",
+	"":         "Describes the attributes of a scale subresource.",
 	"replicas": "desired number of instances for the scaled object.",
 }
 
@@ -603,10 +603,10 @@ func (ScaleSpec) SwaggerDoc() map[string]string {
 }
 
 var map_ScaleStatus = map[string]string{
-	"":               "represents the current status of a scale subresource.",
-	"replicas":       "actual number of observed instances of the scaled object.",
-	"selector":       "label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors",
-	"targetSelector": "label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
+	"":               "Represents the current status of a scale subresource.",
+	"replicas":       "Actual number of observed instances of the scaled object.",
+	"selector":       "Label query over pods that should match the replicas count. More info: http://kubernetes.io/docs/user-guide/labels#label-selectors.",
+	"targetSelector": "Label selector for pods that should match the replicas count. This is a serializated version of both map-based and more expressive set-based selectors. This is done to avoid introspection in the clients. The string will be in the same format as the query-param syntax. If the target type only supports map-based selectors, both this field and map-based selector field are populated. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors",
 }
 
 func (ScaleStatus) SwaggerDoc() map[string]string {
@@ -614,9 +614,9 @@ func (ScaleStatus) SwaggerDoc() map[string]string {
 }
 
 var map_SupplementalGroupsStrategyOptions = map[string]string{
-	"":       "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
-	"rule":   "Rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
-	"ranges": "Ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
+	"":       "Defines the strategy type and options used to create the strategy.",
+	"rule":   "The strategy that will dictate what supplemental groups is used in the SecurityContext.",
+	"ranges": "The allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end.",
 }
 
 func (SupplementalGroupsStrategyOptions) SwaggerDoc() map[string]string {
@@ -624,10 +624,10 @@ func (SupplementalGroupsStrategyOptions) SwaggerDoc() map[string]string {
 }
 
 var map_ThirdPartyResource = map[string]string{
-	"":            "A ThirdPartyResource is a generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
-	"metadata":    "Standard object metadata",
-	"description": "Description is the description of this object.",
-	"versions":    "Versions are versions for this third party object",
+	"":            "A generic representation of a resource, it is used by add-ons and plugins to add new resource types to the API.  It consists of one or more Versions of the api.",
+	"metadata":    "Standard object metadata.",
+	"description": "Description of this object.",
+	"versions":    "Versions for this third party object.",
 }
 
 func (ThirdPartyResource) SwaggerDoc() map[string]string {
@@ -637,7 +637,7 @@ func (ThirdPartyResource) SwaggerDoc() map[string]string {
 var map_ThirdPartyResourceData = map[string]string{
 	"":         "An internal object, used for versioned storage in etcd.  Not exposed to the end user.",
 	"metadata": "Standard object metadata.",
-	"data":     "Data is the raw JSON data for this data.",
+	"data":     "Raw JSON data for this data.",
 }
 
 func (ThirdPartyResourceData) SwaggerDoc() map[string]string {
@@ -645,9 +645,9 @@ func (ThirdPartyResourceData) SwaggerDoc() map[string]string {
 }
 
 var map_ThirdPartyResourceDataList = map[string]string{
-	"":         "ThirdPartyResrouceDataList is a list of ThirdPartyResourceData.",
+	"":         "List of ThirdPartyResourceData.",
 	"metadata": "Standard list metadata More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"items":    "Items is the list of ThirdpartyResourceData.",
+	"items":    "List of ThirdpartyResourceData.",
 }
 
 func (ThirdPartyResourceDataList) SwaggerDoc() map[string]string {
@@ -655,9 +655,9 @@ func (ThirdPartyResourceDataList) SwaggerDoc() map[string]string {
 }
 
 var map_ThirdPartyResourceList = map[string]string{
-	"":         "ThirdPartyResourceList is a list of ThirdPartyResources.",
+	"":         "List of ThirdPartyResources.",
 	"metadata": "Standard list metadata.",
-	"items":    "Items is the list of ThirdPartyResources.",
+	"items":    "List of ThirdPartyResources.",
 }
 
 func (ThirdPartyResourceList) SwaggerDoc() map[string]string {


### PR DESCRIPTION
Fix #51362

Correct the `staging/src/k8s.io/api/extensions/v1beta1/types.go` to
follow the [user facing documentation
guidelines](https://github.com/kubernetes/community/blob/master/contributors/devel/api_changes.md#edit-typesgo).

```release-note
NONE
```