### PR TITLE
[GCE kube-up] Add a warning for kube-proxy DaemonSet option

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -311,7 +311,7 @@ PROMETHEUS_TO_SD_PREFIX="${PROMETHEUS_TO_SD_PREFIX:-custom.googleapis.com}"
 ENABLE_PROMETHEUS_TO_SD="${ENABLE_PROMETHEUS_TO_SD:-false}"
 
 # TODO(#51292): Make kube-proxy Daemonset default and remove the configuration here.
-# Optional: Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
+# Optional: [Experiment Only] Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
 KUBE_PROXY_DAEMONSET="${KUBE_PROXY_DAEMONSET:-false}" # true, false
 
 # Optional: duration of cluster signed certificates.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -369,7 +369,7 @@ PROMETHEUS_TO_SD_PREFIX="${PROMETHEUS_TO_SD_PREFIX:-custom.googleapis.com}"
 ENABLE_PROMETHEUS_TO_SD="${ENABLE_PROMETHEUS_TO_SD:-true}"
 
 # TODO(#51292): Make kube-proxy Daemonset default and remove the configuration here.
-# Optional: Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
+# Optional: [Experiment Only] Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
 KUBE_PROXY_DAEMONSET="${KUBE_PROXY_DAEMONSET:-false}" # true, false
 
 # Optional: duration of cluster signed certificates.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a warning for kube-proxy DaemonSet option for GCE kube-up so that user will be aware of the risks.

Ref: https://github.com/kubernetes/kubernetes/issues/23225

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE 

**Special notes for your reviewer**:
/assign @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
