### PR TITLE
remove replicaset unit tests that are converted to integration tests

### DIFF
--- a/pkg/controller/replicaset/BUILD
+++ b/pkg/controller/replicaset/BUILD
@@ -46,7 +46,6 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/api:go_default_library",
-        "//pkg/api/testapi:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/securitycontext:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR revamps existing replicaset unit tests by removing the tests that have been converted to integration tests.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #52118

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```