### PR TITLE
Restore OWNERS file for k8s.io/metrics

### DIFF
--- a/staging/src/k8s.io/metrics/OWNERS
+++ b/staging/src/k8s.io/metrics/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- DirectXMan12
+- piosz


### PR DESCRIPTION
The owners file for k8s.io/metrics somehow got lost.  This restores it
to its contents on the "legacy" branch of k8s.io/metrics.

```release-note
NONE
```
