### PR TITLE
Fix prober ticking shift for kubelet restart cases

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -99,6 +99,11 @@ func newWorker(
 // run periodically probes the container.
 func (w *worker) run() {
 	probeTickerPeriod := time.Duration(w.spec.PeriodSeconds) * time.Second
+
+	// If kubelet restarted the probes could be started in rapid succession.
+	// Let the worker wait for a random portion of tickerPeriod before probing.
+	time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
+
 	probeTicker := time.NewTicker(probeTickerPeriod)
 
 	defer func() {
@@ -110,10 +115,6 @@ func (w *worker) run() {
 
 		w.probeManager.removeWorker(w.pod.UID, w.container.Name, w.probeType)
 	}()
-
-	// If kubelet restarted the probes could be started in rapid succession.
-	// Let the worker wait for a random portion of tickerPeriod before probing.
-	time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
 
 probeLoop:
 	for w.doProbe() {


### PR DESCRIPTION
Fixes #52154 
call sleep() before `probeTicker` starts ticking, to reduce the number of probers executed at the same time, after kubelete restarted.


**Special notes for your reviewer**:
Before:
![image](https://user-images.githubusercontent.com/6914660/30204947-d900c9ca-94b9-11e7-959d-049c5da1a80b.png)
After:
![image](https://user-images.githubusercontent.com/6914660/30204997-11db2b3c-94ba-11e7-970a-a542f46fc09d.png)


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @kubernetes/sig-node-bugs  