### PR TITLE
[WIP] Add labels to a cluster while joining it in the federation

### DIFF
--- a/federation/pkg/kubefed/join_test.go
+++ b/federation/pkg/kubefed/join_test.go
@@ -57,6 +57,7 @@ const (
 )
 
 func TestJoinFederation(t *testing.T) {
+	// TODO(arthur0): Add/modify tests to labels option
 	cmdErrMsg := ""
 	cmdutil.BehaviorOnFatal(func(str string, code int) {
 		cmdErrMsg = str


### PR DESCRIPTION
kubefed should allow adding a label to cluster API resource while joining it in the federation.

fixes #39482

