### PR TITLE
[WIP/RFC] GCE: validate annotations for Service of LoadBalancer type

### DIFF
--- a/pkg/cloudprovider/providers/gce/BUILD
+++ b/pkg/cloudprovider/providers/gce/BUILD
@@ -32,6 +32,7 @@ go_library(
         "gce_loadbalancer_external.go",
         "gce_loadbalancer_internal.go",
         "gce_loadbalancer_naming.go",
+        "gce_loadbalancer_wrapper.go",
         "gce_op.go",
         "gce_routes.go",
         "gce_targetpool.go",

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -568,7 +568,7 @@ func (gce *GCECloud) Initialize(clientBuilder controller.ControllerClientBuilder
 
 // LoadBalancer returns an implementation of LoadBalancer for Google Compute Engine.
 func (gce *GCECloud) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
-	return gce, true
+	return newWrappedLoadBalancer(gce), true
 }
 
 // Instances returns an implementation of Instances for Google Compute Engine.

--- a/pkg/cloudprovider/providers/gce/gce_annotations.go
+++ b/pkg/cloudprovider/providers/gce/gce_annotations.go
@@ -130,7 +130,7 @@ func validateServiceLBAnnotations(svc *v1.Service) error {
 
 	for k, v := range svc.Annotations {
 		if incompatibleKeys.Has(k) {
-			allErrs = append(allErrs, fmt.Errorf("key %q is compatible with LB type %q", k, lbType))
+			allErrs = append(allErrs, fmt.Errorf("key %q is incompatible with LB type %q", k, lbType))
 			continue
 		}
 		err := validateLBAnnotation(k, v)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer.go
@@ -118,7 +118,7 @@ func (gce *GCECloud) EnsureLoadBalancer(clusterName string, svc *v1.Service, nod
 	// Validate all the relevant annotations before proceeding.
 	if err := validateServiceLBAnnotations(svc); err != nil {
 		glog.Errorf("%s: %v", logPrefix, err)
-		return nil, fmt.Errorf("service %s/%s has invalid annotations: %v", svc.Namespace, svc.Name)
+		return nil, fmt.Errorf("service %s/%s has invalid annotations: %v", svc.Namespace, svc.Name, err)
 	}
 
 	desiredScheme := getSvcScheme(svc)

--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_wrapper.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_wrapper.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gce
+
+import (
+	"github.com/golang/glog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+type wrappedLoadBalancer struct {
+	gce *GCECloud
+}
+
+func newWrappedLoadBalancer(gce *GCECloud) cloudprovider.LoadBalancer {
+	return &wrappedLoadBalancer{gce: gce}
+}
+
+func (w *wrappedLoadBalancer) GetLoadBalancer(clusterName string, service *v1.Service) (status *v1.LoadBalancerStatus, exists bool, err error) {
+	svc := w.convertServiceLBAnnotations(service)
+	return w.gce.GetLoadBalancer(clusterName, svc)
+}
+
+func (w *wrappedLoadBalancer) EnsureLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
+	svc := w.convertServiceLBAnnotations(service)
+	if err := validateServiceLBAnnotations(svc); err != nil {
+		return nil, err
+	}
+	return w.gce.EnsureLoadBalancer(clusterName, svc, nodes)
+}
+
+func (w *wrappedLoadBalancer) UpdateLoadBalancer(clusterName string, service *v1.Service, nodes []*v1.Node) error {
+	svc := w.convertServiceLBAnnotations(service)
+	return w.gce.UpdateLoadBalancer(clusterName, svc, nodes)
+}
+
+func (w *wrappedLoadBalancer) EnsureLoadBalancerDeleted(clusterName string, service *v1.Service) error {
+	svc := w.convertServiceLBAnnotations(service)
+	return w.gce.EnsureLoadBalancerDeleted(clusterName, svc)
+}
+
+func (w *wrappedLoadBalancer) convertServiceLBAnnotations(svc *v1.Service) *v1.Service {
+	results := map[string]string{}
+	for k, v := range svc.Annotations {
+		// Convert to the new key if the current key has been deprecated.
+		if newKey, ok := deprecatedServiceLBAnnotations[k]; ok {
+			// Do we need to log a warning every time?
+			glog.Warning("key %s has been deprecated. Please use %q in the future", k, newKey)
+			k = newKey
+		}
+
+		// Trim annotations owned by gated Alpha features.
+		if r, ok := allServiceLBAnnotations[k]; ok {
+			if r.alphaFeature != "" && !w.gce.AlphaFeatureGate.Enabled(r.alphaFeature) {
+				continue
+			}
+			// Consider doing defaulting here? This would need to be
+			// LB-type-aware (ILB vs ELB).
+		}
+
+		results[k] = v
+	}
+
+	// Make a deep copy of the Service and set the annotations
+	newSvc := svc.DeepCopy()
+	newSvc.Annotations = results
+	return newSvc
+}

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -78,8 +78,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 			setNetworkTier(svc, gcecloud.NetworkTierAnnotationStandard)
 		})
 		// Verify that service has been updated properly.
-		svcTier, err := gcecloud.GetServiceNetworkTier(svc)
-		Expect(err).NotTo(HaveOccurred())
+		svcTier := gcecloud.GetServiceNetworkTier(svc)
 		Expect(svcTier).To(Equal(gcecloud.NetworkTierStandard))
 		// Record the LB name for test cleanup.
 		serviceLBNames = append(serviceLBNames, cloudprovider.GetLoadBalancerName(svc))
@@ -93,8 +92,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 			clearNetworkTier(svc)
 		})
 		// Verify that service has been updated properly.
