### PR TITLE
Add new api groups to the GCE advanced audit policy

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -485,6 +485,8 @@ function create-master-audit-policy {
   local -r known_apis='
       - group: "" # core
       - group: "admissionregistration.k8s.io"
+      - group: "apiextensions.k8s.io"
+      - group: "apiregistration.k8s.io"
       - group: "apps"
       - group: "authentication.k8s.io"
       - group: "authorization.k8s.io"
@@ -492,6 +494,7 @@ function create-master-audit-policy {
       - group: "batch"
       - group: "certificates.k8s.io"
       - group: "extensions"
+      - group: "metrics"
       - group: "networking.k8s.io"
       - group: "policy"
       - group: "rbac.authorization.k8s.io"
@@ -547,6 +550,13 @@ rules:
     resources:
       - group: "" # core
         resources: ["namespaces", "namespaces/status", "namespaces/finalize"]
+  # Don't log HPA fetching metrics.
+  - level: None
+    users:
+      - system:kube-controller-manager
+    verbs: ["get", "list"]
+    resources:
+      - group: "metrics"
 
   # Don't log these read-only URLs.
   - level: None


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52265

It introduces the missing api groups, that were introduced in 1.8 release.

@piosz there's also the 'metrics' api group, should we audit it?