### PR TITLE
fix ingress fields representation

### DIFF
--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -393,16 +393,16 @@ func validateIngressTLS(spec *extensions.IngressSpec, fldPath *field.Path) field
 	allErrs := field.ErrorList{}
 	// TODO: Perform a more thorough validation of spec.TLS.Hosts that takes
 	// the wildcard spec from RFC 6125 into account.
-	for _, itls := range spec.TLS {
-		for i, host := range itls.Hosts {
+	for i, itls := range spec.TLS {
+		for j, host := range itls.Hosts {
 			if strings.Contains(host, "*") {
 				for _, msg := range validation.IsWildcardDNS1123Subdomain(host) {
-					allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("hosts"), host, msg))
+					allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("hosts").Index(j), host, msg))
 				}
 				continue
 			}
 			for _, msg := range validation.IsDNS1123Subdomain(host) {
-				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("hosts"), host, msg))
+				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("hosts").Index(j), host, msg))
 			}
 		}
 	}
@@ -464,7 +464,7 @@ func validateIngressRules(ingressRules []extensions.IngressRule, fldPath *field.
 				allErrs = append(allErrs, field.Invalid(fldPath.Index(i).Child("host"), ih.Host, msg))
 			}
 		}
-		allErrs = append(allErrs, validateIngressRuleValue(&ih.IngressRuleValue, fldPath.Index(0))...)
+		allErrs = append(allErrs, validateIngressRuleValue(&ih.IngressRuleValue, fldPath.Index(i))...)
 	}
 	return allErrs
 }
@@ -501,7 +501,7 @@ func validateHTTPIngressRuleValue(httpIngressRuleValue *extensions.HTTPIngressRu
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("paths").Index(i).Child("path"), rule.Path, "must be a valid regex"))
 			}
 		}
-		allErrs = append(allErrs, validateIngressBackend(&rule.Backend, fldPath.Child("backend"))...)
+		allErrs = append(allErrs, validateIngressBackend(&rule.Backend, fldPath.Child("paths").Index(i).Child("backend"))...)
 	}
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -1641,7 +1641,7 @@ func TestValidateIngressTLS(t *testing.T) {
 			Hosts: []string{wildcardHost},
 		},
 	}
-	badWildcardTLSErr := fmt.Sprintf("spec.tls[0].hosts: Invalid value: '%v'", wildcardHost)
+	badWildcardTLSErr := fmt.Sprintf("spec.tls[0].hosts[0]: Invalid value: '%v'", wildcardHost)
 	errorCases[badWildcardTLSErr] = badWildcardTLS
 
 	for k, v := range errorCases {


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

**What this PR does / why we need it**:

The string representation for ingress fields are not correct, try to fix them.

**Release note**:
```
None
```
