### PR TITLE
kubeadm: Mark self-hosting alpha in v1.8

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -63,7 +63,7 @@ func Keys(featureList FeatureList) []string {
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	SelfHosting:         {Default: false, PreRelease: utilfeature.Beta},
+	SelfHosting:         {Default: false, PreRelease: utilfeature.Alpha},
 	StoreCertsInSecrets: {Default: false, PreRelease: utilfeature.Alpha},
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Self-hosting is alpha in v1.8, not beta. We targeted it to be beta, hence the initial add of this feature gates' value, but now changing back to alpha.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 