### PR TITLE
GlusterFS plugin fails to mount volumes in 1.7.3 branch #50463

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -346,8 +346,8 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 			return nil
 		}
 
-		const invalidOption = "Invalid option auto_unmount"
-		if dstrings.Contains(errs.Error(), invalidOption) {
+		if dstrings.Contains(errs.Error(), "Invalid option auto_unmount") ||
+			dstrings.Contains(errs.Error(), "Invalid argument") {
 			// Give a try without `auto_unmount` mount option, because
 			// it could be that gluster fuse client is older version and
 			// mount.glusterfs is unaware of `auto_unmount`.


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/issues/50463