### PR TITLE
Add bootstrap policy for HPA metrics REST clients

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -163,6 +163,9 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 			rbac.NewRule("list").Groups(legacyGroup).Resources("pods").RuleOrDie(),
 			// TODO: restrict this to the appropriate namespace
 			rbac.NewRule("get").Groups(legacyGroup).Resources("services/proxy").Names("https:heapster:", "http:heapster:").RuleOrDie(),
+			// allow listing resource metrics and custom metrics
+			rbac.NewRule("list").Groups(resMetricsGroup).Resources("pods").RuleOrDie(),
+			rbac.NewRule("list").Groups(customMetricsGroup).Resources("*").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy_test.go
@@ -31,11 +31,13 @@ var rolesWithAllowStar = sets.NewString(
 	saRolePrefix+"namespace-controller",
 	saRolePrefix+"generic-garbage-collector",
 	saRolePrefix+"resourcequota-controller",
+	saRolePrefix+"horizontal-pod-autoscaler",
 )
 
 // TestNoStarsForControllers confirms that no controller role has star verbs, groups,
-// or resources.  There are two known exceptions, namespace lifecycle and GC which have to
-// delete anything
+// or resources.  There are three known exceptions: namespace lifecycle and GC which have to
+// delete anything, and HPA, which has the power to read metrics associated
+// with any object.
 func TestNoStarsForControllers(t *testing.T) {
 	for _, role := range ControllerRoles() {
 		if rolesWithAllowStar.Has(role.Name) {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -46,6 +46,8 @@ const (
 	policyGroup         = "policy"
 	rbacGroup           = "rbac.authorization.k8s.io"
 	storageGroup        = "storage.k8s.io"
+	resMetricsGroup     = "metrics.k8s.io"
+	customMetricsGroup  = "custom.metrics.k8s.io"
 )
 
 func addDefaultMetadata(obj runtime.Object) {

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -483,6 +483,18 @@ items:
     verbs:
     - get
   - apiGroups:
+    - metrics.k8s.io
+    resources:
+    - pods
+    verbs:
+    - list
+  - apiGroups:
+    - custom.metrics.k8s.io
+    resources:
+    - '*'
+    verbs:
+    - list
+  - apiGroups:
     - ""
     resources:
     - events


### PR DESCRIPTION
Since we weren't running the HPA with metrics REST clients by default,
we had no bootstrap policy enabling the HPA controller to talk to the
metrics APIs.

This adds permissions for the HPA controller to talk list
pods.metrics.k8s.io, and list any resource in custom.metrics.k8s.io.

```release-note
Introduce policy to allow the HPA to consume the metrics.k8s.io and custom.metrics.k8s.io API groups.
```
