### PR TITLE
Allow watch cache to be disabled per type

### DIFF
--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -79,6 +79,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/filters"
+	serveroptions "k8s.io/apiserver/pkg/server/options"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	clientgoinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
@@ -239,8 +240,17 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 
 	// TODO: Move this to generic api server (Need to move the command line flag).
 	if s.Etcd.EnableWatchCache {
-		cachesize.InitializeWatchCacheSizes(s.GenericServerRunOptions.TargetRAMMB)
-		cachesize.SetWatchCacheSizes(s.GenericServerRunOptions.WatchCacheSizes)
+		glog.V(2).Infof("Initializing cache sizes based on %dMB limit", s.GenericServerRunOptions.TargetRAMMB)
+		sizes := cachesize.NewHeuristicWatchCacheSizes(s.GenericServerRunOptions.TargetRAMMB)
+		if userSpecified, err := serveroptions.ParseWatchCacheSizes(s.Etcd.WatchCacheSizes); err == nil {
+			for resource, size := range userSpecified {
+				sizes[resource] = size
+			}
+		}
+		s.Etcd.WatchCacheSizes, err = serveroptions.WriteWatchCacheSizes(sizes)
+		if err != nil {
+			return err
+		}
 	}
 
 	m, err := genericConfig.Complete(versionedInformers).New("federation", genericapiserver.EmptyDelegate)

--- a/federation/registry/cluster/etcd/BUILD
+++ b/federation/registry/cluster/etcd/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//federation/apis/federation:go_default_library",
         "//federation/registry/cluster:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/federation/registry/cluster/etcd/etcd.go
