### PR TITLE
Make *fakeMountInterface in container_manager_unsupported_test.go implement mount.Interface again.

### DIFF
--- a/pkg/kubelet/cm/container_manager_unsupported_test.go
+++ b/pkg/kubelet/cm/container_manager_unsupported_test.go
@@ -69,6 +69,10 @@ func (mi *fakeMountInterface) GetDeviceNameFromMount(mountPath, pluginDir string
 	return "", nil
 }
 
+func (mi *fakeMountInterface) MakeRShared(path string) error {
+	return nil
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{


### PR DESCRIPTION
This was broken in #45724

**Release note**:
```release-note
NONE
```
/sig storage
/sig node

/cc @jsafrane, @vishh