### PR TITLE
convert int to int32 in intstr.FromInt

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -71,7 +71,7 @@ func ComponentProbe(port int, path string, scheme v1.URIScheme) *v1.Probe {
 				// Host has to be set to "127.0.0.1" here due to that our static Pods are on the host's network
 				Host:   "127.0.0.1",
 				Path:   path,
-				Port:   intstr.FromInt(port),
+				Port:   intstr.FromInt(int32(port)),
 				Scheme: scheme,
 			},
 		},

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -54,7 +54,7 @@ func TestComponentProbe(t *testing.T) {
 	}
 	for _, rt := range tests {
 		actual := ComponentProbe(rt.port, rt.path, rt.scheme)
-		if actual.Handler.HTTPGet.Port != intstr.FromInt(rt.port) {
+		if actual.Handler.HTTPGet.Port != intstr.FromInt(int32(rt.port)) {
 			t.Errorf(
 				"failed componentProbe:\n\texpected: %v\n\t  actual: %v",
 				rt.port,

--- a/pkg/api/v1/defaults.go
+++ b/pkg/api/v1/defaults.go
@@ -123,7 +123,7 @@ func SetDefaults_Service(obj *v1.Service) {
 			sp.Protocol = v1.ProtocolTCP
 		}
 		if sp.TargetPort == intstr.FromInt(0) || sp.TargetPort == intstr.FromString("") {
-			sp.TargetPort = intstr.FromInt(int(sp.Port))
+			sp.TargetPort = intstr.FromInt(sp.Port)
 		}
 	}
 	// Defaults ExternalTrafficPolicy field for NodePort / LoadBalancer service

--- a/pkg/api/v1/defaults_test.go
+++ b/pkg/api/v1/defaults_test.go
@@ -897,13 +897,13 @@ func TestSetDefaultServicePort(t *testing.T) {
 	if out.Spec.Ports[0].Protocol != v1.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", v1.ProtocolTCP, out.Spec.Ports[0].Protocol)
 	}
-	if out.Spec.Ports[0].TargetPort != intstr.FromInt(int(in.Spec.Ports[0].Port)) {
+	if out.Spec.Ports[0].TargetPort != intstr.FromInt(in.Spec.Ports[0].Port) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[0].Port, out.Spec.Ports[0].TargetPort)
 	}
 	if out.Spec.Ports[1].Protocol != v1.ProtocolTCP {
 		t.Errorf("Expected protocol %s, got %s", v1.ProtocolTCP, out.Spec.Ports[1].Protocol)
 	}
-	if out.Spec.Ports[1].TargetPort != intstr.FromInt(int(in.Spec.Ports[1].Port)) {
+	if out.Spec.Ports[1].TargetPort != intstr.FromInt(in.Spec.Ports[1].Port) {
 		t.Errorf("Expected port %v, got %v", in.Spec.Ports[1].Port, out.Spec.Ports[1].TargetPort)
 	}
 }

--- a/pkg/apis/extensions/fuzzer/fuzzer.go
+++ b/pkg/apis/extensions/fuzzer/fuzzer.go
@@ -47,8 +47,8 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 			} else {
 				rollingUpdate := extensions.RollingUpdateDeployment{}
 				if c.RandBool() {
-					rollingUpdate.MaxUnavailable = intstr.FromInt(int(c.Rand.Int31()))
-					rollingUpdate.MaxSurge = intstr.FromInt(int(c.Rand.Int31()))
+					rollingUpdate.MaxUnavailable = intstr.FromInt(c.Rand.Int31())
+					rollingUpdate.MaxSurge = intstr.FromInt(c.Rand.Int31())
 				} else {
 					rollingUpdate.MaxSurge = intstr.FromString(fmt.Sprintf("%d%%", c.Rand.Int31()))
 				}
@@ -97,7 +97,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				rollingUpdate := extensions.RollingUpdateDaemonSet{}
 				if c.RandBool() {
 					if c.RandBool() {
-						rollingUpdate.MaxUnavailable = intstr.FromInt(1 + int(c.Rand.Int31()))
+						rollingUpdate.MaxUnavailable = intstr.FromInt(1 + c.Rand.Int31())
 					} else {
 						rollingUpdate.MaxUnavailable = intstr.FromString(fmt.Sprintf("%d%%", 1+c.Rand.Int31()))
 					}

--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -36,7 +36,7 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 
 	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
 	ds.Spec.UpdateStrategy.Type = extensions.RollingUpdateDaemonSetStrategyType
-	intStr := intstr.FromInt(maxUnavailable)
+	intStr := intstr.FromInt(int32(maxUnavailable))
 	ds.Spec.UpdateStrategy.RollingUpdate = &extensions.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
 	ds.Spec.TemplateGeneration++
 	manager.dsStore.Update(ds)
@@ -75,7 +75,7 @@ func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 
 	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
 	ds.Spec.UpdateStrategy.Type = extensions.RollingUpdateDaemonSetStrategyType
-	intStr := intstr.FromInt(maxUnavailable)
+	intStr := intstr.FromInt(int32(maxUnavailable))
 	ds.Spec.UpdateStrategy.RollingUpdate = &extensions.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
 	ds.Spec.TemplateGeneration++
 	manager.dsStore.Update(ds)
@@ -101,7 +101,7 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 
 	ds.Spec.Template.Spec.Containers[0].Image = "foo2/bar2"
 	ds.Spec.UpdateStrategy.Type = extensions.RollingUpdateDaemonSetStrategyType
-	intStr := intstr.FromInt(maxUnavailable)
+	intStr := intstr.FromInt(int32(maxUnavailable))
 	ds.Spec.UpdateStrategy.RollingUpdate = &extensions.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
 	ds.Spec.TemplateGeneration++
 	manager.dsStore.Update(ds)
@@ -126,7 +126,7 @@ func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	syncAndValidateDaemonSets(t, manager, ds, podControl, 5, 0, 0)
 
 	ds.Spec.UpdateStrategy.Type = extensions.RollingUpdateDaemonSetStrategyType
-	intStr := intstr.FromInt(maxUnavailable)
+	intStr := intstr.FromInt(int32(maxUnavailable))
 	ds.Spec.UpdateStrategy.RollingUpdate = &extensions.RollingUpdateDaemonSet{MaxUnavailable: &intStr}
 	manager.dsStore.Update(ds)
 

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func intOrStrP(val int) *intstr.IntOrString {
-	intOrStr := intstr.FromInt(val)
+	intOrStr := intstr.FromInt(int32(val))
 	return &intOrStr
 }
 

--- a/pkg/controller/deployment/util/deployment_util_test.go
+++ b/pkg/controller/deployment/util/deployment_util_test.go
@@ -762,11 +762,11 @@ func TestNewRSNewReplicas(t *testing.T) {
 			newDeployment.Spec.Strategy = extensions.DeploymentStrategy{Type: test.strategyType}
 			newDeployment.Spec.Strategy.RollingUpdate = &extensions.RollingUpdateDeployment{
 				MaxUnavailable: func(i int) *intstr.IntOrString {
-					x := intstr.FromInt(i)
+					x := intstr.FromInt(int32(i))
 					return &x
 				}(1),
 				MaxSurge: func(i int) *intstr.IntOrString {
-					x := intstr.FromInt(i)
+					x := intstr.FromInt(int32(i))
 					return &x
 				}(test.maxSurge),
 			}
@@ -953,8 +953,8 @@ func TestDeploymentComplete(t *testing.T) {
 				Replicas: &desired,
 				Strategy: extensions.DeploymentStrategy{
 					RollingUpdate: &extensions.RollingUpdateDeployment{
-						MaxUnavailable: func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxUnavailable)),
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(maxSurge)),
+						MaxUnavailable: func(i int) *intstr.IntOrString { x := intstr.FromInt(int32(i)); return &x }(int(maxUnavailable)),
+						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(int32(i)); return &x }(int(maxSurge)),
 					},
 					Type: extensions.RollingUpdateDeploymentStrategyType,
 				},
@@ -1199,7 +1199,7 @@ func TestMaxUnavailable(t *testing.T) {
 				Replicas: func(i int32) *int32 { return &i }(replicas),
 				Strategy: extensions.DeploymentStrategy{
 					RollingUpdate: &extensions.RollingUpdateDeployment{
-						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(i); return &x }(int(1)),
+						MaxSurge:       func(i int) *intstr.IntOrString { x := intstr.FromInt(int32(i)); return &x }(int(1)),
 						MaxUnavailable: &maxUnavailable,
 					},
 					Type: extensions.RollingUpdateDeploymentStrategyType,

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -195,7 +195,7 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 		if portNum, err := strconv.Atoi(targetPortString); err != nil {
 			targetPort = intstr.FromString(targetPortString)
 		} else {
-			targetPort = intstr.FromInt(portNum)
+			targetPort = intstr.FromInt(int32(portNum))
 		}
 		// Use the same target-port for every port
 		for i := range service.Spec.Ports {
@@ -206,7 +206,7 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 		// should be the same as Port
 		for i := range service.Spec.Ports {
 			port := service.Spec.Ports[i].Port
-			service.Spec.Ports[i].TargetPort = intstr.FromInt(int(port))
+			service.Spec.Ports[i].TargetPort = intstr.FromInt(port)
 		}
 	}
 	if len(params["external-ip"]) > 0 {

--- a/pkg/kubectl/service_basic.go
+++ b/pkg/kubectl/service_basic.go
@@ -90,14 +90,14 @@ func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 		return 0, intstr.FromInt(0), err
 	}
 	if len(portStringSlice) == 1 {
-		return int32(port), intstr.FromInt(int(port)), nil
+		return int32(port), intstr.FromInt(int32(port)), nil
 	}
 
 	var targetPort intstr.IntOrString
 	if portNum, err := strconv.Atoi(portStringSlice[1]); err != nil {
 		targetPort = intstr.FromString(portStringSlice[1])
 	} else {
-		targetPort = intstr.FromInt(portNum)
+		targetPort = intstr.FromInt(int32(portNum))
 	}
 	return int32(port), targetPort, nil
 }

--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -32,7 +32,7 @@ import (
 
 func TestResolvePortInt(t *testing.T) {
 	expected := 80
-	port, err := resolvePort(intstr.FromInt(expected), &v1.Container{})
+	port, err := resolvePort(intstr.FromInt(int32(expected)), &v1.Container{})
 	if port != expected {
 		t.Errorf("expected: %d, saw: %d", expected, port)
 	}

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -212,7 +212,7 @@ func createPortAndServiceSpec(servicePort int, targetServicePort int, nodePort i
 	servicePorts := []api.ServicePort{{Protocol: api.ProtocolTCP,
 		Port:       int32(servicePort),
 		Name:       servicePortName,
-		TargetPort: intstr.FromInt(targetServicePort)}}
+		TargetPort: intstr.FromInt(int32(targetServicePort))}}
 	serviceType := api.ServiceTypeClusterIP
 	if nodePort > 0 {
 		servicePorts[0].NodePort = int32(nodePort)

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -703,7 +703,7 @@ func TestExternalIPsReject(t *testing.T) {
 				Name:       svcPortName.Port,
 				Port:       int32(svcPort),
 				Protocol:   api.ProtocolTCP,
-				TargetPort: intstr.FromInt(svcPort),
+				TargetPort: intstr.FromInt(int32(svcPort)),
 			}}
 		}),
 	)
