### PR TITLE
[fluentd-gcp addon] Update event-exporter to address metrics problem

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: event-exporter
+  name: event-exporter-v0.1.7
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.1.5
+    version: v0.1.7
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -42,13 +42,12 @@ spec:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.1.5
+        version: v0.1.7
     spec:
       serviceAccountName: event-exporter-sa
       containers:
-      # TODO: Add resources in 1.8
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.5
+        image: gcr.io/google-containers/event-exporter:v0.1.7
         command:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD


### PR DESCRIPTION
Follow-up of https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/37:

```
In the clusters with CA, the number of metric streams will continuously grow if the host is included.
```

Name is updated b/c otherwise addon manager will not be able to pick up the change.

```release-note
[fluentd-gcp addon] Bug with event-exporter leaking memory on metrics in clusters with CA is fixed.
```