### PR TITLE
Add statefulset upgrade tests to be run as part of upgrade testing

### DIFF
--- a/test/e2e/lifecycle/cluster_upgrade.go
+++ b/test/e2e/lifecycle/cluster_upgrade.go
@@ -200,7 +200,7 @@ var _ = SIGDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
 	})
 })
 
-var _ = Describe("[sig-apps] stateful Upgrade [Feature:Upgrade]", func() {
+var _ = Describe("[sig-apps] stateful Upgrade [Feature:ClusterUpgrade]", func() {
 	f := framework.NewDefaultFramework("stateful-upgrade")
 
 	// Create the frameworks here because we can only create them

--- a/test/e2e/lifecycle/cluster_upgrade.go
+++ b/test/e2e/lifecycle/cluster_upgrade.go
@@ -200,7 +200,7 @@ var _ = SIGDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
 	})
 })
 
-var _ = Describe("[sig-apps] stateful Upgrade [Feature:StatefulUpgrade]", func() {
+var _ = Describe("[sig-apps] stateful Upgrade [Feature:Upgrade]", func() {
 	f := framework.NewDefaultFramework("stateful-upgrade")
 
 	// Create the frameworks here because we can only create them


### PR DESCRIPTION
Statefulset upgrade testing is not running at all in any testsuite. This has caused issues in the past like: https://github.com/kubernetes/kubernetes/issues/48327
Changing the tag to make it run in existing upgrade test clusters.

@krzyzacy @kubernetes/sig-apps-misc @kubernetes/sig-release-members @kow3ns @enisoc 