### PR TITLE
Let local node e2e return error.

### DIFF
--- a/test/e2e_node/runner/local/run_local.go
+++ b/test/e2e_node/runner/local/run_local.go
@@ -57,16 +57,18 @@ func main() {
 	ginkgo := filepath.Join(outputDir, "ginkgo")
 	test := filepath.Join(outputDir, "e2e_node.test")
 
-	if *systemSpecName == "" {
-		runCommand(ginkgo, *ginkgoFlags, test, "--", *testFlags)
-		return
+	args := []string{*ginkgoFlags, test, "--", *testFlags}
+	if *systemSpecName != "" {
+		rootDir, err := builder.GetK8sRootDir()
+		if err != nil {
+			glog.Fatalf("Failed to get k8s root directory: %v", err)
+		}
+		systemSpecFile := filepath.Join(rootDir, systemSpecPath, *systemSpecName+".yaml")
+		args = append(args, fmt.Sprintf("--system-spec-name=%s --system-spec-file=%s", *systemSpecName, systemSpecFile))
 	}
-	rootDir, err := builder.GetK8sRootDir()
-	if err != nil {
-		glog.Fatalf("Failed to get k8s root directory: %v", err)
+	if err := runCommand(ginkgo, args...); err != nil {
+		glog.Exitf("Test failed: %v", err)
 	}
-	systemSpecFile := filepath.Join(rootDir, systemSpecPath, *systemSpecName+".yaml")
-	runCommand(ginkgo, *ginkgoFlags, test, "--", fmt.Sprintf("--system-spec-name=%s --system-spec-file=%s", *systemSpecName, systemSpecFile), *testFlags)
 	return
 }
 


### PR DESCRIPTION
Fixes #52665

Let `make test-e2e-node` return error when it fails. Now it always returns exit code 0, whenever it fails or not.

@yguo0905 Could you help me review this?

Signed-off-by: Lantao Liu <lantaol@google.com>