### PR TITLE
Convert deprecated gcloud --regexp flag into --filter

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1833,7 +1833,8 @@ function set-replica-name() {
 #
 # $1: project
 function get-template() {
-  gcloud compute instance-templates list -r "${NODE_INSTANCE_PREFIX}-template(-(${KUBE_RELEASE_VERSION_DASHED_REGEX}|${KUBE_CI_VERSION_DASHED_REGEX}))?" \
+  gcloud compute instance-templates list \
+    --filter="name ~ '${NODE_INSTANCE_PREFIX}-template(-(${KUBE_RELEASE_VERSION_DASHED_REGEX}|${KUBE_CI_VERSION_DASHED_REGEX}))?'" \
     --project="${1}" --format='value(name)'
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: #49673 missed a flag in hiding:
```console
WARNING: Flag --regexp is deprecated. Use --filter="name~'REGEXP'" instead.
ERROR: gcloud crashed (TypeError): 'NoneType' object is not iterable

If you would like to report this issue, please run the following command:
  gcloud feedback

To check gcloud for common problems, please run the following command:
  gcloud info --run-diagnostics
```

(Also it's great how gcloud crashes, rather than handling the deprecation gracefully.)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49673

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

cc @pci 