### PR TITLE
move specialDefaultResourcePrefixes out of vendor/k8s.io/apiserver

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -29,6 +29,17 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 )
 
+// specialDefaultResourcePrefixes are prefixes compiled into Kubernetes.
+var specialDefaultResourcePrefixes = map[schema.GroupResource]string{
+	{Group: "", Resource: "replicationControllers"}:        "controllers",
+	{Group: "", Resource: "replicationcontrollers"}:        "controllers",
+	{Group: "", Resource: "endpoints"}:                     "services/endpoints",
+	{Group: "", Resource: "nodes"}:                         "minions",
+	{Group: "", Resource: "services"}:                      "services/specs",
+	{Group: "extensions", Resource: "ingresses"}:           "ingress",
+	{Group: "extensions", Resource: "podsecuritypolicies"}: "podsecuritypolicy",
+}
+
 // NewStorageFactory builds the DefaultStorageFactory.
 // Merges defaultResourceConfig with the user specified overrides and merges
 // defaultAPIResourceConfig with the corresponding user specified overrides as well.
@@ -42,7 +53,7 @@ func NewStorageFactory(storageConfig storagebackend.Config, defaultMediaType str
 	if err != nil {
 		return nil, err
 	}
-	return serverstorage.NewDefaultStorageFactory(storageConfig, defaultMediaType, serializer, resourceEncodingConfig, apiResourceConfig), nil
+	return serverstorage.NewDefaultStorageFactory(storageConfig, defaultMediaType, serializer, resourceEncodingConfig, apiResourceConfig, specialDefaultResourcePrefixes), nil
 }
 
 // Merges the given defaultResourceConfig with specifc GroupvVersionResource overrides.

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -86,7 +86,7 @@ func setUp(t *testing.T) (*etcdtesting.EtcdTestServer, Config, *assert.Assertion
 	resourceEncoding.SetVersionEncoding(extensions.GroupName, *testapi.Extensions.GroupVersion(), schema.GroupVersion{Group: extensions.GroupName, Version: runtime.APIVersionInternal})
 	resourceEncoding.SetVersionEncoding(rbac.GroupName, *testapi.Rbac.GroupVersion(), schema.GroupVersion{Group: rbac.GroupName, Version: runtime.APIVersionInternal})
 	resourceEncoding.SetVersionEncoding(certificates.GroupName, *testapi.Certificates.GroupVersion(), schema.GroupVersion{Group: certificates.GroupName, Version: runtime.APIVersionInternal})
-	storageFactory := serverstorage.NewDefaultStorageFactory(*storageConfig, testapi.StorageMediaType(), api.Codecs, resourceEncoding, DefaultAPIResourceConfigSource())
+	storageFactory := serverstorage.NewDefaultStorageFactory(*storageConfig, testapi.StorageMediaType(), api.Codecs, resourceEncoding, DefaultAPIResourceConfigSource(), nil)
 
 	err := options.NewEtcdOptions(storageConfig).ApplyWithStorageFactoryTo(storageFactory, config.GenericConfig)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory.go
@@ -151,19 +151,7 @@ var _ StorageFactory = &DefaultStorageFactory{}
 
 const AllResources = "*"
 
-// specialDefaultResourcePrefixes are prefixes compiled into Kubernetes.
-// TODO: move out of this package, it is not generic
-var specialDefaultResourcePrefixes = map[schema.GroupResource]string{
-	{Group: "", Resource: "replicationControllers"}:        "controllers",
-	{Group: "", Resource: "replicationcontrollers"}:        "controllers",
-	{Group: "", Resource: "endpoints"}:                     "services/endpoints",
-	{Group: "", Resource: "nodes"}:                         "minions",
-	{Group: "", Resource: "services"}:                      "services/specs",
-	{Group: "extensions", Resource: "ingresses"}:           "ingress",
-	{Group: "extensions", Resource: "podsecuritypolicies"}: "podsecuritypolicy",
-}
-
-func NewDefaultStorageFactory(config storagebackend.Config, defaultMediaType string, defaultSerializer runtime.StorageSerializer, resourceEncodingConfig ResourceEncodingConfig, resourceConfig APIResourceConfigSource) *DefaultStorageFactory {
+func NewDefaultStorageFactory(config storagebackend.Config, defaultMediaType string, defaultSerializer runtime.StorageSerializer, resourceEncodingConfig ResourceEncodingConfig, resourceConfig APIResourceConfigSource, specialDefaultResourcePrefixes map[schema.GroupResource]string) *DefaultStorageFactory {
 	config.Paging = utilfeature.DefaultFeatureGate.Enabled(features.APIListChunking)
 	if len(defaultMediaType) == 0 {
 		defaultMediaType = runtime.ContentTypeJSON

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_factory_test.go
@@ -94,7 +94,7 @@ func (n *fakeNegotiater) DecoderToVersion(serializer runtime.Decoder, gv runtime
 
 func TestConfigurableStorageFactory(t *testing.T) {
 	ns := &fakeNegotiater{types: []string{"test/test"}}
-	f := NewDefaultStorageFactory(storagebackend.Config{}, "test/test", ns, NewDefaultResourceEncodingConfig(registry), NewResourceConfig())
+	f := NewDefaultStorageFactory(storagebackend.Config{}, "test/test", ns, NewDefaultResourceEncodingConfig(registry), NewResourceConfig(), nil)
 	f.AddCohabitatingResources(example.Resource("test"), schema.GroupResource{Resource: "test2", Group: "2"})
 	called := false
 	testEncoderChain := func(e runtime.Encoder) runtime.Encoder {
@@ -147,7 +147,7 @@ func TestUpdateEtcdOverrides(t *testing.T) {
 			ServerList: defaultEtcdLocation,
 			Copier:     scheme,
 		}
-		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(registry), NewResourceConfig())
+		storageFactory := NewDefaultStorageFactory(defaultConfig, "", codecs, NewDefaultResourceEncodingConfig(registry), NewResourceConfig(), nil)
 		storageFactory.SetEtcdLocation(test.resource, test.servers)
 
 		var err error

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -306,7 +306,7 @@ func NewMasterConfig() *master.Config {
 	resourceEncoding.SetVersionEncoding(batch.GroupName, *testapi.Batch.GroupVersion(), schema.GroupVersion{Group: batch.GroupName, Version: runtime.APIVersionInternal})
 	resourceEncoding.SetResourceEncoding(schema.GroupResource{Group: "batch", Resource: "cronjobs"}, schema.GroupVersion{Group: batch.GroupName, Version: "v1beta1"}, schema.GroupVersion{Group: batch.GroupName, Version: runtime.APIVersionInternal})
 
-	storageFactory := serverstorage.NewDefaultStorageFactory(etcdOptions.StorageConfig, runtime.ContentTypeJSON, ns, resourceEncoding, master.DefaultAPIResourceConfigSource())
+	storageFactory := serverstorage.NewDefaultStorageFactory(etcdOptions.StorageConfig, runtime.ContentTypeJSON, ns, resourceEncoding, master.DefaultAPIResourceConfigSource(), nil)
 	storageFactory.SetSerializer(
 		schema.GroupResource{Group: v1.GroupName, Resource: serverstorage.AllResources},
 		"",


### PR DESCRIPTION
just a clean-up, fixes TODO: move out of this package, it is not generic
@sttts PTAL
/assign @sttts 