### PR TITLE
Fix incorrect status msg in podautoscaler

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -441,7 +441,14 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 			desiredReplicas = scaleUpLimit
 		case hpa.Spec.MinReplicas != nil && desiredReplicas < *hpa.Spec.MinReplicas:
 			// make sure we aren't below our minimum
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was less than the minimum replica count")
+			var statusMsg string
+			if desiredReplicas == 0 {
+				statusMsg = "the desired replica count was zero"
+			} else {
+				statusMsg = "the desired replica count was less than the minimum replica count"
+			}
+
+			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", statusMsg)
 			desiredReplicas = *hpa.Spec.MinReplicas
 		case desiredReplicas == 0:
 			//  never scale down to 0, reserved for disabling autoscaling


### PR DESCRIPTION
**Which issue this PR fixes**

Fix #49256

**What this PR does / why we need it**:

When `ScalingLimited = true` for the `hpa`, there is an accompanying
status message, describing why scaling is limited. Previously if the desired
replica count was 0, and spec.minReplicas > 0, the status message
indicated "the desired replica count was less than the min replica
count". This was particularly confusing when `spec.MinReplicas = 1`. If
there was no `spec.minReplicas`, then the status message indicated "the
desired replica count was zero" which is more informative.

Update the calculation of status message so that if the desired replica
count is 0, we always display the clearer "the desired replica count was
zero" status message, even if spec.minReplicas > 0.

Signed-off-by: mattjmcnaughton <mattjmcnaughton@gmail.com>

```release-note
NONE
```
