### PR TITLE
Apiserver - Prevent node-ssh-tunnel health check from failing when not running on cloud

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -157,7 +157,8 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 		"If non-empty, use secure SSH proxy to the nodes, using this user name")
 
 	fs.StringVar(&s.SSHKeyfile, "ssh-keyfile", s.SSHKeyfile,
-		"If non-empty, use secure SSH proxy to the nodes, using this user keyfile")
+		"If non-empty, use secure SSH proxy to the nodes, using this user keyfile. If a pem-encoded public key with the suffix '.pub' "+
+			"is found, it will be automatically installed on all worker nodes if the cloud-provider supports it. If no public key exists, a key will be generated.")
 
 	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
 		"If non-zero, throttle each user connection to this number of bytes/sec. "+

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -68,7 +68,6 @@ go_library(
         "//pkg/util/async:go_default_library",
         "//pkg/util/node:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -66,7 +66,6 @@ import (
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 
 	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/prometheus"
 
 	// RESTStorage installers
 	"k8s.io/client-go/informers"
@@ -385,10 +384,6 @@ func (m *Master) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.
 func (m *Master) installTunneler(nodeTunneler tunneler.Tunneler, nodeClient corev1client.NodeInterface) {
 	nodeTunneler.Run(nodeAddressProvider{nodeClient}.externalAddresses)
 	m.GenericAPIServer.AddHealthzChecks(healthz.NamedCheck("SSH Tunnel Check", tunneler.TunnelSyncHealthChecker(nodeTunneler)))
-	prometheus.NewGaugeFunc(prometheus.GaugeOpts{
-		Name: "apiserver_proxy_tunnel_sync_latency_secs",
-		Help: "The time since the last successful synchronization of the SSH tunnels for proxy requests.",
-	}, func() float64 { return float64(nodeTunneler.SecondsSinceSync()) })
 }
 
 // RESTStorageProvider is a factory type for REST storage.

--- a/pkg/master/tunneler/BUILD
+++ b/pkg/master/tunneler/BUILD
@@ -22,6 +22,7 @@ go_library(
     srcs = ["ssh.go"],
     importpath = "k8s.io/kubernetes/pkg/master/tunneler",
     deps = [
+        "//pkg/cloudprovider:go_default_library",
         "//pkg/ssh:go_default_library",
         "//pkg/util/file:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
The 'SSH Tunnel' health check currently fails when not running on a cloud-provider which supports dynamically installing of ssh-keys after 600 Seconds due to a missing update of a timestamp.

**Release note**:
```release-note
Fix apiserver node-ssh-tunnel health check
```

Only the GCE cloud-provider supports dynamic installation of ssh-keys.