+++ b/federation/registry/cluster/etcd/etcd.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/federation/apis/federation"
 	"k8s.io/kubernetes/federation/registry/cluster"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 type REST struct {
@@ -53,7 +52,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &federation.ClusterList{} },
 		PredicateFunc:            cluster.MatchCluster,
 		DefaultQualifiedResource: federation.Resource("clusters"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusters"),
 
 		CreateStrategy:      cluster.Strategy,
 		UpdateStrategy:      cluster.Strategy,

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -324,7 +324,6 @@ pkg/registry/batch/cronjob/storage
 pkg/registry/batch/job
 pkg/registry/batch/job/storage
 pkg/registry/batch/rest
-pkg/registry/cachesize
 pkg/registry/certificates/certificates
 pkg/registry/certificates/certificates/storage
 pkg/registry/certificates/rest

--- a/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/BUILD
+++ b/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/apis/admissionregistration:go_default_library",
         "//pkg/registry/admissionregistration/externaladmissionhookconfiguration:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",

--- a/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	"k8s.io/kubernetes/pkg/registry/admissionregistration/externaladmissionhookconfiguration"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // rest implements a RESTStorage for pod disruption budgets against etcd
@@ -41,7 +40,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 			return obj.(*admissionregistration.ExternalAdmissionHookConfiguration).Name, nil
 		},
 		DefaultQualifiedResource: admissionregistration.Resource("externaladmissionhookconfigurations"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("externaladmissionhookconfigurations"),
 
 		CreateStrategy: externaladmissionhookconfiguration.Strategy,
 		UpdateStrategy: externaladmissionhookconfiguration.Strategy,

--- a/pkg/registry/admissionregistration/initializerconfiguration/storage/BUILD
+++ b/pkg/registry/admissionregistration/initializerconfiguration/storage/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/apis/admissionregistration:go_default_library",
         "//pkg/registry/admissionregistration/initializerconfiguration:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",

--- a/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
+++ b/pkg/registry/admissionregistration/initializerconfiguration/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/admissionregistration"
 	"k8s.io/kubernetes/pkg/registry/admissionregistration/initializerconfiguration"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // rest implements a RESTStorage for pod disruption budgets against etcd
@@ -41,7 +40,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 			return obj.(*admissionregistration.InitializerConfiguration).Name, nil
 		},
 		DefaultQualifiedResource: admissionregistration.Resource("initializerconfigurations"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("initializerconfigurations"),
 
 		CreateStrategy: initializerconfiguration.Strategy,
 		UpdateStrategy: initializerconfiguration.Strategy,

--- a/pkg/registry/apps/controllerrevision/storage/BUILD
+++ b/pkg/registry/apps/controllerrevision/storage/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/registry/apps/controllerrevision:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",

--- a/pkg/registry/apps/controllerrevision/storage/storage.go
+++ b/pkg/registry/apps/controllerrevision/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/registry/apps/controllerrevision"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // REST implements a RESTStorage for ControllerRevision
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &apps.ControllerRevision{} },
 		NewListFunc:              func() runtime.Object { return &apps.ControllerRevisionList{} },
 		DefaultQualifiedResource: apps.Resource("controllerrevisions"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("controllerrevisions"),
 
 		CreateStrategy: controllerrevision.Strategy,
 		UpdateStrategy: controllerrevision.Strategy,

--- a/pkg/registry/apps/statefulset/storage/BUILD
+++ b/pkg/registry/apps/statefulset/storage/BUILD
@@ -40,7 +40,6 @@ go_library(
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
         "//pkg/registry/apps/statefulset:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -35,7 +35,6 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/apps/statefulset"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // StatefulSetStorage includes dummy storage for StatefulSets, and their Status and Scale subresource.
@@ -68,7 +67,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &apps.StatefulSet{} },
 		NewListFunc:              func() runtime.Object { return &apps.StatefulSetList{} },
 		DefaultQualifiedResource: apps.Resource("statefulsets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("statefulsets"),
 
 		CreateStrategy: statefulset.Strategy,
 		UpdateStrategy: statefulset.Strategy,

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/registry/autoscaling/horizontalpodautoscaler:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	"k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 type REST struct {
@@ -40,7 +39,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &autoscaling.HorizontalPodAutoscaler{} },
 		NewListFunc:              func() runtime.Object { return &autoscaling.HorizontalPodAutoscalerList{} },
 		DefaultQualifiedResource: autoscaling.Resource("horizontalpodautoscalers"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("horizontalpodautoscalers"),
 
 		CreateStrategy: horizontalpodautoscaler.Strategy,
 		UpdateStrategy: horizontalpodautoscaler.Strategy,

--- a/pkg/registry/batch/cronjob/storage/BUILD
+++ b/pkg/registry/batch/cronjob/storage/BUILD
@@ -35,7 +35,6 @@ go_library(
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
         "//pkg/registry/batch/cronjob:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/pkg/registry/batch/cronjob/storage/storage.go
+++ b/pkg/registry/batch/cronjob/storage/storage.go
@@ -29,7 +29,6 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/batch/cronjob"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // REST implements a RESTStorage for scheduled jobs against etcd
@@ -44,7 +43,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &batch.CronJob{} },
 		NewListFunc:              func() runtime.Object { return &batch.CronJobList{} },
 		DefaultQualifiedResource: batch.Resource("cronjobs"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("cronjobs"),
 
 		CreateStrategy: cronjob.Strategy,
 		UpdateStrategy: cronjob.Strategy,

--- a/pkg/registry/batch/job/storage/BUILD
+++ b/pkg/registry/batch/job/storage/BUILD
@@ -33,7 +33,6 @@ go_library(
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
         "//pkg/registry/batch/job:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/pkg/registry/batch/job/storage/storage.go
+++ b/pkg/registry/batch/job/storage/storage.go
@@ -29,7 +29,6 @@ import (
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/batch/job"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 )
 
 // JobStorage includes dummy storage for Job.
@@ -60,7 +59,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &batch.JobList{} },
 		PredicateFunc:            job.MatchJob,
 		DefaultQualifiedResource: batch.Resource("jobs"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("jobs"),
 
 		CreateStrategy: job.Strategy,
 		UpdateStrategy: job.Strategy,

--- a/pkg/registry/cachesize/BUILD
+++ b/pkg/registry/cachesize/BUILD
@@ -8,7 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = ["cachesize.go"],
-    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+    deps = ["//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library"],
 )
 
 filegroup(

--- a/pkg/registry/cachesize/cachesize.go
+++ b/pkg/registry/cachesize/cachesize.go
@@ -14,66 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-//use for --watch-cache-sizes param of kube-apiserver
-//make watch cache size of resources configurable
 package cachesize
 
 import (
-	"strconv"
-	"strings"
-
-	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type Resource string
-
-const (
-	APIServices                Resource = "apiservices"
-	CertificateSigningRequests Resource = "certificatesigningrequests"
-	ClusterRoles               Resource = "clusterroles"
-	ClusterRoleBindings        Resource = "clusterrolebindings"
-	ConfigMaps                 Resource = "configmaps"
-	Controllers                Resource = "controllers"
-	Daemonsets                 Resource = "daemonsets"
-	Deployments                Resource = "deployments"
-	Endpoints                  Resource = "endpoints"
-	HorizontalPodAutoscalers   Resource = "horizontalpodautoscalers"
-	Ingress                    Resource = "ingress"
-	PodDisruptionBudget        Resource = "poddisruptionbudgets"
-	StatefulSet                Resource = "statefulset"
-	Jobs                       Resource = "jobs"
-	LimitRanges                Resource = "limitranges"
-	Namespaces                 Resource = "namespaces"
-	NetworkPolicys             Resource = "networkpolicies"
-	Nodes                      Resource = "nodes"
-	PersistentVolumes          Resource = "persistentvolumes"
-	PersistentVolumeClaims     Resource = "persistentvolumeclaims"
-	Pods                       Resource = "pods"
-	PodSecurityPolicies        Resource = "podsecuritypolicies"
-	PodTemplates               Resource = "podtemplates"
-	PriorityClasses            Resource = "priorityclasses"
-	Replicasets                Resource = "replicasets"
-	ResourceQuotas             Resource = "resourcequotas"
-	CronJobs                   Resource = "cronjobs"
-	Roles                      Resource = "roles"
-	RoleBindings               Resource = "rolebindings"
-	Secrets                    Resource = "secrets"
-	ServiceAccounts            Resource = "serviceaccounts"
-	Services                   Resource = "services"
-	StorageClasses             Resource = "storageclasses"
-)
-
-// TODO: This shouldn't be a global variable.
-var watchCacheSizes map[Resource]int
-
-func init() {
-	watchCacheSizes = make(map[Resource]int)
-}
-
-func InitializeWatchCacheSizes(expectedRAMCapacityMB int) {
-	// This is the heuristics that from memory capacity is trying to infer
-	// the maximum number of nodes in the cluster and set cache sizes based
-	// on that value.
+// NewHeuristicWatchCacheSizes returns a map of suggested watch cache sizes based on total
+// memory.
+func NewHeuristicWatchCacheSizes(expectedRAMCapacityMB int) map[schema.GroupResource]int {
 	// From our documentation, we officially recommend 120GB machines for
 	// 2000 nodes, and we scale from that point. Thus we assume ~60MB of
 	// capacity per node.
@@ -84,43 +33,14 @@ func InitializeWatchCacheSizes(expectedRAMCapacityMB int) {
 	// is supposed to have non-default value.
 	//
 	// TODO: Figure out which resource we should have non-default value.
-	watchCacheSizes[Controllers] = maxInt(5*clusterSize, 100)
-	watchCacheSizes[Endpoints] = maxInt(10*clusterSize, 1000)
-	watchCacheSizes[Nodes] = maxInt(5*clusterSize, 1000)
-	watchCacheSizes[Pods] = maxInt(50*clusterSize, 1000)
-	watchCacheSizes[Services] = maxInt(5*clusterSize, 1000)
-	watchCacheSizes[APIServices] = maxInt(5*clusterSize, 1000)
-}
-
-func SetWatchCacheSizes(cacheSizes []string) {
-	for _, c := range cacheSizes {
-		tokens := strings.Split(c, "#")
-		if len(tokens) != 2 {
-			glog.Errorf("invalid value of watch cache capabilities: %s", c)
-			continue
-		}
-
-		size, err := strconv.Atoi(tokens[1])
-		if err != nil {
-			glog.Errorf("invalid size of watch cache capabilities: %s", c)
-			continue
-		}
-		if size < 0 {
-			glog.Errorf("watch cache size cannot be negative: %s", c)
-			continue
-		}
-
-		watchCacheSizes[Resource(strings.ToLower(tokens[0]))] = size
-	}
-}
-
-// GetWatchCacheSizeByResource returns the configured watch cache size for the given resource.
-// A nil value means to use a default size, zero means to disable caching.
-func GetWatchCacheSizeByResource(resource string) (ret *int) { // TODO this should use schema.GroupResource for lookups
-	if value, found := watchCacheSizes[Resource(resource)]; found {
-		return &value
-	}
-	return nil
+	watchCacheSizes := make(map[schema.GroupResource]int)
+	watchCacheSizes[schema.GroupResource{Resource: "replicationcontrollers"}] = maxInt(5*clusterSize, 100)
+	watchCacheSizes[schema.GroupResource{Resource: "endpoints"}] = maxInt(10*clusterSize, 1000)
+	watchCacheSizes[schema.GroupResource{Resource: "nodes"}] = maxInt(5*clusterSize, 1000)
+	watchCacheSizes[schema.GroupResource{Resource: "pods"}] = maxInt(50*clusterSize, 1000)
+	watchCacheSizes[schema.GroupResource{Resource: "services"}] = maxInt(5*clusterSize, 1000)
+	watchCacheSizes[schema.GroupResource{Resource: "apiservices", Group: "apiregistration.k8s.io"}] = maxInt(5*clusterSize, 1000)
+	return watchCacheSizes
 }
 
 func maxInt(a, b int) int {

--- a/pkg/registry/certificates/certificates/storage/BUILD
+++ b/pkg/registry/certificates/certificates/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/certificates:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/certificates/certificates:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",

--- a/pkg/registry/certificates/certificates/storage/storage.go
+++ b/pkg/registry/certificates/certificates/storage/storage.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/certificates"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	csrregistry "k8s.io/kubernetes/pkg/registry/certificates/certificates"
 )
 
@@ -40,7 +39,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Approva
 		NewFunc:                  func() runtime.Object { return &certificates.CertificateSigningRequest{} },
 		NewListFunc:              func() runtime.Object { return &certificates.CertificateSigningRequestList{} },
 		DefaultQualifiedResource: certificates.Resource("certificatesigningrequests"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("certificatesigningrequests"),
 
 		CreateStrategy: csrregistry.Strategy,
 		UpdateStrategy: csrregistry.Strategy,

--- a/pkg/registry/core/configmap/storage/BUILD
+++ b/pkg/registry/core/configmap/storage/BUILD
@@ -27,7 +27,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/configmap:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/configmap/storage/storage.go
+++ b/pkg/registry/core/configmap/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/configmap"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &api.ConfigMap{} },
 		NewListFunc:              func() runtime.Object { return &api.ConfigMapList{} },
 		DefaultQualifiedResource: api.Resource("configmaps"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("configmaps"),
 
 		CreateStrategy: configmap.Strategy,
 		UpdateStrategy: configmap.Strategy,

--- a/pkg/registry/core/endpoint/storage/BUILD
+++ b/pkg/registry/core/endpoint/storage/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/endpoint:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/endpoint/storage/storage.go
+++ b/pkg/registry/core/endpoint/storage/storage.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/endpoint"
 )
 
@@ -40,7 +39,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &api.Endpoints{} },
 		NewListFunc:              func() runtime.Object { return &api.EndpointsList{} },
 		DefaultQualifiedResource: api.Resource("endpoints"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("endpoints"),
 
 		CreateStrategy: endpoint.Strategy,
 		UpdateStrategy: endpoint.Strategy,

--- a/pkg/registry/core/event/storage/BUILD
+++ b/pkg/registry/core/event/storage/BUILD
@@ -25,7 +25,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/event:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/event/storage/storage.go
+++ b/pkg/registry/core/event/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/event"
 )
 
@@ -51,7 +50,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter, ttl uint64) *REST {
 			return ttl, nil
 		},
 		DefaultQualifiedResource: resource,
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource(resource.Resource),
 
 		CreateStrategy: event.Strategy,
 		UpdateStrategy: event.Strategy,

--- a/pkg/registry/core/limitrange/storage/BUILD
+++ b/pkg/registry/core/limitrange/storage/BUILD
@@ -28,7 +28,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/limitrange:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/limitrange/storage/storage.go
+++ b/pkg/registry/core/limitrange/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/limitrange"
 )
 
@@ -37,7 +36,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &api.LimitRange{} },
 		NewListFunc:              func() runtime.Object { return &api.LimitRangeList{} },
 		DefaultQualifiedResource: api.Resource("limitranges"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("limitranges"),
 
 		CreateStrategy: limitrange.Strategy,
 		UpdateStrategy: limitrange.Strategy,

--- a/pkg/registry/core/namespace/storage/BUILD
+++ b/pkg/registry/core/namespace/storage/BUILD
@@ -27,7 +27,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/namespace:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apiserver/pkg/storage"
 	storageerr "k8s.io/apiserver/pkg/storage/errors"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/namespace"
 )
 
@@ -59,7 +58,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 		NewListFunc:              func() runtime.Object { return &api.NamespaceList{} },
 		PredicateFunc:            namespace.MatchNamespace,
 		DefaultQualifiedResource: api.Resource("namespaces"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("namespaces"),
 
 		CreateStrategy:      namespace.Strategy,
 		UpdateStrategy:      namespace.Strategy,

--- a/pkg/registry/core/node/storage/BUILD
+++ b/pkg/registry/core/node/storage/BUILD
@@ -34,7 +34,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/node:go_default_library",
         "//pkg/registry/core/node/rest:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/registry/core/node/storage/storage.go
+++ b/pkg/registry/core/node/storage/storage.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/node"
 	noderest "k8s.io/kubernetes/pkg/registry/core/node/rest"
 )
@@ -81,7 +80,6 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, kubeletClientConfig client
 		NewListFunc:              func() runtime.Object { return &api.NodeList{} },
 		PredicateFunc:            node.MatchNode,
 		DefaultQualifiedResource: api.Resource("nodes"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("nodes"),
 
 		CreateStrategy: node.Strategy,
 		UpdateStrategy: node.Strategy,

--- a/pkg/registry/core/persistentvolume/storage/BUILD
+++ b/pkg/registry/core/persistentvolume/storage/BUILD
@@ -32,7 +32,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/persistentvolume:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/core/persistentvolume/storage/storage.go
+++ b/pkg/registry/core/persistentvolume/storage/storage.go
@@ -24,7 +24,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolume"
 )
 
@@ -40,7 +39,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeList{} },
 		PredicateFunc:            persistentvolume.MatchPersistentVolumes,
 		DefaultQualifiedResource: api.Resource("persistentvolumes"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumes"),
 
 		CreateStrategy:      persistentvolume.Strategy,
 		UpdateStrategy:      persistentvolume.Strategy,

--- a/pkg/registry/core/persistentvolumeclaim/storage/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/storage/BUILD
@@ -32,7 +32,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/persistentvolumeclaim:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage.go
@@ -24,7 +24,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim"
 )
 
@@ -40,7 +39,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &api.PersistentVolumeClaimList{} },
 		PredicateFunc:            persistentvolumeclaim.MatchPersistentVolumeClaim,
 		DefaultQualifiedResource: api.Resource("persistentvolumeclaims"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("persistentvolumeclaims"),
 
 		CreateStrategy:      persistentvolumeclaim.Strategy,
 		UpdateStrategy:      persistentvolumeclaim.Strategy,

--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -52,7 +52,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/pod:go_default_library",
         "//pkg/registry/core/pod/rest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/registry/core/pod/storage/storage.go
+++ b/pkg/registry/core/pod/storage/storage.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/pod"
 	podrest "k8s.io/kubernetes/pkg/registry/core/pod/rest"
 )
@@ -71,7 +70,6 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, k client.ConnectionInfoGet
 		NewListFunc:              func() runtime.Object { return &api.PodList{} },
 		PredicateFunc:            pod.MatchPod,
 		DefaultQualifiedResource: api.Resource("pods"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("pods"),
 
 		CreateStrategy:      pod.Strategy,
 		UpdateStrategy:      pod.Strategy,

--- a/pkg/registry/core/podtemplate/storage/BUILD
+++ b/pkg/registry/core/podtemplate/storage/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/podtemplate:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/podtemplate/storage/storage.go
+++ b/pkg/registry/core/podtemplate/storage/storage.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/podtemplate"
 )
 
@@ -39,7 +38,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &api.PodTemplate{} },
 		NewListFunc:              func() runtime.Object { return &api.PodTemplateList{} },
 		DefaultQualifiedResource: api.Resource("podtemplates"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podtemplates"),
 
 		CreateStrategy: podtemplate.Strategy,
 		UpdateStrategy: podtemplate.Strategy,

--- a/pkg/registry/core/replicationcontroller/storage/BUILD
+++ b/pkg/registry/core/replicationcontroller/storage/BUILD
@@ -38,7 +38,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/replicationcontroller:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/replicationcontroller/storage/storage.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/replicationcontroller"
 )
 
@@ -70,7 +69,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &api.ReplicationControllerList{} },
 		PredicateFunc:            replicationcontroller.MatchController,
 		DefaultQualifiedResource: api.Resource("replicationcontrollers"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicationcontrollers"),
 
 		CreateStrategy: replicationcontroller.Strategy,
 		UpdateStrategy: replicationcontroller.Strategy,

--- a/pkg/registry/core/resourcequota/storage/BUILD
+++ b/pkg/registry/core/resourcequota/storage/BUILD
@@ -31,7 +31,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/resourcequota:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/core/resourcequota/storage/storage.go
+++ b/pkg/registry/core/resourcequota/storage/storage.go
@@ -24,7 +24,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/resourcequota"
 )
 
@@ -39,7 +38,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &api.ResourceQuota{} },
 		NewListFunc:              func() runtime.Object { return &api.ResourceQuotaList{} },
 		DefaultQualifiedResource: api.Resource("resourcequotas"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("resourcequotas"),
 
 		CreateStrategy:      resourcequota.Strategy,
 		UpdateStrategy:      resourcequota.Strategy,

--- a/pkg/registry/core/secret/storage/BUILD
+++ b/pkg/registry/core/secret/storage/BUILD
@@ -27,7 +27,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/secret:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/secret/storage/storage.go
+++ b/pkg/registry/core/secret/storage/storage.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/secret"
 )
 
