### PR TITLE
enhance kubectl config get clusters command

### DIFF
--- a/pkg/kubectl/cmd/config/get_clusters.go
+++ b/pkg/kubectl/cmd/config/get_clusters.go
@@ -19,13 +19,28 @@ package config
 import (
 	"fmt"
 	"io"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
+	"k8s.io/kubernetes/pkg/printers"
 )
+
+// GetClustersOptions contains the assignable options from the args.
+type GetClustersOptions struct {
+	configAccess clientcmd.ConfigAccess
+	nameOnly     bool
+	showHeaders  bool
+	clusterNames []string
+	out          io.Writer
+}
 
 var (
 	get_clusters_example = templates.Examples(`
@@ -36,30 +51,106 @@ var (
 // NewCmdConfigGetClusters creates a command object for the "get-clusters" action, which
 // lists all clusters defined in the kubeconfig.
 func NewCmdConfigGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
+	options := &GetClustersOptions{configAccess: configAccess}
+
 	cmd := &cobra.Command{
 		Use:     "get-clusters",
 		Short:   i18n.T("Display clusters defined in the kubeconfig"),
 		Long:    "Display clusters defined in the kubeconfig.",
 		Example: get_clusters_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			err := runGetClusters(out, configAccess)
-			cmdutil.CheckErr(err)
+			cmdutil.CheckErr(options.complete(cmd, args, out))
+			cmdutil.CheckErr(options.runGetClusters(configAccess))
 		},
 	}
+	cmd.Flags().StringP("output", "o", "", "Output format. Only support 'name', use other output format will reset to default output format")
+	cmdutil.AddNoHeadersFlags(cmd)
 
 	return cmd
 }
 
-func runGetClusters(out io.Writer, configAccess clientcmd.ConfigAccess) error {
+// complete assigns GetClustersOptions from the args.
+func (o *GetClustersOptions) complete(cmd *cobra.Command, args []string, out io.Writer) error {
+	o.clusterNames = args
+	o.out = out
+	o.nameOnly = false
+	output := cmdutil.GetFlagString(cmd, "output")
+	supportedOutputTypes := sets.NewString("", "name")
+	if !supportedOutputTypes.Has(output) {
+		fmt.Fprintf(out, "--output %v is not available in kubectl config get-contexts; resetting to default output format\n", output)
+		cmd.Flags().Set("output", "")
+	}
+	if output == "name" {
+		o.nameOnly = true
+	}
+	o.showHeaders = true
+	if cmdutil.GetFlagBool(cmd, "no-headers") || o.nameOnly {
+		o.showHeaders = false
+	}
+
+	return nil
+}
+
+func (o GetClustersOptions) runGetClusters(configAccess clientcmd.ConfigAccess) error {
 	config, err := configAccess.GetStartingConfig()
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintf(out, "NAME\n")
-	for name := range config.Clusters {
-		fmt.Fprintf(out, "%s\n", name)
+	out, found := o.out.(*tabwriter.Writer)
+	if !found {
+		out = printers.GetNewTabWriter(o.out)
+		defer out.Flush()
 	}
 
-	return nil
+	allErrs := []error{}
+	toPrint := []string{}
+	if len(o.clusterNames) == 0 {
+		for name := range config.Clusters {
+			toPrint = append(toPrint, name)
+		}
+	} else {
+		for _, name := range o.clusterNames {
+			_, ok := config.Clusters[name]
+			if ok {
+				toPrint = append(toPrint, name)
+			} else {
+				allErrs = append(allErrs, fmt.Errorf("context %v not found", name))
+			}
+		}
+	}
+	if o.showHeaders {
+		err = printClusterHeaders(out, o.nameOnly)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	for _, name := range toPrint {
+		err = printCluster(name, config.Clusters[name], out, o.nameOnly)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrs)
+}
+
+func printClusterHeaders(out io.Writer, nameOnly bool) error {
+	columnNames := []string{"NAME", "SERVER"}
+	if nameOnly {
+		columnNames = columnNames[:1]
+	}
+	_, err := fmt.Fprintf(out, "%s\n", strings.Join(columnNames, "\t"))
+	return err
+}
+
+func printCluster(name string, cluster *clientcmdapi.Cluster, w io.Writer, nameOnly bool) error {
+	if nameOnly {
+		_, err := fmt.Fprintf(w, "%s\n", name)
+		return err
+	}
+
+	_, err := fmt.Fprintf(w, "%s\t%s\n", name, cluster.Server)
+	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
ref #20605
enhance kubectl config get clusters command, 
old just print name, it is really not useful, now add server column. and add two flag.
```
admindeMacBook-Pro-2:kubectl admin$ ./kubectl config get-clusters
NAME         SERVER
minikube     https://192.168.99.100:8443
test-stack   https://192.168.18.110:443
admindeMacBook-Pro-2:kubectl admin$ ./kubectl config get-clusters -o name
test-stack
minikube
```


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
