### PR TITLE
Bumped Metrics Server to v0.2.0

### DIFF
--- a/cluster/addons/metrics-server/metrics-apiservice.yaml
+++ b/cluster/addons/metrics-server/metrics-apiservice.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1alpha1.metrics
+  name: v1beta1.metrics.k8s.io
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -9,8 +9,8 @@ spec:
   service:
     name: metrics-server
     namespace: kube-system
-  group: metrics
-  version: v1alpha1
+  group: metrics.k8s.io
+  version: v1beta1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -10,28 +10,31 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server
+  name: metrics-server-v0.2.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    version: v0.2.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
+      version: v0.2.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
+        version: v0.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:dev
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.0
         imagePullPolicy: Always
         # TODO(piosz): revisit resources
         resources:


### PR DESCRIPTION
ref https://github.com/kubernetes/features/issues/271

**Release note**:
```release-note
Introduced Metrics Server in version v0.2.0. For more details see https://github.com/kubernetes-incubator/metrics-server/releases/tag/v0.2.0.
```
