### PR TITLE
Pass Logs=true in the streaming options to ContainerAttach api

### DIFF
--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -149,6 +149,7 @@ func attachContainer(client libdocker.Interface, containerID string, stdin io.Re
 		Stdin:  stdin != nil,
 		Stdout: stdout != nil,
 		Stderr: stderr != nil,
+		Logs:   true,
 	}
 	sopts := libdocker.StreamOptions{
 		InputStream:  stdin,


### PR DESCRIPTION
**What this PR does / why we need it**:
Gets `kubectl attach` working.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52224

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
/cc @sjenning 