### PR TITLE
add feature: azurefile mount on windows node

### DIFF
--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -74,8 +74,24 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 			return nil
 		}
 
-		// empty implementation for mounting azure file
-		return os.MkdirAll(target, 0755)
+		// currently only SMB mount is supported
+		cmdLine := fmt.Sprintf(`$User = "%s";$PWord = ConvertTo-SecureString -String "%s" -AsPlainText -Force;`+
+			`$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, $PWord`,
+			options[0], options[1])
+
+		driverLetter, err := getAvailableDriveLetter()
+		if err != nil {
+			return err
+		}
+		bindSource = driverLetter + ":"
+		cmdLine += fmt.Sprintf(";New-SmbGlobalMapping -LocalPath %s -RemotePath %s -Credential $Credential", bindSource, source)
+
+		if output, err := exec.Command("powershell", "/c", cmdLine).CombinedOutput(); err != nil {
+			// we don't return error here, even though New-SmbGlobalMapping failed, we still make it successful,
+			// will return error when Windows 2016 RS3 is ready on azure
+			glog.Errorf("azureMount: SmbGlobalMapping failed: %v, only SMB mount is supported now, output: %q", err, string(output))
+			return os.MkdirAll(target, 0755)
+		}
 	}
 
 	if output, err := exec.Command("cmd", "/c", "mklink", "/D", target, bindSource).CombinedOutput(); err != nil {
@@ -176,6 +192,20 @@ func normalizeWindowsPath(path string) string {
 		normalizedPath = "c:" + normalizedPath
 	}
 	return normalizedPath
+}
+
+func getAvailableDriveLetter() (string, error) {
+	cmd := "$used = Get-PSDrive | Select-Object -Expand Name | Where-Object { $_.Length -eq 1 }"
+	cmd += ";$drive = 67..90 | ForEach-Object { [string][char]$_ } | Where-Object { $used -notcontains $_ } | Select-Object -First 1;$drive"
+	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("getAvailableDriveLetter failed: %v, output: %q", err, string(output))
+	}
+
+	if len(output) == 0 {
+		return "", fmt.Errorf("azureMount: there is no available drive letter now")
+	}
+	return string(output)[:1], nil
 }
 
 // ValidateDiskNumber : disk number should be a number in [0, 99]

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -74,7 +74,11 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 			return nil
 		}
 
-		// currently only SMB mount is supported
+		// currently only cifs mount is supported
+		if strings.ToLower(fstype) != "cifs" {
+			return fmt.Errorf("azureMount: only cifs mount is supported now, fstype: %q, mounting source (%q), target (%q), with options (%q)", fstype, source, target, options)
+		}
+
 		cmdLine := fmt.Sprintf(`$User = "%s";$PWord = ConvertTo-SecureString -String "%s" -AsPlainText -Force;`+
 			`$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, $PWord`,
 			options[0], options[1])

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -218,7 +218,7 @@ func (b *azureFileMounter) SetUpAt(dir string, fsGroup *int64) error {
 	source = fmt.Sprintf("%s%s%s.file.%s%s%s", osSeparator, osSeparator, accountName, getStorageEndpointSuffix(b.plugin.host.GetCloudProvider()), osSeparator, b.shareName)
 
 	if runtime.GOOS == "windows" {
-		mountOptions = []string{accountName, accountKey}
+		mountOptions = []string{fmt.Sprintf("AZURE\\%s", accountName), accountKey}
 	} else {
 		os.MkdirAll(dir, 0700)
 		// parameters suggested by https://azure.microsoft.com/en-us/documentation/articles/storage-how-to-use-files-linux/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
feature: azurefile mount on windows node. I created this new PR, close the original one(https://github.com/kubernetes/kubernetes/pull/50233) as there is a big rebase change.
Currently only SMB(a nfs protocol) is supported for windows container in the new Windows 2016 RS3 image, and windows container in RS3 could only use New-SmbGlobalMapping cmdlet for volume mapping, "net use" command does not work for windows container.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
As there is a known blocking issue in Windows 2016 server when mounting a SMB(a NFS protocol in Windows) share on a container host and then bind that share to a container ( Azure file on Windows is using SMB protocol), this PR still could not mount an azure file on current windows 2016 server node, it depends on 2016 RS3 release, and it will still succeed (as a workaround) if customer want to mount an azure file on current windows node.


Main code logic is similar to what it does in Linux node:

1. create target directory in Windows host
2. Use New-SmbGlobalMapping powershell cmdlet to mount SMB azure file to a drive in Windows host
3. Use mklink command to link target directory to the mounted drive

K8s would bind target directory to the container directory
source in mount function would be like:
`\\[accountname].file.core.windows.net\test`

target in mount function would be like:
`c:\var\lib\kubelet\pods\5f679f75-7ce3-11e7-b718-000d3a31dac4\volumes\kubernetes.io~azure-file`

sample azure file config file:
```
apiVersion: v1
kind: Pod
metadata:
 name: iis
spec:
 containers:
  - image: microsoft/iis
    name: iis
    volumeMounts:
      - name: azure
        mountPath: "d:"
 nodeSelector:
   beta.kubernetes.io/os: windows
 volumes:
      - name: azure
        azureFile:
          secretName: azure-secret
          shareName: k8stest
          readOnly: false
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
