### PR TITLE
gen openapi for api/v1

### DIFF
--- a/staging/src/k8s.io/client-go/pkg/api/v1/doc.go
+++ b/staging/src/k8s.io/client-go/pkg/api/v1/doc.go
@@ -14,5 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// +k8s:openapi-gen=true
+
 // Package v1 is the v1 version of the API.
 package v1


### PR DESCRIPTION
Generate openapi for api/v1.
Service catalog apiserver will depend on this to correctly generate openapi and serve it.

```release-note
NONE
```

/assign @mbohlool @caesarxuchao 