### PR TITLE
Clean up kublet secret and configmap unit test

### DIFF
--- a/pkg/kubelet/configmap/configmap_manager.go
+++ b/pkg/kubelet/configmap/configmap_manager.go
@@ -282,6 +282,11 @@ func (c *cachingConfigMapManager) RegisterPod(pod *v1.Pod) {
 	c.registeredPods[key] = pod
 	if prev != nil {
 		for name := range getConfigMapNames(prev) {
+			// On an update, the .Add() call above will have re-incremented the
+			// ref count of any existing items, so any configmaps that are in both
+			// names and prev need to have their ref counts decremented. Any that
+			// are only in prev need to be completely removed. This unconditional
+			// call takes care of both cases.
 			c.configMapStore.Delete(prev.Namespace, name)
 		}
 	}

--- a/pkg/kubelet/secret/secret_manager.go
+++ b/pkg/kubelet/secret/secret_manager.go
@@ -282,6 +282,11 @@ func (c *cachingSecretManager) RegisterPod(pod *v1.Pod) {
 	c.registeredPods[key] = pod
 	if prev != nil {
 		for name := range getSecretNames(prev) {
+			// On an update, the .Add() call above will have re-incremented the
+			// ref count of any existing secrets, so any secrets that are in both
+			// names and prev need to have their ref counts decremented. Any that
+			// are only in prev need to be completely removed. This unconditional
+			// call takes care of both cases.
 			c.secretStore.Delete(prev.Namespace, name)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

These changes are clean-up items to fix confusing code encountered while investigating #52043. No actual bugs are fixed here (except, maybe, correcting unit tests that had actual/expected swapped).

A summary of the changes, as listed in the commit:

* Expected value comes before actual value in assert.Equal()
* Use `assert.Equal()` instead of `assert.True()` when possible
* Add a unit test that verifies no-op pod updates to the `secret_manager` and the `configmap_manager`
* Add a clarifying comment about why it's good to seemingly delete a secret on updates.
* Fix (for now, non-buggy) variable shadowing issue

**Special notes for your reviewer**:

N/A

**Release note**:
```release-note
NONE
```