### PR TITLE
Build kubefed statically.

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -209,6 +209,7 @@ readonly KUBE_STATIC_LIBRARIES=(
   kube-aggregator
   kubeadm
   kubectl
+  kubefed
 )
 
 # Add any files with those //generate annotations in the array below.


### PR DESCRIPTION
Sometimes we need to run kubefed in alpine container, so it is better
to build kubefed statically.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Build `kubefed` statically.
```
