### PR TITLE
Initial integration test setup for DaemonSet controller

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -492,7 +492,7 @@ func TestOneNodeDaemonLaunchesPod(t *testing.T) {
 }
 
 // DaemonSets should place onto NotReady nodes
-func TestNotReadNodeDaemonDoesNotLaunchPod(t *testing.T) {
+func TestNotReadyNodeDaemonDoesLaunchPod(t *testing.T) {
 	for _, strategy := range updateStrategies() {
 		ds := newDaemonSet("foo")
 		ds.Spec.UpdateStrategy = *strategy

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -36,6 +36,7 @@ filegroup(
         "//test/integration/auth:all-srcs",
         "//test/integration/client:all-srcs",
         "//test/integration/configmap:all-srcs",
+        "//test/integration/daemonset:all-srcs",
         "//test/integration/defaulttolerationseconds:all-srcs",
         "//test/integration/deployment:all-srcs",
         "//test/integration/etcd:all-srcs",

--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    size = "large",
+    srcs = [
+        "daemonset_test.go",
+        "main_test.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/integration/daemonset",
+    tags = ["integration"],
+    deps = [
+        "//pkg/api/v1/pod:go_default_library",
+        "//pkg/controller/daemon:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/informers:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/integration/daemonset/OWNERS
+++ b/test/integration/daemonset/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- mikedanese
+- kow3ns
+reviewers:
+- mikedanese
+- kargakis
+- lukaszo
+- janetkuo
+- kow3ns

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	extensionsv1beta1typed "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	"k8s.io/kubernetes/pkg/controller/daemon"
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func setup(t *testing.T) (*httptest.Server, framework.CloseFunc, *daemon.DaemonSetsController, informers.SharedInformerFactory, clientset.Interface) {
+	masterConfig := framework.NewIntegrationTestMasterConfig()
+	_, server, closeFn := framework.RunAMaster(masterConfig)
+
+	config := restclient.Config{Host: server.URL}
+	clientSet, err := clientset.NewForConfig(&config)
+	if err != nil {
+		t.Fatalf("Error in creating clientset: %v", err)
+	}
+	resyncPeriod := 12 * time.Hour
+	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "daemonset-informers")), resyncPeriod)
+	dc := daemon.NewDaemonSetsController(
+		informers.Extensions().V1beta1().DaemonSets(),
+		informers.Apps().V1beta1().ControllerRevisions(),
+		informers.Core().V1().Pods(),
+		informers.Core().V1().Nodes(),
+		clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "daemonset-controller")),
+	)
+
+	return server, closeFn, dc, informers, clientSet
+}
+
+func testLabels() map[string]string {
+	return map[string]string{"name": "test"}
+}
+
+func newDaemonSet(name, namespace string) *v1beta1.DaemonSet {
+	two := int32(2)
+	return &v1beta1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "extensions/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: v1beta1.DaemonSetSpec{
+			RevisionHistoryLimit: &two,
+			Selector:             &metav1.LabelSelector{MatchLabels: testLabels()},
+			UpdateStrategy: v1beta1.DaemonSetUpdateStrategy{
+				Type: v1beta1.OnDeleteDaemonSetStrategyType,
+			},
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: testLabels(),
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{Name: "foo", Image: "bar"}},
+				},
+			},
+		},
+	}
+}
+
+func newRollbackStrategy() *v1beta1.DaemonSetUpdateStrategy {
+	one := intstr.FromInt(1)
+	return &v1beta1.DaemonSetUpdateStrategy{
+		Type:          v1beta1.RollingUpdateDaemonSetStrategyType,
+		RollingUpdate: &v1beta1.RollingUpdateDaemonSet{MaxUnavailable: &one},
+	}
+}
+
+func newOnDeleteStrategy() *v1beta1.DaemonSetUpdateStrategy {
+	return &v1beta1.DaemonSetUpdateStrategy{
+		Type: v1beta1.OnDeleteDaemonSetStrategyType,
+	}
+}
+
+func updateStrategies() []*v1beta1.DaemonSetUpdateStrategy {
+	return []*v1beta1.DaemonSetUpdateStrategy{newOnDeleteStrategy(), newRollbackStrategy()}
+}
+
+func allocatableResources(memory, cpu string) v1.ResourceList {
+	return v1.ResourceList{
+		v1.ResourceMemory: resource.MustParse(memory),
+		v1.ResourceCPU:    resource.MustParse(cpu),
+		v1.ResourcePods:   resource.MustParse("100"),
+	}
+}
+
+func resourcePodSpec(nodeName, memory, cpu string) v1.PodSpec {
+	return v1.PodSpec{
+		NodeName: nodeName,
+		Containers: []v1.Container{
+			{
+				Name:  "foo",
+				Image: "bar",
+				Resources: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceMemory: resource.MustParse(memory),
+						v1.ResourceCPU:    resource.MustParse(cpu),
+					},
+				},
+			},
+		},
+	}
+}
+
+func newNode(name string, label map[string]string) *v1.Node {
+	return &v1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Labels:    label,
+			Namespace: metav1.NamespaceDefault,
+		},
+		Status: v1.NodeStatus{
+			Conditions:  []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}},
+			Allocatable: v1.ResourceList{v1.ResourcePods: resource.MustParse("100")},
+		},
+	}
+}
+
+func addNodes(nodeClient corev1typed.NodeInterface, startIndex, numNodes int, label map[string]string, t *testing.T) {
+	for i := startIndex; i < startIndex+numNodes; i++ {
+		_, err := nodeClient.Create(newNode(fmt.Sprintf("node-%d", i), label))
+		if err != nil {
+			t.Fatalf("Failed to create node: %v", err)
+		}
+	}
+}
+
+func validateDaemonSetPodsAndMarkReady(
+	podClient corev1typed.PodInterface,
+	podInformer cache.SharedIndexInformer,
+	numberPods int,
+	t *testing.T) {
+	if err := wait.Poll(10*time.Second, 60*time.Second, func() (bool, error) {
+		objects := podInformer.GetIndexer().List()
+		if len(objects) != numberPods {
+			return false, nil
+		}
+
+		for _, object := range objects {
+			pod := object.(*v1.Pod)
+
+			ownerReferences := pod.ObjectMeta.OwnerReferences
+			if len(ownerReferences) != 1 {
+				return false, fmt.Errorf("Pod %s has %d OwnerReferences, expected only 1", pod.Name, len(ownerReferences))
+			}
+			controllerRef := ownerReferences[0]
+			if got, want := controllerRef.APIVersion, "extensions/v1beta1"; got != want {
+				t.Errorf("controllerRef.APIVersion = %q, want %q", got, want)
+			}
+			if got, want := controllerRef.Kind, "DaemonSet"; got != want {
+				t.Errorf("controllerRef.Kind = %q, want %q", got, want)
+			}
+			if controllerRef.Controller == nil || *controllerRef.Controller != true {
+				t.Errorf("controllerRef.Controller is not set to true")
+			}
+
+			if !podutil.IsPodReady(pod) {
+				podCopy := pod.DeepCopy()
+				podCopy.Status = v1.PodStatus{
+					Phase:      v1.PodRunning,
+					Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}},
+				}
+				_, err := podClient.UpdateStatus(podCopy)
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateDaemonSetStatus(
+	dsClient extensionsv1beta1typed.DaemonSetInterface,
+	dsName string,
+	dsNamespace string,
+	expectedNumberReady int32,
+	t *testing.T) {
+	if err := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+		ds, err := dsClient.Get(dsName, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		return ds.Status.NumberReady == expectedNumberReady, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func validateFailedPlacementEvent(eventClient corev1typed.EventInterface, t *testing.T) {
+	if err := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
+		eventList, err := eventClient.List(metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(eventList.Items) == 0 {
+			return false, nil
+		}
+		if len(eventList.Items) > 1 {
+			t.Errorf("Expected 1 event got %d", len(eventList.Items))
+		}
+		event := eventList.Items[0]
+		if event.Type != v1.EventTypeWarning {
+			t.Errorf("Event type expected %s got %s", v1.EventTypeWarning, event.Type)
+		}
+		if event.Reason != daemon.FailedPlacementReason {
+			t.Errorf("Event reason expected %s got %s", daemon.FailedPlacementReason, event.Reason)
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOneNodeDaemonLaunchesPod(t *testing.T) {
+	for _, strategy := range updateStrategies() {
+		server, closeFn, dc, informers, clientset := setup(t)
+		defer closeFn()
+		ns := framework.CreateTestingNamespace("one-node-daemonset-test", server, t)
+		defer framework.DeleteTestingNamespace(ns, server, t)
+
+		dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+		podClient := clientset.CoreV1().Pods(ns.Name)
+		nodeClient := clientset.CoreV1().Nodes()
+		podInformer := informers.Core().V1().Pods().Informer()
+		stopCh := make(chan struct{})
+		informers.Start(stopCh)
+		go dc.Run(5, stopCh)
+
+		ds := newDaemonSet("foo", ns.Name)
+		ds.Spec.UpdateStrategy = *strategy
+		_, err := dsClient.Create(ds)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet: %v", err)
+		}
+		_, err = nodeClient.Create(newNode("single-node", nil))
+		if err != nil {
+			t.Fatalf("Failed to create node: %v", err)
+		}
+
+		validateDaemonSetPodsAndMarkReady(podClient, podInformer, 1, t)
+		validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 1, t)
+
+		close(stopCh)
+	}
+}
+
+func TestSimpleDaemonSetLaunchesPods(t *testing.T) {
+	for _, strategy := range updateStrategies() {
+		server, closeFn, dc, informers, clientset := setup(t)
+		defer closeFn()
+		ns := framework.CreateTestingNamespace("simple-daemonset-test", server, t)
+		defer framework.DeleteTestingNamespace(ns, server, t)
+
+		dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+		podClient := clientset.CoreV1().Pods(ns.Name)
+		nodeClient := clientset.CoreV1().Nodes()
+		podInformer := informers.Core().V1().Pods().Informer()
+		stopCh := make(chan struct{})
+		informers.Start(stopCh)
+		go dc.Run(5, stopCh)
+
+		ds := newDaemonSet("foo", ns.Name)
+		ds.Spec.UpdateStrategy = *strategy
+		_, err := dsClient.Create(ds)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet: %v", err)
+		}
+		addNodes(nodeClient, 0, 5, nil, t)
+
+		validateDaemonSetPodsAndMarkReady(podClient, podInformer, 5, t)
+		validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 5, t)
+
+		close(stopCh)
+	}
+}
+
+func TestNotReadyNodeDaemonDoesLaunchPod(t *testing.T) {
+	for _, strategy := range updateStrategies() {
+		server, closeFn, dc, informers, clientset := setup(t)
+		defer closeFn()
+		ns := framework.CreateTestingNamespace("simple-daemonset-test", server, t)
+		defer framework.DeleteTestingNamespace(ns, server, t)
+
+		dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+		podClient := clientset.CoreV1().Pods(ns.Name)
+		nodeClient := clientset.CoreV1().Nodes()
+		podInformer := informers.Core().V1().Pods().Informer()
+		stopCh := make(chan struct{})
+		informers.Start(stopCh)
+		go dc.Run(5, stopCh)
+
+		ds := newDaemonSet("foo", ns.Name)
+		ds.Spec.UpdateStrategy = *strategy
+		_, err := dsClient.Create(ds)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet: %v", err)
+		}
+		node := newNode("single-node", nil)
+		node.Status.Conditions = []v1.NodeCondition{
+			{Type: v1.NodeReady, Status: v1.ConditionFalse},
+		}
+		_, err = nodeClient.Create(node)
+		if err != nil {
+			t.Fatalf("Failed to create node: %v", err)
+		}
+
+		validateDaemonSetPodsAndMarkReady(podClient, podInformer, 1, t)
+		validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 1, t)
+
+		close(stopCh)
+	}
+}
+
+func TestInsufficientCapacityNodeDaemonDoesNotLaunchPod(t *testing.T) {
+	for _, strategy := range updateStrategies() {
+		server, closeFn, dc, informers, clientset := setup(t)
+		defer closeFn()
+		ns := framework.CreateTestingNamespace("insufficient-capacity", server, t)
+		defer framework.DeleteTestingNamespace(ns, server, t)
+
+		dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+		nodeClient := clientset.CoreV1().Nodes()
+		eventClient := corev1typed.New(clientset.CoreV1().RESTClient()).Events(ns.Namespace)
+		stopCh := make(chan struct{})
+		informers.Start(stopCh)
+		go dc.Run(5, stopCh)
+
+		ds := newDaemonSet("foo", ns.Name)
+		ds.Spec.Template.Spec = resourcePodSpec("node-with-limited-memory", "120M", "75m")
+		ds.Spec.UpdateStrategy = *strategy
+		_, err := dsClient.Create(ds)
+		if err != nil {
+			t.Fatalf("Failed to create DaemonSet: %v", err)
+		}
+		node := newNode("node-with-limited-memory", nil)
+		node.Status.Allocatable = allocatableResources("100M", "200m")
+		_, err = nodeClient.Create(node)
+		if err != nil {
+			t.Fatalf("Failed to create node: %v", err)
+		}
+
+		validateFailedPlacementEvent(eventClient, t)
+
+		close(stopCh)
+	}
+}

--- a/test/integration/daemonset/main_test.go
+++ b/test/integration/daemonset/main_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package daemonset
+
+import (
+	"testing"
+
+	"k8s.io/kubernetes/test/integration/framework"
+)
+
+func TestMain(m *testing.M) {
+	framework.EtcdMain(m.Run)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR setup and added some initial integration tests for the DaemonSet controller. All tests included were ported from their unit test counterparts that currently use fake client, informers, reactor, etc. Future PRs will port more tests over once this PR is approved and merged.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: #52191.

**Special notes for your reviewer**:
@kow3ns 

**Release note**:
```release-note
NONE
```
