### PR TITLE
Extends GPUDevicePlugin e2e test to exercise device plugin restarts.

### DIFF
--- a/test/e2e/scheduling/nvidia-gpus.go
+++ b/test/e2e/scheduling/nvidia-gpus.go
@@ -240,6 +240,26 @@ var _ = SIGDescribe("[Feature:GPU]", func() {
 var _ = SIGDescribe("[Feature:GPUDevicePlugin]", func() {
 	f := framework.NewDefaultFramework("device-plugin-gpus")
 	It("run Nvidia GPU Device Plugin tests on Container Optimized OS only", func() {
+		// 1. Verifies GPU resource is successfully advertised on the nodes
+		// and we can run pods using GPUs.
+		By("Starting device plugin daemonset and running GPU pods")
+		testNvidiaGPUsOnCOS(f)
+
+		// 2. Verifies that when the device plugin DaemonSet is removed, resource capacity drops to zero.
+		By("Deleting device plugin daemonset")
+		ds := dsFromManifest(dsYamlUrl)
+		falseVar := false
+		err := f.ClientSet.Extensions().DaemonSets(f.Namespace.Name).Delete(ds.Name, &metav1.DeleteOptions{OrphanDependents: &falseVar})
+		framework.ExpectNoError(err, "failed to delete daemonset")
+		framework.Logf("Successfully deleted device plugin daemonset. Wait for resource to be removed.")
+		// Wait for Nvidia GPUs to be not available on nodes
+		Eventually(func() bool {
+			return !areGPUsAvailableOnAllSchedulableNodes(f)
+		}, 5*time.Minute, time.Second).Should(BeTrue())
+
+		// 3. Restarts the device plugin DaemonSet. Verifies GPU resource is successfully advertised
+		// on the nodes and we can run pods using GPUs.
+		By("Restarting device plugin daemonset and running GPU pods")
 		testNvidiaGPUsOnCOS(f)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This is part of issue #52189 but does not fix it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
/release-note-none
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```