### PR TITLE
Rename NewNodeController to NewController

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -92,7 +92,7 @@ func startNodeController(ctx ControllerContext) (bool, error) {
 		}
 	}
 
-	nodeController, err := nodecontroller.NewNodeController(
+	nodeController, err := nodecontroller.NewController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Nodes(),
 		ctx.InformerFactory.Extensions().V1beta1().DaemonSets(),

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -211,11 +211,11 @@ type Controller struct {
 	taintNodeByCondition bool
 }
 
-// NewNodeController returns a new node controller to sync instances from cloudprovider.
+// NewController returns a new node controller to sync instances from cloudprovider.
 // This method returns an error if it is unable to initialize the CIDR bitmap with
 // podCIDRs it has already allocated to nodes. Since we don't allow podCIDR changes
 // currently, this should be handled as a fatal error.
-func NewNodeController(
+func NewController(
 	podInformer coreinformers.PodInformer,
 	nodeInformer coreinformers.NodeInformer,
 	daemonSetInformer extensionsinformers.DaemonSetInformer,

--- a/pkg/controller/node/nodecontroller_test.go
+++ b/pkg/controller/node/nodecontroller_test.go
@@ -89,7 +89,7 @@ func newNodeControllerFromClient(
 	nodeInformer := factory.Core().V1().Nodes()
 	daemonSetInformer := factory.Extensions().V1beta1().DaemonSets()
 
-	nc, err := NewNodeController(
+	nc, err := NewController(
 		factory.Core().V1().Pods(),
 		nodeInformer,
 		daemonSetInformer,


### PR DESCRIPTION
**What this PR does / why we need it**:

Recent patch renamed type `NodeController` to `Controller`. The constructor function was not updated.
`NewNodeController` should now be `NewController`.

This PR updates the constructor function to mirror the change made to the type name.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig node
/kind cleanup