### PR TITLE
Automated cherry pick of #50381 to release-1.7

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -280,16 +280,14 @@ func parseCRILog(log []byte, msg *logMessage) error {
 	return nil
 }
 
-// dockerJSONLog is the JSON log buffer used in parseDockerJSONLog.
-var dockerJSONLog = &jsonlog.JSONLog{}
-
 // parseDockerJSONLog parses logs in Docker JSON log format. Docker JSON log format
 // example:
 //   {"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
 //   {"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
 func parseDockerJSONLog(log []byte, msg *logMessage) error {
-	dockerJSONLog.Reset()
-	l := dockerJSONLog
+	var l = &jsonlog.JSONLog{}
+	l.Reset()
+
 	// TODO: JSON decoding is fairly expensive, we should evaluate this.
 	if err := json.Unmarshal(log, l); err != nil {
 		return fmt.Errorf("failed with %v to unmarshal log %q", err, l)


### PR DESCRIPTION
Cherry pick of #50381  on release-1.7.

#50381: Bugfix: Use local JSON log buffer in parseDockerJSONLog.