### PR TITLE
Fix some comment in hack/jenkins/*-dockerized.sh

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -29,7 +29,7 @@ retry() {
 # Runs the unit and integration tests, producing JUnit-style XML test
 # reports in ${WORKSPACE}/artifacts. This script is intended to be run from
 # kubekins-test container with a kubernetes repo mapped in. See
-# hack/jenkins/gotest-dockerized.sh
+# k8s.io/test-infra/scenarios/kubernetes_verify.py
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 

--- a/hack/jenkins/verify-dockerized.sh
+++ b/hack/jenkins/verify-dockerized.sh
@@ -27,7 +27,7 @@ retry() {
 }
 
 # This script is intended to be run from kubekins-test container with a
-# kubernetes repo mapped in. See hack/jenkins/gotest-dockerized.sh
+# kubernetes repo mapped in. See k8s.io/test-infra/scenarios/kubernetes_verify.py
 
 export PATH=${GOPATH}/bin:${PWD}/third_party/etcd:/usr/local/go/bin:${PATH}
 


### PR DESCRIPTION
hack/jenkins/gotest-dockerized.sh has been deleted,But the comments are not updated,FYI [The PR #1463](https://github.com/kubernetes/test-infra/pull/1463/files#diff-072eac404bdccadbe14552a7d3c012c2)
```release-note
NONE
```
