### PR TITLE
kubeadm: Create dnsIP by selecting the tenth IP from k8s svc CIDR

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/addons.go
+++ b/cmd/kubeadm/app/cmd/phases/addons.go
@@ -116,6 +116,7 @@ func getAddonsSubCommands() []*cobra.Command {
 
 		if properties.use == "all" || properties.use == "kube-dns" {
 			cmd.Flags().StringVar(&cfg.Networking.DNSDomain, "service-dns-domain", cfg.Networking.DNSDomain, `Use alternative domain for services, e.g. "myorg.internal.`)
+			cmd.Flags().StringVar(&cfg.Networking.ServiceSubnet, "service-cidr", cfg.Networking.ServiceSubnet, `Use alternative range of IP address for service VIPs`)
 		}
 		subCmds = append(subCmds, cmd)
 	}

--- a/cmd/kubeadm/app/cmd/phases/addons_test.go
+++ b/cmd/kubeadm/app/cmd/phases/addons_test.go
@@ -47,6 +47,7 @@ func TestAddonsSubCommandsHasFlags(t *testing.T) {
 				"apiserver-bind-port",
 				"pod-network-cidr",
 				"service-dns-domain",
+				"service-cidr",
 			},
 		},
 		{
@@ -61,6 +62,7 @@ func TestAddonsSubCommandsHasFlags(t *testing.T) {
 			command: "kube-dns",
 			additionalFlags: []string{
 				"service-dns-domain",
+				"service-cidr",
 			},
 		},
 	}

--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/registry/core/service/ipallocator:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -144,3 +144,33 @@ func TestCompileManifests(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDNSIP(t *testing.T) {
+	var tests = []struct {
+		svcSubnet, expectedDNSIP string
+	}{
+		{
+			svcSubnet:     "10.96.0.0/12",
+			expectedDNSIP: "10.96.0.10",
+		},
+		{
+			svcSubnet:     "10.87.116.64/26",
+			expectedDNSIP: "10.87.116.74",
+		},
+	}
+	for _, rt := range tests {
+		dnsIP, err := GetDNSIP(rt.svcSubnet)
+		if err != nil {
+			t.Fatalf("couldn't get dnsIP : %v", err)
+		}
+
+		actualDNSIP := dnsIP.String()
+		if actualDNSIP != rt.expectedDNSIP {
+			t.Errorf(
+				"failed GetDNSIP\n\texpected: %s\n\t  actual: %s",
+				rt.expectedDNSIP,
+				actualDNSIP,
+			)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates dnsIP by selecting the ninth IP from k8s svc cluster IP, instead of appending 0 to the k8s svcIP string. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51997

**Special notes for your reviewer**:
This is helpful when we have service cluster range CIDR as 10.87.116.64/26 (for example), previously this would have failed while parsing the dnsIP, as we used to append a 0 to the k8s svc clusterIP string. This will get the same dnsIP 10.96.0.10 for very widely used service cluster range CIDR 10.96.0.0/12


**Release note**:
```release-note
None
```
