### PR TITLE
Fix nil pointer dereference in cri stats provider when there are no image file systems

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -258,7 +258,7 @@ func (p *criStatsProvider) makeContainerStats(
 			result.Rootfs.InodesUsed = &stats.WritableLayer.InodesUsed.Value
 		}
 	}
-	storageID := stats.WritableLayer.StorageId
+	storageID := stats.GetWritableLayer().GetStorageId()
 	if storageID != nil {
 		imageFsInfo, found := uuidToFsInfo[*storageID]
 		if !found {

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -259,20 +259,22 @@ func (p *criStatsProvider) makeContainerStats(
 		}
 	}
 	storageID := stats.WritableLayer.StorageId
-	imageFsInfo, found := uuidToFsInfo[*storageID]
-	if !found {
-		imageFsInfo = p.getFsInfo(storageID)
-		uuidToFsInfo[*storageID] = imageFsInfo
-	}
-	if imageFsInfo != nil {
-		// The image filesystem UUID is unknown to the local node or there's an
-		// error on retrieving the stats. In these cases, we omit those stats
-		// and return the best-effort partial result. See
-		// https://github.com/kubernetes/heapster/issues/1793.
-		result.Rootfs.AvailableBytes = &imageFsInfo.Available
-		result.Rootfs.CapacityBytes = &imageFsInfo.Capacity
-		result.Rootfs.InodesFree = imageFsInfo.InodesFree
-		result.Rootfs.Inodes = imageFsInfo.Inodes
+	if storageID != nil {
+		imageFsInfo, found := uuidToFsInfo[*storageID]
+		if !found {
+			imageFsInfo = p.getFsInfo(storageID)
+			uuidToFsInfo[*storageID] = imageFsInfo
+		}
+		if imageFsInfo != nil {
+			// The image filesystem UUID is unknown to the local node or there's an
+			// error on retrieving the stats. In these cases, we omit those stats
+			// and return the best-effort partial result. See
+			// https://github.com/kubernetes/heapster/issues/1793.
+			result.Rootfs.AvailableBytes = &imageFsInfo.Available
+			result.Rootfs.CapacityBytes = &imageFsInfo.Capacity
+			result.Rootfs.InodesFree = imageFsInfo.InodesFree
+			result.Rootfs.Inodes = imageFsInfo.Inodes
+		}
 	}
 
 	return result


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR fixes a nil pointer dereference in CRI stats provider when there are no image filesystems. See https://github.com/kubernetes/kubernetes/pull/51152 for discussion.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```

/cc yujuhong yguo0905