### PR TITLE
Add logging gcloud command error in e2e tests

### DIFF
--- a/test/e2e/framework/size.go
+++ b/test/e2e/framework/size.go
@@ -66,6 +66,7 @@ func GetGroupNodes(group string) ([]string, error) {
 			"list-instances", group, "--project="+TestContext.CloudConfig.ProjectID,
 			"--zone="+TestContext.CloudConfig.Zone).CombinedOutput()
 		if err != nil {
+			Logf("Failed to get nodes in instance group: %v", string(output))
 			return nil, err
 		}
 		re := regexp.MustCompile(".*RUNNING")


### PR DESCRIPTION
This adds extra log line to help with debugging GKE tests.