### PR TITLE
set AdvancedAuditing feature gate to true by default

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -191,7 +191,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
 	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.AdvancedAuditing:        {Default: false, PreRelease: utilfeature.Alpha},
+	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
 	genericfeatures.APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
 	genericfeatures.Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
 	genericfeatures.APIListChunking:         {Default: false, PreRelease: utilfeature.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -36,6 +36,7 @@ const (
 
 	// owner: @tallclair
 	// alpha: v1.7
+	// beta: v1.8
 	//
 	// AdvancedAuditing enables a much more general API auditing pipeline, which includes support for
 	// pluggable output backends and an audit policy specifying how different requests should be
@@ -72,7 +73,7 @@ func init() {
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	AdvancedAuditing:        {Default: false, PreRelease: utilfeature.Alpha},
+	AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
 	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
 	Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
 	APIListChunking:         {Default: false, PreRelease: utilfeature.Alpha},

--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -57,8 +57,9 @@ type AuditOptions struct {
 	WebhookOptions AuditWebhookOptions
 }
 
-// AuditLogOptions holds the legacy audit log writer. If the AdvancedAuditing feature
-// is enabled, these options determine the output of the structured audit log.
+// AuditLogOptions determines the output of the structured audit log by default.
+// If the AdvancedAuditing feature is set to false, AuditLogOptions holds the legacy
+// audit log writer.
 type AuditLogOptions struct {
 	Path       string
 	MaxAge     int


### PR DESCRIPTION
All feature commits are merged. The types are updated already to beta. This only enable the feature gate by default.

**Release note**:
```
Promote the AdvancedAuditing feature to beta and enable the feature gate by default.
```
