### PR TITLE
Ignore etcd in other net ns in `kube::etcd::validate()`

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -28,7 +28,15 @@ kube::etcd::validate() {
   }
 
   # validate it is not running
-  if pgrep -x etcd >/dev/null 2>&1; then
+  case "$(uname -s)" in
+    Linux)
+      etcd_running="pgrep --ns $$ --nslist net -x etcd"
+      ;;
+    *)
+      etcd_running="pgrep -x etcd"
+      ;;
+  esac
+  if $etcd_running >/dev/null 2>&1; then
     kube::log::usage "etcd appears to already be running on this machine (`pgrep -xl etcd`) (or its a zombie and you need to kill its parent)."
     kube::log::usage "retry after you resolve this etcd error."
     exit 1


### PR DESCRIPTION
If an instance of etcd runs in a different namespace,
`kube::etcd::validate()` should not abort here.
