### PR TITLE
Simplify deployment in federation CI jobs

### DIFF
--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -25,6 +25,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 FEDERATION_NAME="${FEDERATION_NAME:-e2e-federation}"
 FEDERATION_NAMESPACE=${FEDERATION_NAMESPACE:-federation-system}
 FEDERATION_KUBE_CONTEXT="${FEDERATION_KUBE_CONTEXT:-${FEDERATION_NAME}}"
+FEDERATION_USE_PV_FOR_ETCD=${FEDERATION_USE_PV_FOR_ETCD:-false}
 HOST_CLUSTER_ZONE="${FEDERATION_HOST_CLUSTER_ZONE:-}"
 # If $HOST_CLUSTER_ZONE isn't specified, arbitrarily choose
 # last zone as the host cluster zone.

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -17,9 +17,11 @@
 
 : "${KUBE_ROOT?Must set KUBE_ROOT env var}"
 
-# Provides the $KUBERNETES_PROVIDER, kubeconfig-federation-context()
-# and detect-project function
+# Provides the kubeconfig-federation-context() function
 source "${KUBE_ROOT}/cluster/kube-util.sh"
+
+# For `kube::log::status` function
+source "${KUBE_ROOT}/cluster/lib/logging.sh"
 
 # kubefed configuration
 FEDERATION_NAME="${FEDERATION_NAME:-e2e-federation}"
@@ -64,8 +66,6 @@ function federation_cluster_contexts() {
   echo ${federation_contexts[@]:-}
 }
 
-
-source "${KUBE_ROOT}/cluster/common.sh"
 
 host_kubectl="${KUBE_ROOT}/cluster/kubectl.sh --namespace=${FEDERATION_NAMESPACE}"
 

--- a/federation/cluster/common.sh
+++ b/federation/cluster/common.sh
@@ -52,7 +52,7 @@ function federation_cluster_contexts() {
   federation_contexts=()
   for context in ${contexts}; do
     # Skip federation context
-    if [[ "${context}" == "${FEDERATION_NAME}" ]]; then
+    if [[ "${context}" == "${FEDERATION_KUBE_CONTEXT}" ]]; then
       continue
     fi
     # Skip contexts not beginning with "federation"
@@ -61,7 +61,7 @@ function federation_cluster_contexts() {
     fi
     federation_contexts+=("${context}")
   done
-  echo ${federation_contexts[@]}
+  echo ${federation_contexts[@]:-}
 }
 
 

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -30,7 +30,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
 # "${KUBE_ROOT}/cluster/lib/logging.sh" and DEFAULT_KUBECONFIG
 source "${KUBE_ROOT}/cluster/common.sh"
 # For $FEDERATION_NAME, $FEDERATION_NAMESPACE, $FEDERATION_KUBE_CONTEXT,
-# and $HOST_CLUSTER_CONTEXT.
+# $HOST_CLUSTER_CONTEXT and $FEDERATION_USE_PV_FOR_ETCD.
 source "${KUBE_ROOT}/federation/cluster/common.sh"
 
 DNS_ZONE_NAME="${FEDERATION_DNS_ZONE_NAME:-}"
@@ -118,6 +118,7 @@ function init() {
       --apiserver-enable-token-auth=true \
       --apiserver-arg-overrides="--runtime-config=api/all=true,--v=4" \
       --controllermanager-arg-overrides="--v=4" \
+      --etcd-persistent-storage=${FEDERATION_USE_PV_FOR_ETCD} \
       --v=4
 }
 

--- a/federation/cluster/federation-up.sh
+++ b/federation/cluster/federation-up.sh
@@ -26,9 +26,6 @@ set -o pipefail
 
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-# For `kube::log::status` function since it already sources
-# "${KUBE_ROOT}/cluster/lib/logging.sh" and DEFAULT_KUBECONFIG
-source "${KUBE_ROOT}/cluster/common.sh"
 # For $FEDERATION_NAME, $FEDERATION_NAMESPACE, $FEDERATION_KUBE_CONTEXT,
 # $HOST_CLUSTER_CONTEXT and $FEDERATION_USE_PV_FOR_ETCD.
 source "${KUBE_ROOT}/federation/cluster/common.sh"

--- a/federation/cluster/upgrade.sh
+++ b/federation/cluster/upgrade.sh
@@ -19,9 +19,6 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
-# For `kube::log::status` function since it already sources
-# "${KUBE_ROOT}/cluster/lib/logging.sh"
-source "${KUBE_ROOT}/cluster/common.sh"
 # For $FEDERATION_NAME, $FEDERATION_NAMESPACE, $HOST_CLUSTER_CONTEXT,
 source "${KUBE_ROOT}/federation/cluster/common.sh"
 

--- a/federation/pkg/kubefed/init/init.go
+++ b/federation/pkg/kubefed/init/init.go
@@ -340,16 +340,16 @@ func (i *initFederation) Run(cmdOut io.Writer, config util.AdminConfig) error {
 	}
 	glog.V(4).Info("Credentials secret successfully created")
 
-	glog.V(4).Info("Creating a persistent volume and a claim to store the federation API server's state, including etcd data")
 	var pvc *api.PersistentVolumeClaim
 	if i.options.etcdPersistentStorage {
+		glog.V(4).Info("Creating a persistent volume and a claim to store the federation API server's state, including etcd data")
 		pvc, err = createPVC(hostClientset, i.commonOptions.FederationSystemNamespace, svc.Name, i.commonOptions.Name, i.options.etcdPVCapacity, i.options.etcdPVStorageClass, i.options.dryRun)
 		if err != nil {
 			return err
 		}
+		glog.V(4).Info("Persistent volume and claim created")
+		fmt.Fprintln(cmdOut, " done")
 	}
-	glog.V(4).Info("Persistent volume and claim created")
-	fmt.Fprintln(cmdOut, " done")
 
 	// Since only one IP address can be specified as advertise address,
 	// we arbitrarily pick the first available IP address


### PR DESCRIPTION
**What this PR does / why we need it**:
Introduce a new variable `USE_PV_FOR_ETCD` to control whether to use PV for federation etcd. `USE_PV_FOR_ETCD` is set to false by default and can be overridden in CI jobs where we want to test with PV. For most of the federation CI jobs, it does not matter whether we use PV for etcd or not. We can overcome some issues by not depending on PV's in federation setup like failure to bind to PV and leaking PD's. etc...
#50543 is one such issue associated with PV.

This PR also contain a commit to fix couple of minor issues and removing unnecessary include of cluster/common script.

**Release note**:
```release-note
NONE
```

/assign @madhusudancs 
/cc @kubernetes/sig-federation-pr-reviews 
