### PR TITLE
Use cAdvisor constant for crio imagefs

### DIFF
--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -40,9 +40,8 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 	case "rkt":
 		return cadvisorfs.LabelRktImages, nil
 	case "remote":
-		// TODO: pending rebase including https://github.com/google/cadvisor/pull/1741
 		if i.runtimeEndpoint == "/var/run/crio.sock" {
-			return "crio-images", nil
+			return cadvisorfs.LabelCrioImages, nil
 		}
 	}
 	return "", fmt.Errorf("no imagefs label for configured runtime")


### PR DESCRIPTION
**What this PR does / why we need it**:
code hygiene to use a constant from cAdvisor

**Release note**:
```release-note
NONE
```
