### PR TITLE
fix bug when specifying empty string as storageClass name

### DIFF
--- a/pkg/api/helper/helpers.go
+++ b/pkg/api/helper/helpers.go
@@ -613,7 +613,7 @@ func PersistentVolumeClaimHasClass(claim *api.PersistentVolumeClaim) bool {
 	}
 
 	if claim.Spec.StorageClassName != nil {
-		return true
+		return len(*claim.Spec.StorageClassName) > 0
 	}
 
 	return false

--- a/pkg/api/v1/helper/helpers.go
+++ b/pkg/api/v1/helper/helpers.go
@@ -435,7 +435,7 @@ func PersistentVolumeClaimHasClass(claim *v1.PersistentVolumeClaim) bool {
 	}
 
 	if claim.Spec.StorageClassName != nil {
-		return true
+		return len(*claim.Spec.StorageClassName) > 0
 	}
 
 	return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
xref #52006

From @xingzhou's test
> This is what I have tried in my local env:

> * kubectl create persistentvolumeclaim abc --storage-class="" --capacity=1Gi --access-mode=RWO, after this command, using kubectl get pvc abc -o yaml, the storageClassName field is set as storageClassName:""

> * kubectl create persistentvolumeclaim abc --capacity=1Gi --access-mode=RWO, after this command, using kubectl get pvc abc -o yaml, the storageClassName field is set as storageClassName:standard, note that it's using the default storage class

> * kubectl create persistentvolumeclaim abc --storage-clas=abc --capacity=1Gi --access-mode=RWO, after this command, using kubectl get pvc abc -o yaml, the storageClassName field is set as storageClassName: abc

*When specifying an empty string as the `storageClass`, it failed to assign default `standard` value.*

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/assign @caesarxuchao @liggitt 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix bug when specifying empty string as storageClass name
```
