### PR TITLE
Fix Stackdriver Logging tests for large clusters

### DIFF
--- a/test/e2e/instrumentation/logging/stackdrvier/utils.go
+++ b/test/e2e/instrumentation/logging/stackdrvier/utils.go
@@ -20,7 +20,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -210,13 +209,8 @@ func (p *sdLogProvider) buildFilter() (string, error) {
 		return fmt.Sprintf("resource.type=\"gke_cluster\" AND jsonPayload.metadata.namespace=\"%s\"",
 			p.framework.Namespace.Name), nil
 	case systemScope:
-		nodeFilters := []string{}
-		for _, nodeID := range utils.GetNodeIds(p.framework.ClientSet) {
-			nodeFilter := fmt.Sprintf("resource.labels.instance_id=%s", nodeID)
-			nodeFilters = append(nodeFilters, nodeFilter)
-		}
-		return fmt.Sprintf("resource.type=\"gce_instance\" AND (%s)",
-			strings.Join(nodeFilters, " OR ")), nil
+		// TODO(instrumentation): Filter logs from the current project only.
+		return "resource.type=\"gce_instance\"", nil
 	}
 	return "", fmt.Errorf("Unknown log provider scope: %v", p.scope)
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/51700

Due to the limit on the length of the filter, filtering out all nodes in the cluster is not possible. Removing the filter shouldn't affect the tests, since the checks are made based on the nodeIds in the cluster that are unique anyway