### PR TITLE
Add cluster-name option for cloud controller manager

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -86,6 +86,7 @@ func (s *CloudControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableProfiling, "profiling", true, "Enable profiling via web interface host:port/debug/pprof/.")
 	fs.BoolVar(&s.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled.")
 	fs.StringVar(&s.ClusterCIDR, "cluster-cidr", s.ClusterCIDR, "CIDR Range for Pods in cluster.")
+	fs.StringVar(&s.ClusterName, "cluster-name", s.ClusterName, "The instance prefix for the cluster.")
 	fs.BoolVar(&s.AllocateNodeCIDRs, "allocate-node-cidrs", false, "Should CIDRs for Pods be allocated and set on the cloud provider.")
 	fs.StringVar(&s.Master, "master", s.Master, "The address of the Kubernetes API server (overrides any value in kubeconfig).")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", s.Kubeconfig, "Path to kubeconfig file with authorization and master location information.")


### PR DESCRIPTION
**What this PR does / why we need it**:
`cluster-name` is used by servicecontroller and routecontroller, for controller-manager, we have a parameter to set it, but for cloud-controller-manager, it will always be of default value 'kubernetes'.

An example of impact is Azure's loadbalancer, the loadbalancer resource created will always have the name 'kubernetes', while it used to be the cluster name set via controller manger's option.

**Which issue this PR fixes**
Fixes #52522

**Special notes for your reviewer**:

**Release note**:
```release-note
```
