### PR TITLE
Add node e2e tests for pulling images from credential providers

### DIFF
--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -18,13 +18,17 @@ package e2e_node
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/kubelet/images"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e_node/services"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -256,11 +260,12 @@ while true; do sleep 1; done
 			// testing image pulling, these images don't need to be prepulled. The ImagePullPolicy
 			// is v1.PullAlways, so it won't be blocked by framework image white list check.
 			for _, testCase := range []struct {
-				description string
-				image       string
-				secret      bool
-				phase       v1.PodPhase
-				waiting     bool
+				description        string
+				image              string
+				secret             bool
+				credentialProvider bool
+				phase              v1.PodPhase
+				waiting            bool
 			}{
 				{
 					description: "should not be able to pull image from invalid registry",
@@ -299,6 +304,13 @@ while true; do sleep 1; done
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},
+				{
+					description:        "should be able to pull from private registry with credential provider",
+					image:              "gcr.io/authenticated-image-pulling/alpine:3.1",
+					credentialProvider: true,
+					phase:              v1.PodRunning,
+					waiting:            false,
+				},
 			} {
 				testCase := testCase
 				It(testCase.description+" [Conformance]", func() {
@@ -322,6 +334,12 @@ while true; do sleep 1; done
 						Expect(err).NotTo(HaveOccurred())
 						defer f.ClientSet.Core().Secrets(f.Namespace.Name).Delete(secret.Name, nil)
 						container.ImagePullSecrets = []string{secret.Name}
+					}
+					if testCase.credentialProvider {
+						configFile := filepath.Join(services.KubeletRootDirectory, "config.json")
+						err := ioutil.WriteFile(configFile, []byte(auth), 0644)
+						Expect(err).NotTo(HaveOccurred())
+						defer os.Remove(configFile)
 					}
 					// checkContainerStatus checks whether the container status matches expectation.
 					checkContainerStatus := func() error {

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -85,7 +85,7 @@ const (
 	// Ports of different e2e services.
 	kubeletPort          = "10250"
 	kubeletReadOnlyPort  = "10255"
-	kubeletRootDirectory = "/var/lib/kubelet"
+	KubeletRootDirectory = "/var/lib/kubelet"
 	// Health check url of kubelet
 	kubeletHealthCheckURL = "http://127.0.0.1:" + kubeletReadOnlyPort + "/healthz"
 )
@@ -110,7 +110,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		return nil, err
 	}
 	e.rmDirs = append(e.rmDirs, manifestPath)
-	err = createRootDirectory(kubeletRootDirectory)
+	err = createRootDirectory(KubeletRootDirectory)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +151,7 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		"--address", "0.0.0.0",
 		"--port", kubeletPort,
 		"--read-only-port", kubeletReadOnlyPort,
-		"--root-dir", kubeletRootDirectory,
+		"--root-dir", KubeletRootDirectory,
 		"--volume-stats-agg-period", "10s", // Aggregate volumes frequently so tests don't need to wait as long
 		"--allow-privileged", "true",
 		"--serialize-image-pulls", "false",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Add node e2e tests for pulling images from credential providers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

Refer https://github.com/kubernetes/kubernetes/pull/51870#issuecomment-328234010

**Special notes for your reviewer**:

/assign @yujuhong @Random-Liu 

1. We still need to add ResetDefaultDockerProviderExpiration for facilitating tests
2. Do we need a separate image for pulling private image from credential provider?
3. Any suggestion of also adding this for sandbox images? the pause image is a global config of kubelet, but we only need to set a private one for just one test case. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
