### PR TITLE
Remove warning about changes in default token TTLs

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -128,12 +128,6 @@ func NewCmdInit(out io.Writer) *cobra.Command {
 			i, err := NewInit(cfgPath, internalcfg, skipPreFlight, skipTokenPrint, dryRun)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(i.Validate(cmd))
-
-			// TODO: remove this warning in 1.9
-			if !cmd.Flags().Lookup("token-ttl").Changed {
-				fmt.Println("[kubeadm] WARNING: starting in 1.8, tokens expire after 24 hours by default (if you require a non-expiring token use --token-ttl 0)")
-			}
-
 			kubeadmutil.CheckErr(i.Run(out))
 		},
 	}

--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -110,12 +110,6 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			client, err := getClientset(kubeConfigFile, dryRun)
 			kubeadmutil.CheckErr(err)
 
-			// TODO: remove this warning in 1.9
-			if !tokenCmd.Flags().Lookup("ttl").Changed {
-				// sending this output to stderr s
-				fmt.Fprintln(errW, "[kubeadm] WARNING: starting in 1.8, tokens expire after 24 hours by default (if you require a non-expiring token use --ttl 0)")
-			}
-
 			err = RunCreateToken(out, client, token, tokenDuration, usages, extraGroups, description)
 			kubeadmutil.CheckErr(err)
 		},


### PR DESCRIPTION


**What this PR does / why we need it**:
It was planned for 1.9 cleanup to remove that warning, as change was
done few release cycles ago and users should be already aware of it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/kubeadm#346

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
