### PR TITLE
Support IPVS Flush API

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1076,8 +1076,7 @@
 		},
 		{
 			"ImportPath": "github.com/docker/libnetwork/ipvs",
-			"Comment": "v0.8.0-dev.2-908-gd5c82231",
-			"Rev": "d5c822319097cc01cc9bd5ffedd74c7ce7c894f2"
+			"Rev": "ba46b928444931e6865d8618dc03622cac79aa6f"
 		},
 		{
 			"ImportPath": "github.com/docker/libtrust",

--- a/pkg/util/ipvs/ipvs_linux.go
+++ b/pkg/util/ipvs/ipvs_linux.go
@@ -142,18 +142,7 @@ func (runner *runner) GetVirtualServers() ([]*VirtualServer, error) {
 
 // Flush is part of Interface.  Currently we delete IPVS services one by one
 func (runner *runner) Flush() error {
-	vss, err := runner.GetVirtualServers()
-	if err != nil {
-		return err
-	}
-	for _, vs := range vss {
-		err := runner.DeleteVirtualServer(vs)
-		// TODO: aggregate errors?
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return runner.ipvsHandle.Flush()
 }
 
 // AddRealServer is part of Interface.

--- a/vendor/github.com/docker/libnetwork/ipvs/ipvs.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/ipvs.go
@@ -116,6 +116,13 @@ func (i *Handle) DelService(s *Service) error {
 	return i.doCmd(s, nil, ipvsCmdDelService)
 }
 
+// Flush deletes all existing services in the passed
+// handle.
+func (i *Handle) Flush() error {
+	_, err := i.doCmdWithoutAttr(ipvsCmdFlush)
+	return err
+}
+
 // NewDestination creates a new real server in the passed ipvs
 // service which should already be existing in the passed handle.
 func (i *Handle) NewDestination(s *Service, d *Destination) error {

--- a/vendor/github.com/docker/libnetwork/ipvs/netlink.go
+++ b/vendor/github.com/docker/libnetwork/ipvs/netlink.go
@@ -402,6 +402,13 @@ func (i *Handle) doGetServicesCmd(svc *Service) ([]*Service, error) {
 	return res, nil
 }
 
+// doCmdWithoutAttr a simple wrapper of netlink socket execute command
+func (i *Handle) doCmdWithoutAttr(cmd uint8) ([][]byte, error) {
+	req := newIPVSRequest(cmd)
+	req.Seq = atomic.AddUint32(&i.seq, 1)
+	return execute(i.sock, req, 0)
+}
+
 func assembleDestination(attrs []syscall.NetlinkRouteAttr) (*Destination, error) {
 
 	var d Destination


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Currently, we implement IPVS flush API by deleting IPVS services one by one, which is inefficient.

**Which issue this PR fixes**: 

fixes #52070

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
