### PR TITLE
kubeadm: better default NodeName based on machine-id

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -57,7 +57,6 @@ go_library(
         "//pkg/kubectl/util/i18n:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/util/initsystem:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//pkg/util/version:go_default_library",
         "//pkg/version:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -270,24 +270,17 @@ func (ipc InPathCheck) Check() (warnings, errors []error) {
 	return nil, nil
 }
 
-// HostnameCheck checks if hostname match dns sub domain regex.
-// If hostname doesn't match this regex, kubelet will not launch static pods like kube-apiserver/kube-controller-manager and so on.
-type HostnameCheck struct {
+// NodenameCheck checks if NodeName match dns sub domain regex.
+// If nodename doesn't match this regex, kubelet will not launch static pods like kube-apiserver/kube-controller-manager and so on.
+type NodenameCheck struct {
 	nodeName string
 }
 
-func (hc HostnameCheck) Check() (warnings, errors []error) {
+func (hc NodenameCheck) Check() (warnings, errors []error) {
 	errors = []error{}
 	warnings = []error{}
 	for _, msg := range validation.ValidateNodeName(hc.nodeName, false) {
-		errors = append(errors, fmt.Errorf("hostname \"%s\" %s", hc.nodeName, msg))
-	}
-	addr, err := net.LookupHost(hc.nodeName)
-	if addr == nil {
-		warnings = append(warnings, fmt.Errorf("hostname \"%s\" could not be reached", hc.nodeName))
-	}
-	if err != nil {
-		warnings = append(warnings, fmt.Errorf("hostname \"%s\" %s", hc.nodeName, err))
+		errors = append(errors, fmt.Errorf("node-name \"%s\" %s", hc.nodeName, msg))
 	}
 	return warnings, errors
 }
@@ -600,7 +593,7 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		KubernetesVersionCheck{KubernetesVersion: cfg.KubernetesVersion, KubeadmVersion: kubeadmversion.Get().GitVersion},
 		SystemVerificationCheck{},
 		IsRootCheck{},
-		HostnameCheck{nodeName: cfg.NodeName},
+		NodenameCheck{nodeName: cfg.NodeName},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		FirewalldCheck{ports: []int{int(cfg.API.BindPort), 10250}},
@@ -664,7 +657,7 @@ func RunJoinNodeChecks(cfg *kubeadmapi.NodeConfiguration) error {
 	checks := []Checker{
 		SystemVerificationCheck{},
 		IsRootCheck{},
-		HostnameCheck{cfg.NodeName},
+		NodenameCheck{cfg.NodeName},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
 		ServiceCheck{Service: "docker", CheckIfActive: true},
 		PortOpenCheck{port: 10250},

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -12,12 +12,15 @@ go_library(
         "arguments.go",
         "endpoint.go",
         "error.go",
+        "node.go",
         "template.go",
         "version.go",
     ],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/preflight:go_default_library",
+        "//pkg/util/node:go_default_library",
+        "//vendor/github.com/coreos/go-systemd/util:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/token:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/util/node:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",

--- a/cmd/kubeadm/app/util/config/masterconfig.go
+++ b/cmd/kubeadm/app/util/config/masterconfig.go
@@ -30,7 +30,6 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	tokenutil "k8s.io/kubernetes/cmd/kubeadm/app/util/token"
 	"k8s.io/kubernetes/pkg/api"
-	"k8s.io/kubernetes/pkg/util/node"
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
@@ -73,7 +72,10 @@ func SetInitDynamicDefaults(cfg *kubeadmapi.MasterConfiguration) error {
 		}
 	}
 
-	cfg.NodeName = node.GetHostname(cfg.NodeName)
+	cfg.NodeName, err = kubeadmutil.GetDefaultNodeName(cfg.NodeName)
+	if err != nil {
+		return fmt.Errorf("unable to find a default node name: %v", err)
+	}
 
 	return nil
 }

--- a/cmd/kubeadm/app/util/node.go
+++ b/cmd/kubeadm/app/util/node.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	systemdutil "github.com/coreos/go-systemd/util"
+
+	"k8s.io/kubernetes/pkg/util/node"
+)
+
+// GetDefaultNodeName returns a suitable default NodeName
+func GetDefaultNodeName(override string) (string, error) {
+	if override != "" {
+		return override, nil
+	}
+
+	if mid, err := systemdutil.GetMachineID(); err != nil {
+		return "node-" + mid, nil
+	}
+
+	return node.GetHostname(""), nil
+}


### PR DESCRIPTION
NodeName != hostname.

- NodeName needs to be unique (cluster-wide)
- System hostname (aka utsname.nodename) may not be unique,
  particularly on cloud providers that don't provide internal DNS (eg:
  openstack).
- System hostname can change in response to DHCP/DNS replies
  (eg https://github.com/kubernetes/kubeadm/issues/144)
- NodeName does not need to resolve (historically this was required however)

This patch alters the `--node-name` default to "node-%m" if
`/etc/machine-id` is available, otherwise falls back to the existing
hostname logic.

Also: Rename the pre-flight `HostnameCheck` to `NodenameCheck` to
reduce confusion, and remove the unnecessary warning when the NodeName
fails to resolve.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
