### PR TITLE
s390x ingress controller support

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -566,6 +566,9 @@ def launch_default_ingress_controller():
         return
 
     # Render the ingress replication controller manifest
+    context['ingress_image'] = "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.13"
+    if arch() == 's390x':
+        context['ingress_image'] = "docker.io/cdkbot/nginx-ingress-controller-s390x:0.9.0-beta.13"
     manifest = addon_path.format('ingress-replication-controller.yaml')
     render('ingress-replication-controller.yaml', manifest, context)
     hookenv.log('Creating the ingress replication controller.')

--- a/cluster/juju/layers/kubernetes-worker/templates/ingress-replication-controller.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/ingress-replication-controller.yaml
@@ -24,7 +24,7 @@ spec:
       # see https://github.com/kubernetes/kubernetes/issues/23920
       hostNetwork: true
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.3
+      - image: {{ ingress_image }}
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:
@@ -50,4 +50,4 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
-        - --nginx-configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf
+        - --configmap=$(POD_NAMESPACE)/nginx-load-balancer-conf


### PR DESCRIPTION
**What this PR does / why we need it**: Adds support for an s390x ingress image to the juju kubernetes-worker charm.

**Release note**:
```
Adds support for an s390x ingress image to the juju kubernetes-worker charm.
```
