### PR TITLE
Fix panic in expand controller when checking PVs

### DIFF
--- a/pkg/controller/volume/expand/cache/volume_resize_map.go
+++ b/pkg/controller/volume/expand/cache/volume_resize_map.go
@@ -89,8 +89,8 @@ func NewVolumeResizeMap(kubeClient clientset.Interface) VolumeResizeMap {
 
 // AddPVCUpdate adds pvc for resizing
 func (resizeMap *volumeResizeMap) AddPVCUpdate(pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
-	if pvc.Namespace != pv.Spec.ClaimRef.Namespace || pvc.Name != pv.Spec.ClaimRef.Name {
-		glog.V(4).Infof("Persistent Volume is not mapped to PVC being updated : %s", util.ClaimToClaimKey(pvc))
+	if pv.Spec.ClaimRef == nil || pvc.Namespace != pv.Spec.ClaimRef.Namespace || pvc.Name != pv.Spec.ClaimRef.Name {
+		glog.V(4).Infof("Persistent Volume is not bound to PVC being updated : %s", util.ClaimToClaimKey(pvc))
 		return
 	}
 


### PR DESCRIPTION
Unbound PVs have their Spec.ClaimRef = nil, so we should not dereference it blindly.

In addition, increase AddPVCUpdate test coverage to 100%

fixes #52012 #51995

**Release note**:
```release-note
NONE
```

@kubernetes/sig-storage-pr-reviews 
/assign @gnufied