@@ -37,7 +36,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewListFunc:              func() runtime.Object { return &api.SecretList{} },
 		PredicateFunc:            secret.Matcher,
 		DefaultQualifiedResource: api.Resource("secrets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("secrets"),
 
 		CreateStrategy: secret.Strategy,
 		UpdateStrategy: secret.Strategy,

--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/service:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/core/service/storage/storage.go
+++ b/pkg/registry/core/service/storage/storage.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/service"
 )
 
@@ -42,7 +41,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &api.Service{} },
 		NewListFunc:              func() runtime.Object { return &api.ServiceList{} },
 		DefaultQualifiedResource: api.Resource("services"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("services"),
 
 		CreateStrategy: service.Strategy,
 		UpdateStrategy: service.Strategy,

--- a/pkg/registry/core/serviceaccount/storage/BUILD
+++ b/pkg/registry/core/serviceaccount/storage/BUILD
@@ -27,7 +27,6 @@ go_library(
     srcs = ["storage.go"],
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/core/serviceaccount:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/core/serviceaccount/storage/storage.go
+++ b/pkg/registry/core/serviceaccount/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/core/serviceaccount"
 )
 
@@ -37,7 +36,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &api.ServiceAccount{} },
 		NewListFunc:              func() runtime.Object { return &api.ServiceAccountList{} },
 		DefaultQualifiedResource: api.Resource("serviceaccounts"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("serviceaccounts"),
 
 		CreateStrategy:      serviceaccount.Strategy,
 		UpdateStrategy:      serviceaccount.Strategy,

--- a/pkg/registry/extensions/daemonset/storage/BUILD
+++ b/pkg/registry/extensions/daemonset/storage/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/extensions/daemonset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/extensions/daemonset/storage/storage.go
+++ b/pkg/registry/extensions/daemonset/storage/storage.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/extensions/daemonset"
 )
 
