### PR TITLE
Bump cluster autoscaler to 0.7.0-alpha3

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.7.0-alpha2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.7.0-alpha3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
After adding an extra field to `etc/gce.conf` CA stopped starting properly. After this change CI test suite should become more green.