### PR TITLE
Bump Cluster Autoscaler to 0.7.0-alpha2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.7.0-alpha2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This is a part of Cluster Autoscaler release process for 1.8.