### PR TITLE
Remove the conversion of client config

### DIFF
--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
 
@@ -149,7 +148,7 @@ func observerUpdate(w watch.Interface, expectedUpdate func(runtime.Object) bool)
 	return
 }
 
-var _ = SIGDescribe("Generated release_1_5 clientset", func() {
+var _ = SIGDescribe("Generated clientset", func() {
 	f := framework.NewDefaultFramework("clientset")
 	It("should create pods, set the deletionTimestamp and deletionGracePeriodSeconds of the pod", func() {
 		podClient := f.ClientSet.Core().Pods(f.Namespace.Name)
@@ -261,7 +260,7 @@ func newTestingCronJob(name string, value string) *batchv1beta1.CronJob {
 	}
 }
 
-var _ = SIGDescribe("Generated release_1_5 clientset", func() {
+var _ = SIGDescribe("Generated clientset", func() {
 	f := framework.NewDefaultFramework("clientset")
 
 	BeforeEach(func() {
@@ -324,43 +323,5 @@ var _ = SIGDescribe("Generated release_1_5 clientset", func() {
 			framework.Failf("Failed to list cronJobs to verify deletion: %v", err)
 		}
 		Expect(len(cronJobs.Items)).To(Equal(0))
-	})
-})
-
-var _ = SIGDescribe("Staging client repo client", func() {
-	f := framework.NewDefaultFramework("clientset")
-	It("should create pods, delete pods, watch pods", func() {
-		podClient := f.StagingClient.CoreV1().Pods(f.Namespace.Name)
-		By("constructing the pod")
-		name := "pod" + string(uuid.NewUUID())
-		value := strconv.Itoa(time.Now().Nanosecond())
-		podCopy := stagingClientPod(name, value)
-		pod := &podCopy
-		By("verifying no pod exists before the test")
-		pods, err := podClient.List(metav1.ListOptions{})
-		if err != nil {
-			framework.Failf("Failed to query for pods: %v", err)
-		}
-		Expect(len(pods.Items)).To(Equal(0))
-		By("creating the pod")
-		pod, err = podClient.Create(pod)
-		if err != nil {
-			framework.Failf("Failed to create pod: %v", err)
-		}
-
-		By("verifying the pod is in kubernetes")
-		timeout := 1 * time.Minute
-		if err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
-			pods, err = podClient.List(metav1.ListOptions{})
-			if err != nil {
-				return false, err
-			}
-			if len(pods.Items) == 1 {
-				return true, nil
-			}
-			return false, nil
-		}); err != nil {
-			framework.Failf("Err : %s\n. Failed to wait for 1 pod to be created", err)
-		}
 	})
 })

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -44,10 +44,10 @@ const (
 var _ = SIGDescribe("DisruptionController", func() {
 	f := framework.NewDefaultFramework("disruption")
 	var ns string
-	var cs *kubernetes.Clientset
+	var cs kubernetes.Interface
 
 	BeforeEach(func() {
-		cs = f.StagingClient
+		cs = f.ClientSet
 		ns = f.Namespace.Name
 	})
 
@@ -215,7 +215,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 	}
 })
 
-func createPDBMinAvailableOrDie(cs *kubernetes.Clientset, ns string, minAvailable intstr.IntOrString) {
+func createPDBMinAvailableOrDie(cs kubernetes.Interface, ns string, minAvailable intstr.IntOrString) {
 	pdb := policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -230,7 +230,7 @@ func createPDBMinAvailableOrDie(cs *kubernetes.Clientset, ns string, minAvailabl
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func createPDBMaxUnavailableOrDie(cs *kubernetes.Clientset, ns string, maxUnavailable intstr.IntOrString) {
+func createPDBMaxUnavailableOrDie(cs kubernetes.Interface, ns string, maxUnavailable intstr.IntOrString) {
 	pdb := policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
@@ -245,7 +245,7 @@ func createPDBMaxUnavailableOrDie(cs *kubernetes.Clientset, ns string, maxUnavai
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func createPodsOrDie(cs *kubernetes.Clientset, ns string, n int) {
+func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 	for i := 0; i < n; i++ {
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -269,7 +269,7 @@ func createPodsOrDie(cs *kubernetes.Clientset, ns string, n int) {
 	}
 }
 
-func waitForPodsOrDie(cs *kubernetes.Clientset, ns string, n int) {
+func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 	By("Waiting for all pods to be running")
 	err := wait.PollImmediate(framework.Poll, schedulingTimeout, func() (bool, error) {
 		pods, err := cs.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: "foo=bar"})
@@ -298,7 +298,7 @@ func waitForPodsOrDie(cs *kubernetes.Clientset, ns string, n int) {
 	framework.ExpectNoError(err, "Waiting for pods in namespace %q to be ready", ns)
 }
 
-func createReplicaSetOrDie(cs *kubernetes.Clientset, ns string, size int32, exclusive bool) {
+func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
 		Name:  "busybox",
 		Image: "gcr.io/google_containers/echoserver:1.6",

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -735,10 +735,10 @@ func runDrainTest(f *framework.Framework, migSizes map[string]int, namespace str
 			MinAvailable: &minAvailable,
 		},
 	}
-	_, err = f.StagingClient.Policy().PodDisruptionBudgets(namespace).Create(pdb)
+	_, err = f.ClientSet.Policy().PodDisruptionBudgets(namespace).Create(pdb)
 
 	defer func() {
-		f.StagingClient.Policy().PodDisruptionBudgets(namespace).Delete(pdb.Name, &metav1.DeleteOptions{})
+		f.ClientSet.Policy().PodDisruptionBudgets(namespace).Delete(pdb.Name, &metav1.DeleteOptions{})
 	}()
 
 	framework.ExpectNoError(err)
@@ -1405,7 +1405,7 @@ func addKubeSystemPdbs(f *framework.Framework) (func(), error) {
 	newPdbs := make([]string, 0)
 	cleanup := func() {
 		for _, newPdbName := range newPdbs {
-			f.StagingClient.Policy().PodDisruptionBudgets("kube-system").Delete(newPdbName, &metav1.DeleteOptions{})
+			f.ClientSet.Policy().PodDisruptionBudgets("kube-system").Delete(newPdbName, &metav1.DeleteOptions{})
 		}
 	}
 
@@ -1434,7 +1434,7 @@ func addKubeSystemPdbs(f *framework.Framework) (func(), error) {
 				MinAvailable: &minAvailable,
 			},
 		}
-		_, err := f.StagingClient.Policy().PodDisruptionBudgets("kube-system").Create(pdb)
+		_, err := f.ClientSet.Policy().PodDisruptionBudgets("kube-system").Create(pdb)
 		newPdbs = append(newPdbs, pdbName)
 
 		if err != nil {


### PR DESCRIPTION
It was needed because the clientset code in client-go was a copy of the clientset code in Kubernetes.. client-go is authoritative now, so we can remove the nasty copy.