### PR TITLE
Swap NetworkPolicy storage to networking.k8s.io/v1

### DIFF
--- a/cluster/update-storage-objects.sh
+++ b/cluster/update-storage-objects.sh
@@ -53,6 +53,7 @@ declare -a resources=(
     "rolebindings.rbac.authorization.k8s.io"
     "clusterroles.rbac.authorization.k8s.io"
     "clusterrolebindings.rbac.authorization.k8s.io"
+    "networkpolicies.networking.k8s.io"
 )
 
 # Find all the namespaces.

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -562,11 +562,12 @@ func BuildStorageFactory(s *options.ServerRunOptions) (*serverstorage.DefaultSto
 		return nil, fmt.Errorf("error in initializing storage factory: %s", err)
 	}
 
-	// keep Deployments, NetworkPolicies, Daemonsets and ReplicaSets in extensions for backwards compatibility, we'll have to migrate at some point, eventually
+	storageFactory.AddCohabitatingResources(networking.Resource("networkpolicies"), extensions.Resource("networkpolicies"))
+
+	// keep Deployments, Daemonsets and ReplicaSets in extensions for backwards compatibility, we'll have to migrate at some point, eventually
 	storageFactory.AddCohabitatingResources(extensions.Resource("deployments"), apps.Resource("deployments"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("daemonsets"), apps.Resource("daemonsets"))
 	storageFactory.AddCohabitatingResources(extensions.Resource("replicasets"), apps.Resource("replicasets"))
-	storageFactory.AddCohabitatingResources(extensions.Resource("networkpolicies"), networking.Resource("networkpolicies"))
 	for _, override := range s.Etcd.EtcdServersOverrides {
 		tokens := strings.Split(override, "#")
 		if len(tokens) != 2 {

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -263,6 +263,7 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 	gvr("extensions", "v1beta1", "networkpolicies"): {
 		stub:             `{"metadata": {"name": "np1"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
 		expectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np1",
+		expectedGVK:      gvkP("networking.k8s.io", "v1", "NetworkPolicy"),
 	},
 	gvr("extensions", "v1beta1", "deployments"): {
 		stub:             `{"metadata": {"name": "deployment1"}, "spec": {"selector": {"matchLabels": {"f": "z"}}, "template": {"metadata": {"labels": {"f": "z"}}, "spec": {"containers": [{"image": "fedora:latest", "name": "container6"}]}}}}`,
@@ -278,7 +279,6 @@ var etcdStorageData = map[schema.GroupVersionResource]struct {
 	gvr("networking.k8s.io", "v1", "networkpolicies"): {
 		stub:             `{"metadata": {"name": "np2"}, "spec": {"podSelector": {"matchLabels": {"e": "f"}}}}`,
 		expectedEtcdPath: "/registry/networkpolicies/etcdstoragepathtestnamespace/np2",
-		expectedGVK:      gvkP("extensions", "v1beta1", "NetworkPolicy"),
 	},
 	// --
 


### PR DESCRIPTION
Finishes(?) the NetworkPolicy v1 migration.
Fixes #50604

The integration test passes. I copied the test-update-storage-objects.sh change from #50327 and have no idea if it's right.

/cc @sttts @caesarxuchao @thockin

**Release note**:
```release-note
```
