### PR TITLE
Fix the kube-aggregator help message

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -75,8 +75,8 @@ func NewCommandStartAggregator(out, err io.Writer, stopCh <-chan struct{}) *cobr
 // AddFlags is necessary because hyperkube doesn't work using cobra, so we have to have different registration and execution paths
 func (o *AggregatorOptions) AddFlags(fs *pflag.FlagSet) {
 	o.RecommendedOptions.AddFlags(fs)
-	fs.StringVar(&o.ProxyClientCertFile, "proxy-client-cert-file", o.ProxyClientCertFile, "client certificate used identify the proxy to the API server")
-	fs.StringVar(&o.ProxyClientKeyFile, "proxy-client-key-file", o.ProxyClientKeyFile, "client certificate key used identify the proxy to the API server")
+	fs.StringVar(&o.ProxyClientCertFile, "proxy-client-cert-file", o.ProxyClientCertFile, "client certificate used to identify the proxy to the API server")
+	fs.StringVar(&o.ProxyClientKeyFile, "proxy-client-key-file", o.ProxyClientKeyFile, "client key used to identify the proxy to the API server")
 }
 
 // NewDefaultOptions builds a "normal" set of options.  You wouldn't normally expose this, but hyperkube isn't cobra compatible


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the help message for kube-aggregator.

**Which issue this PR fixes**: fixes #51930

**Special notes for your reviewer**:
Trivial fix.

**Release note**:
```release-note
NONE
```
