### PR TITLE
Fix kubernetes charms not restarting services properly after host reboot on LXD

### DIFF
--- a/cluster/juju/layers/kubernetes-master/layer.yaml
+++ b/cluster/juju/layers/kubernetes-master/layer.yaml
@@ -7,6 +7,7 @@ includes:
   - 'layer:debug'
   - 'layer:metrics'
   - 'layer:nagios'
+  - 'layer:cdk-service-kicker'
   - 'interface:ceph-admin'
   - 'interface:etcd'
   - 'interface:http'
@@ -24,3 +25,8 @@ options:
     server_key_path: '/root/cdk/server.key'
     client_certificate_path: '/root/cdk/client.crt'
     client_key_path: '/root/cdk/client.key'
+  cdk-service-kicker:
+    services:
+      - snap.kube-apiserver.daemon
+      - snap.kube-controller-manager.daemon
+      - snap.kube-scheduler.daemon

--- a/cluster/juju/layers/kubernetes-worker/layer.yaml
+++ b/cluster/juju/layers/kubernetes-worker/layer.yaml
@@ -8,6 +8,7 @@ includes:
   - 'layer:nagios'
   - 'layer:tls-client'
   - 'layer:nvidia-cuda'
+  - 'layer:cdk-service-kicker'
   - 'interface:http'
   - 'interface:kubernetes-cni'
   - 'interface:kube-dns'
@@ -29,3 +30,7 @@ options:
     server_key_path: '/root/cdk/server.key'
     client_certificate_path: '/root/cdk/client.crt'
     client_key_path: '/root/cdk/client.key'
+  cdk-service-kicker:
+    services:
+      - 'snap.kubelet.daemon'
+      - 'snap.kube-proxy.daemon'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This fixes an issue when running the Kubernetes charms on LXD where the services don't restart properly after a reboot of the host machine.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/357

**Special notes for your reviewer**:

See https://github.com/juju-solutions/layer-cdk-service-kicker

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix kubernetes charms not restarting services properly after host reboot on LXD
```
