### PR TITLE
Bump Cluster Autoscaler to 0.6.2 in K8S 1.7 branch

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v0.6.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Contains fixes and better eventing around scale-up failures (like stockout).

```release-note
Cluster Autoscaler 0.6.2
```
