### PR TITLE
Add env var to enable kubelet rotation in kube-up.sh.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -757,6 +757,11 @@ EOF
 FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})
 EOF
   fi
+  if [ -n "${ROTATE_CERTIFICATES:-}" ]; then
+    cat >>$file <<EOF
+ROTATE_CERTIFICATES: $(yaml-quote ${ROTATE_CERTIFICATES})
+EOF
+  fi
   if [[ "${master}" == "true" && "${MASTER_OS_DISTRIBUTION}" == "gci" ]] ||
      [[ "${master}" == "false" && "${NODE_OS_DISTRIBUTION}" == "gci" ]]; then
     cat >>$file <<EOF

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -319,3 +319,6 @@ ENABLE_POD_PRIORITY="${ENABLE_POD_PRIORITY:-}"
 if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then
     FEATURE_GATES="${FEATURE_GATES},PodPriority=true"
 fi
+
+# Optional: enable certificate rotation of the kubelet certificates.
+ROTATE_CERTIFICATES="${ROTATE_CERTIFICATES:-}"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -193,7 +193,7 @@ KUBEPROXY_TEST_ARGS="${KUBEPROXY_TEST_ARGS:-} ${TEST_CLUSTER_API_CONTENT_TYPE}"
 # TODO(piosz): remove this in 1.8
 NODE_LABELS="${KUBE_NODE_LABELS:-beta.kubernetes.io/fluentd-ds-ready=true}"
 
-# To avoid running Calico on a node that is not configured appropriately, 
+# To avoid running Calico on a node that is not configured appropriately,
 # label each Node so that the DaemonSet can run the Pods only on ready Nodes.
 if [[ ${NETWORK_POLICY_PROVIDER:-} == "calico" ]]; then
 	NODE_LABELS="$NODE_LABELS,projectcalico.org/ds-ready=true"
@@ -376,3 +376,6 @@ ENABLE_POD_PRIORITY="${ENABLE_POD_PRIORITY:-}"
 if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then
     FEATURE_GATES="${FEATURE_GATES},PodPriority=true"
 fi
+
+# Optional: enable certificate rotation of the kubelet certificates.
+ROTATE_CERTIFICATES="${ROTATE_CERTIFICATES:-}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -961,6 +961,9 @@ function start-kubelet {
   if [[ -n "${FEATURE_GATES:-}" ]]; then
     flags+=" --feature-gates=${FEATURE_GATES}"
   fi
+  if [[ -n "${ROTATE_CERTIFICATES:-}" ]]; then
+    flags+=" --rotate-certificates=true"
+  fi
 
   local -r kubelet_env_file="/etc/default/kubelet"
   echo "KUBELET_OPTS=\"${flags}\"" > "${kubelet_env_file}"


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52114

```release-note
Adds ROTATE_CERTIFICATES environment variable to kube-up.sh script for GCE
clusters. When that var is set to true, the command line flag enabling kubelet
client certificate rotation will be added to the kubelet command line.
```
