### PR TITLE
Automated cherry pick of #50381 to release-1.6

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_logs.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_logs.go
@@ -280,16 +280,14 @@ func parseCRILog(log []byte, msg *logMessage) error {
 	return nil
 }
 
-// dockerJSONLog is the JSON log buffer used in parseDockerJSONLog.
-var dockerJSONLog = &jsonlog.JSONLog{}
-
 // parseDockerJSONLog parses logs in Docker JSON log format. Docker JSON log format
 // example:
 //   {"log":"content 1","stream":"stdout","time":"2016-10-20T18:39:20.57606443Z"}
 //   {"log":"content 2","stream":"stderr","time":"2016-10-20T18:39:20.57606444Z"}
 func parseDockerJSONLog(log []byte, msg *logMessage) error {
-	dockerJSONLog.Reset()
-	l := dockerJSONLog
+	var l = &jsonlog.JSONLog{}
+	l.Reset()
+
 	// TODO: JSON decoding is fairly expensive, we should evaluate this.
 	if err := json.Unmarshal(log, l); err != nil {
 		return fmt.Errorf("failed with %v to unmarshal log %q", err, l)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Use local JSON log buffer in parseDockerJSONLog.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47800

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed an issue (#47800) where `kubectl logs -f` failed with `unexpected stream type ""`.
```
