### PR TITLE
add FlagPersistent flag in nodePort and other situation

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -952,7 +952,6 @@ func (proxier *Proxier) syncProxyRules(reason syncReason) {
 			Scheduler: proxier.ipvsScheduler,
 		}
 		// Set session affinity flag and timeout for IPVS service
-		var flags utilipvs.ServiceFlags
 		if svcInfo.sessionAffinityType == api.ServiceAffinityClientIP {
 			serv.Flags |= utilipvs.FlagPersistent
 			serv.Timeout = uint32(svcInfo.stickyMaxAgeSeconds)
@@ -1030,10 +1029,10 @@ func (proxier *Proxier) syncProxyRules(reason syncReason) {
 				Address:   net.ParseIP(externalIP),
 				Port:      uint16(svcInfo.port),
 				Protocol:  string(svcInfo.protocol),
-				Flags:     flags,
 				Scheduler: proxier.ipvsScheduler,
 			}
 			if svcInfo.sessionAffinityType == api.ServiceAffinityClientIP {
+				serv.Flags |= utilipvs.FlagPersistent
 				serv.Timeout = uint32(svcInfo.stickyMaxAgeSeconds)
 			}
 			// There is no need to bind externalIP to dummy interface, so set parameter `bindAddr` to `false`.
@@ -1091,10 +1090,10 @@ func (proxier *Proxier) syncProxyRules(reason syncReason) {
 					Address:   net.ParseIP(ingress.IP),
 					Port:      uint16(svcInfo.port),
 					Protocol:  string(svcInfo.protocol),
-					Flags:     flags,
 					Scheduler: proxier.ipvsScheduler,
 				}
 				if svcInfo.sessionAffinityType == api.ServiceAffinityClientIP {
+					serv.Flags |= utilipvs.FlagPersistent
 					serv.Timeout = uint32(svcInfo.stickyMaxAgeSeconds)
 				}
 				// There is no need to bind LB ingress.IP to dummy interface, so set parameter `bindAddr` to `false`.
@@ -1141,10 +1140,10 @@ func (proxier *Proxier) syncProxyRules(reason syncReason) {
 						Address:   nodeIP,
 						Port:      uint16(svcInfo.nodePort),
 						Protocol:  string(svcInfo.protocol),
-						Flags:     flags,
 						Scheduler: proxier.ipvsScheduler,
 					}
 					if svcInfo.sessionAffinityType == api.ServiceAffinityClientIP {
+						serv.Flags |= utilipvs.FlagPersistent
 						serv.Timeout = uint32(svcInfo.stickyMaxAgeSeconds)
 					}
 					// There is no need to bind Node IP to dummy interface, so set parameter `bindAddr` to `false`.


### PR DESCRIPTION
**What this PR does / why we need it**:
For AffinityClientIP service, origin code in ipvs didn't add Persistent flag, which is a bug, so I added it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52626

**Special notes for your reviewer**:
add FlagPersistent flag in nodePort and other situation

**Release note**:
```release-note
NONE
```
