### PR TITLE
fix cleanup step in kubectl cronjob test

### DIFF
--- a/test/e2e/kubectl.go
+++ b/test/e2e/kubectl.go
@@ -201,7 +201,7 @@ var _ = framework.KubeDescribe("Kubectl alpha client", func() {
 		})
 
 		AfterEach(func() {
-			framework.RunKubectlOrDie("delete", "cronjobs", cjName, nsFlag)
+			framework.RunKubectlOrDie("delete", "cronjob.v2alpha1.batch", cjName, nsFlag)
 		})
 
 		It("should create a CronJob", func() {


### PR DESCRIPTION
Skew test is failing because there are multiple version of cronjob.
Explicitly specify group version kind when cleanup.
```
{  cronjobs} matches multiple kinds [batch/v1beta1, Kind=CronJob batch/v2alpha1, Kind=CronJob
```
Fixes: #52219

```release-note
NONE
```
/assign @pwittrock 