### PR TITLE
Improve kubeadm help text

### DIFF
--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -39,13 +39,14 @@ func NewKubeadmCommand(_ io.Reader, out, err io.Writer) *cobra.Command {
 			    │                                                          │
 			    │ But, please try it out! Give us feedback at:             │
 			    │ https://github.com/kubernetes/kubeadm/issues             │
-			    │ and at-mention @kubernetes/sig-cluster-lifecycle-misc    │
+			    │ and at-mention @kubernetes/sig-cluster-lifecycle-bugs    │
+			    │ or @kubernetes/sig-cluster-lifecycle-feature-requests    │
 			    └──────────────────────────────────────────────────────────┘
 
 			Example usage:
 
 			    Create a two-machine cluster with one master (which controls the cluster),
-			    and one node (where your workloads, like Pods and ReplicaSets run).
+			    and one node (where your workloads, like Pods and Deployments run).
 
 			    ┌──────────────────────────────────────────────────────────┐
 			    │ On the first machine                                     │
@@ -56,7 +57,7 @@ func NewKubeadmCommand(_ io.Reader, out, err io.Writer) *cobra.Command {
 			    ┌──────────────────────────────────────────────────────────┐
 			    │ On the second machine                                    │
 			    ├──────────────────────────────────────────────────────────┤
-			    │ node# kubeadm join --token=<token> <ip-of-master>:<port> │
+			    │ node# kubeadm join <arguments-returned-from-init>        │
 			    └──────────────────────────────────────────────────────────┘
 
 			    You can then repeat the second step on as many other machines as you like.


### PR DESCRIPTION
* Replace 'misc' with more specific at-mentions bugs and feature-requests.
* Replace ReplicaSets with Deployments as example, because ReplicaSets are dated.
* Generalize join example.

Before:

```
    ┌──────────────────────────────────────────────────────────┐
    │ KUBEADM IS BETA, DO NOT USE IT FOR PRODUCTION CLUSTERS!  │
    │                                                          │
    │ But, please try it out! Give us feedback at:             │
    │ https://github.com/kubernetes/kubeadm/issues             │
    │ and at-mention @kubernetes/sig-cluster-lifecycle-misc    │
    └──────────────────────────────────────────────────────────┘

Example usage:

    Create a two-machine cluster with one master (which controls the cluster),
    and one node (where your workloads, like Pods and ReplicaSets run).

    ┌──────────────────────────────────────────────────────────┐
    │ On the first machine                                     │
    ├──────────────────────────────────────────────────────────┤
    │ master# kubeadm init                                     │
    └──────────────────────────────────────────────────────────┘

    ┌──────────────────────────────────────────────────────────┐
    │ On the second machine                                    │
    ├──────────────────────────────────────────────────────────┤
    │ node# kubeadm join --token=<token> <ip-of-master>:<port> │
    └──────────────────────────────────────────────────────────┘

    You can then repeat the second step on as many other machines as you like.
```

After (changes highlighted with `<--`):

```
    ┌──────────────────────────────────────────────────────────┐
    │ KUBEADM IS BETA, DO NOT USE IT FOR PRODUCTION CLUSTERS!  │
    │                                                          │
    │ But, please try it out! Give us feedback at:             │
    │ https://github.com/kubernetes/kubeadm/issues             │
    │ and at-mention @kubernetes/sig-cluster-lifecycle-bugs    │ <--
    │ or @kubernetes/sig-cluster-lifecycle-feature-requests    │ <--
    └──────────────────────────────────────────────────────────┘

Example usage:

    Create a two-machine cluster with one master (which controls the cluster),
    and one node (where your workloads, like Pods and Deployments run).  <--

    ┌──────────────────────────────────────────────────────────┐
    │ On the first machine                                     │
    ├──────────────────────────────────────────────────────────┤
    │ master# kubeadm init                                     │
    └──────────────────────────────────────────────────────────┘

    ┌──────────────────────────────────────────────────────────┐
    │ On the second machine                                    │
    ├──────────────────────────────────────────────────────────┤
    │ node# kubeadm join <arguments-returned-from-init>        │ <--
    └──────────────────────────────────────────────────────────┘

    You can then repeat the second step on as many other machines as you like.

```

cc @luxas