### PR TITLE
Automated cherry pick of #50096

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,18 +1,18 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.5
+  name: l7-lb-controller-v0.9.6
   namespace: kube-system
   labels:
     k8s-app: glbc
-    version: v0.9.5
+    version: v0.9.6
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.5
+  - image: gcr.io/google_containers/glbc:0.9.6
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Cherry pick of #50096 on release-1.6.

#50096: Bump GLBC version to 0.9.6


**Release note**:
```release-note
GCE: Bump GLBC version to [0.9.6](https://github.com/kubernetes/ingress/releases/tag/0.9.6).
```
