### PR TITLE
make clean will remove all gitignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,5 +120,8 @@ zz_generated.openapi.go
 # This file used by some vendor repos (e.g. github.com/go-openapi/...) to store secret variables and should not be ignored
 !\.drone\.sec
 
+# Godeps workspace
+/Godeps/_workspace
+
 /bazel-*
 *.pyc

--- a/build/common.sh
+++ b/build/common.sh
@@ -409,8 +409,10 @@ function kube::build::clean() {
     "${DOCKER[@]}" rmi $("${DOCKER[@]}" images -q --filter 'dangling=true') 2> /dev/null || true
   fi
 
-  kube::log::status "Removing _output directory"
-  rm -rf "${LOCAL_OUTPUT_ROOT}"
+  if [[ -d "${LOCAL_OUTPUT_ROOT}" ]]; then
+    kube::log::status "Removing _output directory"
+    rm -rf "${LOCAL_OUTPUT_ROOT}"
+  fi
 }
 
 # Set up the context directory for the kube-build image and build it.

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -309,10 +309,7 @@ clean:
 else
 clean: clean_meta
 	build/make-clean.sh
-	rm -rf $(OUT_DIR)
-	rm -rf Godeps/_workspace # Just until we are sure it is gone
-	# TODO(thockin): Remove this when we call clean_generated.
-	rm -f pkg/generated/openapi/zz_generated.openapi.go
+	git clean -Xdf
 endif
 
 define CLEAN_META_HELP_INFO


### PR DESCRIPTION
**What this PR does / why we need it**:
During review of #51766, it was noticed that we don't fully clean all gitignored files when we run "make clean":
https://github.com/kubernetes/kubernetes/pull/51766#discussion_r136688728

This change will change `make clean` to use `git clean` to remove all files in the gitignore. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
