### PR TITLE
Increase sliding window to 5hr for request_latencies metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -56,8 +56,9 @@ var (
 		prometheus.SummaryOpts{
 			Name: "apiserver_request_latencies_summary",
 			Help: "Response latency summary in microseconds for each verb, resource and subresource.",
-			// Make the sliding window of 1h.
-			MaxAge: time.Hour,
+			// Make the sliding window of 5h.
+			// TODO: The value for this should be based on our SLI definition (medium term).
+			MaxAge: 5 * time.Hour,
 		},
 		[]string{"verb", "resource", "subresource", "scope"},
 	)


### PR DESCRIPTION
We're seeing high latency values for a couple of types of api calls in our density test (ref https://github.com/kubernetes/kubernetes/issues/51899). And we're recording values from only the last 1 hour in the metric (as @wojtek-t told me offline) - so our test result is pretty much counting only the calls during the delete phase.

cc @kubernetes/sig-scalability-misc @kubernetes/sig-api-machinery-misc @gmarek 