### PR TITLE
Do not delete ExternalIPs

### DIFF
--- a/federation/pkg/federation-controller/service/servicecontroller.go
+++ b/federation/pkg/federation-controller/service/servicecontroller.go
@@ -565,6 +565,8 @@ func getOperationsToPerformOnCluster(informer fedutil.FederatedInformer, cluster
 				}
 			}
 		}
+		// ExternalIPs are not managed by Kubernetes, so retain the same if any while updating
+		desiredService.Spec.ExternalIPs = clusterService.Spec.ExternalIPs
 
 		// Update existing service, if needed.
 		if !Equivalent(desiredService, clusterService) {


### PR DESCRIPTION
**What this PR does / why we need it**: ExternalIPs are not managed by Kubernetes and should not be touched.

```release-note
NONE
```
/kind bug