### PR TITLE
[fluentd-gcp addon] Remove some e2e tests out of blocking suites

### DIFF
--- a/test/e2e/instrumentation/logging/stackdrvier/basic.go
+++ b/test/e2e/instrumentation/logging/stackdrvier/basic.go
@@ -44,7 +44,6 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 	})
 
 	ginkgo.It("should ingest logs", func() {
-
 		withLogProviderForScope(f, podsScope, func(p *sdLogProvider) {
 			ginkgo.By("Checking ingesting text logs", func() {
 				pod, err := utils.StartAndReturnSelf(utils.NewRepeatingLoggingPod("synthlogger-1", "hey"), f)
@@ -108,13 +107,17 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 				err = utils.WaitForLogs(c, ingestionInterval, ingestionTimeout)
 				framework.ExpectNoError(err)
 			})
+		})
+	})
 
+	ginkgo.It("should ingest logs [Feature:StackdriverLogging]", func() {
+		withLogProviderForScope(f, podsScope, func(p *sdLogProvider) {
 			ginkgo.By("Checking that too long lines are trimmed", func() {
 				originalLength := 100001
 				cmd := []string{
 					"/bin/sh",
 					"-c",
-					fmt.Sprintf("while :; do printf '%%*s' %d | tr ' ' 'A'; echo; sleep 1; done", originalLength),
+					fmt.Sprintf("while :; do printf '%%*s' %d | tr ' ' 'A'; echo; sleep 60; done", originalLength),
 				}
 				trimPrefix := "[Trimmed]"
 
@@ -174,7 +177,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 		})
 	})
 
-	ginkgo.It("should ingest system logs from all nodes", func() {
+	ginkgo.It("should ingest system logs from all nodes [Feature:StackdriverLogging]", func() {
 		withLogProviderForScope(f, systemScope, func(p *sdLogProvider) {
 			ginkgo.By("Waiting for some kubelet logs to be ingested from each node", func() {
 				nodeIds := utils.GetNodeIds(f.ClientSet)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52433

Some Stackdriver Logging e2e tests are broken in release-blocking suites:

- Due to the change in Docker 1.13, on some systems logs are automatically split by 16K chunks. This PR removes an e2e test that assumes otherwise
- In large clusters, it's not possible to ingest system logs from all nodes

Since it's not a Kubernetes problem per se, mitigating this by removing these tests from blocking suites.