### PR TITLE
fsync config checkpoint files after writing

### DIFF
--- a/pkg/kubelet/kubeletconfig/util/files/files.go
+++ b/pkg/kubelet/kubeletconfig/util/files/files.go
@@ -83,6 +83,10 @@ func ReplaceFile(fs utilfs.Filesystem, path string, data []byte) error {
 	if _, err := tmpFile.Write(data); err != nil {
 		return err
 	}
+	// sync file, to ensure it's written in case a hard reset happens
+	if err := tmpFile.Sync(); err != nil {
+		return err
+	}
 	if err := tmpFile.Close(); err != nil {
 		return err
 	}

--- a/pkg/util/filesystem/defaultfs.go
+++ b/pkg/util/filesystem/defaultfs.go
@@ -101,6 +101,11 @@ func (file *defaultFile) Write(b []byte) (n int, err error) {
 	return file.file.Write(b)
 }
 
+// Sync via os.File.Sync
+func (file *defaultFile) Sync() error {
+	return file.file.Sync()
+}
+
 // Close via os.File.Close
 func (file *defaultFile) Close() error {
 	return file.file.Close()

--- a/pkg/util/filesystem/fakefs.go
+++ b/pkg/util/filesystem/fakefs.go
@@ -107,6 +107,11 @@ func (file *fakeFile) Write(b []byte) (n int, err error) {
 	return file.file.Write(b)
 }
 
+// Sync via afero.File.Sync
+func (file *fakeFile) Sync() error {
+	return file.file.Sync()
+}
+
 // Close via afero.File.Close
 func (file *fakeFile) Close() error {
 	return file.file.Close()

--- a/pkg/util/filesystem/filesystem.go
+++ b/pkg/util/filesystem/filesystem.go
@@ -45,5 +45,6 @@ type File interface {
 	// for now, the only os.File methods used are those below, add more as necessary
 	Name() string
 	Write(b []byte) (n int, err error)
+	Sync() error
 	Close() error
 }


### PR DESCRIPTION
@yujuhong brought up that it's possible for a hard reboot to result in empty checkpoint files, if they haven't been synced to disk yet. This PR ensures that Kubelet configuration checkpoints are synced after writing to avoid this issue.

fixes #52222

**Release note**:
```release-note
NONE
```
