### PR TITLE
Add bsalamat to sig-scheduling-maintainers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,17 +1,18 @@
 aliases:
   sig-scheduling-maintainers:
-    - davidopp
-    - timothysc
-    - wojtek-t
-    - k82cn
-  sig-scheduling:
-    - davidopp
     - bsalamat
+    - davidopp
+    - k82cn
     - timothysc
     - wojtek-t
-    - k82cn
+  sig-scheduling:
+    - bsalamat
+    - davidopp
     - jayunit100
+    - k82cn
     - resouer
+    - timothysc
+    - wojtek-t
   sig-cli-maintainers:
     - adohe
     - brendandburns

--- a/plugin/cmd/kube-scheduler/OWNERS
+++ b/plugin/cmd/kube-scheduler/OWNERS
@@ -1,11 +1,4 @@
 approvers:
-- davidopp
-- timothysc
-- k82cn
+- sig-scheduling-maintainers
 reviewers:
-- davidopp
-- bsalamat
-- timothysc
-- wojtek-t
-- k82cn
-- jayunit100
+- sig-scheduling

--- a/test/integration/scheduler_perf/OWNERS
+++ b/test/integration/scheduler_perf/OWNERS
@@ -1,10 +1,12 @@
 approvers:
+- bsalamat
 - davidopp
 - gmarek
 - jayunit100
 - timothysc
 - wojtek-t
 reviewers:
+- bsalamat
 - davidopp
 - jayunit100
 - k82cn


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Adds bsalamat to sig-scheduling-maintainers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

@kubernetes/sig-scheduling-pr-reviews @davidopp @timothysc @k82cn @wojtek-t 