### PR TITLE
Clear alpha MountPropagation fields.

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -243,4 +243,20 @@ func DropDisabledAlphaFields(podSpec *api.PodSpec) {
 			}
 		}
 	}
+	for i := range podSpec.Containers {
+		DropDisabledVolumeMountsAlphaFields(podSpec.Containers[i].VolumeMounts)
+	}
+	for i := range podSpec.InitContainers {
+		DropDisabledVolumeMountsAlphaFields(podSpec.InitContainers[i].VolumeMounts)
+	}
+}
+
+// DropDisabledVolumeMountsAlphaFields removes disabled fields from []VolumeMount.
+// This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a VolumeMount
+func DropDisabledVolumeMountsAlphaFields(volumeMounts []api.VolumeMount) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.MountPropagation) {
+		for i := range volumeMounts {
+			volumeMounts[i].MountPropagation = nil
+		}
+	}
 }

--- a/pkg/registry/settings/podpreset/BUILD
+++ b/pkg/registry/settings/podpreset/BUILD
@@ -14,6 +14,7 @@ go_library(
     ],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/apis/settings:go_default_library",
         "//pkg/apis/settings/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",

--- a/pkg/registry/settings/podpreset/strategy.go
+++ b/pkg/registry/settings/podpreset/strategy.go
@@ -22,6 +22,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/settings"
 	"k8s.io/kubernetes/pkg/apis/settings/validation"
 )
@@ -44,12 +45,17 @@ func (podPresetStrategy) NamespaceScoped() bool {
 func (podPresetStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {
 	pip := obj.(*settings.PodPreset)
 	pip.Generation = 1
+
+	pod.DropDisabledVolumeMountsAlphaFields(pip.Spec.VolumeMounts)
 }
 
 // PrepareForUpdate clears fields that are not allowed to be set by end users on update.
 func (podPresetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runtime.Object) {
 	newPodPreset := obj.(*settings.PodPreset)
 	oldPodPreset := old.(*settings.PodPreset)
+
+	pod.DropDisabledVolumeMountsAlphaFields(oldPodPreset.Spec.VolumeMounts)
+	pod.DropDisabledVolumeMountsAlphaFields(newPodPreset.Spec.VolumeMounts)
 
 	// Update is not allowed
 	newPodPreset.Spec = oldPodPreset.Spec


### PR DESCRIPTION
This is leftover from #50924, mount propagation introduced a new field that needs to be cleared.

**Which issue this PR fixes**
fixes #51738

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```


@k8s-mirror-api-machinery-pr-reviews 
/assign @liggitt 