### PR TITLE
fix docstring of advanced audit policy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -220,9 +220,9 @@ type GroupResources struct {
 	// +optional
 	Group string
 	// Resources is a list of resources within the API group. Subresources are
-	// matched using a "/" to indicate the subresource. For example, "pods/logs"
-	// would match request to the logs subresource of pods. The top level resource
-	// does not match subresources, "pods" doesn't match "pods/logs".
+	// matched using a "/" to indicate the subresource. For example, "pods/log"
+	// would match request to the log subresource of pods. The top level resource
+	// does not match subresources, "pods" doesn't match "pods/log".
 	// +optional
 	Resources []string
 	// ResourceNames is a list of resource instance names that the policy matches.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
@@ -108,9 +108,9 @@ message GroupResources {
   optional string group = 1;
 
   // Resources is a list of resources within the API group. Subresources are
-  // matched using a "/" to indicate the subresource. For example, "pods/logs"
-  // would match request to the logs subresource of pods. The top level resource
-  // does not match subresources, "pods" doesn't match "pods/logs".
+  // matched using a "/" to indicate the subresource. For example, "pods/log"
+  // would match request to the log subresource of pods. The top level resource
+  // does not match subresources, "pods" doesn't match "pods/log".
   // +optional
   repeated string resources = 2;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
@@ -214,9 +214,9 @@ type GroupResources struct {
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
 	// Resources is a list of resources within the API group. Subresources are
-	// matched using a "/" to indicate the subresource. For example, "pods/logs"
-	// would match request to the logs subresource of pods. The top level resource
-	// does not match subresources, "pods" doesn't match "pods/logs".
+	// matched using a "/" to indicate the subresource. For example, "pods/log"
+	// would match request to the log subresource of pods. The top level resource
+	// does not match subresources, "pods" doesn't match "pods/log".
 	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 	// ResourceNames is a list of resource instance names that the policy matches.


### PR DESCRIPTION
I found this when I write doc for advanced audit beta version.

**Release note**:
```
NONE
```
