### PR TITLE
Remove unused func in pkg k8s.io/pkg/kubelet/cm

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -875,21 +875,6 @@ func isKernelPid(pid int) bool {
 	return err != nil
 }
 
-// Helper for getting the docker API version.
-func getDockerAPIVersion(cadvisor cadvisor.Interface) *utilversion.Version {
-	versions, err := cadvisor.VersionInfo()
-	if err != nil {
-		glog.Errorf("Error requesting cAdvisor VersionInfo: %v", err)
-		return utilversion.MustParseSemantic("0.0")
-	}
-	dockerAPIVersion, err := utilversion.ParseGeneric(versions.DockerAPIVersion)
-	if err != nil {
-		glog.Errorf("Error parsing docker version %q: %v", versions.DockerVersion, err)
-		return utilversion.MustParseSemantic("0.0")
-	}
-	return dockerAPIVersion
-}
-
 func (cm *containerManagerImpl) GetCapacity() v1.ResourceList {
 	cm.RLock()
 	defer cm.RUnlock()


### PR DESCRIPTION
This commit removes the function getDockerAPIVersion which is not
exported neither used anywhere.

```release-note
NONE
```