### PR TITLE
Fixes issue #52446 where TestApps appears to continually fail in test grid.

### DIFF
--- a/pkg/kubectl/apps/apps_suite_test.go
+++ b/pkg/kubectl/apps/apps_suite_test.go
@@ -17,13 +17,33 @@ limitations under the License.
 package apps_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/config"
+	. "github.com/onsi/ginkgo/types"
 	. "github.com/onsi/gomega"
 )
 
 func TestApps(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Apps Suite")
+	RunSpecsWithDefaultAndCustomReporters(t, "Apps Suite", []Reporter{newlineReporter{}})
 }
+
+// Print a newline after the default newlineReporter due to issue
+// https://github.com/jstemmer/go-junit-report/issues/31
+type newlineReporter struct{}
+
+func (newlineReporter) SpecSuiteWillBegin(config GinkgoConfigType, summary *SuiteSummary) {}
+
+func (newlineReporter) BeforeSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) AfterSuiteDidRun(setupSummary *SetupSummary) {}
+
+func (newlineReporter) SpecWillRun(specSummary *SpecSummary) {}
+
+func (newlineReporter) SpecDidComplete(specSummary *SpecSummary) {}
+
+// SpecSuiteDidEnd Prints a newline between "8 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
+func (newlineReporter) SpecSuiteDidEnd(summary *SuiteSummary) { fmt.Printf("\n") }


### PR DESCRIPTION
Print a newline after ginkgo tests so the test infra doesn't think that they fail. This is a known [issue](https://github.com/jstemmer/go-junit-report/issues/31).

fixes #52446 

Test Grid [Test](https://k8s-testgrid.appspot.com/sig-cli#unit-integration-cmd&sort-by-failures=&exclude-non-failed-tests=)

```release-note
NONE
```
