### PR TITLE
[fluentd-gcp addon] Update Stackdriver plugin to version 0.6.7

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -364,6 +364,8 @@ data:
     <match kubernetes.**>
       @type google_cloud
 
+      # Try to detect JSON formatted log entries.
+      detect_json true
       # Collect metrics in Prometheus registry about plugin activity.
       enable_monitoring true
       monitoring_type prometheus
@@ -373,11 +375,11 @@ data:
       # Set queue_full action to block because we want to pause gracefully
       # in case of the off-the-limits load instead of throwing an exception
       buffer_queue_full_action block
-      # Set the chunk limit conservatively to avoid exceeding the GCL limit
-      # of 10MiB per write request.
-      buffer_chunk_limit 2M
+      # Set the chunk limit conservatively to avoid exceeding the recommended
+      # chunk size of 5MB per write request.
+      buffer_chunk_limit 1M
       # Cap the combined memory usage of this buffer and the one below to
-      # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+      # 1MiB/chunk * (6 + 2) chunks = 8 MiB
       buffer_queue_limit 6
       # Never wait more than 5 seconds before flushing logs in the non-error case.
       flush_interval 5s
@@ -394,13 +396,14 @@ data:
     <match **>
       @type google_cloud
 
+      detect_json true
       enable_monitoring true
       monitoring_type prometheus
       detect_subservice false
       buffer_type file
       buffer_path /var/log/fluentd-buffers/kubernetes.system.buffer
       buffer_queue_full_action block
-      buffer_chunk_limit 2M
+      buffer_chunk_limit 1M
       buffer_queue_limit 2
       flush_interval 5s
       max_retry_wait 30
@@ -408,7 +411,7 @@ data:
       num_threads 2
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.2.0
+  name: fluentd-gcp-config-v1.2.2
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,13 +1,13 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: fluentd-gcp-v2.0
+  name: fluentd-gcp-v2.0.9
   namespace: kube-system
   labels:
     k8s-app: fluentd-gcp
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v2.0
+    version: v2.0.9
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -16,7 +16,7 @@ spec:
       labels:
         k8s-app: fluentd-gcp
         kubernetes.io/cluster-service: "true"
-        version: v2.0
+        version: v2.0.9
       # This annotation ensures that fluentd does not get evicted if the node
       # supports critical pod annotation based priority scheme.
       # Note that this does not guarantee admission on the nodes (#40573).
@@ -27,7 +27,7 @@ spec:
       hostNetwork: true
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.8
+        image: gcr.io/google-containers/fluentd-gcp:2.0.9
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
@@ -117,7 +117,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.2.0
+          name: fluentd-gcp-config-v1.2.2
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs


### PR DESCRIPTION
A new gem among all fixes Java logging severity parsing and string timestamp parsing

Also sync the buffer size with the gem guidelines, making it 1M instead of 2M.

/cc @igorpeshansky