### PR TITLE
Need to validate taint effect when removing taints.

### DIFF
--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -45,15 +45,14 @@ func parseTaint(st string) (v1.Taint, error) {
 
 	parts2 := strings.Split(parts[1], ":")
 
-	effect := v1.TaintEffect(parts2[1])
-
 	errs := validation.IsValidLabelValue(parts2[0])
 	if len(parts2) != 2 || len(errs) != 0 {
 		return taint, fmt.Errorf("invalid taint spec: %v, %s", st, strings.Join(errs, "; "))
 	}
 
-	if effect != v1.TaintEffectNoSchedule && effect != v1.TaintEffectPreferNoSchedule && effect != v1.TaintEffectNoExecute {
-		return taint, fmt.Errorf("invalid taint spec: %v, unsupported taint effect", st)
+	effect := v1.TaintEffect(parts2[1])
+	if err := validateTaintEffect(effect); err != nil {
+		return taint, err
 	}
 
 	taint.Key = parts[0]
@@ -61,6 +60,14 @@ func parseTaint(st string) (v1.Taint, error) {
 	taint.Effect = effect
 
 	return taint, nil
+}
+
+func validateTaintEffect(effect v1.TaintEffect) error {
+	if effect != v1.TaintEffectNoSchedule && effect != v1.TaintEffectPreferNoSchedule && effect != v1.TaintEffectNoExecute {
+		return fmt.Errorf("invalid taint effect: %v, unsupported taint effect", effect)
+	}
+
+	return nil
 }
 
 // NewTaintsVar wraps []api.Taint in a struct that implements flag.Value to allow taints to be
@@ -133,6 +140,14 @@ func ParseTaints(spec []string) ([]v1.Taint, []v1.Taint, error) {
 				parts := strings.Split(taintKey, ":")
 				taintKey = parts[0]
 				effect = v1.TaintEffect(parts[1])
+			}
+
+			// If effect is specified, need to validate it.
+			if len(effect) > 0 {
+				err := validateTaintEffect(effect)
+				if err != nil {
+					return nil, nil, err
+				}
 			}
 			taintsToRemove = append(taintsToRemove, v1.Taint{Key: taintKey, Effect: effect})
 		} else {


### PR DESCRIPTION
Instead of reporting taint not found, it's better to report user
that the effect is invalid. This will help user to check errors.
So when user tries to remove a taint, two conditions will be checked:
1. Whether or not the effect is an empty string.
2. Whether or not the non-empty effect is a valid taint effect.

**Release note**:
```release-note
None
```
