### PR TITLE
Remove unused variables and constant from pkg/apis/componentconfig/v1…

### DIFF
--- a/pkg/apis/componentconfig/v1alpha1/defaults.go
+++ b/pkg/apis/componentconfig/v1alpha1/defaults.go
@@ -29,21 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 )
 
-const (
-	DefaultRootDir = "/var/lib/kubelet"
-
-	AutoDetectCloudProvider = "auto-detect"
-
-	defaultIPTablesMasqueradeBit = 14
-	defaultIPTablesDropBit       = 15
-)
-
-var (
-	zeroDuration = metav1.Duration{}
-	// Refer to [Node Allocatable](https://git.k8s.io/community/contributors/design-proposals/node-allocatable.md) doc for more information.
-	defaultNodeAllocatableEnforcement = []string{"pods"}
-)
-
 func addDefaultingFuncs(scheme *kruntime.Scheme) error {
 	return RegisterDefaults(scheme)
 }


### PR DESCRIPTION
…alpha1/defaults.go

This commit will remove variables `zeroDuration`, `defaultNodeAllocatableEnforcement` and
constants `defaultIPTablesMasqueradeBit` and `defaultIPTablesDropBit` as they are unused.



```release-note
NONE
```