### PR TITLE
Automated cherry pick of #51199

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2476,6 +2476,16 @@ func ValidatePodUpdate(newPod, oldPod *api.Pod) field.ErrorList {
 
 	// handle updateable fields by munging those fields prior to deep equal comparison.
 	mungedPod := *newPod
+
+	// allow hostname and subdomain to be updated if they are empty. This allows for migration between the beta
+	// annotations and the GA field when upgrading between Kubernetes 1.6.x and 1.7.x.
+	if oldPod.Spec.Hostname == "" {
+		mungedPod.Spec.Hostname = oldPod.Spec.Hostname
+	}
+	if oldPod.Spec.Subdomain == "" {
+		mungedPod.Spec.Subdomain = oldPod.Spec.Subdomain
+	}
+
 	// munge containers[*].image
 	var newContainers []api.Container
 	for ix, container := range mungedPod.Spec.Containers {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -4836,6 +4836,54 @@ func TestValidatePodUpdate(t *testing.T) {
 			false,
 			"added invalid new toleration to existing tolerations in pod spec updates",
 		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Hostname: "bar"},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Hostname: ""},
+			},
+			true,
+			"update empty hostname",
+		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Subdomain: "bar"},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Subdomain: ""},
+			},
+			true,
+			"update empty subdomain",
+		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Hostname: "bar"},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Hostname: "baz"},
+			},
+			false,
+			"update hostname",
+		},
+		{
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Subdomain: "bar"},
+			},
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+				Spec:       api.PodSpec{Subdomain: "baz"},
+			},
+			false,
+			"update subdomain",
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -207,6 +207,12 @@ func updateStorage(set *apps.StatefulSet, pod *v1.Pod) {
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Name = getPodName(set, getOrdinal(pod))
 	pod.Namespace = set.Namespace
+	if pod.Spec.Hostname == "" {
+		pod.Spec.Hostname = pod.Name
+	}
+	if pod.Spec.Subdomain == "" {
+		pod.Spec.Subdomain = set.Spec.ServiceName
+	}
 	if pod.Annotations == nil {
 		pod.Annotations = make(map[string]string)
 	}

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -139,6 +139,22 @@ func TestUpdateIdentity(t *testing.T) {
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to update the Pods namespace")
 	}
+	pod.Spec.Hostname = ""
+	pod.Spec.Subdomain = ""
+	updateIdentity(set, pod)
+	if pod.Spec.Hostname != pod.Name || pod.Spec.Subdomain != set.Spec.ServiceName {
+		t.Errorf("want hostame=%s subdomain=%s got hostname=%s subdomain=%s",
+			pod.Name,
+			set.Spec.ServiceName,
+			pod.Spec.Hostname,
+			set.Spec.ServiceName)
+	}
+	pod.Spec.Hostname = "foo"
+	pod.Spec.Subdomain = "bar"
+	updateIdentity(set, pod)
+	if pod.Spec.Hostname != "foo" || pod.Spec.Subdomain != "bar" {
+		t.Errorf("want hostame=foo subdomain=bar got hostname=%s subdomain=%s", pod.Spec.Hostname, set.Spec.ServiceName)
+	}
 	pod = newStatefulSetPod(set, 1)
 	delete(pod.Annotations, podapi.PodHostnameAnnotation)
 	pod.Spec.Hostname = ""


### PR DESCRIPTION
Cherry pick of #51199 on release-1.6.

This allows users to completely avoid any disruption due to #48327, by first upgrading to a 1.6.x release containing this patch, before upgrading to 1.7.x.

#51199: Makes Hostname and Subdomain fields of v1.PodSpec settable