### PR TITLE
[WIP] Support project-id and project-name in the OpenStack config

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -113,17 +113,19 @@ type OpenStack struct {
 
 type Config struct {
 	Global struct {
-		AuthUrl    string `gcfg:"auth-url"`
-		Username   string
-		UserId     string `gcfg:"user-id"`
-		Password   string
-		TenantId   string `gcfg:"tenant-id"`
-		TenantName string `gcfg:"tenant-name"`
-		TrustId    string `gcfg:"trust-id"`
-		DomainId   string `gcfg:"domain-id"`
-		DomainName string `gcfg:"domain-name"`
-		Region     string
-		CAFile     string `gcfg:"ca-file"`
+		AuthUrl     string `gcfg:"auth-url"`
+		Username    string
+		UserId      string `gcfg:"user-id"`
+		Password    string
+		TenantId    string `gcfg:"tenant-id"`
+		TenantName  string `gcfg:"tenant-name"`
+		ProjectId   string `gcfg:"project-id"`
+		ProjectName string `gcfg:"project-name"`
+		TrustId     string `gcfg:"trust-id"`
+		DomainId    string `gcfg:"domain-id"`
+		DomainName  string `gcfg:"domain-name"`
+		Region      string
+		CAFile      string `gcfg:"ca-file"`
 	}
 	LoadBalancer LoadBalancerOpts
 	BlockStorage BlockStorageOpts
@@ -143,7 +145,7 @@ func init() {
 }
 
 func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
-	return gophercloud.AuthOptions{
+	options := gophercloud.AuthOptions{
 		IdentityEndpoint: cfg.Global.AuthUrl,
 		Username:         cfg.Global.Username,
 		UserID:           cfg.Global.UserId,
@@ -156,6 +158,16 @@ func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
 		// Persistent service, so we need to be able to renew tokens.
 		AllowReauth: true,
 	}
+
+	options.TenantID = cfg.Global.TenantId
+	options.TenantName = cfg.Global.TenantName
+	if cfg.Global.ProjectId != "" {
+		options.TenantID = cfg.Global.ProjectId
+	}
+	if cfg.Global.ProjectName != "" {
+		options.TenantName = cfg.Global.ProjectName
+	}
+	return options
 }
 
 func (cfg Config) toAuth3Options() tokens3.AuthOptions {

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -362,6 +362,11 @@ func configFromEnv() (cfg Config, ok bool) {
 		cfg.Global.TenantName = os.Getenv("OS_TENANT_NAME")
 	}
 
+	cfg.Global.ProjectId = os.Getenv("OS_PROJECT_ID")
+	if cfg.Global.ProjectId == "" {
+		cfg.Global.ProjectName = os.Getenv("OS_PROJECT_NAME")
+	}
+
 	cfg.Global.Username = os.Getenv("OS_USERNAME")
 	cfg.Global.Password = os.Getenv("OS_PASSWORD")
 	cfg.Global.Region = os.Getenv("OS_REGION_NAME")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In the configuration file we use for --cloud-config, we should allow
the new name "Project" instead of "Tenant". Note that since gophercloud
does not support the new names, we just map them to the same tenant
id/name we use currently in the gophercloud data structure.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #52563


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Operators can use "project-name" and "project-id" in their config files when they use the Keystone V3 API endpoint
```
