### PR TITLE
Add 'ETCD_DOCKER_REPOSITORY' env var override to 'cluster/' scripts.

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -830,6 +830,12 @@ EOF
 ETCD_IMAGE: $(yaml-quote ${ETCD_IMAGE})
 EOF
     fi
+    # ETCD_DOCKER_REPOSITORY (if set) allows to use a custom etcd docker repository to pull the etcd image from.
+    if [ -n "${ETCD_DOCKER_REPOSITORY:-}" ]; then
+      cat >>$file <<EOF
+ETCD_DOCKER_REPOSITORY: $(yaml-quote ${ETCD_DOCKER_REPOSITORY})
+EOF
+    fi
     # ETCD_VERSION (if set) allows you to use custom version of etcd.
     # The main purpose of using it may be rollback of etcd v3 API,
     # where we need 3.0.* image, but are rolling back to 2.3.7.

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -146,6 +146,7 @@ HEAPSTER_MACHINE_TYPE="${HEAPSTER_MACHINE_TYPE:-}"
 # Set etcd image (e.g. gcr.io/google_containers/etcd) and version (e.g. 3.1.10) if you need
 # non-default version.
 ETCD_IMAGE="${TEST_ETCD_IMAGE:-}"
+ETCD_DOCKER_REPOSITORY="${TEST_ETCD_DOCKER_REPOSITORY:-}"
 ETCD_VERSION="${TEST_ETCD_VERSION:-}"
 
 # Default Log level for all components in test clusters and variables to override it in specific components.

--- a/cluster/gce/configure-vm.sh
+++ b/cluster/gce/configure-vm.sh
@@ -482,6 +482,11 @@ EOF
 etcd_docker_tag: '$(echo "$ETCD_IMAGE" | sed -e "s/'/''/g")'
 EOF
     fi
+    if [ -n "${ETCD_DOCKER_REPOSITORY:-}" ]; then
+      cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
+etcd_docker_repository: '$(echo "$ETCD_DOCKER_REPOSITORY" | sed -e "s/'/''/g")'
+EOF
+    fi
     if [ -n "${ETCD_VERSION:-}" ]; then
       cat <<EOF >>/srv/salt-overlay/pillar/cluster-params.sls
 etcd_version: '$(echo "$ETCD_VERSION" | sed -e "s/'/''/g")'

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -803,6 +803,11 @@ function prepare-etcd-manifest {
   else
     sed -i -e "s@{{ *pillar\.get('etcd_docker_tag', '\(.*\)') *}}@\1@g" "${temp_file}"
   fi
+  if [[ -n "${ETCD_DOCKER_REPOSITORY:-}" ]]; then
+    sed -i -e "s@{{ *pillar\.get('etcd_docker_repository', '\(.*\)') *}}@${ETCD_DOCKER_REPOSITORY}@g" "${temp_file}"
+  else
+    sed -i -e "s@{{ *pillar\.get('etcd_docker_repository', '\(.*\)') *}}@\1@g" "${temp_file}"
+  fi
 
   sed -i -e "s@{{ *etcd_protocol *}}@$etcd_protocol@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_creds *}}@$etcd_creds@g" "${temp_file}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1194,6 +1194,11 @@ function prepare-etcd-manifest {
   else
     sed -i -e "s@{{ *pillar\.get('etcd_docker_tag', '\(.*\)') *}}@\1@g" "${temp_file}"
   fi
+  if [[ -n "${ETCD_DOCKER_REPOSITORY:-}" ]]; then
+    sed -i -e "s@{{ *pillar\.get('etcd_docker_repository', '\(.*\)') *}}@${ETCD_DOCKER_REPOSITORY}@g" "${temp_file}"
+  else
+    sed -i -e "s@{{ *pillar\.get('etcd_docker_repository', '\(.*\)') *}}@\1@g" "${temp_file}"
+  fi
   sed -i -e "s@{{ *etcd_protocol *}}@$etcd_protocol@g" "${temp_file}"
   sed -i -e "s@{{ *etcd_creds *}}@$etcd_creds@g" "${temp_file}"
   if [[ -n "${ETCD_VERSION:-}" ]]; then

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -39,7 +39,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "gcr.io/google_containers/etcd:{{ pillar.get('etcd_docker_tag', '3.1.10') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'gcr.io/google_containers/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.1.10') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the etcd docker registry that is currently hard coded to `gcr.io/google_containers/etcd` in the `etcd.manifest` template to be overridden.  This can be used to test new versions of etcd with kubernetes that have not yet been published to `gcr.io/google_containers/etcd` and also enables cluster operators that use the 'cluster/' scripts to manage the etcd images used by their cluster in an internal repository.

Example usage:

```
$ export ETCD_DOCKER_REPOSITORY=gcr.io/jpbetz-public-images/etcd 
$ export ETCD_IMAGE=3.0.17 
$ cluster/kube-up.sh
...
$ gcloud compute ssh kubernetes-master
~ $ sudo cat /etc/kubernetes/manifests/etcd.manifest
{
"apiVersion": "v1",
"kind": "Pod",
"metadata": {
  "name":"etcd-server",
  ...
},
"spec":{
"hostNetwork": true,
"containers":[
    {
    "name": "etcd-container",
    "image": "gcr.io/jpbetz-public-images/etcd:3.0.17",
...
```
**Release note**:
```release-note
```
