### PR TITLE
Log a warning when --audit-policy-file not passed to apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/audit.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	"gopkg.in/natefinch/lumberjack.v2"
 
@@ -163,6 +164,10 @@ func (o *AuditOptions) ApplyTo(c *server.Config) error {
 	}
 	if err := o.WebhookOptions.applyTo(c); err != nil {
 		return err
+	}
+
+	if c.AuditBackend != nil && c.AuditPolicyChecker == nil {
+		glog.V(2).Info("No audit policy file provided for AdvancedAuditing, no events will be recorded.")
 	}
 	return nil
 }


### PR DESCRIPTION
When audit backend provided, but --audit-policy-file is not passed, leave a info in log.
**Release note**:
```
Log a warning when --audit-policy-file not passed to apiserver
```
