### PR TITLE
Allow updating objects with empty pending initializers list

### DIFF
--- a/plugin/pkg/admission/initialization/initialization_test.go
+++ b/plugin/pkg/admission/initialization/initialization_test.go
@@ -152,6 +152,22 @@ func TestAdmitUpdate(t *testing.T) {
 			newInitializers: &metav1.Initializers{Pending: []metav1.Initializer{{Name: "init.k8s.io"}}},
 			err:             "field is immutable once initialization has completed",
 		},
+		{
+			name:            "empty initializer list is treated as nil initializer",
+			oldInitializers: nil,
+			newInitializers: &metav1.Initializers{},
+			verifyUpdatedObj: func(obj runtime.Object) (bool, string) {
+				accessor, err := meta.Accessor(obj)
+				if err != nil {
+					return false, "cannot get accessor"
+				}
+				if accessor.GetInitializers() != nil {
+					return false, "expect nil initializers"
+				}
+				return true, ""
+			},
+			err: "",
+		},
 	}
 
 	plugin := initializer{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: When updating an object, an empty pending list should be treated as a nil initializer. This PR fixes a bug which prevented this functionality and also adds a test which will ensure this functionality is preserved.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52202

**Special notes for your reviewer**:

/cc @caesarxuchao

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixes an initializer bug where update requests which had an empty pending initializers list were erroneously rejected.
```