### PR TITLE
kubeadm: Use the release-1.8 branch by default

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -28,7 +28,7 @@ import (
 const (
 	DefaultServiceDNSDomain   = "cluster.local"
 	DefaultServicesSubnet     = "10.96.0.0/12"
-	DefaultKubernetesVersion  = "stable-1.7"
+	DefaultKubernetesVersion  = "stable-1.8"
 	DefaultAPIBindPort        = 6443
 	DefaultAuthorizationModes = "Node,RBAC"
 	DefaultCACertPath         = "/etc/kubernetes/pki/ca.crt"

--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -38,14 +38,22 @@ func NewCmdCerts() *cobra.Command {
 		RunE:    cmdutil.SubCmdRunE("certs"),
 	}
 
-	cmd.AddCommand(getCertsSubCommands()...)
+	cmd.AddCommand(getCertsSubCommands("")...)
 	return cmd
 }
 
 // getCertsSubCommands returns sub commands for certs phase
-func getCertsSubCommands() []*cobra.Command {
+func getCertsSubCommands(defaultKubernetesVersion string) []*cobra.Command {
 
 	cfg := &kubeadmapiext.MasterConfiguration{}
+
+	// This is used for unit testing only...
+	// If we wouldn't set this to something, the code would dynamically look up the version from the internet
+	// By setting this explicitely for tests workarounds that
+	if defaultKubernetesVersion != "" {
+		cfg.KubernetesVersion = defaultKubernetesVersion
+	}
+
 	// Default values for the cobra help text
 	api.Scheme.Default(cfg)
 

--- a/cmd/kubeadm/app/cmd/phases/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/certs_test.go
@@ -33,9 +33,12 @@ import (
 	cmdtestutil "k8s.io/kubernetes/cmd/kubeadm/test/cmd"
 )
 
+// phaseTestK8sVersion is a fake kubernetes version to use when testing
+const phaseTestK8sVersion = "v1.8.0"
+
 func TestCertsSubCommandsHasFlags(t *testing.T) {
 
-	subCmds := getCertsSubCommands()
+	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	commonFlags := []string{
 		"cert-dir",
@@ -89,7 +92,7 @@ func TestCertsSubCommandsHasFlags(t *testing.T) {
 
 func TestSubCmdCertsCreateFilesWithFlags(t *testing.T) {
 
-	subCmds := getCertsSubCommands()
+	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	var tests = []struct {
 		subCmds       []string
@@ -138,7 +141,7 @@ func TestSubCmdCertsCreateFilesWithFlags(t *testing.T) {
 
 func TestSubCmdCertsApiServerForwardsFlags(t *testing.T) {
 
-	subCmds := getCertsSubCommands()
+	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	// Create temp folder for the test case
 	tmpdir := testutil.SetupTempDir(t)
@@ -180,7 +183,7 @@ func TestSubCmdCertsApiServerForwardsFlags(t *testing.T) {
 
 func TestSubCmdCertsCreateFilesWithConfigFile(t *testing.T) {
 
-	subCmds := getCertsSubCommands()
+	subCmds := getCertsSubCommands(phaseTestK8sVersion)
 
 	var tests = []struct {
 		subCmds       []string

--- a/cmd/kubeadm/app/cmd/phases/controlplane.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane.go
@@ -36,14 +36,22 @@ func NewCmdControlplane() *cobra.Command {
 	}
 
 	manifestPath := kubeadmconstants.GetStaticPodDirectory()
-	cmd.AddCommand(getControlPlaneSubCommands(manifestPath)...)
+	cmd.AddCommand(getControlPlaneSubCommands(manifestPath, "")...)
 	return cmd
 }
 
 // getControlPlaneSubCommands returns sub commands for Controlplane phase
-func getControlPlaneSubCommands(outDir string) []*cobra.Command {
+func getControlPlaneSubCommands(outDir, defaultKubernetesVersion string) []*cobra.Command {
 
 	cfg := &kubeadmapiext.MasterConfiguration{}
+
+	// This is used for unit testing only...
+	// If we wouldn't set this to something, the code would dynamically look up the version from the internet
+	// By setting this explicitely for tests workarounds that
+	if defaultKubernetesVersion != "" {
+		cfg.KubernetesVersion = defaultKubernetesVersion
+	}
+
 	// Default values for the cobra help text
 	api.Scheme.Default(cfg)
 

--- a/cmd/kubeadm/app/cmd/phases/controlplane_test.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestControlPlaneSubCommandsHasFlags(t *testing.T) {
 
-	subCmds := getControlPlaneSubCommands("")
+	subCmds := getControlPlaneSubCommands("", phaseTestK8sVersion)
 
 	commonFlags := []string{
 		"cert-dir",
@@ -137,7 +137,7 @@ func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
 		defer os.RemoveAll(tmpdir)
 
 		// Get subcommands working in the temporary directory
-		subCmds := getControlPlaneSubCommands(tmpdir)
+		subCmds := getControlPlaneSubCommands(tmpdir, phaseTestK8sVersion)
 
 		// Execute the subcommand
 		certDirFlag := fmt.Sprintf("--cert-dir=%s", tmpdir)

--- a/cmd/kubeadm/app/cmd/phases/etcd.go
+++ b/cmd/kubeadm/app/cmd/phases/etcd.go
@@ -36,14 +36,22 @@ func NewCmdEtcd() *cobra.Command {
 	}
 
 	manifestPath := kubeadmconstants.GetStaticPodDirectory()
-	cmd.AddCommand(getEtcdSubCommands(manifestPath)...)
+	cmd.AddCommand(getEtcdSubCommands(manifestPath, "")...)
 	return cmd
 }
 
 // getEtcdSubCommands returns sub commands for etcd phase
-func getEtcdSubCommands(outDir string) []*cobra.Command {
+func getEtcdSubCommands(outDir, defaultKubernetesVersion string) []*cobra.Command {
 
 	cfg := &kubeadmapiext.MasterConfiguration{}
+
+	// This is used for unit testing only...
+	// If we wouldn't set this to something, the code would dynamically look up the version from the internet
+	// By setting this explicitely for tests workarounds that
+	if defaultKubernetesVersion != "" {
+		cfg.KubernetesVersion = defaultKubernetesVersion
+	}
+
 	// Default values for the cobra help text
 	api.Scheme.Default(cfg)
 

--- a/cmd/kubeadm/app/cmd/phases/etcd_test.go
+++ b/cmd/kubeadm/app/cmd/phases/etcd_test.go
@@ -30,7 +30,7 @@ import (
 
 func TestEtcdSubCommandsHasFlags(t *testing.T) {
 
-	subCmds := getEtcdSubCommands("")
+	subCmds := getEtcdSubCommands("", phaseTestK8sVersion)
 
 	commonFlags := []string{
 		"cert-dir",
@@ -73,7 +73,7 @@ func TestEtcdCreateFilesWithFlags(t *testing.T) {
 		defer os.RemoveAll(tmpdir)
 
 		// Get subcommands working in the temporary directory
-		subCmds := getEtcdSubCommands(tmpdir)
+		subCmds := getEtcdSubCommands(tmpdir, phaseTestK8sVersion)
 
 		// Execute the subcommand
 		certDirFlag := fmt.Sprintf("--cert-dir=%s", tmpdir)

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig.go
@@ -38,14 +38,22 @@ func NewCmdKubeConfig(out io.Writer) *cobra.Command {
 		RunE:  cmdutil.SubCmdRunE("kubeconfig"),
 	}
 
-	cmd.AddCommand(getKubeConfigSubCommands(out, kubeadmconstants.KubernetesDir)...)
+	cmd.AddCommand(getKubeConfigSubCommands(out, kubeadmconstants.KubernetesDir, "")...)
 	return cmd
 }
 
 // getKubeConfigSubCommands returns sub commands for kubeconfig phase
-func getKubeConfigSubCommands(out io.Writer, outDir string) []*cobra.Command {
+func getKubeConfigSubCommands(out io.Writer, outDir, defaultKubernetesVersion string) []*cobra.Command {
 
 	cfg := &kubeadmapiext.MasterConfiguration{}
+
+	// This is used for unit testing only...
+	// If we wouldn't set this to something, the code would dynamically look up the version from the internet
+	// By setting this explicitely for tests workarounds that
+	if defaultKubernetesVersion != "" {
+		cfg.KubernetesVersion = defaultKubernetesVersion
+	}
+
 	// Default values for the cobra help text
 	api.Scheme.Default(cfg)
 

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig_test.go
@@ -38,7 +38,7 @@ import (
 
 func TestKubeConfigCSubCommandsHasFlags(t *testing.T) {
 
-	subCmds := getKubeConfigSubCommands(nil, "")
+	subCmds := getKubeConfigSubCommands(nil, "", phaseTestK8sVersion)
 
 	commonFlags := []string{
 		"cert-dir",
@@ -174,7 +174,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithFlags(t *testing.T) {
 		}
 
 		// Get subcommands working in the temporary directory
-		subCmds := getKubeConfigSubCommands(nil, tmpdir)
+		subCmds := getKubeConfigSubCommands(nil, tmpdir, phaseTestK8sVersion)
 
 		// Execute the subcommand
 		certDirFlag := fmt.Sprintf("--cert-dir=%s", pkidir)
@@ -282,7 +282,7 @@ func TestKubeConfigSubCommandsThatCreateFilesWithConfigFile(t *testing.T) {
 		cfgPath := testutil.SetupMasterConfigurationFile(t, tmpdir, cfg)
 
 		// Get subcommands working in the temporary directory
-		subCmds := getKubeConfigSubCommands(nil, tmpdir)
+		subCmds := getKubeConfigSubCommands(nil, tmpdir, phaseTestK8sVersion)
 
 		// Execute the subcommand
 		configFlag := fmt.Sprintf("--config=%s", cfgPath)
@@ -354,7 +354,7 @@ func TestKubeConfigSubCommandsThatWritesToOut(t *testing.T) {
 		buf := new(bytes.Buffer)
 
 		// Get subcommands working in the temporary directory
-		subCmds := getKubeConfigSubCommands(buf, tmpdir)
+		subCmds := getKubeConfigSubCommands(buf, tmpdir, phaseTestK8sVersion)
 
 		// Execute the subcommand
 		allFlags := append(commonFlags, test.additionalFlags...)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In line with https://github.com/kubernetes/kubeadm/blob/master/docs/release-cycle.md, the default branch for kubeadm to deploy should be bumped right before the `rc.1`.
This can even be manually merged by the someone from the release team.

Adding do-not-merge until we're ready for the release candidate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: https://github.com/kubernetes/kubeadm/issues/427

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
kubeadm: Use the release-1.8 branch by default
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/kubernetes-release-managers 