@@ -44,7 +43,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &extensions.DaemonSet{} },
 		NewListFunc:              func() runtime.Object { return &extensions.DaemonSetList{} },
 		DefaultQualifiedResource: extensions.Resource("daemonsets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("daemonsets"),
 
 		CreateStrategy: daemonset.Strategy,
 		UpdateStrategy: daemonset.Strategy,

--- a/pkg/registry/extensions/deployment/storage/BUILD
+++ b/pkg/registry/extensions/deployment/storage/BUILD
@@ -37,7 +37,6 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/validation:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/extensions/deployment:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/extensions/deployment/storage/storage.go
+++ b/pkg/registry/extensions/deployment/storage/storage.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	extvalidation "k8s.io/kubernetes/pkg/apis/extensions/validation"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/extensions/deployment"
 )
 
@@ -68,7 +67,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Rollbac
 		NewFunc:                  func() runtime.Object { return &extensions.Deployment{} },
 		NewListFunc:              func() runtime.Object { return &extensions.DeploymentList{} },
 		DefaultQualifiedResource: extensions.Resource("deployments"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("deployments"),
 
 		CreateStrategy: deployment.Strategy,
 		UpdateStrategy: deployment.Strategy,

--- a/pkg/registry/extensions/ingress/storage/BUILD
+++ b/pkg/registry/extensions/ingress/storage/BUILD
@@ -33,7 +33,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/extensions/ingress:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/extensions/ingress/storage/storage.go
+++ b/pkg/registry/extensions/ingress/storage/storage.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/extensions/ingress"
 )
 
