### PR TITLE
bazel: update sha256sum on rules_go and io_bazel dependencies

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -1,6 +1,6 @@
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "abdea3986d9e850eda27b12163b0b558accdb5bca69ef945b022356f920d430d",
+    sha256 = "08969d1cb8ad523f451098da53117108ae564698bcee281c9a2890836e5be0ee",
     strip_prefix = "rules_go-473417ec48310325e1fcb1c154621a83197a17fe",
     urls = ["https://github.com/bazelbuild/rules_go/archive/473417ec48310325e1fcb1c154621a83197a17fe.tar.gz"],
 )
@@ -17,7 +17,7 @@ http_archive(
 # https://bazel-review.googlesource.com/#/c/10390/
 http_archive(
     name = "io_bazel",
-    sha256 = "667d32da016b1e2f63cf345cd3583989ec4a165034df383a01996d93635753a0",
+    sha256 = "892a84aa1e7c1f99fb57bb056cb648745c513077252815324579a012d263defb",
     strip_prefix = "bazel-df2c687c22bdd7c76f3cdcc85f38fefd02f0b844",
     urls = ["https://github.com/ixdy/bazel/archive/df2c687c22bdd7c76f3cdcc85f38fefd02f0b844.tar.gz"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**: fixes bazel build (#52307) for release-1.7. This is not a straight cherry-pick because release-1.7 and master are using different versions of rules_go.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
