### PR TITLE
dockershim: check if f.Sync() returns an error and surface it

### DIFF
--- a/pkg/kubelet/dockershim/checkpoint_store.go
+++ b/pkg/kubelet/dockershim/checkpoint_store.go
@@ -76,7 +76,10 @@ func writeFileAndSync(filename string, data []byte, perm os.FileMode) error {
 	if err == nil && n < len(data) {
 		err = io.ErrShortWrite
 	}
-	f.Sync()
+	if err == nil {
+		// Only sync if the Write completed successfully.
+		err = f.Sync()
+	}
 	if err1 := f.Close(); err == nil {
 		err = err1
 	}


### PR DESCRIPTION
```release-note
dockershim: check the error when syncing the checkpoint.
```
