### PR TITLE
Add unit test case for storage of resource Admissionregistration

### DIFF
--- a/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/BUILD
+++ b/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -29,4 +30,20 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["storage_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/apis/admissionregistration:go_default_library",
+        "//pkg/registry/registrytest:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/etcd/testing:go_default_library",
+    ],
 )

--- a/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage_test.go
+++ b/pkg/registry/admissionregistration/externaladmissionhookconfiguration/storage/storage_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
+	"k8s.io/kubernetes/pkg/apis/admissionregistration"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+)
+
+func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, admissionregistration.GroupName)
+	restOptions := generic.RESTOptions{
+		StorageConfig:           etcdStorage,
+		Decorator:               generic.UndecoratedStorage,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          "externaladmissionhookconfigurations",
+	}
+	return NewREST(restOptions), server
+}
+
+func validExternalAdmissionHookConfiguration() *admissionregistration.ExternalAdmissionHookConfiguration {
+	return &admissionregistration.ExternalAdmissionHookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		ExternalAdmissionHooks: []admissionregistration.ExternalAdmissionHook{
+			{
+				Name: "webhook.k8s.io",
+				Rules: []admissionregistration.RuleWithOperations{
+					{
+						Operations: []admissionregistration.OperationType{"CREATE"},
+						Rule: admissionregistration.Rule{
+							APIGroups:   []string{"a"},
+							APIVersions: []string{"a"},
+							Resources:   []string{"a"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	externalAdmissionHookConfiguration := validExternalAdmissionHookConfiguration()
+	externalAdmissionHookConfiguration.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
+	test.TestCreate(
+		// valid
+		externalAdmissionHookConfiguration,
+		// invalid
+		&admissionregistration.ExternalAdmissionHookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "_-a123-a_"},
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestUpdate(
+		// valid
+		validExternalAdmissionHookConfiguration(),
+		// updateFunc
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*admissionregistration.ExternalAdmissionHookConfiguration)
+			object.ExternalAdmissionHooks = []admissionregistration.ExternalAdmissionHook{
+				{
+					Name: "webhook.k8s.io",
+					Rules: []admissionregistration.RuleWithOperations{
+						{
+							Operations: []admissionregistration.OperationType{"DELETE"},
+							Rule: admissionregistration.Rule{
+								APIGroups:   []string{"b"},
+								APIVersions: []string{"b"},
+								Resources:   []string{"b"},
+							},
+						},
+					},
+				},
+			}
+			return object
+		},
+		// invalid updateFunc
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*admissionregistration.ExternalAdmissionHookConfiguration)
+			object.ExternalAdmissionHooks = []admissionregistration.ExternalAdmissionHook{
+				{
+					Name: "webhook.k8s.io",
+					Rules: []admissionregistration.RuleWithOperations{
+						{
+							Operations: nil,
+							Rule: admissionregistration.Rule{
+								APIGroups:   []string{"a"},
+								APIVersions: []string{"a"},
+								Resources:   []string{"a"},
+							},
+						},
+					},
+				},
+			}
+			return object
+		},
+	)
+}
+
+func TestDelete(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestDelete(validExternalAdmissionHookConfiguration())
+}
+
+func TestGet(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestGet(validExternalAdmissionHookConfiguration())
+}
+
+func TestList(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestList(validExternalAdmissionHookConfiguration())
+}
+
+func TestWatch(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestWatch(
+		validExternalAdmissionHookConfiguration(),
+		// matching labels
+		[]labels.Set{},
+		// not matching labels
+		[]labels.Set{
+			{"foo": "bar"},
+		},
+		// matching fields
+		[]fields.Set{
+			{"metadata.name": "foo"},
+		},
+		// not matching fields
+		[]fields.Set{
+			{"metadata.name": "bar"},
+			{"name": "foo"},
+		},
+	)
+}

--- a/pkg/registry/admissionregistration/initializerconfiguration/storage/BUILD
+++ b/pkg/registry/admissionregistration/initializerconfiguration/storage/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -29,4 +30,20 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["storage_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/apis/admissionregistration:go_default_library",
+        "//pkg/registry/registrytest:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/storage/etcd/testing:go_default_library",
+    ],
 )

--- a/pkg/registry/admissionregistration/initializerconfiguration/storage/storage_test.go
+++ b/pkg/registry/admissionregistration/initializerconfiguration/storage/storage_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic"
+	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
+	"k8s.io/kubernetes/pkg/apis/admissionregistration"
+	"k8s.io/kubernetes/pkg/registry/registrytest"
+)
+
+func newStorage(t *testing.T) (*REST, *etcdtesting.EtcdTestServer) {
+	etcdStorage, server := registrytest.NewEtcdStorage(t, admissionregistration.GroupName)
+	restOptions := generic.RESTOptions{
+		StorageConfig:           etcdStorage,
+		Decorator:               generic.UndecoratedStorage,
+		DeleteCollectionWorkers: 1,
+		ResourcePrefix:          "initializerconfigurations",
+	}
+	return NewREST(restOptions), server
+}
+
+func validInitializerConfiguration() *admissionregistration.InitializerConfiguration {
+	return &admissionregistration.InitializerConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo",
+		},
+		Initializers: []admissionregistration.Initializer{{
+			Name: "initializer.k8s.io",
+			Rules: []admissionregistration.Rule{{
+				APIGroups:   []string{"a"},
+				APIVersions: []string{"a"},
+				Resources:   []string{"a"},
+			}},
+		}},
+	}
+}
+
+func TestCreate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	initializerConfiguration := validInitializerConfiguration()
+	initializerConfiguration.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
+	test.TestCreate(
+		// valid
+		initializerConfiguration,
+		// invalid
+		&admissionregistration.InitializerConfiguration{
+			ObjectMeta: metav1.ObjectMeta{Name: "_-a123-a_"},
+		},
+	)
+}
+
+func TestUpdate(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestUpdate(
+		// valid
+		validInitializerConfiguration(),
+		// updateFunc
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*admissionregistration.InitializerConfiguration)
+			object.Initializers = []admissionregistration.Initializer{{
+				Name: "initializer.k8s.io",
+				Rules: []admissionregistration.Rule{{
+					APIGroups:   []string{"a", "b"},
+					APIVersions: []string{"a", "b"},
+					Resources:   []string{"a", "b"},
+				}},
+			}}
+			return object
+		},
+		// invalid updateFunc
+		func(obj runtime.Object) runtime.Object {
+			object := obj.(*admissionregistration.InitializerConfiguration)
+			object.Initializers = []admissionregistration.Initializer{{
+				Name: "initializer.k8s.io",
+				Rules: []admissionregistration.Rule{{
+					APIGroups:   []string{"a"},
+					APIVersions: []string{"a"},
+					Resources:   []string{"a/b"},
+				}},
+			}}
+			return object
+		},
+	)
+}
+
+func TestDelete(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestDelete(validInitializerConfiguration())
+}
+
+func TestGet(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestGet(validInitializerConfiguration())
+}
+
+func TestList(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestList(validInitializerConfiguration())
+}
+
+func TestWatch(t *testing.T) {
+	storage, server := newStorage(t)
+	defer server.Terminate(t)
+	defer storage.Store.DestroyFunc()
+	test := registrytest.New(t, storage.Store).ClusterScope()
+	test.TestWatch(
+		validInitializerConfiguration(),
+		// matching labels
+		[]labels.Set{},
+		// not matching labels
+		[]labels.Set{
+			{"foo": "bar"},
+		},
+		// matching fields
+		[]fields.Set{
+			{"metadata.name": "foo"},
+		},
+		// not matching fields
+		[]fields.Set{
+			{"metadata.name": "bar"},
+			{"name": "foo"},
+		},
+	)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

add unit test for storage of resource Admissionregistration

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```