### PR TITLE
[fluentd-gcp addon] By default ingest audit logs in JSON format

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -170,23 +170,10 @@ data:
       tag kube-apiserver
     </source>
 
-    # Example:
-    # 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
-    # 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+    # Audit logs in JSON format.
     <source>
       type tail
-      format multiline
-      multiline_flush_interval 5s
-      format_firstline /^\S+\s+AUDIT:/
-      # Fields must be explicitly captured by name to be parsed into the record.
-      # Fields may not always be present, and order may change, so this just looks
-      # for a list of key="\"quoted\" value" pairs separated by spaces.
-      # Unknown fields are ignored.
-      # Note: We can't separate query/response lines as format1/format2 because
-      #       they don't always come one after the other for a given query.
-      # TODO: Maybe add a JSON output mode to audit log so we can get rid of this?
-      format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
-      time_format %FT%T.%L%Z
+      format json
       path /var/log/kube-apiserver-audit.log
       pos_file /var/log/gcp-kube-apiserver-audit.log.pos
       tag kube-apiserver-audit
@@ -408,7 +395,7 @@ data:
       num_threads 2
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.2.0
+  name: fluentd-gcp-config-v1.2.1
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -117,7 +117,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.2.0
+          name: fluentd-gcp-config-v1.2.1
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs


### PR DESCRIPTION
As https://github.com/kubernetes/kubernetes/pull/50971 set default audit log format for advanced auditing to JSON and https://github.com/kubernetes/kubernetes/pull/51943 makes advanced auditing default, fluentd should also ingest audit logs as JSON by default.

```release-note
[fluentd-gcp addon] By default ingest apiserver audit logs written to file in JSON format.
```