### PR TITLE
fix annoying leader election typo

### DIFF
--- a/pkg/client/leaderelectionconfig/config.go
+++ b/pkg/client/leaderelectionconfig/config.go
@@ -62,5 +62,5 @@ func BindFlags(l *componentconfig.LeaderElectionConfiguration, fs *pflag.FlagSet
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
-		"leader election. Supported options are `endpoints` (default) and `configmap`.")
+		"leader election. Supported options are `endpoints` (default) and `configmaps`.")
 }


### PR DESCRIPTION
Small typo that annoyed me. It expected `configmaps`