### PR TITLE
Use glog.*f when a format string is passed (update)

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_address_manager.go
+++ b/pkg/cloudprovider/providers/gce/gce_address_manager.go
@@ -168,7 +168,7 @@ func (am *addressManager) ensureAddressReservation() (string, error) {
 	if am.isManagedAddress(addr) {
 		// The address with this name is checked at the beginning of 'HoldAddress()', but for some reason
 		// it was re-created by this point. May be possible that two controllers are running.
-		glog.Warning("%v: address %q unexpectedly existed with IP %q.", am.logPrefix, addr.Name, am.targetIP)
+		glog.Warningf("%v: address %q unexpectedly existed with IP %q.", am.logPrefix, addr.Name, am.targetIP)
 	} else {
 		// If the retrieved address is not named with the loadbalancer name, then the controller does not own it, but will allow use of it.
 		glog.V(4).Infof("%v: address %q was already reserved with name: %q, description: %q", am.logPrefix, am.targetIP, addr.Name, addr.Description)

--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
@@ -102,7 +102,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	dummyVM, err = datastore.Datacenter.GetVMByPath(ctx, vmdisk.vmOptions.VMFolder.InventoryPath+"/"+dummyVMFullName)
 	if err != nil {
 		// Create a dummy VM
-		glog.V(1).Info("Creating Dummy VM: %q", dummyVMFullName)
+		glog.V(1).Infof("Creating Dummy VM: %q", dummyVMFullName)
 		dummyVM, err = vmdisk.createDummyVM(ctx, datastore.Datacenter, dummyVMFullName)
 		if err != nil {
 			glog.Errorf("Failed to create Dummy VM. err: %v", err)
@@ -132,7 +132,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 		fileAlreadyExist = isAlreadyExists(vmdisk.diskPath, err)
 		if fileAlreadyExist {
 			//Skip error and continue to detach the disk as the disk was already created on the datastore.
-			glog.V(vclib.LogLevel).Info("File: %v already exists", vmdisk.diskPath)
+			glog.V(vclib.LogLevel).Infof("File: %v already exists", vmdisk.diskPath)
 		} else {
 			glog.Errorf("Failed to attach the disk to VM: %q with err: %+v", dummyVMFullName, err)
 			return err
@@ -143,7 +143,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	if err != nil {
 		if vclib.DiskNotFoundErrMsg == err.Error() && fileAlreadyExist {
 			// Skip error if disk was already detached from the dummy VM but still present on the datastore.
-			glog.V(vclib.LogLevel).Info("File: %v is already detached", vmdisk.diskPath)
+			glog.V(vclib.LogLevel).Infof("File: %v is already detached", vmdisk.diskPath)
 		} else {
 			glog.Errorf("Failed to detach the disk: %q from VM: %q with err: %+v", vmdisk.diskPath, dummyVMFullName, err)
 			return err

--- a/pkg/controller/node/ipam/controller.go
+++ b/pkg/controller/node/ipam/controller.go
@@ -203,7 +203,7 @@ func (c *Controller) onDelete(node *v1.Node) error {
 		syncer.Delete(node)
 		delete(c.syncers, node.Name)
 	} else {
-		glog.Warning("Node %q was already deleted", node.Name)
+		glog.Warningf("Node %q was already deleted", node.Name)
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does**:
rel: 
[PR#47829](https://github.com/kubernetes/kubernetes/pull/47829)

Just  like  @CaoShuFeng did before,
I use the following commands to search all the invalid usage:
$ grep "glog.Warning(" * -r | grep %
$ grep "glog.Info(" * -r | grep %
$ grep "glog.Error(" * -r | grep %
$ grep ").Info(" * -r | grep % | grep glog.V\\(
