### PR TITLE
Do not install metrics/v1alpha1 by default

### DIFF
--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/install/BUILD
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/install/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/metrics/pkg/apis/metrics:go_default_library",
-        "//vendor/k8s.io/metrics/pkg/apis/metrics/v1alpha1:go_default_library",
         "//vendor/k8s.io/metrics/pkg/apis/metrics/v1beta1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/metrics/pkg/apis/metrics"
-	"k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 	"k8s.io/metrics/pkg/apis/metrics/v1beta1"
 )
 
@@ -33,13 +32,12 @@ func Install(groupFactoryRegistry announced.APIGroupFactoryRegistry, registry *r
 	if err := announced.NewGroupMetaFactory(
 		&announced.GroupMetaFactoryArgs{
 			GroupName:                  metrics.GroupName,
-			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version, v1alpha1.SchemeGroupVersion.Version},
+			VersionPreferenceOrder:     []string{v1beta1.SchemeGroupVersion.Version},
 			RootScopedKinds:            sets.NewString("NodeMetrics"),
 			AddInternalObjectsToScheme: metrics.AddToScheme,
 		},
 		announced.VersionToSchemeFunc{
-			v1alpha1.SchemeGroupVersion.Version: v1alpha1.AddToScheme,
-			v1beta1.SchemeGroupVersion.Version:  v1beta1.AddToScheme,
+			v1beta1.SchemeGroupVersion.Version: v1beta1.AddToScheme,
 		},
 	).Announce(groupFactoryRegistry).RegisterAndEnable(registry, scheme); err != nil {
 		panic(err)


### PR DESCRIPTION
We want to have `metrics/v1alpha1` in the repo in order to support the previous version of HPA, but we don't want to install them by default.

ref https://github.com/kubernetes-incubator/metrics-server/pull/15