### PR TITLE
Error message / exit code fixes

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -694,6 +694,10 @@ run_pod_tests() {
   ## Patch can modify a local object
   kubectl patch --local -f pkg/kubectl/validation/testdata/v1/validPod.yaml --patch='{"spec": {"restartPolicy":"Never"}}' -o jsonpath='{.spec.restartPolicy}' | grep -q "Never"
 
+  ## Patch fails with error message "not patched" and exit code 1
+  output_message=$(! kubectl patch "${kube_flags[@]}" pod valid-pod -p='{"spec":{"replicas":7}}' 2>&1)
+  kube::test::if_has_string "${output_message}" 'not patched'
+
   ## Patch pod can change image
   # Command
   kubectl patch "${kube_flags[@]}" pod valid-pod --record -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "nginx"}]}}'

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -239,7 +239,8 @@ __custom_func() {
     * services (aka 'svc')
     * statefulsets
     * storageclasses
-    `
+
+`
 )
 
 var (

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -183,6 +183,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 		if !options.Local {
 			dataChangedMsg := "not patched"
+			didPatch := false
 			helper := resource.NewHelper(client, mapping)
 			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes)
 			if err != nil {
@@ -213,6 +214,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 				return err
 			}
 			if !reflect.DeepEqual(oldData, newData) {
+				didPatch = true
 				dataChangedMsg = "patched"
 			}
 
@@ -229,6 +231,12 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 				return err
 			}
 			cmdutil.PrintSuccess(mapper, options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
+
+			// if object was not successfully patched, exit with error code 1
+			if !didPatch {
+				return cmdutil.ErrExit
+			}
+
 			return nil
 		}
 


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Miscellaneous error message tweaks.
Makes the error message displayed in `kubectl get` more visible.
Returns exit code 1 if a patch fails.

Addresses the following downstream bugzillas:
- https://bugzilla.redhat.com/show_bug.cgi?id=1311786
- https://bugzilla.redhat.com/show_bug.cgi?id=1414227

cc @fabianofranz @kubernetes/sig-cli-misc
