### PR TITLE
Correct TestUpdatePod comment

### DIFF
--- a/pkg/kubelet/pod_workers_test.go
+++ b/pkg/kubelet/pod_workers_test.go
@@ -128,7 +128,6 @@ func drainWorkers(podWorkers *podWorkers, numPods int) {
 func TestUpdatePod(t *testing.T) {
 	podWorkers, processed := createPodWorkers()
 
-	// Check whether all pod updates will be processed.
 	numPods := 20
 	for i := 0; i < numPods; i++ {
 		for j := i; j < numPods; j++ {
@@ -151,6 +150,7 @@ func TestUpdatePod(t *testing.T) {
 			continue
 		}
 
+		// PodWorker guarantees the first and the last event will be processed
 		first := 0
 		last := len(processed[uid]) - 1
 		if processed[uid][first].name != string(0) {


### PR DESCRIPTION
Signed-off-by: mYmNeo <thomassong2012@gmail.com>

**What this PR does / why we need it**:
Correct TestUpdatePod comment

**Which issue this PR fixes**

The original one wants to check whether all updates has been caught by podWorker, but podWorker can guarantee only the first event and the last one will processed. Correct the comment if others misunderstand the unit test.