### PR TITLE
Fixes device plugin re-registration handling logic to make sure:

### DIFF
--- a/pkg/kubelet/deviceplugin/device_plugin_stub.go
+++ b/pkg/kubelet/deviceplugin/device_plugin_stub.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"net"
 	"os"
+	"path"
 	"time"
 
 	"golang.org/x/net/context"
@@ -84,6 +85,30 @@ func (m *Stub) Stop() error {
 	m.server.Stop()
 
 	return m.cleanup()
+}
+
+// Register registers the device plugin for the given resourceName with Kubelet.
+func (m *Stub) Register(kubeletEndpoint, resourceName string) error {
+	conn, err := grpc.Dial(kubeletEndpoint, grpc.WithInsecure(),
+		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
+			return net.DialTimeout("unix", addr, timeout)
+		}))
+	defer conn.Close()
+	if err != nil {
+		return err
+	}
+	client := pluginapi.NewRegistrationClient(conn)
+	reqt := &pluginapi.RegisterRequest{
+		Version:      pluginapi.Version,
+		Endpoint:     path.Base(m.socket),
+		ResourceName: resourceName,
+	}
+
+	_, err = client.Register(context.Background(), reqt)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // ListAndWatch lists devices and update that list according to the Update call

--- a/pkg/kubelet/deviceplugin/manager.go
+++ b/pkg/kubelet/deviceplugin/manager.go
@@ -35,7 +35,7 @@ type ManagerImpl struct {
 	socketname string
 	socketdir  string
 
-	Endpoints map[string]*endpoint // Key is ResourceName
+	endpoints map[string]*endpoint // Key is ResourceName
 	mutex     sync.Mutex
 
 	callback MonitorCallback
@@ -55,7 +55,7 @@ func NewManagerImpl(socketPath string, f MonitorCallback) (*ManagerImpl, error) 
 
 	dir, file := filepath.Split(socketPath)
 	return &ManagerImpl{
-		Endpoints: make(map[string]*endpoint),
+		endpoints: make(map[string]*endpoint),
 
 		socketname: file,
 		socketdir:  dir,
@@ -138,7 +138,7 @@ func (m *ManagerImpl) Devices() map[string][]*pluginapi.Device {
 	defer m.mutex.Unlock()
 
 	devs := make(map[string][]*pluginapi.Device)
-	for k, e := range m.Endpoints {
+	for k, e := range m.endpoints {
 		glog.V(3).Infof("Endpoint: %+v: %+v", k, e)
 		devs[k] = e.getDevices()
 	}
@@ -157,7 +157,7 @@ func (m *ManagerImpl) Allocate(resourceName string, devs []string) (*pluginapi.A
 	glog.V(3).Infof("Recieved allocation request for devices %v for device plugin %s",
 		devs, resourceName)
 	m.mutex.Lock()
-	e, ok := m.Endpoints[resourceName]
+	e, ok := m.endpoints[resourceName]
 	m.mutex.Unlock()
 	if !ok {
 		return nil, fmt.Errorf("Unknown Device Plugin %s", resourceName)
@@ -189,7 +189,7 @@ func (m *ManagerImpl) Register(ctx context.Context,
 
 // Stop is the function that can stop the gRPC server.
 func (m *ManagerImpl) Stop() error {
-	for _, e := range m.Endpoints {
+	for _, e := range m.endpoints {
 		e.stop()
 	}
 	m.server.Stop()
@@ -197,40 +197,40 @@ func (m *ManagerImpl) Stop() error {
 }
 
 func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
-	// Stops existing endpoint if there is any.
-	m.mutex.Lock()
-	old, ok := m.Endpoints[r.ResourceName]
-	m.mutex.Unlock()
-	if ok && old != nil {
-		old.stop()
-	}
-
 	socketPath := filepath.Join(m.socketdir, r.Endpoint)
 	e, err := newEndpoint(socketPath, r.ResourceName, m.callback)
 	if err != nil {
 		glog.Errorf("Failed to dial device plugin with request %v: %v", r, err)
 		return
 	}
-
 	stream, err := e.list()
 	if err != nil {
 		glog.Errorf("Failed to List devices for plugin %v: %v", r.ResourceName, err)
 		return
 	}
 
+	// Associates the newly created endpoint with the corresponding resource name.
+	// Stops existing endpoint if there is any.
+	m.mutex.Lock()
+	old, ok := m.endpoints[r.ResourceName]
+	m.endpoints[r.ResourceName] = e
+	m.mutex.Unlock()
+	glog.V(2).Infof("Registered endpoint %v", e)
+	if ok && old != nil {
+		old.stop()
+	}
+
 	go func() {
 		e.listAndWatch(stream)
 
 		m.mutex.Lock()
-		if old, ok := m.Endpoints[r.ResourceName]; ok && old == e {
-			delete(m.Endpoints, r.ResourceName)
+		if old, ok := m.endpoints[r.ResourceName]; ok && old == e {
+			glog.V(2).Infof("Delete resource for endpoint %v", e)
+			delete(m.endpoints, r.ResourceName)
+			// Issues callback to delete all of devices.
+			e.callback(e.resourceName, []*pluginapi.Device{}, []*pluginapi.Device{}, e.getDevices())
 		}
 		glog.V(2).Infof("Unregistered endpoint %v", e)
 		m.mutex.Unlock()
 	}()
-
-	m.mutex.Lock()
-	m.Endpoints[r.ResourceName] = e
-	glog.V(2).Infof("Registered endpoint %v", e)
-	m.mutex.Unlock()
 }


### PR DESCRIPTION
- If a device plugin exits, its exported resource will be removed.
- No capacity change if a new device plugin instance comes up to replace the old instance.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/kubernetes/kubernetes/issues/52510

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
