### PR TITLE
Fix dynamic discovery error in e2e

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1151,7 +1151,7 @@ func isDynamicDiscoveryError(err error) bool {
 			return false
 		}
 	}
-	return false
+	return true
 }
 
 // hasRemainingContent checks if there is remaining content in the namespace via API discovery


### PR DESCRIPTION
Actually fixes #51910 (I blame the reviewer of #51915, definitely not the author)
The helper function never identified dynamic discovery errors