### PR TITLE
refactor NsenterWriter to utilize pkg/util/nsenter

### DIFF
--- a/pkg/util/io/BUILD
+++ b/pkg/util/io/BUILD
@@ -12,7 +12,10 @@ go_library(
         "writer.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/util/io",
-    deps = ["//vendor/github.com/golang/glog:go_default_library"],
+    deps = [
+        "//pkg/util/nsenter:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/util/io/writer.go
+++ b/pkg/util/io/writer.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
+
+	"k8s.io/kubernetes/pkg/util/nsenter"
 
 	"github.com/golang/glog"
 )
@@ -54,25 +55,20 @@ type NsenterWriter struct{}
 // WriteFile calls 'nsenter cat - > <the file>' and 'nsenter chmod' to create a
 // file on the host.
 func (writer *NsenterWriter) WriteFile(filename string, data []byte, perm os.FileMode) error {
-	cmd := "nsenter"
-	baseArgs := []string{
-		"--mount=/rootfs/proc/1/ns/mnt",
-		"--",
-	}
-
-	echoArgs := append(baseArgs, "sh", "-c", fmt.Sprintf("cat > %s", filename))
-	glog.V(5).Infof("Command to write data to file: %v %v", cmd, echoArgs)
-	command := exec.Command(cmd, echoArgs...)
-	command.Stdin = bytes.NewBuffer(data)
+	ne := nsenter.NewNsenter()
+	echoArgs := []string{"-c", fmt.Sprintf("cat > %s", filename)}
+	glog.V(5).Infof("nsenter: write data to file %s by nsenter", filename)
+	command := ne.Exec("sh", echoArgs)
+	command.SetStdin(bytes.NewBuffer(data))
 	outputBytes, err := command.CombinedOutput()
 	if err != nil {
 		glog.Errorf("Output from writing to %q: %v", filename, string(outputBytes))
 		return err
 	}
 
-	chmodArgs := append(baseArgs, "chmod", fmt.Sprintf("%o", perm), filename)
-	glog.V(5).Infof("Command to change permissions to file: %v %v", cmd, chmodArgs)
-	outputBytes, err = exec.Command(cmd, chmodArgs...).CombinedOutput()
+	chmodArgs := []string{fmt.Sprintf("%o", perm), filename}
+	glog.V(5).Infof("nsenter: change permissions of file %s to %s", filename, chmodArgs[0])
+	outputBytes, err = ne.Exec("chmod", chmodArgs).CombinedOutput()
 	if err != nil {
 		glog.Errorf("Output from chmod command: %v", string(outputBytes))
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Per [discussion](https://github.com/kubernetes/kubernetes/pull/51771#discussion_r138824451)
Depend on #51771

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
