### PR TITLE
Allow kubectl cp large amounts of files from container

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -257,8 +257,12 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 		if err != nil {
 			return err
 		}
-		defer outFile.Close()
-		io.Copy(outFile, tarReader)
+		if _, err := io.Copy(outFile, tarReader); err != nil {
+			return err
+		}
+		if err := outFile.Close(); err != nil {
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
When we try to copy out a dir with large amounts of files from container, we hit such error:

```bash
kubectl cp  mypod:/ ./a/
tar: Removing leading `/' from member names
tar: Removing leading `/' from hard link targets
error: open a/usr/share/zoneinfo/Asia/Rangoon: too many open files
```

This is because kubectl opens too many files at the same. We should close them after Write() function.
**Release note**:
```
NONE
```
