### PR TITLE
Drop --experimental-bootstrap-token-auth flag.

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -180,10 +180,6 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 	}
 
 	if s.BootstrapToken != nil {
-		fs.BoolVar(&s.BootstrapToken.Enable, "experimental-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
-			"Deprecated (use --enable-bootstrap-token-auth).")
-		fs.MarkDeprecated("experimental-bootstrap-token-auth", "use --enable-bootstrap-token-auth instead.")
-
 		fs.BoolVar(&s.BootstrapToken.Enable, "enable-bootstrap-token-auth", s.BootstrapToken.Enable, ""+
 			"Enable to allow secrets of type 'bootstrap.kubernetes.io/token' in the 'kube-system' "+
 			"namespace to be used for TLS bootstrapping authentication.")


### PR DESCRIPTION
**What this PR does / why we need it**:
Drops support for the `--experimental-bootstrap-token-auth` flag for the API server. This flag was replaced by `--enable-bootstrap-token-auth` in 1.8 (https://github.com/kubernetes/kubernetes/pull/51198) but the old flag was accepted with a deprecation warning. In 1.9 we want to totally drop it.

**Which issue this PR fixes**: fixes #50613

**Special notes for your reviewer**:
There are other places in kubeadm where we need to drop support for this flag (at init and at postupgrade). We can tackle those in a separate PR.

**Release note**:
I think this change is already document well enough in the changelog for 1.8.
```release-note
NONE
```

@kubernetes/sig-cluster-lifecycle-pr-reviews @kubernetes/sig-auth-pr-reviews 

/kind cleanup
