### PR TITLE
Fix unbound variable in configure-helper.sh

### DIFF
--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -448,7 +448,7 @@ initial_etcd_cluster: '$(echo "${INITIAL_ETCD_CLUSTER:-}" | sed -e "s/'/''/g")'
 initial_etcd_cluster_state: '$(echo "${INITIAL_ETCD_CLUSTER_STATE:-}" | sed -e "s/'/''/g")'
 ca_cert_bundle_path: '$(echo "${CA_CERT_BUNDLE_PATH:-}" | sed -e "s/'/''/g")'
 hostname: $(hostname -s)
-enable_pod_priority: '$(echo "$ENABLE_POD_PRIORITY" | sed -e "s/'/''/g")'
+enable_pod_priority: '$(echo "${ENABLE_POD_PRIORITY:-}" | sed -e "s/'/''/g")'
 enable_default_storage_class: '$(echo "$ENABLE_DEFAULT_STORAGE_CLASS" | sed -e "s/'/''/g")'
 kube_proxy_daemonset: '$(echo "$KUBE_PROXY_DAEMONSET" | sed -e "s/'/''/g")'
 EOF

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -706,7 +706,7 @@ function prepare-kube-proxy-manifest-variables {
     kube_cache_mutation_detector_env_value="value: \"${ENABLE_CACHE_MUTATION_DETECTOR}\""
   fi
   local pod_priority=""
-  if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then
+  if [[ "${ENABLE_POD_PRIORITY:-}" == "true" ]]; then
     pod_priority="priorityClassName: system-node-critical"
   fi
   sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${src_file}

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1042,7 +1042,7 @@ function prepare-kube-proxy-manifest-variables {
     kube_cache_mutation_detector_env_value="value: \"${ENABLE_CACHE_MUTATION_DETECTOR}\""
   fi
   local pod_priority=""
-  if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then
+  if [[ "${ENABLE_POD_PRIORITY:-}" == "true" ]]; then
     pod_priority="priorityClassName: system-node-critical"
   fi
   sed -i -e "s@{{kubeconfig}}@${kubeconfig}@g" ${src_file}


### PR DESCRIPTION
This isn't plumbed yet on GKE, so results in an unbound variable.

```release-note
NONE
```
