### PR TITLE
Load kernel modules automatically inside a kube-proxy pod

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -53,6 +53,9 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
+        - mountPath: /lib/modules
+          name: lib-modules
+          readOnly: true
       volumes:
       - name: varlog
         hostPath:
@@ -64,4 +67,7 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
       serviceAccountName: kube-proxy

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -96,6 +96,9 @@ spec:
     - mountPath: /run/xtables.lock
       name: iptableslock
       readOnly: false
+    - mountPath: /lib/modules
+      name: lib-modules
+      readOnly: true
   volumes:
   - hostPath:
       path: /usr/share/ca-certificates
@@ -114,3 +117,6 @@ spec:
       path: /run/xtables.lock
       type: FileOrCreate
     name: iptableslock
+  - name: lib-modules
+    hostPath:
+      path: /lib/modules


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This change will mount `/lib/modules` on host to the kube-proxy pod,
so that a kube-proxy pod can load kernel modules by need
or when `modprobe <kmod>` is run inside the pod.

This will be convenient for kube-proxy running in IPVS mode.
Users will don't have to run `modprobe ip_vs` on nodes before starting
a kube-proxy pod.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
The kube-proxy IPVS proxier will check if the kernel supports IPVS, or it will fallback to iptables or userspace modes. There is a false negative condition in the check, #51874 addressed that issue.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Load kernel modules automatically inside a kube-proxy pod
```
