### PR TITLE
Enable go race detection for bazel tests.

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -17,3 +17,6 @@ build --sandbox_fake_username
 # TODO(ixdy): Remove this default once rules_go is bumped.
 # Ref kubernetes/kubernetes#52677
 build --incompatible_comprehension_variables_do_not_leak=false
+
+# Enable go race detection.
+test --features=race

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -109,6 +109,7 @@ go_test(
         "master_openapi_test.go",
         "master_test.go",
     ],
+    features = ["-race"],
     library = ":go_default_library",
     deps = [
         "//pkg/api:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -22,6 +22,7 @@ go_test(
         "store_test.go",
         "undelta_store_test.go",
     ],
+    features = ["-race"],
     library = ":go_default_library",
     deps = [
         "//vendor/github.com/google/gofuzz:go_default_library",


### PR DESCRIPTION
Testing if setting `features = ["-race"]` fixes the breaks in #50792.

**Release note**:
```release-note
NONE
```
