### PR TITLE
Enable HPA metrics REST clients by default

### DIFF
--- a/cluster/addons/metrics-server/metrics-apiservice.yaml
+++ b/cluster/addons/metrics-server/metrics-apiservice.yaml
@@ -1,7 +1,7 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1alpha1.metrics
+  name: v1beta1.metrics.k8s.io
   labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
@@ -9,8 +9,8 @@ spec:
   service:
     name: metrics-server
     namespace: kube-system
-  group: metrics
-  version: v1alpha1
+  group: metrics.k8s.io
+  version: v1beta1
   insecureSkipTLSVerify: true
   groupPriorityMinimum: 100
   versionPriority: 100

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -10,28 +10,31 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server
+  name: metrics-server-v0.2.0
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
+    version: v0.2.0
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
+      version: v0.2.0
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
+        version: v0.2.0
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:dev
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.0
         imagePullPolicy: Always
         # TODO(piosz): revisit resources
         resources:

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1476,6 +1476,11 @@ function start-kube-apiserver {
     params+=" --experimental-encryption-provider-config=${encryption_provider_config_path}"
   fi
 
+  # disable using HPA metrics REST clients if metrics-server isn't enabled
+  if [[ "${ENABLE_METRICS_SERVER:-}" != "true" ]]; then
+    params+=" --horizontal-pod-autoscaler-use-rest-clients=false"
+  fi
+
   src_file="${src_dir}/kube-apiserver.manifest"
   remove-salt-config-comments "${src_file}"
   # Evaluate variables.

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -113,7 +113,7 @@ func NewCMServer() *CMServer {
 			ClusterSigningDuration:                metav1.Duration{Duration: helpers.OneYear},
 			ReconcilerSyncLoopPeriod:              metav1.Duration{Duration: 60 * time.Second},
 			EnableTaintManager:                    true,
-			HorizontalPodAutoscalerUseRESTClients: false,
+			HorizontalPodAutoscalerUseRESTClients: true,
 		},
 	}
 	s.LeaderElection.LeaderElect = true

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -163,6 +163,9 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 			rbac.NewRule("list").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 			// TODO: restrict this to the appropriate namespace
 			rbac.NewRule("get").Groups(legacyGroup).Resources("services/proxy").Names("https:heapster:", "http:heapster:").RuleOrDie(),
+			// allow listing resource metrics and custom metrics
+			rbac.NewRule("list").Groups(resMetricsGroup).Resources("pods").RuleOrDie(),
+			rbac.NewRule("list").Groups(customMetricsGroup).Resources("*").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -31,11 +31,13 @@ var rolesWithAllowStar = sets.NewString(
 	saRolePrefix+"namespace-controller",
 	saRolePrefix+"generic-garbage-collector",
 	saRolePrefix+"resourcequota-controller",
+	saRolePrefix+"horizontal-pod-autoscaler",
 )
 
 // TestNoStarsForControllers confirms that no controller role has star verbs, groups,
-// or resources.  There are two known exceptions, namespace lifecycle and GC which have to
-// delete anything
+// or resources.  There are three known exceptions: namespace lifecycle and GC which have to
+// delete anything, and HPA, which has the power to read metrics associated
+// with any object.
 func TestNoStarsForControllers(t *testing.T) {
 	for _, role := range ControllerRoles() {
 		if rolesWithAllowStar.Has(role.Name) {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -46,6 +46,8 @@ const (
 	policyGroup         = "policy"
 	rbacGroup           = "rbac.authorization.k8s.io"
 	storageGroup        = "storage.k8s.io"
+	resMetricsGroup     = "metrics.k8s.io"
+	customMetricsGroup  = "custom.metrics.k8s.io"
 )
 
 func addDefaultMetadata(obj runtime.Object) {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -483,6 +483,18 @@ items:
     verbs:
     - get
   - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - list
+  - apiGroups:
+    - custom.metrics.k8s.io
+    resources:
+    - '*'
+    verbs:
+    - list
+  - apiGroups:
     - ""
     resources:
     - events


### PR DESCRIPTION
Now that the metrics APIs are in beta and metrics-server has the appropriate support (as of #52548), we should enable the REST metrics clients by default instead of using the legacy clients.

```release-note
The --horizontal-pod-autoscaler-use-rest-clients flag now defaults to true.  You must have metrics-server enabled for this to work.
```