@@ -44,7 +43,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &extensions.Ingress{} },
 		NewListFunc:              func() runtime.Object { return &extensions.IngressList{} },
 		DefaultQualifiedResource: extensions.Resource("ingresses"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("ingresses"),
 
 		CreateStrategy: ingress.Strategy,
 		UpdateStrategy: ingress.Strategy,

--- a/pkg/registry/extensions/podsecuritypolicy/storage/BUILD
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/BUILD
@@ -29,7 +29,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/extensions:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/extensions/podsecuritypolicy:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &extensions.PodSecurityPolicy{} },
 		NewListFunc:              func() runtime.Object { return &extensions.PodSecurityPolicyList{} },
 		DefaultQualifiedResource: extensions.Resource("podsecuritypolicies"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podsecuritypolicies"),
 
 		CreateStrategy:      podsecuritypolicy.Strategy,
 		UpdateStrategy:      podsecuritypolicy.Strategy,

--- a/pkg/registry/extensions/replicaset/storage/BUILD
+++ b/pkg/registry/extensions/replicaset/storage/BUILD
@@ -38,7 +38,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/extensions/replicaset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/extensions/replicaset/storage/storage.go
+++ b/pkg/registry/extensions/replicaset/storage/storage.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/extensions/replicaset"
 )
 
