### PR TITLE
Build test targets for all server platforms

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -112,6 +112,10 @@ else
   # Which platforms we should compile test targets for. Not all client platforms need these tests
   readonly KUBE_TEST_PLATFORMS=(
     linux/amd64
+    linux/arm
+    linux/arm64
+    linux/s390x
+    linux/ppc64le
     darwin/amd64
     windows/amd64
   )

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/testserver/resources.go
@@ -33,6 +33,10 @@ import (
 	"k8s.io/client-go/dynamic"
 )
 
+const (
+	noxuInstanceNum int64 = 9223372036854775807
+)
+
 //NewRandomNameCustomResourceDefinition generates a CRD with random name to avoid name conflict in e2e tests
 func NewRandomNameCustomResourceDefinition(scope apiextensionsv1beta1.ResourceScope) *apiextensionsv1beta1.CustomResourceDefinition {
 	// ensure the singular doesn't end in an s for now
@@ -84,7 +88,7 @@ func NewNoxuInstance(namespace, name string) *unstructured.Unstructured {
 				"key": "value",
 			},
 			"num": map[string]interface{}{
-				"num1": 9223372036854775807,
+				"num1": noxuInstanceNum,
 				"num2": 1000000,
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

:facepalm:

I really should have checked this before code freeze, but tbh forgot it in the rush. Also I thought this was the case already...
As part of https://github.com/kubernetes/features/issues/288; these binaries should be built for all server platforms indeed.

This is just a straightforward add to that list.
Can we please get this into v1.8?
There is virtually no risk involved here really...

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Build test targets for all server platforms
```
@ixdy @jdumars @mkumatag 