### PR TITLE
Refactor Device Plugin Registration

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/BUILD
+++ b/pkg/kubelet/cm/deviceplugin/BUILD
@@ -10,7 +10,10 @@ go_library(
     name = "go_default_library",
     srcs = [
         "device_plugin_stub.go",
+        "device_store.go",
         "endpoint.go",
+        "endpoint_handler.go",
+        "endpoint_store_shim.go",
         "manager.go",
         "manager_stub.go",
         "pod_devices.go",
@@ -52,6 +55,10 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "device_store_test.go",
+        "endpoint_handler_test.go",
+        "endpoint_store_shim_test.go",
+        "endpoint_store_test.go",
         "endpoint_test.go",
         "manager_test.go",
     ],

--- a/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
+++ b/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
@@ -87,8 +87,9 @@ func (m *Stub) Start() error {
 
 // Stop stops the gRPC server
 func (m *Stub) Stop() error {
-	m.server.Stop()
 	close(m.stop)
+
+	m.server.Stop()
 
 	return m.cleanup()
 }

--- a/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
+++ b/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/net/context"
@@ -58,6 +59,9 @@ func (m *Stub) Start() error {
 		return err
 	}
 
+	dir, _ := filepath.Split(m.socket)
+	os.MkdirAll(dir, 0755)
+
 	sock, err := net.Listen("unix", m.socket)
 	if err != nil {
 		return err
@@ -73,6 +77,7 @@ func (m *Stub) Start() error {
 		if len(services) > 1 {
 			break
 		}
+
 		time.Sleep(1 * time.Second)
 	}
 	log.Println("Starting to serve on", m.socket)

--- a/pkg/kubelet/cm/deviceplugin/device_store.go
+++ b/pkg/kubelet/cm/deviceplugin/device_store.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"sync"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+)
+
+type deviceStore interface {
+	Devices() []pluginapi.Device
+	HealthyDevices() []pluginapi.Device
+	Update(devs []*pluginapi.Device) (added, updated, deleted []pluginapi.Device)
+
+	// Callback invokes the manager callback function with the sent parameters
+	Callback(resourceName string, added, updated, deleted []pluginapi.Device)
+
+	// Testing methods
+	UpdateDevices(added, updated, deleted []pluginapi.Device)
+	UpdateAndCallback(resourceName string, added, updated, deleted []pluginapi.Device)
+}
+
+type deviceStoreImpl struct {
+	sync.Mutex
+	devices map[string]pluginapi.Device
+
+	callback managerCallback
+}
+
+type alwaysEmptyDeviceStore struct {
+}
+
+func newDeviceStoreImpl(callback managerCallback) *deviceStoreImpl {
+	return &deviceStoreImpl{
+		devices:  make(map[string]pluginapi.Device),
+		callback: callback,
+	}
+}
+
+func (s *deviceStoreImpl) Devices() []pluginapi.Device {
+	s.Lock()
+	defer s.Unlock()
+
+	var devs []pluginapi.Device
+
+	for _, d := range s.devices {
+		devs = append(devs, d)
+	}
+
+	return devs
+}
+
+func (s *deviceStoreImpl) HealthyDevices() []pluginapi.Device {
+	s.Lock()
+	defer s.Unlock()
+
+	var devs []pluginapi.Device
+
+	for _, d := range s.devices {
+		if d.Health != pluginapi.Healthy {
+			continue
+		}
+
+		devs = append(devs, d)
+	}
+
+	return devs
+}
+
+func (s *deviceStoreImpl) Update(devs []*pluginapi.Device) (added, updated, deleted []pluginapi.Device) {
+	newDevs := make(map[string]pluginapi.Device)
+
+	s.Lock()
+	defer s.Unlock()
+
+	for _, d := range devs {
+		dOld, ok := s.devices[d.ID]
+		newDevs[d.ID] = *d
+
+		if !ok {
+			s.devices[d.ID] = *d
+			added = append(added, *d)
+
+			continue
+		}
+
+		if d.Health == dOld.Health {
+			continue
+		}
+
+		s.devices[d.ID] = *d
+		updated = append(updated, *d)
+	}
+
+	for id, d := range s.devices {
+		if _, ok := newDevs[id]; ok {
+			continue
+		}
+
+		deleted = append(deleted, d)
+		delete(s.devices, id)
+	}
+
+	return added, updated, deleted
+}
+
+func (s *deviceStoreImpl) Callback(resourceName string, added, updated, deleted []pluginapi.Device) {
+	s.callback(resourceName, added, updated, deleted)
+}
+
+func (s *deviceStoreImpl) UpdateDevices(added, updated, deleted []pluginapi.Device) {
+	s.Lock()
+	defer s.Unlock()
+
+	for _, a := range added {
+		s.devices[a.ID] = a
+	}
+
+	for _, u := range updated {
+		s.devices[u.ID] = u
+	}
+
+	for _, r := range deleted {
+		delete(s.devices, r.ID)
+	}
+}
+
+func (s *deviceStoreImpl) UpdateAndCallback(resourceName string, added, updated, deleted []pluginapi.Device) {
+	s.UpdateDevices(added, updated, deleted)
+	s.Callback(resourceName, added, updated, deleted)
+}
+
+func newAlwaysEmptyDeviceStore() *alwaysEmptyDeviceStore {
+	return &alwaysEmptyDeviceStore{}
+}
+
+func (s *alwaysEmptyDeviceStore) Devices() []pluginapi.Device {
+	return nil
+}
+
+func (s *alwaysEmptyDeviceStore) HealthyDevices() []pluginapi.Device {
+	return nil
+}
+
+func (s *alwaysEmptyDeviceStore) Update(devs []*pluginapi.Device) (added, updated, deleted []pluginapi.Device) {
+	return nil, nil, nil
+}
+
+func (s *alwaysEmptyDeviceStore) Callback(resourceName string, added, updated, deleted []pluginapi.Device) {
+}
+
+func (s *alwaysEmptyDeviceStore) UpdateDevices(added, updated, deleted []pluginapi.Device) {
+}
+
+func (s *alwaysEmptyDeviceStore) UpdateAndCallback(resourceName string, added, updated, deleted []pluginapi.Device) {
+}

--- a/pkg/kubelet/cm/deviceplugin/device_store_test.go
+++ b/pkg/kubelet/cm/deviceplugin/device_store_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+)
+
+func TestDeviceStore(t *testing.T) {
+	callbackChan := make(chan interface{})
+	callbackFunc := func(n string, a, u, r []pluginapi.Device) {
+		require.Equal(t, n, "foo")
+		require.Len(t, a, 0)
+		require.Len(t, u, 1)
+		require.Len(t, r, 1)
+
+		close(callbackChan)
+	}
+
+	d := newDeviceStoreImpl(callbackFunc)
+	a, u, r := d.Update([]*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+		{ID: "AnotherDeviceId", Health: pluginapi.Healthy},
+	})
+
+	require.Len(t, a, 2)
+	require.Len(t, u, 0)
+	require.Len(t, r, 0)
+
+	a, u, r = d.Update([]*pluginapi.Device{
+		{ID: "AnotherDeviceId", Health: pluginapi.Unhealthy},
+	})
+
+	require.Len(t, a, 0)
+	require.Len(t, u, 1)
+	require.Len(t, r, 1)
+
+	d.Callback("foo", a, u, r)
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	require.Len(t, d.Devices(), 1)
+	require.Len(t, d.HealthyDevices(), 0)
+}
+
+func TestAlwaysEmptyDeviceStore(t *testing.T) {
+	d := newAlwaysEmptyDeviceStore()
+	a, u, r := d.Update([]*pluginapi.Device{
+		{ID: "ADeviceId", Health: pluginapi.Healthy},
+		{ID: "AnotherDeviceId", Health: pluginapi.Healthy},
+	})
+
+	require.Len(t, a, 0)
+	require.Len(t, u, 0)
+	require.Len(t, r, 0)
+
+	a, u, r = d.Update([]*pluginapi.Device{
+		{ID: "AnotherDeviceId", Health: pluginapi.Unhealthy},
+	})
+
+	require.Len(t, a, 0)
+	require.Len(t, u, 0)
+	require.Len(t, r, 0)
+
+	d.Callback("foo", a, u, r)
+	require.Len(t, d.Devices(), 0)
+	require.Len(t, d.HealthyDevices(), 0)
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint.go
@@ -163,7 +163,7 @@ func (e *endpointImpl) Stop() error {
 	select {
 	case <-e.stopChan:
 		break
-	case <-time.After(5 * time.Second):
+	case <-time.After(1 * time.Second):
 		return fmt.Errorf("Could not stop endpoint %s", e.resourceName)
 	}
 

--- a/pkg/kubelet/cm/deviceplugin/endpoint.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint.go
@@ -33,11 +33,14 @@ import (
 // for managing gRPC communications with the device plugin and caching
 // device states reported by the device plugin.
 type endpoint interface {
-	run()
-	stop()
-	allocate(devs []string) (*pluginapi.AllocateResponse, error)
-	getDevices() []pluginapi.Device
-	callback(resourceName string, added, updated, deleted []pluginapi.Device)
+	Run()
+	Stop() error
+
+	Allocate(devs []string) (*pluginapi.AllocateResponse, error)
+	ResourceName() string
+
+	Store() deviceStore
+	SetStore(deviceStore)
 }
 
 type endpointImpl struct {
@@ -47,19 +50,26 @@ type endpointImpl struct {
 	socketPath   string
 	resourceName string
 
-	devices map[string]pluginapi.Device
-	mutex   sync.Mutex
+	stopChan chan interface{}
+	ctx      context.Context
+	cancel   context.CancelFunc
 
-	cb monitorCallback
+	sync.Mutex
+	devStore deviceStore
 }
 
 // newEndpoint creates a new endpoint for the given resourceName.
-func newEndpointImpl(socketPath, resourceName string, devices map[string]pluginapi.Device, callback monitorCallback) (*endpointImpl, error) {
+func newEndpoint(socketPath, resourceName string) (*endpointImpl, error) {
+	return newEndpointWithStore(socketPath, resourceName, nil)
+}
+
+func newEndpointWithStore(socketPath, resourceName string, devStore deviceStore) (*endpointImpl, error) {
 	client, c, err := dial(socketPath)
 	if err != nil {
-		glog.Errorf("Can't create new endpoint with path %s err %v", socketPath, err)
 		return nil, err
 	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	return &endpointImpl{
 		client:     client,
@@ -68,25 +78,29 @@ func newEndpointImpl(socketPath, resourceName string, devices map[string]plugina
 		socketPath:   socketPath,
 		resourceName: resourceName,
 
-		devices: devices,
-		cb:      callback,
+		ctx:    ctx,
+		cancel: cancel,
+
+		devStore: devStore,
 	}, nil
 }
 
-func (e *endpointImpl) callback(resourceName string, added, updated, deleted []pluginapi.Device) {
-	e.cb(resourceName, added, updated, deleted)
+func (e *endpointImpl) Store() deviceStore {
+	e.Lock()
+	defer e.Unlock()
+
+	return e.devStore
 }
 
-func (e *endpointImpl) getDevices() []pluginapi.Device {
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-	var devs []pluginapi.Device
+func (e *endpointImpl) SetStore(s deviceStore) {
+	e.Lock()
+	defer e.Unlock()
 
-	for _, d := range e.devices {
-		devs = append(devs, d)
-	}
+	e.devStore = s
+}
 
-	return devs
+func (e *endpointImpl) ResourceName() string {
+	return e.resourceName
 }
 
 // run initializes ListAndWatch gRPC call for the device plugin and
@@ -95,96 +109,70 @@ func (e *endpointImpl) getDevices() []pluginapi.Device {
 // device states with its cached states to get list of new, updated, and deleted devices.
 // It then issues a callback to pass this information to the device manager which
 // will adjust the resource available information accordingly.
-func (e *endpointImpl) run() {
-	stream, err := e.client.ListAndWatch(context.Background(), &pluginapi.Empty{})
+func (e *endpointImpl) Run() {
+	glog.V(3).Infof("Starting to run endpoint %s", e.resourceName)
+	e.stopChan = make(chan interface{}, 0)
+
+	stream, err := e.client.ListAndWatch(e.ctx, &pluginapi.Empty{})
 	if err != nil {
 		glog.Errorf(errListAndWatch, e.resourceName, err)
-
 		return
 	}
-
-	devices := make(map[string]pluginapi.Device)
-
-	e.mutex.Lock()
-	for _, d := range e.devices {
-		devices[d.ID] = d
-	}
-	e.mutex.Unlock()
 
 	for {
 		response, err := stream.Recv()
 		if err != nil {
+			glog.Errorf("Stopping to receive from Endpoint")
+			s := e.Store()
+
+			s.Callback(e.resourceName, nil, nil, s.Devices())
+			e.clientConn.Close()
+
 			glog.Errorf(errListAndWatch, e.resourceName, err)
+
+			close(e.stopChan)
 			return
 		}
 
-		devs := response.Devices
-		glog.V(2).Infof("State pushed for device plugin %s", e.resourceName)
+		glog.V(2).Infof("Endpoint %s updated", e.resourceName)
 
-		newDevs := make(map[string]*pluginapi.Device)
-		var added, updated []pluginapi.Device
-
-		for _, d := range devs {
-			dOld, ok := devices[d.ID]
-			newDevs[d.ID] = d
-
-			if !ok {
-				glog.V(2).Infof("New device for Endpoint %s: %v", e.resourceName, d)
-
-				devices[d.ID] = *d
-				added = append(added, *d)
-
-				continue
-			}
-
-			if d.Health == dOld.Health {
-				continue
-			}
-
-			if d.Health == pluginapi.Unhealthy {
-				glog.Errorf("Device %s is now Unhealthy", d.ID)
-			} else if d.Health == pluginapi.Healthy {
-				glog.V(2).Infof("Device %s is now Healthy", d.ID)
-			}
-
-			devices[d.ID] = *d
-			updated = append(updated, *d)
-		}
-
-		var deleted []pluginapi.Device
-		for id, d := range devices {
-			if _, ok := newDevs[id]; ok {
-				continue
-			}
-
-			glog.Errorf("Device %s was deleted", d.ID)
-
-			deleted = append(deleted, d)
-			delete(devices, id)
-		}
-
-		e.mutex.Lock()
-		e.devices = devices
-		e.mutex.Unlock()
-
-		e.callback(e.resourceName, added, updated, deleted)
+		s := e.Store()
+		added, updated, deleted := s.Update(response.Devices)
+		s.Callback(e.resourceName, added, updated, deleted)
 	}
 }
 
 // allocate issues Allocate gRPC call to the device plugin.
-func (e *endpointImpl) allocate(devs []string) (*pluginapi.AllocateResponse, error) {
+func (e *endpointImpl) Allocate(devs []string) (*pluginapi.AllocateResponse, error) {
 	return e.client.Allocate(context.Background(), &pluginapi.AllocateRequest{
 		DevicesIDs: devs,
 	})
 }
 
-func (e *endpointImpl) stop() {
+func (e *endpointImpl) Stop() error {
+	if e.stopChan == nil {
+		e.cancel()
+		e.clientConn.Close()
+
+		return nil
+	}
+
+	e.cancel()
 	e.clientConn.Close()
+
+	select {
+	case <-e.stopChan:
+		break
+	case <-time.After(5 * time.Second):
+		return fmt.Errorf("Could not stop endpoint %s", e.resourceName)
+	}
+
+	return nil
 }
 
 // dial establishes the gRPC communication with the registered device plugin.
 func dial(unixSocketPath string) (pluginapi.DevicePluginClient, *grpc.ClientConn, error) {
-	c, err := grpc.Dial(unixSocketPath, grpc.WithInsecure(),
+	c, err := grpc.Dial(unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
 		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
 			return net.DialTimeout("unix", addr, timeout)
 		}),

--- a/pkg/kubelet/cm/deviceplugin/endpoint_handler.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_handler.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+)
+
+// endpointHandler handles all operations related to endpoints
+// namely creating the endpoints, keeping a map of them and stoping them
+type endpointHandler interface {
+	NewEndpoint(resourceName, socketPath string) error
+
+	Devices() map[string][]pluginapi.Device
+	Endpoint(resourceName string) (endpoint, bool)
+
+	Stop() error
+
+	Store() endpointStore
+	SetStore(endpointStore)
+
+	SetCallback(f managerCallback)
+}
+
+type endpointStore interface {
+	Endpoint(resourceName string) (endpoint, bool)
+	SynchronizedEndpoint(resourceName string) (*synchronizedEndpoint, bool)
+
+	SwapEndpoint(e endpoint) (endpoint, bool)
+	DeleteEndpoint(resourceName string) error
+
+	Range(func(string, *synchronizedEndpoint))
+}
+
+type synchronizedEndpoint struct {
+	e    endpoint
+	done chan string
+}
+
+type endpointStoreImpl struct {
+	sync.Mutex
+	endpoints map[string]*synchronizedEndpoint
+}
+
+type endpointHandlerImpl struct {
+	store    endpointStore
+	callback managerCallback
+}
+
+func newEndpointHandlerImpl(f managerCallback) *endpointHandlerImpl {
+	return &endpointHandlerImpl{
+		store:    newEndpointStoreImpl(),
+		callback: f,
+	}
+}
+
+func (h *endpointHandlerImpl) NewEndpoint(resourceName, socketPath string) error {
+	e, err := newEndpoint(socketPath, resourceName)
+	if err != nil {
+		return err
+	}
+
+	// If an endpoint with this resourceName is already present
+	var devStore deviceStore = newDeviceStoreImpl(h.callback)
+	if old, ok := h.store.Endpoint(resourceName); ok && old != nil {
+		devStore = old.Store()
+	}
+
+	// set a new store or the old store
+	e.SetStore(devStore)
+
+	// Add the endpoint to the store (and get the old one)
+	old, ok := h.store.SwapEndpoint(e)
+	go h.trackEnpoint(e)
+
+	if ok && old != nil {
+		// Prevent it to issue a Callback to the manager before stopping it
+		old.SetStore(newAlwaysEmptyDeviceStore())
+
+		if err = old.Stop(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// This function has two code path:
+//  - The endpoint was stopped to be removed
+//     - It's still in the store and has the same value
+//     - Remove it from the store
+//     - Emit it's resource name to signal code has terminated
+//       - If this is a test Stop was called and it can know when the
+//         endpoint stopped
+//       - If the endpoint terminated / was removed by the user then the
+//         channel does not exist and no value is emited
+//  - The endpoint was stopped to be replaced
+//     - It's still in the store but was already replaced
+//     - Do nothing and return
+func (h *endpointHandlerImpl) trackEnpoint(e endpoint) {
+	rName := e.ResourceName()
+	e.Run()
+
+	curr, ok := h.store.SynchronizedEndpoint(rName)
+	if !ok || curr.e != e {
+		return
+	}
+
+	h.store.DeleteEndpoint(rName)
+
+	if curr.done != nil {
+		curr.done <- rName
+	}
+}
+
+func (h *endpointHandlerImpl) Devices() map[string][]pluginapi.Device {
+	devs := make(map[string][]pluginapi.Device)
+
+	h.store.Range(func(k string, s *synchronizedEndpoint) {
+		devs[k] = s.e.Store().Devices()
+	})
+
+	return devs
+}
+
+func (h *endpointHandlerImpl) Endpoint(resourceName string) (endpoint, bool) {
+	return h.store.Endpoint(resourceName)
+}
+
+func (h *endpointHandlerImpl) Stop() error {
+	syncChan := make(chan string)
+
+	var endpoints []*synchronizedEndpoint
+	h.store.Range(func(k string, s *synchronizedEndpoint) {
+		endpoints = append(endpoints, s)
+	})
+
+	for _, s := range endpoints {
+		s.done = syncChan
+		s.e.Stop()
+
+		select {
+		case <-syncChan:
+			continue
+
+		// This can only be called if a code change creates a code path
+		// where the endpoint does not emit on the done chan upon death
+		case <-time.After(time.Second):
+			return fmt.Errorf("Could not stop endpoint %s", s.e.ResourceName())
+		}
+	}
+
+	return nil
+}
+
+func (h *endpointHandlerImpl) Store() endpointStore {
+	return h.store
+}
+
+func (h *endpointHandlerImpl) SetStore(s endpointStore) {
+	h.store = s
+}
+
+func (h *endpointHandlerImpl) SetCallback(f managerCallback) {
+	h.callback = f
+}
+
+func newEndpointStoreImpl() *endpointStoreImpl {
+	return &endpointStoreImpl{
+		endpoints: make(map[string]*synchronizedEndpoint),
+	}
+}
+
+func (s *endpointStoreImpl) Endpoint(resourceName string) (endpoint, bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	se, ok := s.endpoints[resourceName]
+	if ok && se != nil {
+		return se.e, true
+	}
+
+	return nil, false
+}
+
+func (s *endpointStoreImpl) SynchronizedEndpoint(resourceName string) (*synchronizedEndpoint, bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	se, ok := s.endpoints[resourceName]
+	return se, ok
+}
+
+func (s *endpointStoreImpl) SwapEndpoint(e endpoint) (endpoint, bool) {
+	s.Lock()
+	defer s.Unlock()
+
+	old, ok := s.endpoints[e.ResourceName()]
+	s.endpoints[e.ResourceName()] = &synchronizedEndpoint{e: e}
+
+	if ok && old != nil {
+		return old.e, ok
+	}
+
+	return nil, ok
+}
+
+func (s *endpointStoreImpl) DeleteEndpoint(resourceName string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	_, ok := s.endpoints[resourceName]
+	if !ok {
+		return fmt.Errorf("Endpoint %s does not exist", resourceName)
+	}
+
+	delete(s.endpoints, resourceName)
+	return nil
+}
+
+func (s *endpointStoreImpl) Range(f func(string, *synchronizedEndpoint)) {
+	s.Lock()
+	defer s.Unlock()
+
+	for k, v := range s.endpoints {
+		f(k, v)
+	}
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint_handler_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_handler_test.go
@@ -1,0 +1,264 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+)
+
+func TestHandlerNewEndpoint(t *testing.T) {
+	callbackCount := int32(0)
+	callbackChan := make(chan int32, 1)
+	callbackExpected := int32(0)
+
+	// We expect this to be called twice:
+	// - once at "registration" time (when devices are sent by the stub)
+	// - once at "stop" time
+	f := managerCallback(func(n string, a, u, r []pluginapi.Device) {
+		if callbackCount > atomic.LoadInt32(&callbackExpected) {
+			t.FailNow()
+		}
+
+		callbackCount++
+		callbackChan <- callbackCount
+	})
+
+	hdlr := newEndpointHandlerImpl(f)
+	defer hdlr.Stop()
+
+	store := hdlr.Store()
+	hdlr.SetStore(store)
+	require.Equal(t, hdlr.Store(), store)
+
+	p := NewDevicePluginStub(nil, pluginSocketName)
+	require.NoError(t, p.Start())
+	defer p.Stop()
+
+	atomic.StoreInt32(&callbackExpected, 1)
+	hdlr.NewEndpoint(testResourceName, pluginSocketName)
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	e, ok := hdlr.Store().Endpoint(testResourceName)
+	require.True(t, ok)
+
+	atomic.StoreInt32(&callbackExpected, 2)
+	require.NoError(t, e.Stop())
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+}
+
+func TestTrackEndpoint(t *testing.T) {
+	// setup
+	p := NewDevicePluginStub(nil, pluginSocketName)
+	require.NoError(t, p.Start())
+
+	hdlr := newEndpointHandlerImpl(func(n string, a, u, r []pluginapi.Device) {})
+	defer hdlr.Stop()
+
+	updateChan := make(chan interface{})
+	dStore := newDeviceStoreImpl(func(n string, a, u, r []pluginapi.Device) {
+		if updateChan == nil {
+			return
+		}
+
+		close(updateChan)
+	})
+
+	e, err := newEndpointWithStore(pluginSocketName, testResourceName, dStore)
+	require.NoError(t, err)
+
+	// insert endpoint in the store
+	hdlr.store.SwapEndpoint(e)
+	s, ok := hdlr.Store().SynchronizedEndpoint(e.resourceName)
+	require.True(t, ok)
+
+	// setup the channel for the synchronized endpoint
+	c := make(chan string, 1)
+	s.done = c
+
+	gofuncChan := make(chan interface{})
+	// stop the endpoint as soon as possible (here after sending the devices)
+	go func() {
+		select {
+		case <-updateChan:
+			updateChan = nil
+			break
+		case <-time.After(time.Second):
+			t.FailNow()
+		}
+
+		e.Stop()
+		p.Stop()
+
+		close(gofuncChan)
+	}()
+
+	// Test that the endpoint was deleted
+	hdlr.trackEnpoint(e)
+	select {
+	case <-gofuncChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	_, ok = hdlr.Store().SynchronizedEndpoint(e.resourceName)
+	require.False(t, ok)
+
+	_, ok = hdlr.Store().Endpoint(e.resourceName)
+	require.False(t, ok)
+
+	// test that the endpoint was broadcasted on the chan
+	select {
+	case resourceName := <-c:
+		require.Equal(t, resourceName, e.resourceName)
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+}
+
+// Tests that the device plugin manager correctly handles registration and re-registration by
+// making sure that after registration, devices are correctly updated and if a re-registration
+// happens, we will NOT delete devices.
+func TestReRegistration(t *testing.T) {
+	devs := []*pluginapi.Device{
+		{ID: "Dev1", Health: pluginapi.Healthy},
+		{ID: "Dev2", Health: pluginapi.Healthy},
+	}
+
+	callbackCount := int32(0)
+	callbackChan := make(chan int32, 1)
+	callbackExpected := int32(0)
+
+	// We expect this to be called twice:
+	// - once at "registration" time (when devices are sent by the stub)
+	// - once at "stop" time
+	f := func(n string, a, u, r []pluginapi.Device) {
+		if callbackCount > atomic.LoadInt32(&callbackExpected) {
+			t.FailNow()
+		}
+
+		callbackCount++
+		callbackChan <- callbackCount
+	}
+
+	// setup
+	hdlr := newEndpointHandlerImpl(f)
+	defer hdlr.Stop()
+
+	outChan := make(chan interface{})
+	continueChan := make(chan bool)
+
+	hdlr.SetStore(newInstrumentedEndpointStoreShim(outChan, continueChan))
+
+	p1 := NewDevicePluginStub(devs, pluginSocketName)
+	p2 := NewDevicePluginStub(devs, pluginSocketName+".new")
+	require.NoError(t, p1.Start())
+
+	// Create first endpoint
+	go func() {
+		select {
+		case <-outChan:
+			continueChan <- true
+			break
+		case <-time.After(time.Second):
+			t.FailNow()
+		}
+	}()
+
+	atomic.StoreInt32(&callbackExpected, 1)
+	hdlr.NewEndpoint(testResourceName, p1.socket)
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	require.Len(t, hdlr.Devices(), 1)
+	require.Len(t, hdlr.Devices()[testResourceName], 2)
+
+	// Create second endpoint
+	require.NoError(t, p2.Start())
+
+	// Check that the old endpoint's store has not been removed before
+	// swapping it with the new store. Also check that the new endpoint's
+	// store points to the old endpoint's store.
+	//
+	// InstrumentedEndpoint allows to execute code before swap is called
+	go func() {
+		endpoints := (<-outChan).(swapMessage)
+
+		require.NotNil(t, endpoints.Old)
+		require.Len(t, endpoints.Old.Store().Devices(), 2)
+
+		require.NotNil(t, endpoints.New)
+		require.Equal(t, endpoints.New.Store(), endpoints.Old.Store())
+
+		continueChan <- true
+	}()
+
+	atomic.StoreInt32(&callbackExpected, 2)
+	hdlr.NewEndpoint(testResourceName, pluginSocketName+".new")
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	// Check that the callback is called at stop time
+	e, ok := hdlr.Store().Endpoint(testResourceName)
+	require.True(t, ok)
+
+	atomic.StoreInt32(&callbackExpected, 3)
+	e.Stop()
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	require.NoError(t, p1.Stop())
+	require.NoError(t, p2.Stop())
+
+	close(outChan)
+	close(continueChan)
+	close(callbackChan)
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint_store_shim.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_store_shim.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+type endpointStoreShim struct {
+	store endpointStore
+
+	outChan      chan interface{}
+	continueChan chan bool
+}
+
+type swapMessage struct {
+	Old endpoint
+	New endpoint
+}
+
+// outChan sends a message containing the parameters of the method called.
+// After sending that message, execution blocks until continueChan is written on
+func newInstrumentedEndpointStoreShim(outChan chan interface{}, continueChan chan bool) *endpointStoreShim {
+	return &endpointStoreShim{
+		store: newEndpointStoreImpl(),
+
+		outChan:      outChan,
+		continueChan: continueChan,
+	}
+}
+
+func (s *endpointStoreShim) Endpoint(resourceName string) (endpoint, bool) {
+	return s.store.Endpoint(resourceName)
+}
+
+func (s *endpointStoreShim) SynchronizedEndpoint(resourceName string) (*synchronizedEndpoint, bool) {
+	return s.store.SynchronizedEndpoint(resourceName)
+}
+
+func (s *endpointStoreShim) DeleteEndpoint(resourceName string) error {
+	return s.store.DeleteEndpoint(resourceName)
+}
+
+func (s *endpointStoreShim) SwapEndpoint(e endpoint) (endpoint, bool) {
+	m := swapMessage{New: e}
+	if old, ok := s.store.Endpoint(e.ResourceName()); ok {
+		m.Old = old
+	}
+
+	s.outChan <- m
+	<-s.continueChan
+
+	return s.store.SwapEndpoint(e)
+}
+
+func (s *endpointStoreShim) Range(f func(k string, e *synchronizedEndpoint)) {
+	s.store.Range(f)
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint_store_shim_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_store_shim_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstrumentedEndpointStore(t *testing.T) {
+	outChan := make(chan interface{})
+	continueChan := make(chan bool)
+
+	iStore := newInstrumentedEndpointStoreShim(outChan, continueChan)
+	store := iStore.store
+
+	ie, iok := iStore.Endpoint("foo")
+	e, ok := store.Endpoint("foo")
+
+	require.Equal(t, ie, e)
+	require.Equal(t, iok, ok)
+
+	iSe, iok := iStore.SynchronizedEndpoint("foo")
+	se, ok := store.SynchronizedEndpoint("foo")
+
+	require.Equal(t, iSe, se)
+	require.Equal(t, iok, ok)
+
+	ierr := iStore.DeleteEndpoint("foo")
+	err := store.DeleteEndpoint("foo")
+
+	require.Equal(t, ierr, err)
+
+	go func() {
+		select {
+		case <-outChan:
+			break
+		case <-time.After(time.Second):
+			t.FailNow()
+		}
+
+		continueChan <- true
+	}()
+
+	e = newTestEndpoint("foo")
+	ie, iok = iStore.SwapEndpoint(e)
+	require.False(t, iok)
+	require.Nil(t, ie)
+
+	go func() {
+		select {
+		case <-outChan:
+			break
+		case <-time.After(time.Second):
+			t.FailNow()
+		}
+
+		continueChan <- true
+	}()
+
+	ie2, iok := iStore.SwapEndpoint(newTestEndpoint("foo"))
+	require.True(t, iok)
+	require.Equal(t, ie2, e)
+
+	endpoints := []*synchronizedEndpoint{}
+	iStore.Range(func(k string, e *synchronizedEndpoint) {
+		endpoints = append(endpoints, e)
+	})
+
+	require.Len(t, endpoints, 1)
+	require.Equal(t, endpoints[0].e.ResourceName(), "foo")
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint_store_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_store_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deviceplugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+)
+
+func TestEndpointStore(t *testing.T) {
+	p := NewDevicePluginStub(nil, pluginSocketName)
+	require.NoError(t, p.Start())
+
+	store := newEndpointStoreImpl()
+
+	dStore := newDeviceStoreImpl(func(n string, a, u, r []pluginapi.Device) {})
+	e, err := newEndpointWithStore(pluginSocketName, testResourceName, dStore)
+	require.NoError(t, err)
+
+	_, ok := store.Endpoint(e.ResourceName())
+	require.False(t, ok)
+
+	_, ok = store.SynchronizedEndpoint(e.ResourceName())
+	require.False(t, ok)
+
+	store.SwapEndpoint(e)
+
+	curr, ok := store.Endpoint(e.ResourceName())
+	require.True(t, ok)
+	require.Equal(t, curr, e)
+
+	se, ok := store.SynchronizedEndpoint(e.ResourceName())
+	require.True(t, ok)
+	require.Equal(t, se.e, e)
+
+	devs := make(map[string][]pluginapi.Device)
+	store.Range(func(k string, s *synchronizedEndpoint) {
+		devs[k] = s.e.Store().Devices()
+	})
+
+	require.Len(t, devs, 1)
+
+	require.NoError(t, e.Stop())
+	p.Stop()
+}
+
+func TestSwapEndpoint(t *testing.T) {
+	p1 := NewDevicePluginStub(nil, pluginSocketName)
+	require.NoError(t, p1.Start())
+
+	p2 := NewDevicePluginStub(nil, pluginSocketName+".new")
+	require.NoError(t, p2.Start())
+
+	store := newEndpointStoreImpl()
+
+	f := func(n string, a, u, r []pluginapi.Device) {}
+	dStore := newDeviceStoreImpl(f)
+	e1, err := newEndpointWithStore(pluginSocketName, testResourceName, dStore)
+	require.NoError(t, err)
+
+	_, ok := store.SwapEndpoint(e1)
+	require.False(t, ok)
+
+	e2, err := newEndpointWithStore(pluginSocketName+".new", testResourceName, dStore)
+	require.NoError(t, err)
+
+	old, ok := store.SwapEndpoint(e2)
+	require.True(t, ok)
+	require.Equal(t, old, e1)
+
+	curr, ok := store.Endpoint(e2.ResourceName())
+	require.True(t, ok)
+	require.Equal(t, curr, e2)
+
+	se, ok := store.SynchronizedEndpoint(e2.ResourceName())
+	require.True(t, ok)
+	require.Equal(t, se.e, e2)
+
+	require.NoError(t, e1.Stop())
+	require.NoError(t, e2.Stop())
+	p1.Stop()
+	p2.Stop()
+}
+
+func TestDeleteEndpoint(t *testing.T) {
+	p := NewDevicePluginStub(nil, pluginSocketName)
+	require.NoError(t, p.Start())
+
+	store := newEndpointStoreImpl()
+
+	f := func(n string, a, u, r []pluginapi.Device) {}
+	dStore := newDeviceStoreImpl(f)
+	e, err := newEndpointWithStore(pluginSocketName, testResourceName, dStore)
+	require.NoError(t, err)
+
+	err = store.DeleteEndpoint(e.ResourceName())
+	require.Error(t, err)
+
+	_, ok := store.SwapEndpoint(e)
+	require.False(t, ok)
+	err = store.DeleteEndpoint(e.ResourceName())
+	require.NoError(t, err)
+
+	err = store.DeleteEndpoint(e.ResourceName())
+	require.Error(t, err)
+
+	require.NoError(t, e.Stop())
+	p.Stop()
+}

--- a/pkg/kubelet/cm/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_test.go
@@ -54,61 +54,96 @@ func TestRun(t *testing.T) {
 		{ID: "AThirdDeviceId", Health: pluginapi.Healthy},
 	}
 
+	umap := make(map[string]*pluginapi.Device)
+	for _, d := range updated {
+		umap[d.ID] = d
+	}
+
+	callbackChan := make(chan int)
+	callbackCount := 0
+
 	p, e := esetup(t, devs, socket, "mock", func(n string, a, u, r []pluginapi.Device) {
-		require.Len(t, a, 1)
-		require.Len(t, u, 1)
-		require.Len(t, r, 1)
+		if callbackCount == 0 {
+			require.Len(t, a, 2)
+			require.Len(t, u, 0)
+			require.Len(t, r, 0)
+		} else if callbackCount == 1 {
+			require.Len(t, a, 1)
+			require.Len(t, u, 1)
+			require.Len(t, r, 1)
 
-		require.Equal(t, a[0].ID, updated[1].ID)
+			require.Equal(t, a[0].ID, updated[1].ID)
 
-		require.Equal(t, u[0].ID, updated[0].ID)
-		require.Equal(t, u[0].Health, updated[0].Health)
+			require.Equal(t, u[0].ID, updated[0].ID)
+			require.Equal(t, u[0].Health, updated[0].Health)
 
-		require.Equal(t, r[0].ID, devs[1].ID)
+			require.Equal(t, r[0].ID, devs[1].ID)
+		}
+
+		callbackCount++
+		if callbackChan != nil {
+			callbackChan <- callbackCount
+		}
 	})
+
 	defer ecleanup(t, p, e)
 
-	go e.run()
+	go e.Run()
+
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
+
+	// Ensure we have recieved the devices
+	resp, err := e.Allocate([]string{e.Store().Devices()[0].ID})
+	require.NotNil(t, resp)
+	require.NoError(t, err)
+
 	p.Update(updated)
-	time.Sleep(time.Second)
+	select {
+	case <-callbackChan:
+		break
+	case <-time.After(time.Second):
+		t.FailNow()
+	}
 
-	e.mutex.Lock()
-	defer e.mutex.Unlock()
-
-	require.Len(t, e.devices, 2)
-	for _, dref := range updated {
-		d, ok := e.devices[dref.ID]
+	require.Len(t, e.Store().Devices(), 2)
+	require.Len(t, e.Store().HealthyDevices(), 1)
+	edevs := e.Store().Devices()
+	for _, d := range edevs {
+		dref, ok := umap[d.ID]
 
 		require.True(t, ok)
 		require.Equal(t, d.ID, dref.ID)
 		require.Equal(t, d.Health, dref.Health)
 	}
 
+	close(callbackChan)
+	callbackChan = nil
 }
 
-func TestGetDevices(t *testing.T) {
-	e := endpointImpl{
-		devices: map[string]pluginapi.Device{
-			"ADeviceId": {ID: "ADeviceId", Health: pluginapi.Healthy},
-		},
-	}
-	devs := e.getDevices()
-	require.Len(t, devs, 1)
-}
-
-func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string, callback monitorCallback) (*Stub, *endpointImpl) {
+func esetup(t *testing.T, devs []*pluginapi.Device, socket, resourceName string, callback managerCallback) (*Stub, *endpointImpl) {
 	p := NewDevicePluginStub(devs, socket)
+	require.NoError(t, p.Start())
 
-	err := p.Start()
-	require.NoError(t, err)
-
-	e, err := newEndpointImpl(socket, "mock", make(map[string]pluginapi.Device), func(n string, a, u, r []pluginapi.Device) {})
+	dStore := newDeviceStoreImpl(callback)
+	e, err := newEndpointWithStore(socket, resourceName, dStore)
 	require.NoError(t, err)
 
 	return p, e
 }
 
+func newTestEndpoint(resourceName string) endpoint {
+	return &endpointImpl{
+		resourceName: resourceName,
+		devStore:     newDeviceStoreImpl(nil),
+	}
+}
+
 func ecleanup(t *testing.T, p *Stub, e *endpointImpl) {
+	e.Stop()
 	p.Stop()
-	e.stop()
 }

--- a/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -22,9 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"sync/atomic"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,90 +44,30 @@ const (
 	testResourceName = "fake-domain/resource"
 )
 
+func init() {
+	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
+	var logLevel string
+	flag.StringVar(&logLevel, "logLevel", "4", "test")
+	flag.Lookup("v").Value.Set(logLevel)
+}
+
 func TestNewManagerImpl(t *testing.T) {
 	_, err := newManagerImpl(socketName)
 	require.NoError(t, err)
 }
 
 func TestNewManagerImplStart(t *testing.T) {
-	m, p := setup(t, []*pluginapi.Device{}, func(n string, a, u, r []pluginapi.Device) {})
+	m, p := setup(t, nil, func(n string, a, u, r []pluginapi.Device) {})
+	require.NoError(t, p.Register(socketName, testResourceName))
+
 	cleanup(t, m, p)
 }
 
-// Tests that the device plugin manager correctly handles registration and re-registration by
-// making sure that after registration, devices are correctly updated and if a re-registration
-// happens, we will NOT delete devices; and no orphaned devices left.
-func TestDevicePluginReRegistration(t *testing.T) {
-	devs := []*pluginapi.Device{
-		{ID: "Dev1", Health: pluginapi.Healthy},
-		{ID: "Dev2", Health: pluginapi.Healthy},
-	}
-	devsForRegistration := []*pluginapi.Device{
-		{ID: "Dev3", Health: pluginapi.Healthy},
-	}
-
-	callbackCount := 0
-	callbackChan := make(chan int)
-	var stopping int32
-	stopping = 0
-	callback := func(n string, a, u, r []pluginapi.Device) {
-		// Should be called three times, one for each plugin registration, till we are stopping.
-		if callbackCount > 2 && atomic.LoadInt32(&stopping) <= 0 {
-			t.FailNow()
-		}
-		callbackCount++
-		callbackChan <- callbackCount
-	}
-	m, p1 := setup(t, devs, callback)
-	p1.Register(socketName, testResourceName)
-	// Wait for the first callback to be issued.
-
-	<-callbackChan
-	// Wait till the endpoint is added to the manager.
-	for i := 0; i < 20; i++ {
-		if len(m.Devices()) > 0 {
-			break
-		}
-		time.Sleep(1)
-	}
-	devices := m.Devices()
-	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
-
-	p2 := NewDevicePluginStub(devs, pluginSocketName+".new")
-	err := p2.Start()
-	require.NoError(t, err)
-	p2.Register(socketName, testResourceName)
-	// Wait for the second callback to be issued.
-	<-callbackChan
-
-	devices2 := m.Devices()
-	require.Equal(t, 2, len(devices2[testResourceName]), "Devices shouldn't change.")
-
-	// Test the scenario that a plugin re-registers with different devices.
-	p3 := NewDevicePluginStub(devsForRegistration, pluginSocketName+".third")
-	err = p3.Start()
-	require.NoError(t, err)
-	p3.Register(socketName, testResourceName)
-	// Wait for the second callback to be issued.
-	<-callbackChan
-
-	devices3 := m.Devices()
-	require.Equal(t, 1, len(devices3[testResourceName]), "Devices of plugin previously registered should be removed.")
-	// Wait long enough to catch unexpected callbacks.
-	time.Sleep(5 * time.Second)
-
-	atomic.StoreInt32(&stopping, 1)
-	p2.Stop()
-	p3.Stop()
-	cleanup(t, m, p1)
-
-}
-
-func setup(t *testing.T, devs []*pluginapi.Device, callback monitorCallback) (Manager, *Stub) {
+func setup(t *testing.T, devs []*pluginapi.Device, callback managerCallback) (Manager, *Stub) {
 	m, err := newManagerImpl(socketName)
 	require.NoError(t, err)
 
-	m.callback = callback
+	m.endpointHandler.SetCallback(callback)
 
 	activePods := func() []*v1.Pod {
 		return []*v1.Pod{}
@@ -150,9 +88,9 @@ func cleanup(t *testing.T, m Manager, p *Stub) {
 }
 
 func TestUpdateCapacity(t *testing.T) {
-	testManager, err := newManagerImpl(socketName)
+	mgr, err := newManagerImpl(socketName)
 	as := assert.New(t)
-	as.NotNil(testManager)
+	as.NotNil(mgr)
 	as.Nil(err)
 
 	devs := []pluginapi.Device{
@@ -160,68 +98,89 @@ func TestUpdateCapacity(t *testing.T) {
 		{ID: "Device2", Health: pluginapi.Healthy},
 		{ID: "Device3", Health: pluginapi.Unhealthy},
 	}
-	callback := testManager.genericDeviceUpdateCallback
+	store := mgr.endpointHandler.Store()
 
 	// Adds three devices for resource1, two healthy and one unhealthy.
 	// Expects capacity for resource1 to be 2.
 	resourceName1 := "domain1.com/resource1"
-	testManager.endpoints[resourceName1] = &endpointImpl{devices: make(map[string]pluginapi.Device)}
-	callback(resourceName1, devs, []pluginapi.Device{}, []pluginapi.Device{})
-	capacity, removedResources := testManager.GetCapacity()
-	resource1Capacity, ok := capacity[v1.ResourceName(resourceName1)]
-	as.True(ok)
-	as.Equal(int64(2), resource1Capacity.Value())
-	as.Equal(0, len(removedResources))
+	dStore := newDeviceStoreImpl(mgr.genericDeviceUpdateCallback)
+	store.SwapEndpoint(&endpointImpl{
+		resourceName: resourceName1,
+		devStore:     dStore,
+	})
+
+	dStore.UpdateAndCallback(resourceName1, devs, nil, nil)
+	capacity, removedResources := mgr.GetCapacity()
+	require.Len(t, removedResources, 0)
+
+	c, ok := capacity[v1.ResourceName(resourceName1)]
+	require.True(t, ok)
+	require.Equal(t, int64(2), c.Value())
 
 	// Deletes an unhealthy device should NOT change capacity.
-	callback(resourceName1, []pluginapi.Device{}, []pluginapi.Device{}, []pluginapi.Device{devs[2]})
-	capacity, removedResources = testManager.GetCapacity()
-	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
-	as.True(ok)
-	as.Equal(int64(2), resource1Capacity.Value())
-	as.Equal(0, len(removedResources))
+	dStore.UpdateAndCallback(resourceName1, nil, nil, []pluginapi.Device{devs[2]})
+	capacity, removedResources = mgr.GetCapacity()
+	require.Len(t, removedResources, 0)
+
+	c, ok = capacity[v1.ResourceName(resourceName1)]
+	require.True(t, ok)
+	require.Equal(t, int64(2), c.Value())
 
 	// Updates a healthy device to unhealthy should reduce capacity by 1.
-	dev2 := devs[1]
-	dev2.Health = pluginapi.Unhealthy
-	callback(resourceName1, []pluginapi.Device{}, []pluginapi.Device{dev2}, []pluginapi.Device{})
-	capacity, removedResources = testManager.GetCapacity()
-	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
-	as.True(ok)
-	as.Equal(int64(1), resource1Capacity.Value())
-	as.Equal(0, len(removedResources))
+	devs[1].Health = pluginapi.Unhealthy
+	dStore.UpdateAndCallback(resourceName1, nil, []pluginapi.Device{devs[1]}, nil)
+	capacity, removedResources = mgr.GetCapacity()
+	require.Len(t, removedResources, 0)
+
+	c, ok = capacity[v1.ResourceName(resourceName1)]
+	require.True(t, ok)
+	require.Equal(t, int64(1), c.Value())
 
 	// Deletes a healthy device should reduce capacity by 1.
-	callback(resourceName1, []pluginapi.Device{}, []pluginapi.Device{}, []pluginapi.Device{devs[0]})
-	capacity, removedResources = testManager.GetCapacity()
-	resource1Capacity, ok = capacity[v1.ResourceName(resourceName1)]
-	as.True(ok)
-	as.Equal(int64(0), resource1Capacity.Value())
-	as.Equal(0, len(removedResources))
+	dStore.UpdateAndCallback(resourceName1, nil, nil, []pluginapi.Device{devs[0]})
+	capacity, removedResources = mgr.GetCapacity()
+	require.Len(t, removedResources, 0)
+
+	c, ok = capacity[v1.ResourceName(resourceName1)]
+	require.True(t, ok)
+	require.Equal(t, int64(0), c.Value())
 
 	// Tests adding another resource.
 	resourceName2 := "resource2"
-	testManager.endpoints[resourceName2] = &endpointImpl{devices: make(map[string]pluginapi.Device)}
-	callback(resourceName2, devs, []pluginapi.Device{}, []pluginapi.Device{})
-	capacity, removedResources = testManager.GetCapacity()
-	as.Equal(2, len(capacity))
-	resource2Capacity, ok := capacity[v1.ResourceName(resourceName2)]
-	as.True(ok)
-	as.Equal(int64(2), resource2Capacity.Value())
-	as.Equal(0, len(removedResources))
+	dStore = newDeviceStoreImpl(mgr.genericDeviceUpdateCallback)
+	store.SwapEndpoint(&endpointImpl{
+		resourceName: resourceName2,
+		devStore:     dStore,
+	})
 
-	// Removes resourceName1 endpoint. Verifies testManager.GetCapacity() reports that resourceName1
-	// is removed from capacity and it no longer exists in allDevices after the call.
-	delete(testManager.endpoints, resourceName1)
-	capacity, removed := testManager.GetCapacity()
-	as.Equal([]string{resourceName1}, removed)
-	_, ok = capacity[v1.ResourceName(resourceName1)]
-	as.False(ok)
-	val, ok := capacity[v1.ResourceName(resourceName2)]
-	as.True(ok)
-	as.Equal(int64(2), val.Value())
-	_, ok = testManager.allDevices[resourceName1]
-	as.False(ok)
+	devs = []pluginapi.Device{
+		{ID: "Device1", Health: pluginapi.Healthy},
+		{ID: "Device2", Health: pluginapi.Healthy},
+	}
+
+	dStore.UpdateAndCallback(resourceName2, devs, nil, nil)
+	capacity, removedResources = mgr.GetCapacity()
+	require.Len(t, removedResources, 0)
+
+	c, ok = capacity[v1.ResourceName(resourceName2)]
+	require.True(t, ok)
+	require.Equal(t, int64(2), c.Value())
+
+	// Removes resourceName1 endpoint.
+	// Verifies Manager.GetCapacity() reports that resourceName1 is
+	// removed from capacity and no longer exists in allDevices after the
+	// call.
+	store.DeleteEndpoint(resourceName1)
+	capacity, removed := mgr.GetCapacity()
+	require.Len(t, removed, 1)
+	require.Equal(t, removed[0], resourceName1)
+
+	c, ok = capacity[v1.ResourceName(resourceName2)]
+	require.True(t, ok)
+	require.Equal(t, int64(2), c.Value())
+
+	_, ok = mgr.allDevices[resourceName1]
+	require.False(t, ok)
 }
 
 type stringPairType struct {
@@ -346,20 +305,20 @@ func (a *activePodsStub) updateActivePods(newPods []*v1.Pod) {
 	a.activePods = newPods
 }
 
-type MockEndpoint struct {
+type mockEndpoint struct {
+	resourceName string
 	allocateFunc func(devs []string) (*pluginapi.AllocateResponse, error)
 }
 
-func (m *MockEndpoint) stop() {}
-func (m *MockEndpoint) run()  {}
-
-func (m *MockEndpoint) getDevices() []pluginapi.Device {
-	return []pluginapi.Device{}
+func (m *mockEndpoint) Stop() error            { return nil }
+func (m *mockEndpoint) Run()                   {}
+func (m *mockEndpoint) Store() deviceStore     { return nil }
+func (m *mockEndpoint) SetStore(d deviceStore) {}
+func (m *mockEndpoint) ResourceName() string {
+	return m.resourceName
 }
 
-func (m *MockEndpoint) callback(resourceName string, added, updated, deleted []pluginapi.Device) {}
-
-func (m *MockEndpoint) allocate(devs []string) (*pluginapi.AllocateResponse, error) {
+func (m *mockEndpoint) Allocate(devs []string) (*pluginapi.AllocateResponse, error) {
 	if m.allocateFunc != nil {
 		return m.allocateFunc(devs)
 	}
@@ -383,26 +342,36 @@ func makePod(requests v1.ResourceList) *v1.Pod {
 	}
 }
 
+type TestResource struct {
+	resourceName     string
+	resourceQuantity resource.Quantity
+	devs             []string
+}
+
 func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestResource) *ManagerImpl {
-	monitorCallback := func(resourceName string, added, updated, deleted []pluginapi.Device) {}
+	managerCallback := func(resourceName string, added, updated, deleted []pluginapi.Device) {}
 	testManager := &ManagerImpl{
 		socketdir:        tmpDir,
-		callback:         monitorCallback,
 		allDevices:       make(map[string]sets.String),
 		allocatedDevices: make(map[string]sets.String),
-		endpoints:        make(map[string]endpoint),
 		podDevices:       make(podDevices),
 		activePods:       activePods,
 		sourcesReady:     &sourcesReadyStub{},
+		endpointHandler:  newEndpointHandlerImpl(managerCallback),
 	}
+
 	testManager.store, _ = utilstore.NewFileStore("/tmp/", utilfs.DefaultFs{})
+	store := testManager.endpointHandler.Store()
+
 	for _, res := range testRes {
 		testManager.allDevices[res.resourceName] = sets.NewString()
 		for _, dev := range res.devs {
 			testManager.allDevices[res.resourceName].Insert(dev)
 		}
+
 		if res.resourceName == "domain1.com/resource1" {
-			testManager.endpoints[res.resourceName] = &MockEndpoint{
+			store.SwapEndpoint(&mockEndpoint{
+				resourceName: res.resourceName,
 				allocateFunc: func(devs []string) (*pluginapi.AllocateResponse, error) {
 					resp := new(pluginapi.AllocateResponse)
 					resp.Envs = make(map[string]string)
@@ -445,10 +414,12 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 					}
 					return resp, nil
 				},
-			}
+			})
 		}
+
 		if res.resourceName == "domain2.com/resource2" {
-			testManager.endpoints[res.resourceName] = &MockEndpoint{
+			store.SwapEndpoint(&mockEndpoint{
+				resourceName: res.resourceName,
 				allocateFunc: func(devs []string) (*pluginapi.AllocateResponse, error) {
 					resp := new(pluginapi.AllocateResponse)
 					resp.Envs = make(map[string]string)
@@ -463,9 +434,10 @@ func getTestManager(tmpDir string, activePods ActivePodsFunc, testRes []TestReso
 					}
 					return resp, nil
 				},
-			}
+			})
 		}
 	}
+
 	return testManager
 }
 
@@ -480,17 +452,7 @@ func getTestNodeInfo(allocatable v1.ResourceList) *schedulercache.NodeInfo {
 	return nodeInfo
 }
 
-type TestResource struct {
-	resourceName     string
-	resourceQuantity resource.Quantity
-	devs             []string
-}
-
 func TestPodContainerDeviceAllocation(t *testing.T) {
-	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
-	var logLevel string
-	flag.StringVar(&logLevel, "logLevel", "4", "test")
-	flag.Lookup("v").Value.Set(logLevel)
 	res1 := TestResource{
 		resourceName:     "domain1.com/resource1",
 		resourceQuantity: *resource.NewQuantity(int64(2), resource.DecimalSI),
@@ -501,16 +463,19 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		resourceQuantity: *resource.NewQuantity(int64(1), resource.DecimalSI),
 		devs:             []string{"dev3", "dev4"},
 	}
-	testResources := make([]TestResource, 2)
-	testResources = append(testResources, res1)
+
+	testResources := append([]TestResource{}, res1)
 	testResources = append(testResources, res2)
+
 	as := require.New(t)
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
 	}
+
 	tmpDir, err := ioutil.TempDir("", "checkpoint")
 	as.Nil(err)
 	defer os.RemoveAll(tmpDir)
+
 	nodeInfo := getTestNodeInfo(v1.ResourceList{})
 	testManager := getTestManager(tmpDir, podsStub.getActivePods, testResources)
 
@@ -524,6 +489,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		makePod(v1.ResourceList{
 			v1.ResourceName(res2.resourceName): res2.resourceQuantity}),
 	}
+
 	testCases := []struct {
 		description               string
 		testPod                   *v1.Pod
@@ -557,16 +523,19 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 			expErr: nil,
 		},
 	}
+
 	activePods := []*v1.Pod{}
 	for _, testCase := range testCases {
 		pod := testCase.testPod
 		activePods = append(activePods, pod)
+
 		podsStub.updateActivePods(activePods)
 		err := testManager.Allocate(nodeInfo, &lifecycle.PodAdmitAttributes{Pod: pod})
 		if !reflect.DeepEqual(err, testCase.expErr) {
 			t.Errorf("DevicePluginManager error (%v). expected error: %v but got: %v",
 				testCase.description, testCase.expErr, err)
 		}
+
 		runContainerOpts := testManager.GetDeviceRunContainerOptions(pod, &pod.Spec.Containers[0])
 		if testCase.expectedContainerOptsLen == nil {
 			as.Nil(runContainerOpts)
@@ -575,6 +544,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 			as.Equal(len(runContainerOpts.Mounts), testCase.expectedContainerOptsLen[1])
 			as.Equal(len(runContainerOpts.Envs), testCase.expectedContainerOptsLen[2])
 		}
+
 		as.Equal(testCase.expectedAllocatedResName1, testManager.allocatedDevices[res1.resourceName].Len())
 		as.Equal(testCase.expectedAllocatedResName2, testManager.allocatedDevices[res2.resourceName].Len())
 	}
@@ -594,13 +564,15 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 		resourceQuantity: *resource.NewQuantity(int64(1), resource.DecimalSI),
 		devs:             []string{"dev3", "dev4"},
 	}
-	testResources := make([]TestResource, 2)
-	testResources = append(testResources, res1)
+
+	testResources := append([]TestResource{}, res1)
 	testResources = append(testResources, res2)
+
 	as := require.New(t)
 	podsStub := activePodsStub{
 		activePods: []*v1.Pod{},
 	}
+
 	nodeInfo := getTestNodeInfo(v1.ResourceList{})
 	tmpDir, err := ioutil.TempDir("", "checkpoint")
 	as.Nil(err)
@@ -652,18 +624,24 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 			},
 		},
 	}
+
 	podsStub.updateActivePods([]*v1.Pod{podWithPluginResourcesInInitContainers})
 	err = testManager.Allocate(nodeInfo, &lifecycle.PodAdmitAttributes{Pod: podWithPluginResourcesInInitContainers})
 	as.Nil(err)
+
 	podUID := string(podWithPluginResourcesInInitContainers.UID)
 	initCont1 := podWithPluginResourcesInInitContainers.Spec.InitContainers[0].Name
 	initCont2 := podWithPluginResourcesInInitContainers.Spec.InitContainers[1].Name
+
 	normalCont1 := podWithPluginResourcesInInitContainers.Spec.Containers[0].Name
 	normalCont2 := podWithPluginResourcesInInitContainers.Spec.Containers[1].Name
+
 	initCont1Devices := testManager.podDevices.containerDevices(podUID, initCont1, res1.resourceName)
 	initCont2Devices := testManager.podDevices.containerDevices(podUID, initCont2, res1.resourceName)
+
 	normalCont1Devices := testManager.podDevices.containerDevices(podUID, normalCont1, res1.resourceName)
 	normalCont2Devices := testManager.podDevices.containerDevices(podUID, normalCont2, res1.resourceName)
+
 	as.True(initCont2Devices.IsSuperset(initCont1Devices))
 	as.True(initCont2Devices.IsSuperset(normalCont1Devices))
 	as.True(initCont2Devices.IsSuperset(normalCont2Devices))
@@ -678,13 +656,13 @@ func TestSanitizeNodeAllocatable(t *testing.T) {
 	devID2 := "dev2"
 
 	as := assert.New(t)
-	monitorCallback := func(resourceName string, added, updated, deleted []pluginapi.Device) {}
+	managerCallback := func(resourceName string, added, updated, deleted []pluginapi.Device) {}
 
 	testManager := &ManagerImpl{
-		callback:         monitorCallback,
 		allDevices:       make(map[string]sets.String),
 		allocatedDevices: make(map[string]sets.String),
 		podDevices:       make(podDevices),
+		endpointHandler:  newEndpointHandlerImpl(managerCallback),
 	}
 	testManager.store, _ = utilstore.NewFileStore("/tmp/", utilfs.DefaultFs{})
 	// require one of resource1 and one of resource2


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR moves the storage responsibility away from the Manager struct and into an "Endpoint storage"
This allows for more extensive and reliable testing of the ReRegistration test introduced in PR #52290

This PR introduces multiple files and adds multiple tests:
- device_plugin_store.go (100% code coverage)
- endpoint.go (91.8% code coverage)
- endpoint_handler.go (95.8% code coverage)
- endpoint_store_shim.go (100% code coverage)

When paired with PR #52612 performance of the tests can get to <1s on a beefy machine.
Current test time usually takes at least 60s and more.
With this PR adding tests this reaches a whooping fixed 115s.

Note that most of the code not covered are error handling cases that can usually only be triggered
through changes that forgot to close or cleanup the structures.

This PR introduces an `EndpointHandler` interface that handles all interactions with the manager and abstracts away the complexity of handling registration and device usage:
```golang
type endpointHandler interface {
	NewEndpoint(resourceName, socketPath string) error

	Devices() map[string][]pluginapi.Device
	Endpoint(resourceName string) (endpoint, bool)

	Stop() error

	Store() endpointStore
	SetStore(endpointStore)

	SetCallback(f managerCallback)
}
```

![future arch](https://user-images.githubusercontent.com/2519571/34269352-4097a092-e684-11e7-88de-582a83946b43.png)


This allows for simple handling of complex behaviors such as the Re-registration bug:
```golang
func (h *endpointHandlerImpl) NewEndpoint(resourceName, socketPath string) error {
	e, err := newEndpoint(socketPath, resourceName)
	if err != nil {
		return err
	}

	// If an endpoint with this resourceName is already present
	var devStore deviceStore = newDeviceStoreImpl(h.callback)
	if old, ok := h.store.Endpoint(resourceName); ok && old != nil {
		devStore = old.Store()
	}

	// set a new store or the old store
	e.SetStore(devStore)

	// Add the endpoint to the store (and get the old one)
	old, ok := h.store.SwapEndpoint(e)
	go h.trackEnpoint(e)

	if ok && old != nil {
		// Prevent it to issue a Callback to the manager before stopping it
		old.SetStore(newAlwaysEmptyDeviceStore())

		if err = old.Stop(); err != nil {
			return err
		}
	}

	return nil
}
```

**Special notes for your reviewer**:
- @vishh @jiayingz @mindprince 
- Fixes #56026

**Release note**:
```release-note
NONE
```
