### PR TITLE
Only return true if a ProviderID exists for GCE #52546

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -641,7 +641,14 @@ func (gce *GCECloud) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []
 
 // HasClusterID returns true if the cluster has a clusterID
 func (gce *GCECloud) HasClusterID() bool {
-	return true
+	if id, err := gce.ClusterID.GetID(); err != nil && id != "" {
+		return true
+	} else {
+		if err != nil {
+			glog.Warningf("Unable to retrieve ClusterID: %v", err)
+		}
+		return false
+	}
 }
 
 // Project IDs cannot have a digit for the first characeter. If the id contains a digit,


### PR DESCRIPTION
The GCE Cloud Provider will always return true for HasClusterID.  This change will only return true if the ClusterID is not empty and there is no issue retrieving it.

fixes #52546 

@saad-ali @jingxu97