### PR TITLE
More descriptive error message for `make test`

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -211,6 +211,41 @@ junitFilenamePrefix() {
   echo "${KUBE_JUNIT_REPORT_DIR}/junit_${KUBE_TEST_API_HASH}_$(kube::util::sortable_date)"
 }
 
+verifyAndSuggestPackagePath() {
+  local specified_package_path="$1"
+  local alternative_package_path="$2"
+  local original_package_path="$3"
+  local suggestion_package_path="$4"
+
+  if ! [ -d "$specified_package_path" ]; then
+    # Because k8s sets a localized $GOPATH for testing, seeing the actual
+    # directory can be confusing. Instead, just show $GOPATH if it exists in the
+    # $specified_package_path.
+    local printable_package_path=$(echo "$specified_package_path" | sed "s|$GOPATH|\$GOPATH|")
+    kube::log::error "specified test path '$printable_package_path' does not exist"
+
+    if [ -d "$alternative_package_path" ]; then
+      kube::log::info "try changing \"$original_package_path\" to \"$suggestion_package_path\""
+    fi
+    exit 1
+  fi
+}
+
+verifyPathsToPackagesUnderTest() {
+  local packages_under_test=($@)
+
+  for package_path in "${packages_under_test[@]}"; do
+    local local_package_path="$package_path"
+    local go_package_path="$GOPATH/src/$package_path"
+
+    if [[ "${package_path:0:2}" == "./" ]] ; then
+      verifyAndSuggestPackagePath "$local_package_path" "$go_package_path" "$package_path" "${package_path:2}"
+    else
+      verifyAndSuggestPackagePath "$go_package_path" "$local_package_path" "$package_path" "./$package_path"
+    fi
+  done
+}
+
 produceJUnitXMLReport() {
   local -r junit_filename_prefix=$1
   if [[ -z "${junit_filename_prefix}" ]]; then
@@ -236,6 +271,8 @@ produceJUnitXMLReport() {
 runTests() {
   local junit_filename_prefix
   junit_filename_prefix=$(junitFilenamePrefix)
+
+  verifyPathsToPackagesUnderTest "$@"
 
   # If we're not collecting coverage, run all requested tests with one 'go test'
   # command, which is much faster.


### PR DESCRIPTION
**Which issue this PR fixes**
Fix #52025

**What this PR does / why we need it**:

The `[packages]` argument to `go test` can be confusing. If the
`package` does not begin with `./`, `go test` considers it relative to
`$GOPATH/src`. If it does begin with `./`, `go test` considers it
relative to `pwd`. `hack/make-rules/test.sh`, and thus `make test`, use
`go test`.

This commit adds a verify step to `hack/make-rules/test.sh`. Before we
run `go test`, we check the packages under test exist. If the user
specified the package path in the incorrect format - for example they
didn't prepend with `./` when they should have, the check logs a
suggestion of the alternative path they should use.

Running the test suites for a package is an activity many all first time
contributors will take. Hopefully including a more descriptive error
message, with a suggestion for a fix if applicable, will make this an
easier experience.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>

```release-note
NONE
```
