### PR TITLE
Use const instead of hard code for volume plugin

### DIFF
--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -32,7 +32,10 @@ import (
 	"k8s.io/utils/exec"
 )
 
-const flexVolumePluginName = "kubernetes.io/flexvolume"
+const (
+	flexVolumePluginName       = "kubernetes.io/flexvolume"
+	flexVolumePluginNamePrefix = "flexvolume-"
+)
 
 // FlexVolumePlugin object.
 type flexVolumePlugin struct {
@@ -102,7 +105,7 @@ func (plugin *flexVolumePlugin) getExecutable() string {
 
 // Name is part of the volume.VolumePlugin interface.
 func (plugin *flexVolumePlugin) GetPluginName() string {
-	return "flexvolume-" + plugin.driverName
+	return flexVolumePluginNamePrefix + plugin.driverName
 }
 
 // GetVolumeName is part of the volume.VolumePlugin interface.

--- a/pkg/volume/plugins_test.go
+++ b/pkg/volume/plugins_test.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const testPluginName = "kubernetes.io/testPlugin"
+
 func TestSpecSourceConverters(t *testing.T) {
 	v := &v1.Volume{
 		Name:         "foo",
@@ -62,7 +64,7 @@ func (plugin *testPlugins) Init(host VolumeHost) error {
 }
 
 func (plugin *testPlugins) GetPluginName() string {
-	return "testPlugin"
+	return testPluginName
 }
 
 func (plugin *testPlugins) GetVolumeName(spec *Spec) (string, error) {
@@ -106,11 +108,11 @@ func TestVolumePluginMgrFunc(t *testing.T) {
 	var prober DynamicPluginProber = nil // TODO (#51147) inject mock
 	vpm.InitPlugins(newTestPlugin(), prober, nil)
 
-	plug, err := vpm.FindPluginByName("testPlugin")
+	plug, err := vpm.FindPluginByName(testPluginName)
 	if err != nil {
 		t.Errorf("Can't find the plugin by name")
 	}
-	if plug.GetPluginName() != "testPlugin" {
+	if plug.GetPluginName() != testPluginName {
 		t.Errorf("Wrong name: %s", plug.GetPluginName())
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
nits: cleanup hard-coded volume plugin name

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