@@ -946,7 +946,7 @@ func addTestPort(array []api.ServicePort, name string, protocol api.Protocol, po
 		Protocol:   protocol,
 		Port:       port,
 		NodePort:   nodeport,
-		TargetPort: intstr.FromInt(targetPort),
+		TargetPort: intstr.FromInt(int32(targetPort)),
 	}
 	return append(array, svcPort)
 }

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -416,7 +416,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 				Name:       svcPortName.Port,
 				Port:       int32(svcPort),
 				Protocol:   api.ProtocolTCP,
-				TargetPort: intstr.FromInt(svcPort),
+				TargetPort: intstr.FromInt(int32(svcPort)),
 			}}
 		}),
 	)
@@ -470,7 +470,7 @@ func TestExternalIPs(t *testing.T) {
 				Name:       svcPortName.Port,
 				Port:       int32(svcPort),
 				Protocol:   api.ProtocolTCP,
-				TargetPort: intstr.FromInt(svcPort),
+				TargetPort: intstr.FromInt(int32(svcPort)),
 			}}
 		}),
 	)
@@ -709,7 +709,7 @@ func addTestPort(array []api.ServicePort, name string, protocol api.Protocol, po
 		Protocol:   protocol,
 		Port:       port,
 		NodePort:   nodeport,
-		TargetPort: intstr.FromInt(targetPort),
+		TargetPort: intstr.FromInt(int32(targetPort)),
 	}
 	return append(array, svcPort)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -57,8 +57,7 @@ const (
 // FromInt creates an IntOrString object with an int32 value. It is
 // your responsibility not to call this method with a value greater
 // than int32.
-// TODO: convert to (val int32)
-func FromInt(val int) IntOrString {
+func FromInt(val int32) IntOrString {
 	if val > math.MaxInt32 || val < math.MinInt32 {
 		glog.Errorf("value: %d overflows int32\n%s\n", val, debug.Stack())
 	}
@@ -77,7 +76,7 @@ func Parse(val string) IntOrString {
 	if err != nil {
 		return FromString(val)
 	}
-	return FromInt(i)
+	return FromInt(int32(i))
 }
 
 // UnmarshalJSON implements the json.Unmarshaller interface.

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -162,7 +162,7 @@ func failureTrap(c clientset.Interface, ns string) {
 }
 
 func intOrStrP(num int) *intstr.IntOrString {
-	intstr := intstr.FromInt(num)
+	intstr := intstr.FromInt(int32(num))
 	return &intstr
 }
 

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -722,7 +722,7 @@ func runDrainTest(f *framework.Framework, migSizes map[string]int, namespace str
 	defer framework.DeleteRCAndPods(f.ClientSet, f.InternalClientset, namespace, "reschedulable-pods")
 
 	By("Create a PodDisruptionBudget")
-	minAvailable := intstr.FromInt(numPods - pdbSize)
+	minAvailable := intstr.FromInt(int32(numPods - pdbSize))
 	pdb := &policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test_pdb",
@@ -1432,7 +1432,7 @@ func addKubeSystemPdbs(f *framework.Framework) (func(), error) {
 		By(fmt.Sprintf("Create PodDisruptionBudget for %v", pdbData.label))
 		labelMap := map[string]string{"k8s-app": pdbData.label}
 		pdbName := fmt.Sprintf("test-pdb-for-%v", pdbData.label)
-		minAvailable := intstr.FromInt(pdbData.min_available)
+		minAvailable := intstr.FromInt(int32(pdbData.min_available))
 		pdb := &policy.PodDisruptionBudget{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      pdbName,

--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -430,7 +430,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, internalCli
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Port:       port,
-				TargetPort: intstr.FromInt(targetPort),
+				TargetPort: intstr.FromInt(int32(targetPort)),
 			}},
 
 			Selector: map[string]string{
@@ -484,7 +484,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, internalCli
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				Port:       port,
-				TargetPort: intstr.FromInt(targetPort),
+				TargetPort: intstr.FromInt(int32(targetPort)),
 			}},
 
 			Selector: map[string]string{

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -79,7 +79,7 @@ func svcByName(name string, port int) *v1.Service {
 			},
 			Ports: []v1.ServicePort{{
 				Port:       int32(port),
-				TargetPort: intstr.FromInt(port),
+				TargetPort: intstr.FromInt(int32(port)),
 			}},
 		},
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -485,7 +485,7 @@ func (f *Framework) CreateServiceForSimpleApp(contPort, svcPort int, appName str
 			return []v1.ServicePort{{
 				Protocol:   "TCP",
 				Port:       int32(svcPort),
-				TargetPort: intstr.FromInt(contPort),
+				TargetPort: intstr.FromInt(int32(contPort)),
 			}}
 		}
 	}

--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -421,8 +421,8 @@ func (config *NetworkingTestConfig) createNodePortService(selector map[string]st
 		Spec: v1.ServiceSpec{
 			Type: v1.ServiceTypeNodePort,
 			Ports: []v1.ServicePort{
-				{Port: ClusterHttpPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(EndpointHttpPort)},
-				{Port: ClusterUdpPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(EndpointUdpPort)},
+				{Port: ClusterHttpPort, Name: "http", Protocol: v1.ProtocolTCP, TargetPort: intstr.FromInt(int32(EndpointHttpPort))},
+				{Port: ClusterUdpPort, Name: "udp", Protocol: v1.ProtocolUDP, TargetPort: intstr.FromInt(int32(EndpointUdpPort))},
 			},
 			Selector: selector,
 		},

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -659,7 +659,7 @@ func (j *ServiceTestJig) CreatePDBOrFail(namespace string, rc *v1.ReplicationCon
 // this jig, but does not actually create the PDB.  The default PDB specifies a
 // MinAvailable of N-1 and matches the pods created by the RC.
 func (j *ServiceTestJig) newPDBTemplate(namespace string, rc *v1.ReplicationController) *policyv1beta1.PodDisruptionBudget {
-	minAvailable := intstr.FromInt(int(*rc.Spec.Replicas) - 1)
+	minAvailable := intstr.FromInt(*rc.Spec.Replicas - 1)
 
 	pdb := &policyv1beta1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -210,7 +210,7 @@ func (t *dnsTestCommon) createUtilPod() {
 				{
 					Protocol:   "TCP",
 					Port:       servicePort,
-					TargetPort: intstr.FromInt(servicePort),
+					TargetPort: intstr.FromInt(int32(servicePort)),
 				},
 			},
 		},

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -382,7 +382,7 @@ func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, 
 		servicePorts = append(servicePorts, v1.ServicePort{
 			Name:       fmt.Sprintf("%s-%d", podName, port),
 			Port:       int32(port),
-			TargetPort: intstr.FromInt(port),
+			TargetPort: intstr.FromInt(int32(port)),
 		})
 	}
 

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1145,7 +1145,7 @@ var _ = SIGDescribe("Services", func() {
 				Ports: []v1.ServicePort{{
 					Name:       "http",
 					Port:       int32(port),
-					TargetPort: intstr.FromInt(port),
+					TargetPort: intstr.FromInt(int32(port)),
 				}},
 			},
 		}
@@ -1520,7 +1520,7 @@ var _ = SIGDescribe("ESIPP [Slow]", func() {
 				// Change service port to avoid collision with opened hostPorts
 				// in other tests that run in parallel.
 				if len(svc.Spec.Ports) != 0 {
-					svc.Spec.Ports[0].TargetPort = intstr.FromInt(int(svc.Spec.Ports[0].Port))
+					svc.Spec.Ports[0].TargetPort = intstr.FromInt(svc.Spec.Ports[0].Port)
 					svc.Spec.Ports[0].Port = 8081
 				}
 

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -212,7 +212,7 @@ func createGitServer(f *framework.Framework) (gitURL string, gitRepo string, cle
 				{
 					Name:       "http-portal",
 					Port:       int32(httpPort),
-					TargetPort: intstr.FromInt(containerPort),
+					TargetPort: intstr.FromInt(int32(containerPort)),
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
A `TODO` was left in `staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go` which required converting `int` to `int32` as the parameter of function `FromInt`.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
`NONE`
