### PR TITLE
integration test:error message should use t.Errorf

### DIFF
--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -112,7 +112,7 @@ func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespa
 	var ret = true
 	if len(pods.Items) != podNum {
 		ret = false
-		t.Logf("expect %d pods, got %d pods", podNum, len(pods.Items))
+		t.Errorf("expect %d pods, got %d pods", podNum, len(pods.Items))
 	}
 	rss, err := rsClient.List(metav1.ListOptions{})
 	if err != nil {
@@ -120,7 +120,7 @@ func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespa
 	}
 	if len(rss.Items) != rsNum {
 		ret = false
-		t.Logf("expect %d RSs, got %d RSs", rsNum, len(rss.Items))
+		t.Errorf("expect %d RSs, got %d RSs", rsNum, len(rss.Items))
 	}
 	return ret, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
integration test:error message should use t.Errorf

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
