### PR TITLE
add --list option to label cmd

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -49,6 +49,7 @@ type LabelOptions struct {
 
 	// Common user flags
 	overwrite       bool
+	list            bool
 	local           bool
 	dryrun          bool
 	all             bool
@@ -127,6 +128,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	}
 	cmdutil.AddPrinterFlags(cmd)
 	cmd.Flags().Bool("overwrite", false, "If true, allow labels to be overwritten, otherwise reject label updates that overwrite existing labels.")
+	cmd.Flags().BoolVar(&options.list, "list", options.list, "If true, display the labels for a given resource.")
 	cmd.Flags().Bool("local", false, "If true, label will NOT contact api-server but run locally.")
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).")
 	cmd.Flags().Bool("all", false, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
@@ -144,6 +146,7 @@ func NewCmdLabel(f cmdutil.Factory, out io.Writer) *cobra.Command {
 // Complete adapts from the command line args and factory to the data required.
 func (o *LabelOptions) Complete(out io.Writer, cmd *cobra.Command, args []string) (err error) {
 	o.out = out
+	o.list = cmdutil.GetFlagBool(cmd, "list")
 	o.local = cmdutil.GetFlagBool(cmd, "local")
 	o.overwrite = cmdutil.GetFlagBool(cmd, "overwrite")
 	o.all = cmdutil.GetFlagBool(cmd, "all")
@@ -158,6 +161,11 @@ func (o *LabelOptions) Complete(out io.Writer, cmd *cobra.Command, args []string
 	}
 	o.resources = resources
 	o.newLabels, o.removeLabels, err = parseLabels(labelArgs)
+
+	if o.list && len(o.outputFormat) > 0 {
+		return cmdutil.UsageErrorf(cmd, "--list and --output may not be specified together")
+	}
+
 	return err
 }
 
@@ -166,7 +174,7 @@ func (o *LabelOptions) Validate() error {
 	if len(o.resources) < 1 && cmdutil.IsFilenameSliceEmpty(o.FilenameOptions.Filenames) {
 		return fmt.Errorf("one or more resources must be specified as <resource> <name> or <resource>/<name>")
 	}
-	if len(o.newLabels) < 1 && len(o.removeLabels) < 1 {
+	if len(o.newLabels) < 1 && len(o.removeLabels) < 1 && !o.list {
 		return fmt.Errorf("at least one label update is required")
 	}
 	return nil
@@ -218,7 +226,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 
 		var outputObj runtime.Object
 		dataChangeMsg := "not labeled"
-		if o.dryrun || o.local {
+		if o.dryrun || o.local || o.list {
 			err = labelFunc(info.Object, o.overwrite, o.resourceVersion, o.newLabels, o.removeLabels)
 			if err != nil {
 				return err
@@ -278,6 +286,19 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 			if err != nil {
 				return err
 			}
+		}
+
+		if o.list {
+			accessor, err := meta.Accessor(outputObj)
+			if err != nil {
+				return err
+			}
+
+			for k, v := range accessor.GetLabels() {
+				fmt.Fprintf(o.out, "%s=%s\n", k, v)
+			}
+
+			return nil
 		}
 
 		var mapper meta.RESTMapper


### PR DESCRIPTION
**Release note**:
```release-note
added --list option to the `kubectl label` command
```

Adds a `--list` option to `kubectl label ...` with similar behavior to `kubectl env ... --list`

**Before**
```
$ kubectl label pod/mypod --list
Error: unknown flag: --list

Usage:
...
```

**After**
```
$ kubectl label pod/mypod --list
labelkey1=existinglabel1
labelkey2=existinglabel2

$ kubectl label pod/mypod --list label1=newlabel1
labelkey1=existinglabel1
labelkey2=existinglabel2
label1=newlabel1
```

Related downstream bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1268877

cc @fabianofranz @kubernetes/sig-cli-misc