### PR TITLE
RBD Plugin: Omit volume.MetricsProvider field and add some testcases.

### DIFF
--- a/pkg/volume/rbd/BUILD
+++ b/pkg/volume/rbd/BUILD
@@ -40,6 +40,7 @@ go_test(
         "//pkg/util/mount:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -409,8 +409,8 @@ type rbd struct {
 	mounter  *mount.SafeFormatAndMount
 	exec     mount.Exec
 	// Utility interface that provides API calls to the provider to attach/detach disks.
-	manager diskManager
-	volume.MetricsProvider
+	manager                diskManager
+	volume.MetricsProvider `json:"-"`
 }
 
 func (rbd *rbd) GetPath() string {

--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -18,9 +18,13 @@ package rbd
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -242,5 +246,86 @@ func TestPersistentClaimReadOnlyFlag(t *testing.T) {
 
 	if !mounter.GetAttributes().ReadOnly {
 		t.Errorf("Expected true for mounter.IsReadOnly")
+	}
+}
+
+func TestPersistAndLoadRBD(t *testing.T) {
+	tmpDir, err := utiltesting.MkTmpdir("rbd_test")
+	if err != nil {
+		t.Fatalf("error creating temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	testcases := []struct {
+		rbdMounter               rbdMounter
+		expectedJSONStr          string
+		expectedLoadedRBDMounter rbdMounter
+	}{
+		{
+			rbdMounter{},
+			`{"Mon":null,"Id":"","Keyring":"","Secret":""}`,
+			rbdMounter{},
+		},
+		{
+			rbdMounter{
+				rbd: &rbd{
+					podUID:          "poduid",
+					Pool:            "kube",
+					Image:           "some-test-image",
+					ReadOnly:        false,
+					MetricsProvider: volume.NewMetricsStatFS("/tmp"),
+				},
+				Mon:     []string{"127.0.0.1"},
+				Id:      "kube",
+				Keyring: "",
+				Secret:  "QVFEcTdKdFp4SmhtTFJBQUNwNDI3UnhGRzBvQ1Y0SUJwLy9pRUE9PQ==",
+			},
+			`
+{
+	"Pool": "kube",
+	"Image": "some-test-image",
+	"ReadOnly": false,
+	"Mon": ["127.0.0.1"],
+	"Id": "kube",
+	"Keyring": "",
+	"Secret": "QVFEcTdKdFp4SmhtTFJBQUNwNDI3UnhGRzBvQ1Y0SUJwLy9pRUE9PQ=="
+}
+			`,
+			rbdMounter{
+				rbd: &rbd{
+					Pool:     "kube",
+					Image:    "some-test-image",
+					ReadOnly: false,
+				},
+				Mon:     []string{"127.0.0.1"},
+				Id:      "kube",
+				Keyring: "",
+				Secret:  "QVFEcTdKdFp4SmhtTFJBQUNwNDI3UnhGRzBvQ1Y0SUJwLy9pRUE9PQ==",
+			},
+		},
+	}
+
+	util := &RBDUtil{}
+	for _, c := range testcases {
+		err = util.persistRBD(c.rbdMounter, tmpDir)
+		if err != nil {
+			t.Errorf("failed to persist rbd: %v, err: %v", c.rbdMounter, err)
+		}
+		jsonFile := filepath.Join(tmpDir, "rbd.json")
+		jsonData, err := ioutil.ReadFile(jsonFile)
+		if err != nil {
+			t.Errorf("failed to read json file %s: %v", jsonFile, err)
+		}
+		if !assert.JSONEq(t, c.expectedJSONStr, string(jsonData)) {
+			t.Errorf("json file does not match expected one: %s, should be %s", string(jsonData), c.expectedJSONStr)
+		}
+		tmpRBDMounter := rbdMounter{}
+		err = util.loadRBD(&tmpRBDMounter, tmpDir)
+		if err != nil {
+			t.Errorf("faild to load rbd: %v", err)
+		}
+		if !reflect.DeepEqual(tmpRBDMounter, c.expectedLoadedRBDMounter) {
+			t.Errorf("loaded rbd does not equal to expected one: %v, should be %v", tmpRBDMounter, c.rbdMounter)
+		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Embedded struct `volume.MetricProvider` is capitalized and should be omitted in JSON marshalling.   It's also a unmarshalable struct, will cause error in `RBDUtil.loadRBD`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

It's a bug I introduced in https://github.com/kubernetes/kubernetes/pull/48486. It's my bad, sorry about that.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