@@ -69,7 +68,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &extensions.ReplicaSetList{} },
 		PredicateFunc:            replicaset.MatchReplicaSet,
 		DefaultQualifiedResource: extensions.Resource("replicasets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("replicasets"),
 
 		CreateStrategy: replicaset.Strategy,
 		UpdateStrategy: replicaset.Strategy,

--- a/pkg/registry/networking/networkpolicy/storage/BUILD
+++ b/pkg/registry/networking/networkpolicy/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/networking:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/networking/networkpolicy:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/networking/networkpolicy/storage/storage.go
+++ b/pkg/registry/networking/networkpolicy/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	networkingapi "k8s.io/kubernetes/pkg/apis/networking"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/networking/networkpolicy"
 )
 
@@ -39,7 +38,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &networkingapi.NetworkPolicy{} },
 		NewListFunc:              func() runtime.Object { return &networkingapi.NetworkPolicyList{} },
 		DefaultQualifiedResource: networkingapi.Resource("networkpolicies"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("networkpolicies"),
 
 		CreateStrategy: networkpolicy.Strategy,
 		UpdateStrategy: networkpolicy.Strategy,

--- a/pkg/registry/policy/poddisruptionbudget/storage/BUILD
+++ b/pkg/registry/policy/poddisruptionbudget/storage/BUILD
@@ -34,7 +34,6 @@ go_library(
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",
         "//pkg/printers/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/policy/poddisruptionbudget:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget"
 )
 
@@ -44,7 +43,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewFunc:                  func() runtime.Object { return &policyapi.PodDisruptionBudget{} },
 		NewListFunc:              func() runtime.Object { return &policyapi.PodDisruptionBudgetList{} },
 		DefaultQualifiedResource: policyapi.Resource("poddisruptionbudgets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("poddisruptionbudgets"),
 
 		CreateStrategy: poddisruptionbudget.Strategy,
 		UpdateStrategy: poddisruptionbudget.Strategy,

--- a/pkg/registry/rbac/clusterrole/storage/BUILD
+++ b/pkg/registry/rbac/clusterrole/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/rbac/clusterrole:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/rbac/clusterrole"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &rbac.ClusterRole{} },
 		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleList{} },
 		DefaultQualifiedResource: rbac.Resource("clusterroles"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterroles"),
 
 		CreateStrategy: clusterrole.Strategy,
 		UpdateStrategy: clusterrole.Strategy,

--- a/pkg/registry/rbac/clusterrolebinding/storage/BUILD
+++ b/pkg/registry/rbac/clusterrolebinding/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/rbac/clusterrolebinding:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/clusterrolebinding/storage/storage.go
+++ b/pkg/registry/rbac/clusterrolebinding/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/rbac/clusterrolebinding"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &rbac.ClusterRoleBinding{} },
 		NewListFunc:              func() runtime.Object { return &rbac.ClusterRoleBindingList{} },
 		DefaultQualifiedResource: rbac.Resource("clusterrolebindings"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("clusterrolebindings"),
 
 		CreateStrategy: clusterrolebinding.Strategy,
 		UpdateStrategy: clusterrolebinding.Strategy,

--- a/pkg/registry/rbac/role/storage/BUILD
+++ b/pkg/registry/rbac/role/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/rbac/role:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/role/storage/storage.go
+++ b/pkg/registry/rbac/role/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/rbac/role"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &rbac.Role{} },
 		NewListFunc:              func() runtime.Object { return &rbac.RoleList{} },
 		DefaultQualifiedResource: rbac.Resource("roles"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("roles"),
 
 		CreateStrategy: role.Strategy,
 		UpdateStrategy: role.Strategy,

--- a/pkg/registry/rbac/rolebinding/storage/BUILD
+++ b/pkg/registry/rbac/rolebinding/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/rbac:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/rbac/rolebinding:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/rolebinding/storage/storage.go
+++ b/pkg/registry/rbac/rolebinding/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/apis/rbac"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/rbac/rolebinding"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &rbac.RoleBinding{} },
 		NewListFunc:              func() runtime.Object { return &rbac.RoleBindingList{} },
 		DefaultQualifiedResource: rbac.Resource("rolebindings"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("rolebindings"),
 
 		CreateStrategy: rolebinding.Strategy,
 		UpdateStrategy: rolebinding.Strategy,

--- a/pkg/registry/registrytest/validate.go
+++ b/pkg/registry/registrytest/validate.go
@@ -18,6 +18,7 @@ package registrytest
 
 import (
 	"fmt"
+
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/util/slice"

--- a/pkg/registry/scheduling/priorityclass/storage/BUILD
+++ b/pkg/registry/scheduling/priorityclass/storage/BUILD
@@ -28,7 +28,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/scheduling:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/scheduling/priorityclass:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/scheduling/priorityclass/storage/storage.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	schedulingapi "k8s.io/kubernetes/pkg/apis/scheduling"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/scheduling/priorityclass"
 )
 
@@ -39,7 +38,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &schedulingapi.PriorityClass{} },
 		NewListFunc:              func() runtime.Object { return &schedulingapi.PriorityClassList{} },
 		DefaultQualifiedResource: schedulingapi.Resource("priorityclasses"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("priorityclasses"),
 
 		CreateStrategy: priorityclass.Strategy,
 		UpdateStrategy: priorityclass.Strategy,

--- a/pkg/registry/settings/podpreset/storage/BUILD
+++ b/pkg/registry/settings/podpreset/storage/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/settings:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/settings/podpreset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/settings/podpreset/storage/storage.go
+++ b/pkg/registry/settings/podpreset/storage/storage.go
@@ -22,7 +22,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/api"
 	settingsapi "k8s.io/kubernetes/pkg/apis/settings"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/settings/podpreset"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &settingsapi.PodPreset{} },
 		NewListFunc:              func() runtime.Object { return &settingsapi.PodPresetList{} },
 		DefaultQualifiedResource: settingsapi.Resource("podpresets"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("podpresets"),
 
 		CreateStrategy: podpreset.Strategy,
 		UpdateStrategy: podpreset.Strategy,

--- a/pkg/registry/storage/storageclass/storage/BUILD
+++ b/pkg/registry/storage/storageclass/storage/BUILD
@@ -29,7 +29,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/storage:go_default_library",
-        "//pkg/registry/cachesize:go_default_library",
         "//pkg/registry/storage/storageclass:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/storage/storageclass/storage/storage.go
+++ b/pkg/registry/storage/storageclass/storage/storage.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/kubernetes/pkg/api"
 	storageapi "k8s.io/kubernetes/pkg/apis/storage"
-	"k8s.io/kubernetes/pkg/registry/cachesize"
 	"k8s.io/kubernetes/pkg/registry/storage/storageclass"
 )
 
@@ -38,7 +37,6 @@ func NewREST(optsGetter generic.RESTOptionsGetter) *REST {
 		NewFunc:                  func() runtime.Object { return &storageapi.StorageClass{} },
 		NewListFunc:              func() runtime.Object { return &storageapi.StorageClassList{} },
 		DefaultQualifiedResource: storageapi.Resource("storageclasses"),
-		WatchCacheSize:           cachesize.GetWatchCacheSizeByResource("storageclass"),
 
 		CreateStrategy:      storageclass.Strategy,
 		UpdateStrategy:      storageclass.Strategy,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -175,10 +175,6 @@ type Store struct {
 	Storage storage.Interface
 	// Called to cleanup clients used by the underlying Storage; optional.
 	DestroyFunc func()
-	// Maximum size of the watch history cached in memory, in number of entries.
-	// This value is ignored if Storage is non-nil. Nil is replaced with a default value.
-	// A zero integer will disable caching.
-	WatchCacheSize *int
 }
 
 // Note: the rest.StandardStorage interface aggregates the common REST verbs
@@ -1337,7 +1333,6 @@ func (e *Store) CompleteWithOptions(options *generic.StoreOptions) error {
 		e.Storage, e.DestroyFunc = opts.Decorator(
 			e.Copier,
 			opts.StorageConfig,
-			e.WatchCacheSize,
 			e.NewFunc(),
 			prefix,
 			keyFunc,

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/storage_decorator.go
@@ -26,11 +26,9 @@ import (
 
 // StorageDecorator is a function signature for producing a storage.Interface
 // and an associated DestroyFunc from given parameters.
-// A zero capacity means to disable caching, nil means to use a default.
 type StorageDecorator func(
 	copier runtime.ObjectCopier,
 	config *storagebackend.Config,
-	capacity *int,
 	objectType runtime.Object,
 	resourcePrefix string,
 	keyFunc func(obj runtime.Object) (string, error),
@@ -43,7 +41,6 @@ type StorageDecorator func(
 func UndecoratedStorage(
 	copier runtime.ObjectCopier,
 	config *storagebackend.Config,
-	capacity *int,
 	objectType runtime.Object,
 	resourcePrefix string,
 	keyFunc func(obj runtime.Object) (string, error),

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -19,6 +19,8 @@ package options
 import (
 	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/spf13/pflag"
 
@@ -51,6 +53,8 @@ type EtcdOptions struct {
 	EnableWatchCache bool
 	// Set DefaultWatchCacheSize to zero to disable watch caches for those resources that have no explicit cache size set
 	DefaultWatchCacheSize int
+	// WatchCacheSizes represents override to a given resource
+	WatchCacheSizes []string
 }
 
 var storageTypes = sets.NewString(
@@ -107,9 +111,16 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enables the generic garbage collector. MUST be synced with the corresponding flag "+
 		"of the kube-controller-manager.")
 
-	// TODO: enable cache in integration tests.
 	fs.BoolVar(&s.EnableWatchCache, "watch-cache", s.EnableWatchCache,
 		"Enable watch caching in the apiserver")
+
+	fs.IntVar(&s.DefaultWatchCacheSize, "default-watch-cache-size", s.DefaultWatchCacheSize,
+		"Default watch cache size. If zero, watch cache will be disabled for resources that do not have a default watch size set.")
+
+	fs.StringSliceVar(&s.WatchCacheSizes, "watch-cache-sizes", s.WatchCacheSizes, ""+
+		"List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. "+
+		"The individual override format: resource#size, where size is a number. It takes effect "+
+		"when watch-cache is enabled.")
 
 	fs.StringVar(&s.StorageConfig.Type, "storage-backend", s.StorageConfig.Type,
 		"The storage backend for persistence. Options: 'etcd3' (default), 'etcd2'.")
@@ -181,7 +192,15 @@ func (f *SimpleRestOptionsFactory) GetRESTOptions(resource schema.GroupResource)
 		ResourcePrefix:          resource.Group + "/" + resource.Resource,
 	}
 	if f.Options.EnableWatchCache {
-		ret.Decorator = genericregistry.StorageWithCacher(f.Options.DefaultWatchCacheSize)
+		sizes, err := ParseWatchCacheSizes(f.Options.WatchCacheSizes)
+		if err != nil {
+			return generic.RESTOptions{}, err
+		}
+		cacheSize, ok := sizes[resource]
+		if !ok {
+			cacheSize = f.Options.DefaultWatchCacheSize
+		}
+		ret.Decorator = genericregistry.StorageWithCacher(cacheSize)
 	}
 	return ret, nil
 }
@@ -205,8 +224,52 @@ func (f *storageFactoryRestOptionsFactory) GetRESTOptions(resource schema.GroupR
 		ResourcePrefix:          f.StorageFactory.ResourcePrefix(resource),
 	}
 	if f.Options.EnableWatchCache {
-		ret.Decorator = genericregistry.StorageWithCacher(f.Options.DefaultWatchCacheSize)
+		sizes, err := ParseWatchCacheSizes(f.Options.WatchCacheSizes)
+		if err != nil {
+			return generic.RESTOptions{}, err
+		}
+		cacheSize, ok := sizes[resource]
+		if !ok {
+			cacheSize = f.Options.DefaultWatchCacheSize
+		}
+		ret.Decorator = genericregistry.StorageWithCacher(cacheSize)
 	}
 
 	return ret, nil
+}
+
+// ParseWatchCacheSizes turns a list of cache size values into a map of group resources
+// to requested sizes.
+func ParseWatchCacheSizes(cacheSizes []string) (map[schema.GroupResource]int, error) {
+	watchCacheSizes := make(map[schema.GroupResource]int)
+	for _, c := range cacheSizes {
+		tokens := strings.Split(c, "#")
+		if len(tokens) != 2 {
+			return nil, fmt.Errorf("invalid value of watch cache size: %s", c)
+		}
+
+		size, err := strconv.Atoi(tokens[1])
+		if err != nil {
+			return nil, fmt.Errorf("invalid size of watch cache size: %s", c)
+		}
+		if size < 0 {
+			return nil, fmt.Errorf("watch cache size cannot be negative: %s", c)
+		}
+
+		watchCacheSizes[schema.ParseGroupResource(tokens[0])] = size
+	}
+	return watchCacheSizes, nil
+}
+
+// WriteWatchCacheSizes turns a map of cache size values into a list of string specifications.
+func WriteWatchCacheSizes(watchCacheSizes map[schema.GroupResource]int) ([]string, error) {
+	var cacheSizes []string
+
+	for resource, size := range watchCacheSizes {
+		if size < 0 {
+			return nil, fmt.Errorf("watch cache size cannot be negative for resource %s", resource)
+		}
+		cacheSizes = append(cacheSizes, fmt.Sprintf("%s#%d", resource.String(), size))
+	}
+	return cacheSizes, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -43,7 +43,6 @@ type ServerRunOptions struct {
 	RequestTimeout              time.Duration
 	MinRequestTimeout           int
 	TargetRAMMB                 int
-	WatchCacheSizes             []string
 }
 
 func NewServerRunOptions() *ServerRunOptions {
@@ -150,11 +149,6 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"a request open before timing it out. Currently only honored by the watch request "+
 		"handler, which picks a randomized value above this number as the connection timeout, "+
 		"to spread out load.")
-
-	fs.StringSliceVar(&s.WatchCacheSizes, "watch-cache-sizes", s.WatchCacheSizes, ""+
-		"List of watch cache sizes for every resource (pods, nodes, etc.), comma separated. "+
-		"The individual override format: resource#size, where size is a number. It takes effect "+
-		"when watch-cache is enabled.")
 
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }


### PR DESCRIPTION
Currently setting watch cache size for a given resource does not disable
the watch cache. This commit adds a new `default-watch-cache-size` flag
to map to the existing field, and refactors how watch cache sizes are
calculated to bring all of the code into one place. It also adds debug
logging to startup to allow us to verify watch cache enablement in
production.

Part of #51825 

Will allow watch cache to be disabled selectively.