### PR TITLE
Skip cronjob e2e test for adoption of jobs without ControllerRef

### DIFF
--- a/test/e2e/cronjob.go
+++ b/test/e2e/cronjob.go
@@ -46,9 +46,10 @@ const (
 )
 
 var (
-	CronJobGroupVersionResource      = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "cronjobs"}
-	ScheduledJobGroupVersionResource = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}
-	removedScheduledJobsVersion      = utilversion.MustParseSemantic("v1.8.0")
+	CronJobGroupVersionResource                = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "cronjobs"}
+	ScheduledJobGroupVersionResource           = schema.GroupVersionResource{Group: batchv2alpha1.GroupName, Version: "v2alpha1", Resource: "scheduledjobs"}
+	removedScheduledJobsVersion                = utilversion.MustParseSemantic("v1.8.0")
+	skippedAdoptionWithoutControllerRefVersion = utilversion.MustParseSemantic("v1.8.0-alpha.0")
 )
 
 var _ = framework.KubeDescribe("CronJob", func() {
@@ -282,6 +283,7 @@ var _ = framework.KubeDescribe("CronJob", func() {
 	// Adopt Jobs it owns that don't have ControllerRef yet.
 	// That is, the Jobs were created by a pre-v1.6.0 master.
 	It("should adopt Jobs it owns that don't have ControllerRef yet", func() {
+		framework.SkipUnlessServerVersionLT(skippedAdoptionWithoutControllerRefVersion, f.ClientSet.Discovery())
 		By("Creating a cronjob")
 		cronJob := newTestCronJob("adopt", "*/1 * * * ?", batchv2alpha1.ForbidConcurrent,
 			sleepCommand, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the logic to skip cronjob e2e test for adoption of jobs without ControllerRef when testing against v1.8 cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52571 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
