### PR TITLE
Fix secret/configmap failed mount race condition

### DIFF
--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -282,7 +282,10 @@ func (c *cachingConfigMapManager) RegisterPod(pod *v1.Pod) {
 	c.registeredPods[key] = pod
 	if prev != nil {
 		for name := range getConfigMapNames(prev) {
-			c.configMapStore.Delete(prev.Namespace, name)
+			// remove entries which were in prev but are not in names
+			if !names.Has(name) {
+				c.configMapStore.Delete(prev.Namespace, name)
+			}
 		}
 	}
 }

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -282,7 +282,10 @@ func (c *cachingSecretManager) RegisterPod(pod *v1.Pod) {
 	c.registeredPods[key] = pod
 	if prev != nil {
 		for name := range getSecretNames(prev) {
-			c.secretStore.Delete(prev.Namespace, name)
+			// remove secrets which were in prev but are not in names
+			if !names.Has(name) {
+				c.secretStore.Delete(prev.Namespace, name)
+			}
 		}
 	}
 }

--- a/pkg/kubelet/secret/secret_manager_test.go
+++ b/pkg/kubelet/secret/secret_manager_test.go
@@ -465,7 +465,7 @@ func TestCacheRefcounts(t *testing.T) {
 	}
 	assert.True(t, verify("ns1", "s1", 3))
 	assert.True(t, verify("ns1", "s10", 1))
-	assert.True(t, verify("ns1", "s2", 3))
+	assert.True(t, verify("ns1", "s2", 5)) // "s2" is in both s1 and s2
 	assert.True(t, verify("ns1", "s3", 3))
 	assert.True(t, verify("ns1", "s30", 2))
 	assert.True(t, verify("ns1", "s4", 2))


### PR DESCRIPTION
**What this PR does / why we need it**:

Sometimes a configmap or secret volume will fail to be mounted for a pod due to an apparent bug where any pod updates cause the secret or configmap entry to be removed from the manager. If a pod update happens before the volume mounter gets the secret or configmap item, the item will be lost and the volume can never be mounted during the pod's lifetime.

**Which issue this PR fixes**: fixes #52043

**Special notes for your reviewer**:

This change is probably what the original author meant to do (and that's why a string set was used).

**Release note**:

```NONE
```