### PR TITLE
Configure user and cluster name in KubeConfigFile deployed by kubeadm

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -43,6 +43,8 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.CIImageRepository = ""
 			obj.UnifiedControlPlaneImage = "foo"
 			obj.FeatureGates = map[string]bool{}
+			obj.ClusterName = "kubernetes"
+			obj.AdminUserName = "kubernetes-admin"
 		},
 		func(obj *kubeadm.NodeConfiguration, c fuzz.Continue) {
 			c.FuzzNoCustom(obj)
@@ -53,6 +55,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.DiscoveryTokenAPIServers = []string{"foo"}
 			obj.TLSBootstrapToken = "foo"
 			obj.Token = "foo"
+			obj.ClusterName = "kubernetes"
 		},
 	}
 }

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -31,6 +31,8 @@ type MasterConfiguration struct {
 	KubernetesVersion  string
 	CloudProvider      string
 	NodeName           string
+	ClusterName        string
+	AdminUserName      string
 	AuthorizationModes []string
 
 	Token    string
@@ -100,6 +102,7 @@ type NodeConfiguration struct {
 	// Currently we only pay attention to one api server but hope to support >1 in the future
 	DiscoveryTokenAPIServers []string
 	NodeName                 string
+	ClusterName              string
 	TLSBootstrapToken        string
 	Token                    string
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -35,6 +35,8 @@ const (
 	DefaultCertificatesDir    = "/etc/kubernetes/pki"
 	DefaultEtcdDataDir        = "/var/lib/etcd"
 	DefaultImageRepository    = "gcr.io/google_containers"
+	DefaultClusterName        = "kubernetes"
+	DefaultAdminUserName      = "kubernetes-admin"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -79,11 +81,22 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 	if obj.Etcd.DataDir == "" {
 		obj.Etcd.DataDir = DefaultEtcdDataDir
 	}
+
+	if obj.ClusterName == "" {
+		obj.ClusterName = DefaultClusterName
+	}
+
+	if obj.AdminUserName == "" {
+		obj.AdminUserName = DefaultAdminUserName
+	}
 }
 
 func SetDefaults_NodeConfiguration(obj *NodeConfiguration) {
 	if obj.CACertPath == "" {
 		obj.CACertPath = DefaultCACertPath
+	}
+	if obj.ClusterName == "" {
+		obj.ClusterName = DefaultClusterName
 	}
 	if len(obj.TLSBootstrapToken) == 0 {
 		obj.TLSBootstrapToken = obj.Token

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -31,6 +31,8 @@ type MasterConfiguration struct {
 	KubernetesVersion  string     `json:"kubernetesVersion"`
 	CloudProvider      string     `json:"cloudProvider"`
 	NodeName           string     `json:"nodeName"`
+	ClusterName        string     `json:"clusterName"`
+	AdminUserName      string     `json:"adminUserName"`
 	AuthorizationModes []string   `json:"authorizationModes,omitempty"`
 
 	Token    string          `json:"token"`
@@ -94,6 +96,7 @@ type NodeConfiguration struct {
 	DiscoveryToken           string   `json:"discoveryToken"`
 	DiscoveryTokenAPIServers []string `json:"discoveryTokenAPIServers,omitempty"`
 	NodeName                 string   `json:"nodeName"`
+	ClusterName              string   `json:"clusterName"`
 	TLSBootstrapToken        string   `json:"tlsBootstrapToken"`
 	Token                    string   `json:"token"`
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -117,6 +117,8 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.KubernetesVersion = in.KubernetesVersion
 	out.CloudProvider = in.CloudProvider
 	out.NodeName = in.NodeName
+	out.ClusterName = in.ClusterName
+	out.AdminUserName = in.AdminUserName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
 	out.TokenTTL = in.TokenTTL
@@ -149,6 +151,8 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.KubernetesVersion = in.KubernetesVersion
 	out.CloudProvider = in.CloudProvider
 	out.NodeName = in.NodeName
+	out.ClusterName = in.ClusterName
+	out.AdminUserName = in.AdminUserName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
 	out.TokenTTL = in.TokenTTL
@@ -199,6 +203,7 @@ func autoConvert_v1alpha1_NodeConfiguration_To_kubeadm_NodeConfiguration(in *Nod
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
 	out.NodeName = in.NodeName
+	out.ClusterName = in.ClusterName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token
 	out.DiscoveryTokenCACertHashes = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenCACertHashes))
@@ -217,6 +222,7 @@ func autoConvert_kubeadm_NodeConfiguration_To_v1alpha1_NodeConfiguration(in *kub
 	out.DiscoveryToken = in.DiscoveryToken
 	out.DiscoveryTokenAPIServers = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenAPIServers))
 	out.NodeName = in.NodeName
+	out.ClusterName = in.ClusterName
 	out.TLSBootstrapToken = in.TLSBootstrapToken
 	out.Token = in.Token
 	out.DiscoveryTokenCACertHashes = *(*[]string)(unsafe.Pointer(&in.DiscoveryTokenCACertHashes))

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -183,6 +183,14 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfigur
 		`Specify the node name`,
 	)
 	flagSet.StringVar(
+		&cfg.ClusterName, "cluster-name", cfg.ClusterName,
+		`Specify the cluster name`,
+	)
+	flagSet.StringVar(
+		&cfg.AdminUserName, "admin-user-name", cfg.AdminUserName,
+		`Specify the admin user name`,
+	)
+	flagSet.StringVar(
 		&cfg.Token, "token", cfg.Token,
 		"The token to use for establishing bidirectional trust between nodes and masters.",
 	)

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -133,6 +133,9 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 		&cfg.NodeName, "node-name", "",
 		"Specify the node name")
 	cmd.PersistentFlags().StringVar(
+		&cfg.ClusterName, "cluster-name", "",
+		"Specify the cluster name")
+	cmd.PersistentFlags().StringVar(
 		&cfg.TLSBootstrapToken, "tls-bootstrap-token", "",
 		"A token used for TLS bootstrapping")
 	cmd.PersistentFlags().StringSliceVar(

--- a/cmd/kubeadm/app/cmd/phases/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/certs.go
@@ -111,6 +111,9 @@ func getCertsSubCommands() []*cobra.Command {
 			cmd.Flags().StringSliceVar(&cfg.APIServerCertSANs, "apiserver-cert-extra-sans", []string{}, "Optional extra altnames to use for the API Server serving cert. Can be both IP addresses and dns names.")
 			cmd.Flags().StringVar(&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress, "The IP address the API Server will advertise it's listening on. 0.0.0.0 means the default network interface's address.")
 		}
+		if properties.use == "all" || properties.use == "ca" || properties.use == "front-proxy-ca" {
+			cmd.PersistentFlags().StringVar(&cfg.ClusterName, "cluster-name", "", "Specify the cluster name")
+		}
 
 		subCmds = append(subCmds, cmd)
 	}

--- a/cmd/kubeadm/app/cmd/phases/kubeconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/kubeconfig.go
@@ -116,8 +116,12 @@ func getKubeConfigSubCommands(out io.Writer, outDir string) []*cobra.Command {
 		cmd.Flags().StringVar(&cfg.CertificatesDir, "cert-dir", cfg.CertificatesDir, "The path where certificates are stored.")
 		cmd.Flags().StringVar(&cfg.API.AdvertiseAddress, "apiserver-advertise-address", cfg.API.AdvertiseAddress, "The IP address or DNS name the API Server is accessible on.")
 		cmd.Flags().Int32Var(&cfg.API.BindPort, "apiserver-bind-port", cfg.API.BindPort, "The port the API Server is accessible on.")
+		cmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", cfg.ClusterName, "Specify the cluster name.")
 		if properties.use == "all" || properties.use == "kubelet" {
 			cmd.Flags().StringVar(&cfg.NodeName, "node-name", cfg.NodeName, `The node name that the kubelet client cert should use.`)
+		}
+		if properties.use == "all" || properties.use == "admin" {
+			cmd.Flags().StringVar(&cfg.AdminUserName, "admin-user-name", cfg.AdminUserName, "Specify the admin user name")
 		}
 		if properties.use == "user" {
 			cmd.Flags().StringVar(&token, "token", token, "The token that should be used as the authentication mechanism for this kubeconfig.")

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -38,11 +38,13 @@ func TestPrintConfiguration(t *testing.T) {
 				KubernetesVersion: "v1.7.1",
 			},
 			expectedBytes: []byte(`[upgrade/config] Configuration used:
+	adminUserName: ""
 	api:
 	  advertiseAddress: ""
 	  bindPort: 0
 	certificatesDir: ""
 	cloudProvider: ""
+	clusterName: ""
 	etcd:
 	  caFile: ""
 	  certFile: ""
@@ -70,11 +72,13 @@ func TestPrintConfiguration(t *testing.T) {
 				},
 			},
 			expectedBytes: []byte(`[upgrade/config] Configuration used:
+	adminUserName: ""
 	api:
 	  advertiseAddress: ""
 	  bindPort: 0
 	certificatesDir: ""
 	cloudProvider: ""
+	clusterName: ""
 	etcd:
 	  caFile: ""
 	  certFile: ""

--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -42,7 +42,7 @@ func For(cfg *kubeadmapi.NodeConfiguration) (*clientcmdapi.Config, error) {
 
 	return kubeconfigutil.CreateWithToken(
 		clusterinfo.Server,
-		"kubernetes",
+		cfg.ClusterName,
 		TokenUser,
 		clusterinfo.CertificateAuthorityData,
 		cfg.TLSBootstrapToken,
@@ -54,11 +54,11 @@ func GetValidatedClusterInfoObject(cfg *kubeadmapi.NodeConfiguration) (*clientcm
 	switch {
 	case len(cfg.DiscoveryFile) != 0:
 		if isHTTPSURL(cfg.DiscoveryFile) {
-			return https.RetrieveValidatedClusterInfo(cfg.DiscoveryFile)
+			return https.RetrieveValidatedClusterInfo(cfg.DiscoveryFile, cfg.ClusterName)
 		}
-		return file.RetrieveValidatedClusterInfo(cfg.DiscoveryFile)
+		return file.RetrieveValidatedClusterInfo(cfg.DiscoveryFile, cfg.ClusterName)
 	case len(cfg.DiscoveryToken) != 0:
-		return token.RetrieveValidatedClusterInfo(cfg.DiscoveryToken, cfg.DiscoveryTokenAPIServers, cfg.DiscoveryTokenCACertHashes)
+		return token.RetrieveValidatedClusterInfo(cfg.DiscoveryToken, cfg.DiscoveryTokenAPIServers, cfg.DiscoveryTokenCACertHashes, cfg.ClusterName)
 	default:
 		return nil, fmt.Errorf("couldn't find a valid discovery configuration.")
 	}

--- a/cmd/kubeadm/app/discovery/file/file.go
+++ b/cmd/kubeadm/app/discovery/file/file.go
@@ -33,18 +33,18 @@ import (
 // RetrieveValidatedClusterInfo connects to the API Server and makes sure it can talk
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
-func RetrieveValidatedClusterInfo(filepath string) (*clientcmdapi.Cluster, error) {
+func RetrieveValidatedClusterInfo(filepath, clustername string) (*clientcmdapi.Cluster, error) {
 	clusterinfo, err := clientcmd.LoadFromFile(filepath)
 	if err != nil {
 		return nil, err
 	}
-	return ValidateClusterInfo(clusterinfo)
+	return ValidateClusterInfo(clusterinfo, clustername)
 }
 
 // ValidateClusterInfo connects to the API Server and makes sure it can talk
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
-func ValidateClusterInfo(clusterinfo *clientcmdapi.Config) (*clientcmdapi.Cluster, error) {
+func ValidateClusterInfo(clusterinfo *clientcmdapi.Config, clustername string) (*clientcmdapi.Cluster, error) {
 	err := validateClusterInfoKubeConfig(clusterinfo)
 	if err != nil {
 		return nil, err
@@ -57,7 +57,7 @@ func ValidateClusterInfo(clusterinfo *clientcmdapi.Config) (*clientcmdapi.Cluste
 	// We do this in order to not pick up other possible misconfigurations in the clusterinfo file
 	configFromClusterInfo := kubeconfigutil.CreateBasic(
 		defaultCluster.Server,
-		"kubernetes",
+		clustername,
 		"", // no user provided
 		defaultCluster.CertificateAuthorityData,
 	)

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -28,7 +28,7 @@ import (
 // RetrieveValidatedClusterInfo connects to the API Server and makes sure it can talk
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
-func RetrieveValidatedClusterInfo(httpsURL string) (*clientcmdapi.Cluster, error) {
+func RetrieveValidatedClusterInfo(httpsURL, clustername string) (*clientcmdapi.Cluster, error) {
 	response, err := http.Get(httpsURL)
 	if err != nil {
 		return nil, err
@@ -44,5 +44,5 @@ func RetrieveValidatedClusterInfo(httpsURL string) (*clientcmdapi.Cluster, error
 	if err != nil {
 		return nil, err
 	}
-	return file.ValidateClusterInfo(clusterinfo)
+	return file.ValidateClusterInfo(clusterinfo, clustername)
 }

--- a/cmd/kubeadm/app/phases/certs/certs.go
+++ b/cmd/kubeadm/app/phases/certs/certs.go
@@ -61,7 +61,7 @@ func CreatePKIAssets(cfg *kubeadmapi.MasterConfiguration) error {
 // If the CA certificate and key files already exists in the target folder, they are used only if evaluated equal; otherwise an error is returned.
 func CreateCACertAndKeyfiles(cfg *kubeadmapi.MasterConfiguration) error {
 
-	caCert, caKey, err := NewCACertAndKey()
+	caCert, caKey, err := NewCACertAndKey(cfg.ClusterName)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func CreateServiceAccountKeyAndPublicKeyFiles(cfg *kubeadmapi.MasterConfiguratio
 // If the front proxy CA certificate and key files already exists in the target folder, they are used only if evaluated equals; otherwise an error is returned.
 func CreateFrontProxyCACertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) error {
 
-	frontProxyCACert, frontProxyCAKey, err := NewFrontProxyCACertAndKey()
+	frontProxyCACert, frontProxyCAKey, err := NewFrontProxyCACertAndKey(cfg.ClusterName)
 	if err != nil {
 		return err
 	}
@@ -183,9 +183,9 @@ func CreateFrontProxyClientCertAndKeyFiles(cfg *kubeadmapi.MasterConfiguration) 
 }
 
 // NewCACertAndKey will generate a self signed CA.
-func NewCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
+func NewCACertAndKey(clustername string) (*x509.Certificate, *rsa.PrivateKey, error) {
 
-	caCert, caKey, err := pkiutil.NewCertificateAuthority()
+	caCert, caKey, err := pkiutil.NewCertificateAuthority(clustername)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failure while generating CA certificate and key: %v", err)
 	}
@@ -243,9 +243,9 @@ func NewServiceAccountSigningKey() (*rsa.PrivateKey, error) {
 }
 
 // NewFrontProxyCACertAndKey generate a self signed front proxy CA.
-func NewFrontProxyCACertAndKey() (*x509.Certificate, *rsa.PrivateKey, error) {
+func NewFrontProxyCACertAndKey(clustername string) (*x509.Certificate, *rsa.PrivateKey, error) {
 
-	frontProxyCACert, frontProxyCAKey, err := pkiutil.NewCertificateAuthority()
+	frontProxyCACert, frontProxyCAKey, err := pkiutil.NewCertificateAuthority(clustername)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failure while generating front-proxy CA certificate and key: %v", err)
 	}

--- a/cmd/kubeadm/app/phases/certs/certs_test.go
+++ b/cmd/kubeadm/app/phases/certs/certs_test.go
@@ -34,8 +34,8 @@ import (
 
 func TestWriteCertificateAuthorithyFilesIfNotExist(t *testing.T) {
 
-	setupCert, setupKey, _ := NewCACertAndKey()
-	caCert, caKey, _ := NewCACertAndKey()
+	setupCert, setupKey, _ := NewCACertAndKey("kubernetes")
+	caCert, caKey, _ := NewCACertAndKey("kubernetes")
 
 	var tests = []struct {
 		setupFunc     func(pkiDir string) error
@@ -110,7 +110,7 @@ func TestWriteCertificateAuthorithyFilesIfNotExist(t *testing.T) {
 
 func TestWriteCertificateFilesIfNotExist(t *testing.T) {
 
-	caCert, caKey, _ := NewFrontProxyCACertAndKey()
+	caCert, caKey, _ := NewFrontProxyCACertAndKey("kubernetes")
 	setupCert, setupKey, _ := NewFrontProxyClientCertAndKey(caCert, caKey)
 	cert, key, _ := NewFrontProxyClientCertAndKey(caCert, caKey)
 
@@ -137,7 +137,7 @@ func TestWriteCertificateFilesIfNotExist(t *testing.T) {
 		},
 		{ // cert exists, is signed by another ca > err
 			setupFunc: func(pkiDir string) error {
-				anotherCaCert, anotherCaKey, _ := NewFrontProxyCACertAndKey()
+				anotherCaCert, anotherCaKey, _ := NewFrontProxyCACertAndKey("kubernetes")
 				anotherCert, anotherKey, _ := NewFrontProxyClientCertAndKey(anotherCaCert, anotherCaKey)
 
 				return writeCertificateFilesIfNotExist(pkiDir, "dummy", anotherCaCert, anotherCert, anotherKey)
@@ -304,7 +304,7 @@ func TestGetAltNames(t *testing.T) {
 }
 
 func TestNewCACertAndKey(t *testing.T) {
-	caCert, _, err := NewCACertAndKey()
+	caCert, _, err := NewCACertAndKey("kubernetes")
 	if err != nil {
 		t.Fatalf("failed call NewCACertAndKey: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestNewAPIServerCertAndKey(t *testing.T) {
 			Networking: kubeadmapi.Networking{ServiceSubnet: "10.96.0.0/12", DNSDomain: "cluster.local"},
 			NodeName:   "valid-hostname",
 		}
-		caCert, caKey, err := NewCACertAndKey()
+		caCert, caKey, err := NewCACertAndKey("kubernetes")
 
 		apiServerCert, _, err := NewAPIServerCertAndKey(cfg, caCert, caKey)
 		if err != nil {
@@ -337,7 +337,7 @@ func TestNewAPIServerCertAndKey(t *testing.T) {
 }
 
 func TestNewAPIServerKubeletClientCertAndKey(t *testing.T) {
-	caCert, caKey, err := NewCACertAndKey()
+	caCert, caKey, err := NewCACertAndKey("kubernetes")
 
 	apiClientCert, _, err := NewAPIServerKubeletClientCertAndKey(caCert, caKey)
 	if err != nil {
@@ -362,7 +362,7 @@ func TestNewNewServiceAccountSigningKey(t *testing.T) {
 }
 
 func TestNewFrontProxyCACertAndKey(t *testing.T) {
-	frontProxyCACert, _, err := NewFrontProxyCACertAndKey()
+	frontProxyCACert, _, err := NewFrontProxyCACertAndKey("kubernetes")
 	if err != nil {
 		t.Fatalf("failed creation of cert and key: %v", err)
 	}
@@ -371,7 +371,7 @@ func TestNewFrontProxyCACertAndKey(t *testing.T) {
 }
 
 func TestNewFrontProxyClientCertAndKey(t *testing.T) {
-	frontProxyCACert, frontProxyCAKey, err := NewFrontProxyCACertAndKey()
+	frontProxyCACert, frontProxyCAKey, err := NewFrontProxyCACertAndKey("kubernetes")
 
 	frontProxyClientCert, _, err := NewFrontProxyClientCertAndKey(frontProxyCACert, frontProxyCAKey)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers.go
@@ -27,14 +27,14 @@ import (
 	certutil "k8s.io/client-go/util/cert"
 )
 
-func NewCertificateAuthority() (*x509.Certificate, *rsa.PrivateKey, error) {
+func NewCertificateAuthority(clustername string) (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := certutil.NewPrivateKey()
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to create private key [%v]", err)
 	}
 
 	config := certutil.Config{
-		CommonName: "kubernetes",
+		CommonName: clustername,
 	}
 	cert, err := certutil.NewSelfSignedCACert(config, key)
 	if err != nil {

--- a/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers_test.go
+++ b/cmd/kubeadm/app/phases/certs/pkiutil/pki_helpers_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestNewCertificateAuthority(t *testing.T) {
-	cert, key, err := NewCertificateAuthority()
+	cert, key, err := NewCertificateAuthority("kubernetes")
 
 	if cert == nil {
 		t.Errorf(
@@ -88,7 +88,7 @@ func TestNewCertAndKey(t *testing.T) {
 }
 
 func TestHasServerAuth(t *testing.T) {
-	caCert, caKey, _ := NewCertificateAuthority()
+	caCert, caKey, _ := NewCertificateAuthority("kubernetes")
 
 	var tests = []struct {
 		config   certutil.Config
@@ -259,7 +259,7 @@ func TestTryLoadCertAndKeyFromDisk(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	caCert, caKey, err := NewCertificateAuthority()
+	caCert, caKey, err := NewCertificateAuthority("kubernetes")
 	if err != nil {
 		t.Errorf(
 			"failed to create cert and key with an error: %v",
@@ -309,7 +309,7 @@ func TestTryLoadCertFromDisk(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	caCert, _, err := NewCertificateAuthority()
+	caCert, _, err := NewCertificateAuthority("kubernetes")
 	if err != nil {
 		t.Errorf(
 			"failed to create cert and key with an error: %v",
@@ -359,7 +359,7 @@ func TestTryLoadKeyFromDisk(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 
-	_, caKey, err := NewCertificateAuthority()
+	_, caKey, err := NewCertificateAuthority("kubernetes")
 	if err != nil {
 		t.Errorf(
 			"failed to create cert and key with an error: %v",

--- a/cmd/kubeadm/test/certs/util.go
+++ b/cmd/kubeadm/test/certs/util.go
@@ -28,7 +28,7 @@ import (
 // SetupCertificateAuthorithy is a utility function for kubeadm testing that creates a
 // CertificateAuthorithy cert/key pair
 func SetupCertificateAuthorithy(t *testing.T) (*x509.Certificate, *rsa.PrivateKey) {
-	caCert, caKey, err := pkiutil.NewCertificateAuthority()
+	caCert, caKey, err := pkiutil.NewCertificateAuthority("kubernetes")
 	if err != nil {
 		t.Fatalf("failure while generating CA certificate and key: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure user in AdminKubeConfigFile and cluster name in all ConfigFiles when using kubeadm deploy k8s cluster.
Has been successfully deployed in my environment.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes  [#kubernetes/kubeadm/416](https://github.com/kubernetes/kubeadm/issues/416)

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
