### PR TITLE
Revert "Update addon-resizer version"

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -78,7 +78,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:2.0
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -102,10 +102,12 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=heapster
             - --poll-period=300000
-        - image: gcr.io/google_containers/addon-resizer:2.0
+            - --estimator=exponential
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:
@@ -129,9 +131,11 @@ spec:
             - --extra-cpu=0m
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=eventer
             - --poll-period=300000
+            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -79,7 +79,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:2.0
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -103,10 +103,12 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=heapster
             - --poll-period=300000
-        - image: gcr.io/google_containers/addon-resizer:2.0
+            - --estimator=exponential
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:
@@ -130,9 +132,11 @@ spec:
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=eventer
             - --poll-period=300000
+            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -64,7 +64,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/addon-resizer:2.0
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -88,10 +88,12 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=heapster
             - --poll-period=300000
-        - image: gcr.io/google_containers/addon-resizer:2.0
+            - --estimator=exponential
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:
@@ -115,9 +117,11 @@ spec:
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=eventer
             - --poll-period=300000
+            - --estimator=exponential
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -86,7 +86,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: gcr.io/google_containers/addon-resizer:2.0
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -110,9 +110,11 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=heapster
             - --poll-period=300000
+            - --estimator=exponential
       volumes:
         - name: ssl-certs
           hostPath:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -55,7 +55,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: gcr.io/google_containers/addon-resizer:2.0
+        - image: gcr.io/google_containers/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -79,9 +79,11 @@ spec:
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --threshold=5
             - --deployment=heapster-v1.5.0-beta.0
             - --container=heapster
             - --poll-period=300000
+            - --estimator=exponential
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"


### PR DESCRIPTION
This reverts #46850 due to several issues with new version of addon resizer (#50599, #52535), as recommended by @piosz. 

cc @fgrzadkowski @x13n 