### PR TITLE
apiextensions: fix conversion of CRD schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -50,7 +50,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			for i := 0; i < tobj.NumField(); i++ {
 				field := tobj.Field(i)
 				switch field.Name {
-				case "Default", "Enum", "Example":
+				case "Default", "Enum", "Example", "Ref":
 					continue
 				default:
 					isValue := true
@@ -73,6 +73,10 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			if c.RandBool() {
 				validJSON := apiextensions.JSON(`"foobarbaz"`)
 				obj.Example = &validJSON
+			}
+			if c.RandBool() {
+				validRef := "validRef"
+				obj.Ref = &validRef
 			}
 		},
 		func(obj *apiextensions.JSONSchemaPropsOrBool, c fuzz.Continue) {


### PR DESCRIPTION
- [x] Fix conversion of CRD schema to go-openapi types.
- [x] Add roundtrip tests for this conversion: https://github.com/kubernetes/kubernetes/pull/52793.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/cc @sttts 