### PR TITLE
ignore unknown resource version in scaler error

### DIFF
--- a/pkg/kubectl/scale.go
+++ b/pkg/kubectl/scale.go
@@ -104,9 +104,11 @@ type ScaleError struct {
 }
 
 func (c ScaleError) Error() string {
-	return fmt.Sprintf(
-		"Scaling the resource failed with: %v; Current resource version %s",
-		c.ActualError, c.ResourceVersion)
+	msg := fmt.Sprintf("Scaling the resource failed with: %v", c.ActualError)
+	if len(c.ResourceVersion) > 0 {
+		msg += fmt.Sprintf("; Current resource version %s", c.ResourceVersion)
+	}
+	return msg
 }
 
 // RetryParams encapsulates the retry parameters used by kubectl's scaler.
@@ -169,7 +171,7 @@ type ReplicationControllerScaler struct {
 func (scaler *ReplicationControllerScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
 	controller, err := scaler.c.ReplicationControllers(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", ScaleError{ScaleGetFailure, "Unknown", err}
+		return "", ScaleError{ScaleGetFailure, "", err}
 	}
 	if preconditions != nil {
 		if err := preconditions.ValidateReplicationController(controller); err != nil {
@@ -267,7 +269,7 @@ type ReplicaSetScaler struct {
 func (scaler *ReplicaSetScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
 	rs, err := scaler.c.ReplicaSets(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", ScaleError{ScaleGetFailure, "Unknown", err}
+		return "", ScaleError{ScaleGetFailure, "", err}
 	}
 	if preconditions != nil {
 		if err := preconditions.ValidateReplicaSet(rs); err != nil {
@@ -338,7 +340,7 @@ type StatefulSetScaler struct {
 func (scaler *StatefulSetScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
 	ss, err := scaler.c.StatefulSets(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", ScaleError{ScaleGetFailure, "Unknown", err}
+		return "", ScaleError{ScaleGetFailure, "", err}
 	}
 	if preconditions != nil {
 		if err := preconditions.ValidateStatefulSet(ss); err != nil {
@@ -391,7 +393,7 @@ type JobScaler struct {
 func (scaler *JobScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
 	job, err := scaler.c.Jobs(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", ScaleError{ScaleGetFailure, "Unknown", err}
+		return "", ScaleError{ScaleGetFailure, "", err}
 	}
 	if preconditions != nil {
 		if err := preconditions.ValidateJob(job); err != nil {
@@ -460,7 +462,7 @@ type DeploymentScaler struct {
 func (scaler *DeploymentScaler) ScaleSimple(namespace, name string, preconditions *ScalePrecondition, newSize uint) (string, error) {
 	deployment, err := scaler.c.Deployments(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		return "", ScaleError{ScaleGetFailure, "Unknown", err}
+		return "", ScaleError{ScaleGetFailure, "", err}
 	}
 	if preconditions != nil {
 		if err := preconditions.ValidateDeployment(deployment); err != nil {


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Rather than printing `Scaling the resource failed with: An Error; Current resource version Unknown` whenever a ScalerError occurs and a resource version is not known, we should avoid printing the resource version part of the error message in order to avoid potential confusion by a user.

Related downstream comment: https://github.com/openshift/origin/issues/16056#issuecomment-326049457

cc @fabianofranz @soltysh @stevekuznetsov @kubernetes/sig-cli-misc
