### PR TITLE
Automated cherry pick of #50647

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -27,7 +27,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google-containers/metadata-proxy:0.1.2
+        image: gcr.io/google-containers/metadata-proxy:0.1.3
         imagePullPolicy: Always
         securityContext:
           privileged: true


### PR DESCRIPTION
Cherry pick of #50647 on release-1.7.

#50647: Bump gce metadata-proxy from 0.1.2 to 0.1.3