### PR TITLE
fluentd-gcp: 256KiB buffer chunks

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -375,10 +375,10 @@ data:
       buffer_queue_full_action block
       # Set the chunk limit conservatively to avoid exceeding the GCL limit
       # of 10MiB per write request.
-      buffer_chunk_limit 2M
+      buffer_chunk_limit 256k
       # Cap the combined memory usage of this buffer and the one below to
-      # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-      buffer_queue_limit 6
+      # 256KiB/chunk * (48 + 16) chunks = 16 MiB
+      buffer_queue_limit 48
       # Never wait more than 5 seconds before flushing logs in the non-error case.
       flush_interval 5s
       # Never wait longer than 30 seconds between retries.
@@ -386,7 +386,7 @@ data:
       # Disable the limit on the number of retries (retry forever).
       disable_retry_limit
       # Use multiple threads for processing.
-      num_threads 2
+      num_threads 16
     </match>
 
     # Keep a smaller buffer here since these logs are less important than the user's
@@ -400,12 +400,12 @@ data:
       buffer_type file
       buffer_path /var/log/fluentd-buffers/kubernetes.system.buffer
       buffer_queue_full_action block
-      buffer_chunk_limit 2M
-      buffer_queue_limit 2
+      buffer_chunk_limit 256k
+      buffer_queue_limit 16
       flush_interval 5s
       max_retry_wait 30
       disable_retry_limit
-      num_threads 2
+      num_threads 16
     </match>
 metadata:
   name: fluentd-gcp-config-v1.2.0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Lower the size of the fluentd buffer chunks to avoid GCL request timeouts like these in GKE:

```
{"log":"2017-09-12 15:39:58 +0000 [warn]: temporarily failed to flush the buffer. next_retry=2017-09-12 15:40:08 +0000 error_class=\"Google::Apis::TransmissionError\" error=\"execution expired\" plugin_id=\"object:3f91cf43c0ec\"\n","stream":"stdout","time":"2017-09-12T15:39:58.58912385Z"}
```

To compensate for the increased network latency overhead of 8x smaller chunks, increase GCL request parallelism by 8x and use 16 threads instead of 2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
