### PR TITLE
Fix panic in ControllerManager when GCE external loadbalancer healthcheck is nil

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -514,8 +514,9 @@ func (gce *GCECloud) createTargetPool(svc *v1.Service, name, serviceName, ipAddr
 			return err
 		}
 		var err error
+		hcRequestPath, hcPort := hc.RequestPath, hc.Port
 		if hc, err = gce.ensureHttpHealthCheck(hc.Name, hc.RequestPath, int32(hc.Port)); err != nil || hc == nil {
-			return fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", name, hc.Port, hc.RequestPath, err)
+			return fmt.Errorf("Failed to ensure health check for %v port %d path %v: %v", name, hcPort, hcRequestPath, err)
 		}
 		hcLinks = append(hcLinks, hc.SelfLink)
 	}


### PR DESCRIPTION
Fix #52722

We should cherry pick it to 1.7 and 1.6.

cc @nicksardo @abgworrall @wojtek-t @ethernetdan @enisoc 

```release-note
Fix panic in ControllerManager on GCE when it has a problem with creating external loadbalancer healthcheck
```