### PR TITLE
fix issue #51920 of ipvs

### DIFF
--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -20,6 +20,7 @@ go_test(
             "//pkg/api:go_default_library",
             "//pkg/proxy:go_default_library",
             "//pkg/proxy/util:go_default_library",
+            "//pkg/util/async:go_default_library",
             "//pkg/util/iptables:go_default_library",
             "//pkg/util/iptables/testing:go_default_library",
             "//pkg/util/ipvs:go_default_library",

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -853,12 +853,6 @@ func (proxier *Proxier) OnEndpointsSynced() {
 	proxier.syncProxyRules()
 }
 
-type syncReason string
-
-const syncReasonServices syncReason = "ServicesUpdate"
-const syncReasonEndpoints syncReason = "EndpointsUpdate"
-const syncReasonForce syncReason = "Force"
-
 // This is where all of the ipvs calls happen.
 // assumes proxier.mu is held
 func (proxier *Proxier) syncProxyRules() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the problem of when endpoint changed, ipvs chain can't change corresponding. 
**Which issue this PR fixes** : fixes #51920 

**Special notes for your reviewer**:
Use `async.BoundedFrequencyRunner` to avoid proxier block in one event, can't handler the following, or can only handler after a really long time.
**Release note**:
```
None
```