### PR TITLE
kubeadm: Perform TLS Bootstrapping in kubeadm join for v1.7 kubelets

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//cmd/kubeadm/app/discovery:go_default_library",
         "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
+        "//cmd/kubeadm/app/node:go_default_library",
         "//cmd/kubeadm/app/phases/addons/dns:go_default_library",
         "//cmd/kubeadm/app/phases/addons/proxy:go_default_library",
         "//cmd/kubeadm/app/phases/apiconfig:go_default_library",

--- a/cmd/kubeadm/app/node/BUILD
+++ b/cmd/kubeadm/app/node/BUILD
@@ -8,10 +8,18 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["validate.go"],
+    srcs = [
+        "csr.go",
+        "validate.go",
+    ],
     deps = [
+        "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
+        "//pkg/kubelet/util/csr:go_default_library",
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/csr"
 )
 
+// CSRContextAndUser defines the context to use for the client certs in the kubelet kubeconfig file
 const CSRContextAndUser = "kubelet-csr"
 
 // PerformTLSBootstrap executes a node certificate signing request.

--- a/cmd/kubeadm/app/node/csr.go
+++ b/cmd/kubeadm/app/node/csr.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	certutil "k8s.io/client-go/util/cert"
+	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+	"k8s.io/kubernetes/pkg/kubelet/util/csr"
+)
+
+const CSRContextAndUser = "kubelet-csr"
+
+// PerformTLSBootstrap executes a node certificate signing request.
+func PerformTLSBootstrap(cfg *clientcmdapi.Config, hostName string) error {
+	client, err := kubeconfigutil.KubeConfigToClientSet(cfg)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("[csr] Created API client to obtain unique certificate for this node, generating keys and certificate signing request")
+
+	key, err := certutil.MakeEllipticPrivateKeyPEM()
+	if err != nil {
+		return fmt.Errorf("failed to generate private key [%v]", err)
+	}
+
+	cert, err := csr.RequestNodeCertificate(client.CertificatesV1beta1().CertificateSigningRequests(), key, types.NodeName(hostName))
+	if err != nil {
+		return fmt.Errorf("failed to request signed certificate from the API server [%v]", err)
+	}
+	fmt.Println("[csr] Received signed certificate from the API server, generating KubeConfig...")
+
+	cfg.AuthInfos[CSRContextAndUser] = &clientcmdapi.AuthInfo{
+		ClientKeyData:         key,
+		ClientCertificateData: cert,
+	}
+	cfg.Contexts[CSRContextAndUser] = &clientcmdapi.Context{
+		AuthInfo: CSRContextAndUser,
+		Cluster:  cfg.Contexts[cfg.CurrentContext].Cluster,
+	}
+	cfg.CurrentContext = CSRContextAndUser
+	return nil
+}

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -17,6 +17,7 @@ cmd/kubeadm/app/discovery
 cmd/kubeadm/app/discovery/file
 cmd/kubeadm/app/discovery/token
 cmd/kubeadm/app/images
+cmd/kubeadm/app/node
 cmd/kubeadm/app/phases/certs/pkiutil
 cmd/kubeadm/app/preflight
 cmd/kubeadm/app/util

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -17,7 +17,6 @@ cmd/kubeadm/app/discovery
 cmd/kubeadm/app/discovery/file
 cmd/kubeadm/app/discovery/token
 cmd/kubeadm/app/images
-cmd/kubeadm/app/node
 cmd/kubeadm/app/phases/certs/pkiutil
 cmd/kubeadm/app/preflight
 cmd/kubeadm/app/util


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Partially reverts https://github.com/kubernetes/kubernetes/commit/9dc3a661d71c18e33ac93a6125bb187fa83b8853
Performs the TLS Bootstrap if `kubeadm join` v1.8 is executed on a node with a kubelet v1.7.
Since the kubelet arguments for v1.7 (from the kubeadm dropin) expects a TLS bootstrapped kubeconfig, we still have to provide this functionality in kubeadm CLI v1.8 (as we support one minor version down)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes: https://github.com/kubernetes/kubeadm/issues/429

**Special notes for your reviewer**:

This is a required bug fix for v1.8

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 