### PR TITLE
Ensure we log the flag apiserver starts with.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
@@ -49,6 +49,6 @@ func InitFlags() {
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	pflag.Parse()
 	pflag.VisitAll(func(flag *pflag.Flag) {
-		glog.V(4).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
+		glog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
 }


### PR DESCRIPTION
Trying to make sure we always log the flags an instance of apiserver
starts with.
This can be especially valuable for emailed logs or e2e/kubemark tests.

**What this PR does / why we need it**: Ensures we log the flags an apiserver was started with.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #none

**Special notes for your reviewer**:

**Release note**:```release-note NONE
```
