### PR TITLE
add cloud controller manager examples

### DIFF
--- a/examples/cloud-controller-manager/cloud-controller-manager-as-daemonset.yml
+++ b/examples/cloud-controller-manager/cloud-controller-manager-as-daemonset.yml
@@ -1,0 +1,68 @@
+# This is an example of how to setup cloud-controller-maanger as a Daemonset in your cluster.
+# It assumes that your masters can run pods and has the role node-role.kubernetes.io/master
+# Note that this Daemonset is unlikely to work straight out of the box for your cloud, this is
+# meant to be a guideline.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  labels:
+    app: cloud-controller-manager
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      containers:
+      - name: cloud-controller-manager
+        image: gcr.io/google_containers/cloud-controller-manager:v1.7.0
+        command:
+        - /usr/local/bin/cloud-controller-manager
+        - --cloud-provider=<YOUR_CLOUD_PROVIDER>   # Add your own cloud provider here!
+        - --leader-elect=true
+        # these flags will vary for every cloud provider
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=true
+        - --cluster-cidr=172.17.0.0/16
+        volumeMounts:
+        - name: etcssl
+          mountPath: /etc/ssl
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      volumes:
+      - name: etcssl
+        hostPath:
+          path: /etc/ssl

--- a/examples/cloud-controller-manager/cloud-controller-manager-as-deployment.yml
+++ b/examples/cloud-controller-manager/cloud-controller-manager-as-deployment.yml
@@ -1,0 +1,65 @@
+# This is an example of how to setup cloud-controller-manager as a Deployment in your cluster.
+# Note that this Deployment is unlikely to work straight out of the box for your cloud, this is 
+# meant to be a guideline.
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: system:cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: Deployment 
+metadata:
+  labels:
+    app: cloud-controller-manager
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+  name: cloud-controller-manager
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: cloud-controller-manager
+    spec:
+      serviceAccountName: cloud-controller-manager
+      containers:
+      - name: cloud-controller-manager
+        image: gcr.io/google_containers/cloud-controller-manager:v1.7.0
+        command:
+        - /usr/local/bin/cloud-controller-manager
+        - --cloud-provider=<YOUR_CLOUD_PROVIDER>   # Add your own cloud provider here!
+        - --leader-elect=true
+        # these flags will vary for every cloud provider
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=true
+        - --cluster-cidr=172.17.0.0/16
+        volumeMounts:
+        - name: etcssl
+          mountPath: /etc/ssl
+      tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule
+      volumes:
+      - name: etcssl
+        hostPath:
+          path: /etc/ssl


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds examples to run CCM as daemonset or deployment. Examples to be used with docs in https://github.com/kubernetes/kubernetes.github.io/pull/5400. 

Related: https://github.com/kubernetes/kubernetes/issues/48690, https://github.com/kubernetes/features/issues/88c

cc @luxas @wlan0 @jhorwit2 