### PR TITLE
Check container dir exists before delete log symlink

### DIFF
--- a/pkg/kubelet/container/os.go
+++ b/pkg/kubelet/container/os.go
@@ -38,6 +38,8 @@ type OSInterface interface {
 	Pipe() (r *os.File, w *os.File, err error)
 	ReadDir(dirname string) ([]os.FileInfo, error)
 	Glob(pattern string) ([]string, error)
+	Dir(path string) string
+	Readlink(name string) (string, error)
 }
 
 // RealOS is used to dispatch the real system level operations.
@@ -104,4 +106,14 @@ func (RealOS) ReadDir(dirname string) ([]os.FileInfo, error) {
 // pattern.
 func (RealOS) Glob(pattern string) ([]string, error) {
 	return filepath.Glob(pattern)
+}
+
+// // Dir returns all but the last element of path
+func (RealOS) Dir(path string) string {
+	return filepath.Dir(path)
+}
+
+// Readlink returns the destination of the named symbolic link
+func (RealOS) Readlink(name string) (string, error) {
+	return os.Readlink(name)
 }

--- a/pkg/kubelet/container/testing/os.go
+++ b/pkg/kubelet/container/testing/os.go
@@ -115,3 +115,13 @@ func (f *FakeOS) ReadDir(dirname string) ([]os.FileInfo, error) {
 func (f *FakeOS) Glob(pattern string) ([]string, error) {
 	return nil, nil
 }
+
+// Dir returns all but the last element of path
+func (f *FakeOS) Dir(path string) string {
+	return ""
+}
+
+// Readlink returns the destination of the named symbolic link
+func (f *FakeOS) Readlink(name string) (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
#52172 

This PR fixes #52172 race condition where docker rotate the symlink and kube garbage collection eliminates the log syslink for a running container.

