### PR TITLE
Update test initializer name to pass 1.8 validation

### DIFF
--- a/test/e2e/extension/initializers.go
+++ b/test/e2e/extension/initializers.go
@@ -214,7 +214,7 @@ var _ = framework.KubeDescribe("Initializers", func() {
 func newUninitializedPod(podName string) *v1.Pod {
 	pod := newPod(podName)
 	pod.Initializers = &metav1.Initializers{
-		Pending: []metav1.Initializer{{Name: "Test"}},
+		Pending: []metav1.Initializer{{Name: "test.k8s.io"}},
 	}
 	return pod
 }


### PR DESCRIPTION
e2e portion of https://github.com/kubernetes/kubernetes/pull/51283/files#diff-e3afa632328a4a5271f4b8578faa34bd

fixes https://github.com/kubernetes/kubernetes/issues/52585

```release-note
fixes upgrade test to work with tightened validation of initializer names in 1.8
```