### PR TITLE
Deviceplugin refactoring: merge func list and listwatch in endpoint into one

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/endpoint.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint.go
@@ -46,7 +46,7 @@ type endpoint struct {
 }
 
 // newEndpoint creates a new endpoint for the given resourceName.
-func newEndpoint(socketPath, resourceName string, callback MonitorCallback) (*endpoint, error) {
+func newEndpoint(socketPath, resourceName string, devices map[string]pluginapi.Device, callback MonitorCallback) (*endpoint, error) {
 	client, c, err := dial(socketPath)
 	if err != nil {
 		glog.Errorf("Can't create new endpoint with path %s err %v", socketPath, err)
@@ -60,7 +60,7 @@ func newEndpoint(socketPath, resourceName string, callback MonitorCallback) (*en
 		socketPath:   socketPath,
 		resourceName: resourceName,
 
-		devices:  make(map[string]pluginapi.Device),
+		devices:  devices,
 		callback: callback,
 	}, nil
 }

--- a/pkg/kubelet/cm/deviceplugin/endpoint.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint.go
@@ -60,7 +60,7 @@ func newEndpoint(socketPath, resourceName string, callback MonitorCallback) (*en
 		socketPath:   socketPath,
 		resourceName: resourceName,
 
-		devices:  nil,
+		devices:  make(map[string]pluginapi.Device),
 		callback: callback,
 	}, nil
 }
@@ -77,44 +77,21 @@ func (e *endpoint) getDevices() []pluginapi.Device {
 	return devs
 }
 
-// list initializes ListAndWatch gRPC call for the device plugin and gets the
-// initial list of the devices. Returns ListAndWatch gRPC stream on success.
-func (e *endpoint) list() (pluginapi.DevicePlugin_ListAndWatchClient, error) {
-	stream, err := e.client.ListAndWatch(context.Background(), &pluginapi.Empty{})
-	if err != nil {
-		glog.Errorf(errListAndWatch, e.resourceName, err)
-		return nil, err
-	}
-
-	devs, err := stream.Recv()
-	if err != nil {
-		glog.Errorf(errListAndWatch, e.resourceName, err)
-		return nil, err
-	}
-
-	devices := make(map[string]pluginapi.Device)
-	var added, updated, deleted []pluginapi.Device
-	for _, d := range devs.Devices {
-		devices[d.ID] = *d
-		added = append(added, *d)
-	}
-
-	e.mutex.Lock()
-	e.devices = devices
-	e.mutex.Unlock()
-
-	e.callback(e.resourceName, added, updated, deleted)
-
-	return stream, nil
-}
-
-// listAndWatch blocks on receiving ListAndWatch gRPC stream updates. Each ListAndWatch
+// run initializes ListAndWatch gRPC call for the device plugin and
+// blocks on receiving ListAndWatch gRPC stream updates. Each ListAndWatch
 // stream update contains a new list of device states. listAndWatch compares the new
 // device states with its cached states to get list of new, updated, and deleted devices.
 // It then issues a callback to pass this information to the device_plugin_handler which
 // will adjust the resource available information accordingly.
-func (e *endpoint) listAndWatch(stream pluginapi.DevicePlugin_ListAndWatchClient) {
+func (e *endpoint) run() {
 	glog.V(3).Infof("Starting ListAndWatch")
+
+	stream, err := e.client.ListAndWatch(context.Background(), &pluginapi.Empty{})
+	if err != nil {
+		glog.Errorf(errListAndWatch, e.resourceName, err)
+
+		return
+	}
 
 	devices := make(map[string]pluginapi.Device)
 

--- a/pkg/kubelet/cm/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_test.go
@@ -102,7 +102,7 @@ func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string,
 	err := p.Start()
 	require.NoError(t, err)
 
-	e, err := newEndpoint(socket, "mock", func(n string, a, u, r []pluginapi.Device) {})
+	e, err := newEndpoint(socket, "mock", make(map[string]pluginapi.Device), func(n string, a, u, r []pluginapi.Device) {})
 	require.NoError(t, err)
 
 	return p, e

--- a/pkg/kubelet/cm/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_test.go
@@ -41,32 +41,7 @@ func TestNewEndpoint(t *testing.T) {
 	defer ecleanup(t, p, e)
 }
 
-func TestList(t *testing.T) {
-	socket := path.Join("/tmp", esocketName)
-
-	devs := []*pluginapi.Device{
-		{ID: "ADeviceId", Health: pluginapi.Healthy},
-	}
-
-	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []pluginapi.Device) {})
-	defer ecleanup(t, p, e)
-
-	_, err := e.list()
-	require.NoError(t, err)
-
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-
-	require.Len(t, e.devices, 1)
-
-	d, ok := e.devices[devs[0].ID]
-	require.True(t, ok)
-
-	require.Equal(t, d.ID, devs[0].ID)
-	require.Equal(t, d.Health, devs[0].Health)
-}
-
-func TestListAndWatch(t *testing.T) {
+func TestRun(t *testing.T) {
 	socket := path.Join("/tmp", esocketName)
 
 	devs := []*pluginapi.Device{
@@ -93,10 +68,7 @@ func TestListAndWatch(t *testing.T) {
 	})
 	defer ecleanup(t, p, e)
 
-	s, err := e.list()
-	require.NoError(t, err)
-
-	go e.listAndWatch(s)
+	go e.run()
 	p.Update(updated)
 	time.Sleep(time.Second)
 

--- a/pkg/kubelet/cm/deviceplugin/manager.go
+++ b/pkg/kubelet/cm/deviceplugin/manager.go
@@ -97,13 +97,13 @@ func (m *ManagerImpl) removeContents(dir string) error {
 }
 
 const (
-	// defaultCheckpoint is the file name of device plugin checkpoint
-	defaultCheckpoint = "kubelet_internal_checkpoint"
+	// kubeletDevicePluginCheckpoint is the file name of device plugin checkpoint
+	kubeletDevicePluginCheckpoint = "kubelet_internal_checkpoint"
 )
 
 // CheckpointFile returns device plugin checkpoint file path.
 func (m *ManagerImpl) CheckpointFile() string {
-	return filepath.Join(m.socketdir, defaultCheckpoint)
+	return filepath.Join(m.socketdir, kubeletDevicePluginCheckpoint)
 }
 
 // Start starts the Device Plugin Manager
@@ -209,13 +209,6 @@ func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
 		return
 	}
 
-	stream, err := e.list()
-	if err != nil {
-		glog.Errorf("Failed to List devices for plugin %v: %v", r.ResourceName, err)
-		e.stop()
-		return
-	}
-
 	// Associates the newly created endpoint with the corresponding resource name.
 	// Stops existing endpoint if there is any.
 	m.mutex.Lock()
@@ -229,7 +222,7 @@ func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
 	}
 
 	go func() {
-		e.listAndWatch(stream)
+		e.run()
 		e.stop()
 
 		m.mutex.Lock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
merge func list and listwatch in endpoint into one, since we won't call list func individually

**Which issue this PR fixes**
fixes #51993
Part2

**Special notes for your reviewer**:
/cc @jiayingz @RenaudWasTaken @vishh

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```