### PR TITLE
Workaround go-junit-report bug for TestApps

### DIFF
--- a/pkg/kubectl/apps/BUILD
+++ b/pkg/kubectl/apps/BUILD
@@ -37,6 +37,8 @@ go_test(
     deps = [
         ":go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/config:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/types:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/kubectl/apps/apps_suite_test.go
+++ b/pkg/kubectl/apps/apps_suite_test.go
@@ -17,13 +17,33 @@ limitations under the License.
 package apps_test
 
 import (
-	"testing"
-
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
+	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
+
+	"fmt"
+	"testing"
 )
 
 func TestApps(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Apps Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Apps Suite", []Reporter{newlineReporter{}})
 }
+
+// Print a newline after the default newlineReporter due to issue
+// https://github.com/jstemmer/go-junit-report/issues/31
+type newlineReporter struct{}
+
+func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
+
+func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
+
+func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
+
+// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
+func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }


### PR DESCRIPTION
**What this PR does / why we need it**: Fix output from pkg/kubectl/apps/TestApps unit test

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51253

**Special notes for your reviewer**: Literally copy-pasta of the approach taken in #45320.  Maybe a sign that this should be extracted into something shared. I'm just trying to see if we can make https://k8s-testgrid.appspot.com/kubernetes-presubmits and https://k8s-testgrid.appspot.com/release-master-blocking a little more green for now.

```release-note
NONE
```