### PR TITLE
Add check for IPv6 '::' when calculating kube-proxy's node IP

### DIFF
--- a/cmd/kube-proxy/app/server_test.go
+++ b/cmd/kube-proxy/app/server_test.go
@@ -177,7 +177,7 @@ func TestProxyServerWithCleanupAndExit(t *testing.T) {
 	// Each bind address below is a separate test case
 	bindAddresses := []string{
 		"0.0.0.0",
-		"2001:db8::1",
+		"::",
 	}
 	for _, addr := range bindAddresses {
 		options, err := NewOptions()
@@ -308,12 +308,53 @@ udpTimeoutMilliseconds: 123ms
 		metricsBindAddress string
 	}{
 		{
-			name:               "iptables mode, IPv4 config",
+			name:               "iptables mode, IPv4 all-zeros bind address",
+			mode:               "iptables",
+			bindAddress:        "0.0.0.0",
+			clusterCIDR:        "1.2.3.0/24",
+			healthzBindAddress: "1.2.3.4:12345",
+			metricsBindAddress: "2.3.4.5:23456",
+		},
+		{
+			name:               "iptables mode, non-zeros IPv4 config",
 			mode:               "iptables",
 			bindAddress:        "9.8.7.6",
 			clusterCIDR:        "1.2.3.0/24",
 			healthzBindAddress: "1.2.3.4:12345",
 			metricsBindAddress: "2.3.4.5:23456",
+		},
+		{
+			// Test for 'bindAddress: "::"' (IPv6 all-zeros) in kube-proxy
+			// config file. The user will need to put quotes around '::' since
+			// 'bindAddress: ::' is invalid yaml syntax.
+			name:               "iptables mode, IPv6 \"::\" bind address",
+			mode:               "iptables",
+			bindAddress:        "\"::\"",
+			clusterCIDR:        "fd00:1::0/64",
+			healthzBindAddress: "[fd00:1::5]:12345",
+			metricsBindAddress: "[fd00:2::5]:23456",
+		},
+		{
+			// Test for 'bindAddress: "[::]"' (IPv6 all-zeros in brackets)
+			// in kube-proxy config file. The user will need to use
+			// surrounding quotes here since 'bindAddress: [::]' is invalid
+			// yaml syntax.
+			name:               "iptables mode, IPv6 \"[::]\" bind address",
+			mode:               "iptables",
+			bindAddress:        "\"[::]\"",
+			clusterCIDR:        "fd00:1::0/64",
+			healthzBindAddress: "[fd00:1::5]:12345",
+			metricsBindAddress: "[fd00:2::5]:23456",
+		},
+		{
+			// Test for 'bindAddress: ::0' (another form of IPv6 all-zeros).
+			// No surrounding quotes are required around '::0'.
+			name:               "iptables mode, IPv6 ::0 bind address",
+			mode:               "iptables",
+			bindAddress:        "::0",
+			clusterCIDR:        "fd00:1::0/64",
+			healthzBindAddress: "[fd00:1::5]:12345",
+			metricsBindAddress: "[fd00:2::5]:23456",
 		},
 		{
 			name:               "ipvs mode, IPv6 config",
@@ -326,8 +367,13 @@ udpTimeoutMilliseconds: 123ms
 	}
 
 	for _, tc := range testCases {
+		expBindAddr := tc.bindAddress
+		if tc.bindAddress[0] == '"' {
+			// Surrounding double quotes will get stripped by the yaml parser.
+			expBindAddr = expBindAddr[1 : len(tc.bindAddress)-1]
+		}
 		expected := &componentconfig.KubeProxyConfiguration{
-			BindAddress: tc.bindAddress,
+			BindAddress: expBindAddr,
 			ClientConnection: componentconfig.ClientConnectionConfiguration{
 				AcceptContentTypes: "abc",
 				Burst:              100,
@@ -374,7 +420,7 @@ udpTimeoutMilliseconds: 123ms
 		config, err := options.loadConfig([]byte(yaml))
 		assert.NoError(t, err, "unexpected error for %s: %v", tc.name, err)
 		if !reflect.DeepEqual(expected, config) {
-			t.Fatalf("unexpected config for %s test, diff = %s", tc.name, diff.ObjectDiff(config, expected))
+			t.Fatalf("unexpected config for %s, diff = %s", tc.name, diff.ObjectDiff(config, expected))
 		}
 	}
 }
@@ -395,6 +441,11 @@ func TestLoadConfigFailures(t *testing.T) {
 			name:   "Bad config type test",
 			config: "kind: KubeSchedulerConfiguration",
 			expErr: "unexpected config type",
+		},
+		{
+			name:   "Missing quotes around :: bindAddress",
+			config: "bindAddress: ::",
+			expErr: "mapping values are not allowed in this context",
 		},
 	}
 	version := "apiVersion: componentconfig/v1alpha1"

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -942,7 +942,7 @@ func iptablesFlush(ipt iptables.Interface) error {
 var zeroIPv4 = net.ParseIP("0.0.0.0")
 var localhostIPv4 = net.ParseIP("127.0.0.1")
 
-var zeroIPv6 = net.ParseIP("::0")
+var zeroIPv6 = net.ParseIP("::")
 var localhostIPv6 = net.ParseIP("::1")
 
 // Build a slice of iptables args that are common to from-container and from-host portal rules.


### PR DESCRIPTION
kube-proxy currently checks for a bind address of 0.0.0.0 (IPv4 all-zeros)
when calculating kube-proxy's node IP, but it does not check for
an address of '::' (IPv6 all-zeros). For either of those all-zeros
addresses, the node IP should be determined based on the hostname,
rather than using the address directly.

Also added a helpful log message when the kube-proxy protocol is
determined to be IPv6.

fixes #52613

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds a check for a bind address of IPv6 '::' (all zeros) when kube-proxy is calculating its node IP,
similar to what is done for a bind address of IPv4 0.0.0.0. For either of these all-zeros addresses,
kube-proxy should derive the node IP based on the hostname, rather than use the bind address
directly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52613

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
