### PR TITLE
discover valid resources for kubectl instead of current hard-coded way

### DIFF
--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -72,7 +72,7 @@ var (
 		* If --overwrite is true, then existing annotations can be overwritten, otherwise attempting to overwrite an annotation will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.
 
-		` + validResources)
+		`)
 
 	annotateExample = templates.Examples(i18n.T(`
     # Update pod 'foo' with the annotation 'description' and the value 'my frontend'.
@@ -110,10 +110,13 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		argAliases = kubectl.ResourceAliases(validArgs)
 	}
 
+	validResources, err := cmdutil.ValidResources(f)
+	cmdutil.CheckErr(err)
+
 	cmd := &cobra.Command{
 		Use:     "annotate [--overwrite] (-f FILENAME | TYPE NAME) KEY_1=VAL_1 ... KEY_N=VAL_N [--resource-version=version]",
 		Short:   i18n.T("Update the annotations on a resource"),
-		Long:    annotateLong,
+		Long:    annotateLong + validResources,
 		Example: annotateExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := options.Complete(out, cmd, args); err != nil {

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -195,51 +195,6 @@ __custom_func() {
     esac
 }
 `
-
-	// If you add a resource to this list, please also take a look at pkg/kubectl/kubectl.go
-	// and add a short forms entry in expandResourceShortcut() when appropriate.
-	// TODO: This should be populated using the discovery information from apiserver.
-	validResources = `Valid resource types include:
-
-    * all
-    * certificatesigningrequests (aka 'csr')
-    * clusterrolebindings
-    * clusterroles
-    * clusters (valid only for federation apiservers)
-    * componentstatuses (aka 'cs')
-    * configmaps (aka 'cm')
-    * controllerrevisions
-    * cronjobs
-    * customresourcedefinition (aka 'crd')
-    * daemonsets (aka 'ds')
-    * deployments (aka 'deploy')
-    * endpoints (aka 'ep')
-    * events (aka 'ev')
-    * horizontalpodautoscalers (aka 'hpa')
-    * ingresses (aka 'ing')
-    * jobs
-    * limitranges (aka 'limits')
-    * namespaces (aka 'ns')
-    * networkpolicies (aka 'netpol')
-    * nodes (aka 'no')
-    * persistentvolumeclaims (aka 'pvc')
-    * persistentvolumes (aka 'pv')
-    * poddisruptionbudgets (aka 'pdb')
-    * podpreset
-    * pods (aka 'po')
-    * podsecuritypolicies (aka 'psp')
-    * podtemplates
-    * replicasets (aka 'rs')
-    * replicationcontrollers (aka 'rc')
-    * resourcequotas (aka 'quota')
-    * rolebindings
-    * roles
-    * secrets
-    * serviceaccounts (aka 'sa')
-    * services (aka 'svc')
-    * statefulsets
-    * storageclasses
-    `
 )
 
 var (

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -48,7 +48,7 @@ var (
 		will first check for an exact match on TYPE and NAME_PREFIX. If no such resource
 		exists, it will output details for every resource that has a name prefixed with NAME_PREFIX.
 
-		` + validResources)
+		`)
 
 	describe_example = templates.Examples(i18n.T(`
 		# Describe a node
@@ -80,10 +80,13 @@ func NewCmdDescribe(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 	validArgs := printersinternal.DescribableResources()
 	argAliases := kubectl.ResourceAliases(validArgs)
 
+	validResources, err := cmdutil.ValidResources(f)
+	cmdutil.CheckErr(err)
+
 	cmd := &cobra.Command{
 		Use:     "describe (-f FILENAME | TYPE [NAME_PREFIX | -l label] | TYPE/NAME)",
 		Short:   i18n.T("Show details of a specific resource or group of resources"),
-		Long:    describe_long,
+		Long:    describe_long + validResources,
 		Example: describe_example,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunDescribe(f, out, cmdErr, cmd, args, options, describerSettings)
@@ -113,6 +116,10 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		enforceNamespace = false
 	}
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
+		validResources, err := cmdutil.ValidResources(f)
+		if err != nil {
+			return err
+		}
 		fmt.Fprint(cmdErr, "You must specify the type of resource to describe. ", validResources)
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -34,7 +34,7 @@ var (
 	explainLong = templates.LongDesc(`
 		Documentation of resources.
 
-		` + validResources)
+		`)
 
 	explainExamples = templates.Examples(i18n.T(`
 		# Get the documentation of the resource and its fields
@@ -46,10 +46,13 @@ var (
 
 // NewCmdExplain returns a cobra command for swagger docs
 func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
+	validResources, err := cmdutil.ValidResources(f)
+	cmdutil.CheckErr(err)
+
 	cmd := &cobra.Command{
 		Use:     "explain RESOURCE",
 		Short:   i18n.T("Documentation of resources"),
-		Long:    explainLong,
+		Long:    explainLong + validResources,
 		Example: explainExamples,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunExplain(f, out, cmdErr, cmd, args)
@@ -65,6 +68,10 @@ func NewCmdExplain(f cmdutil.Factory, out, cmdErr io.Writer) *cobra.Command {
 // RunExplain executes the appropriate steps to print a model's documentation
 func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
+		validResources, err := cmdutil.ValidResources(f)
+		if err != nil {
+			return err
+		}
 		fmt.Fprintf(cmdErr, "You must specify the type of resource to explain. %s\n", validResources)
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -54,7 +54,7 @@ var (
 	getLong = templates.LongDesc(`
 		Display one or many resources.
 
-		` + validResources + `
+		` + "%s" + `
 
 		This command will hide resources that have completed, such as pods that are
 		in the Succeeded or Failed phases. You can see the full results for any
@@ -113,10 +113,13 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 		argAliases = kubectl.ResourceAliases(validArgs)
 	}
 
+	validResources, err := cmdutil.ValidResources(f)
+	cmdutil.CheckErr(err)
+
 	cmd := &cobra.Command{
 		Use:     "get [(-o|--output=)json|yaml|wide|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=...] (TYPE [NAME | -l label] | TYPE/NAME ...) [flags]",
 		Short:   i18n.T("Display one or many resources"),
-		Long:    getLong,
+		Long:    fmt.Sprintf(getLong, validResources),
 		Example: getExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			err := RunGet(f, out, errOut, cmd, args, options)
@@ -184,6 +187,10 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 	}
 
 	if len(args) == 0 && cmdutil.IsFilenameSliceEmpty(options.Filenames) {
+		validResources, err := cmdutil.ValidResources(f)
+		if err != nil {
+			return err
+		}
 		fmt.Fprint(errOut, "You must specify the type of resource to get. ", validResources)
 
 		fullCmdName := cmd.Parent().CommandPath()

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -268,6 +268,9 @@ func NewTestFactory() (cmdutil.Factory, *TestFactory, runtime.Codec, runtime.Neg
 }
 
 func (f *FakeFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	if f.tf.ClientConfig == nil {
+		return nil, fmt.Errorf("nil pointer for FakeFactory.ClientConfig")
+	}
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(f.tf.ClientConfig)
 	if err != nil {
 		return nil, err
@@ -647,6 +650,9 @@ func (f *fakeAPIFactory) RESTClient() (*restclient.RESTClient, error) {
 }
 
 func (f *fakeAPIFactory) DiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	if f.tf.Client == nil {
+		return nil, fmt.Errorf("nil pointer for TestFactory.Client")
+	}
 	fakeClient := f.tf.Client.(*fake.RESTClient)
 	discoveryClient := discovery.NewDiscoveryClientForConfigOrDie(f.tf.ClientConfig)
 	discoveryClient.RESTClient().(*restclient.RESTClient).Client = fakeClient.Client

--- a/pkg/kubectl/cmd/util/helpers_test.go
+++ b/pkg/kubectl/cmd/util/helpers_test.go
@@ -319,3 +319,54 @@ func TestDumpReaderToFile(t *testing.T) {
 		t.Fatalf("Wrong file content %s != %s", testString, stringData)
 	}
 }
+
+func TestUnqiueValidResources(t *testing.T) {
+	vr := []ValidResource{
+		{
+			shortNames: []string{},
+			name:       "tokenreviews",
+			apiGroup:   "authentication.k8s.io",
+		},
+		{
+			shortNames: []string{},
+			name:       "localsubjectaccessreviews",
+			apiGroup:   "authorization.k8s.io",
+		},
+		{
+			shortNames: []string{},
+			name:       "selfsubjectaccessreviews",
+			apiGroup:   "authorization.k8s.io",
+		},
+		{
+			shortNames: []string{"rs"},
+			name:       "replicasets",
+			apiGroup:   "extensions",
+		},
+		{
+			shortNames: []string{"deploy"},
+			name:       "deployments",
+			apiGroup:   "extensions",
+		},
+		{
+			shortNames: []string{"psp"},
+			name:       "podsecuritypolicies",
+			apiGroup:   "extensions",
+		},
+		{
+			shortNames: []string{"rs"},
+			name:       "replicasets",
+			apiGroup:   "apps",
+		},
+		{
+			shortNames: []string{"deploy"},
+			name:       "deployments",
+			apiGroup:   "apps",
+		},
+	}
+
+	expected := "[tokenreviews localsubjectaccessreviews selfsubjectaccessreviews replicasets (aka 'rs') deployments (aka 'deploy') podsecuritypolicies (aka 'psp')]"
+	uvr := unqiueValidResources(vr)
+	if fmt.Sprintf("%s", uvr) != expected {
+		t.Errorf("Got: %s, expected: %s", uvr, expected)
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Per [discussion](https://github.com/kubernetes/kubernetes/pull/51089#issuecomment-326748956) and [discussion](https://github.com/kubernetes/kubernetes.github.io/pull/5260#discussion_r136697237).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
xref #51089

**Special notes for your reviewer**:
/assign @liggitt @caesarxuchao 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
discover valid resources for kubectl instead of current hard-coded way
```
