### PR TITLE
Fail controller-manager startup when certificate controller cannot start

### DIFF
--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -46,7 +46,7 @@ func startCSRSigningController(ctx ControllerContext) (bool, error) {
 	)
 	if err != nil {
 		glog.Errorf("Failed to start certificate controller: %v", err)
-		return false, nil
+		return false, err
 	}
 	go signer.Run(1, ctx.Stop)
 

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -64,10 +64,8 @@ func startCSRApprovingController(ctx ControllerContext) (bool, error) {
 		ctx.InformerFactory.Certificates().V1beta1().CertificateSigningRequests(),
 	)
 	if err != nil {
-		// TODO this is failing consistently in test-cmd and local-up-cluster.sh.  Fix them and make it consistent with all others which
-		// cause a crash loop
 		glog.Errorf("Failed to start certificate controller: %v", err)
-		return false, nil
+		return false, err
 	}
 	go approver.Run(1, ctx.Stop)
 


### PR DESCRIPTION
Without it, misconfiguration errors are skipped and controller
manager process continues to run with controller disabled.

```release-note
NONE
```