-		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
-		Expect(err).NotTo(HaveOccurred())
+		svcTier = gcecloud.GetServiceNetworkTier(svc)
 		Expect(svcTier).To(Equal(gcecloud.NetworkTierDefault))
 
 		// Wait until the ingress IP changes. Each tier has its own pool of
@@ -124,8 +122,7 @@ var _ = SIGDescribe("Services [Feature:GCEAlphaFeature][Slow]", func() {
 		})
 		// Verify that service has been updated properly.
 		Expect(svc.Spec.LoadBalancerIP).To(Equal(requestedIP))
-		svcTier, err = gcecloud.GetServiceNetworkTier(svc)
-		Expect(err).NotTo(HaveOccurred())
+		svcTier = gcecloud.GetServiceNetworkTier(svc)
 		Expect(svcTier).To(Equal(gcecloud.NetworkTierStandard))
 
 		// Wait until the ingress IP changes and verifies the LB.
@@ -160,8 +157,7 @@ func waitAndVerifyLBWithTier(jig *framework.ServiceTestJig, ns, svcName, existin
 	jig.TestReachableHTTPWithRetriableErrorCodes(ingressIP, svcPort, []int{http.StatusNotFound}, checkTimeout)
 
 	// Verify the network tier matches the desired.
-	svcNetTier, err := gcecloud.GetServiceNetworkTier(svc)
-	Expect(err).NotTo(HaveOccurred())
+	svcNetTier := gcecloud.GetServiceNetworkTier(svc)
 	netTier, err := getLBNetworkTierByIP(ingressIP)
 	Expect(err).NotTo(HaveOccurred(), "failed to get the network tier of the load balancer")
 	Expect(netTier).To(Equal(svcNetTier))


### PR DESCRIPTION
This change adds validation for annotations so that incompatible
annotations can be caught and reported. Once the Service passed
the validation, all subsequent operations can assume a valid
value exists for the annotation key, and no further check is needed.

**NOTE TO THE REVIEWERS**: This PR is more of a POC. Feedback is welcome, but no need to waste your time on detailed code review :-)
This PR doesn't solve our annotation-overload issue. It provides some *very* basic validation and conversion for the LoadBalancer functions to make the user experience slightly better.

/cc @nicksardo