### PR TITLE
Updating kubenet for CNI with IPv6

### DIFF
--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -209,7 +209,7 @@ func findMinMTU() (*net.Interface, error) {
 }
 
 const NET_CONFIG_TEMPLATE = `{
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.3.1",
   "name": "kubenet",
   "type": "bridge",
   "bridge": "%s",
@@ -220,10 +220,11 @@ const NET_CONFIG_TEMPLATE = `{
   "hairpinMode": %t,
   "ipam": {
     "type": "host-local",
-    "subnet": "%s",
-    "gateway": "%s",
-    "routes": [
-      { "dst": "0.0.0.0/0" }
+    "ranges": [
+    {
+     "subnet": "%s",
+     "gateway": "%s"
+    }
     ]
   }
 }`


### PR DESCRIPTION
CNI has been updated with IPv6, and these changes allow
kubenet to use IPv6 with the latest CNI.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This updated the config sent to CNI to allow for using IPv6 with the latest CNI.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52179

**Special notes for your reviewer**:

**Release note**:

```release-note NONE
```
