### PR TITLE
Fill in creationtimestamp in audit events

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/filters/audit.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"net/http"
 	"sync"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -147,6 +148,7 @@ func processAuditEvent(sink audit.Sink, ev *auditinternal.Event, omitStages []au
 			return
 		}
 	}
+	ev.CreationTimestamp = metav1.NewTime(time.Now())
 	audit.ObserveEvent()
 	sink.ProcessEvents(ev)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is fixing null creationtimestamp in audit events.

@sttts @crassirostris like we've talked earlier today

**Release note**:
```release-note
none
```
