### PR TITLE
Automated cherry pick of #52227

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/restmapper_test.go
+++ b/staging/src/k8s.io/client-go/discovery/restmapper_test.go
@@ -67,6 +67,32 @@ func TestRESTMapper(t *testing.T) {
 				},
 			},
 		},
+
+		// This group tests finding and prioritizing resources that only exist in non-preferred versions
+		{
+			Group: metav1.APIGroup{
+				Name: "unpreferred",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{Version: "v1"},
+					{Version: "v2beta1"},
+					{Version: "v2alpha1"},
+				},
+				PreferredVersion: metav1.GroupVersionForDiscovery{Version: "v1"},
+			},
+			VersionedResources: map[string][]metav1.APIResource{
+				"v1": {
+					{Name: "broccoli", Namespaced: true, Kind: "Broccoli"},
+				},
+				"v2beta1": {
+					{Name: "broccoli", Namespaced: true, Kind: "Broccoli"},
+					{Name: "peas", Namespaced: true, Kind: "Pea"},
+				},
+				"v2alpha1": {
+					{Name: "broccoli", Namespaced: true, Kind: "Broccoli"},
+					{Name: "peas", Namespaced: true, Kind: "Pea"},
+				},
+			},
+		},
 	}
 
 	restMapper := NewRESTMapper(resources, nil)
@@ -121,6 +147,16 @@ func TestRESTMapper(t *testing.T) {
 				Group:   "extensions",
 				Version: "v1beta",
 				Kind:    "Job",
+			},
+		},
+		{
+			input: schema.GroupVersionResource{
+				Resource: "peas",
+			},
+			want: schema.GroupVersionKind{
+				Group:   "unpreferred",
+				Version: "v2beta1",
+				Kind:    "Pea",
 			},
 		},
 	}


### PR DESCRIPTION
Cherry pick of #52227 on release-1.7.

Fixes: #52219

The discovery rest mapper was only populating the priority rest mapper's search list with preferred groupversions.

That meant that if a resource existed in multiple non-preferred versions, AND did not exist in the preferred version (like cronjob, which only exists in v1beta2.batch and v2alpha1.batch, but not v1.batch), the priority restmapper would not find it in its group/version priority list, and would return an error.

```release-note
Fixed an issue looking up cronjobs when they existed in more than one API version
```