### PR TITLE
Add configuration support for signing duration.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -883,6 +883,11 @@ EOF
 ETCD_QUORUM_READ: $(yaml-quote ${ETCD_QUORUM_READ})
 EOF
     fi
+    if [ -n "${CLUSTER_SIGNING_DURATION:-}" ]; then
+      cat >>$file <<EOF
+CLUSTER_SIGNING_DURATION: $(yaml-quote ${CLUSTER_SIGNING_DURATION})
+EOF
+    fi
 
   else
     # Node-only env vars.

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -316,6 +316,9 @@ ENABLE_PROMETHEUS_TO_SD="${ENABLE_PROMETHEUS_TO_SD:-false}"
 # Optional: [Experiment Only] Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
 KUBE_PROXY_DAEMONSET="${KUBE_PROXY_DAEMONSET:-false}" # true, false
 
+# Optional: duration of cluster signed certificates.
+CLUSTER_SIGNING_DURATION="${CLUSTER_SIGNING_DURATION:-}"
+
 # Optional: enable pod priority
 ENABLE_POD_PRIORITY="${ENABLE_POD_PRIORITY:-}"
 if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -370,6 +370,9 @@ ENABLE_PROMETHEUS_TO_SD="${ENABLE_PROMETHEUS_TO_SD:-true}"
 # Optional: [Experiment Only] Run kube-proxy as a DaemonSet if set to true, run as static pods otherwise.
 KUBE_PROXY_DAEMONSET="${KUBE_PROXY_DAEMONSET:-false}" # true, false
 
+# Optional: duration of cluster signed certificates.
+CLUSTER_SIGNING_DURATION="${CLUSTER_SIGNING_DURATION:-}"
+
 # Optional: enable pod priority
 ENABLE_POD_PRIORITY="${ENABLE_POD_PRIORITY:-}"
 if [[ "${ENABLE_POD_PRIORITY}" == "true" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1562,6 +1562,10 @@ function start-kube-controller-manager {
   if [[ -n "${VOLUME_PLUGIN_DIR:-}" ]]; then
     params+=" --flex-volume-plugin-dir=${VOLUME_PLUGIN_DIR}"
   fi
+  if [[ -n "${CLUSTER_SIGNING_DURATION:-}" ]]; then
+    params+=" --experimental-cluster-signing-duration=$CLUSTER_SIGNING_DURATION"
+  fi
+
   local -r kube_rc_docker_tag=$(cat /home/kubernetes/kube-docker-files/kube-controller-manager.docker_tag)
   local container_env=""
   if [[ -n "${ENABLE_CACHE_MUTATION_DETECTOR:-}" ]]; then


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52286
Fixes https://github.com/kubernetes/kubernetes/issues/52282
Reverses revert (with fixes) https://github.com/kubernetes/kubernetes/pull/52299

```release-note
Add CLUSTER_SIGNING_DURATION environment variable to cluster
configuration scripts to allow configuration of signing duration of
certificates issued via the Certificate Signing Request API.
```