### PR TITLE
Fix: update system spec to support Docker 17.03

### DIFF
--- a/test/e2e_node/system/docker_validator.go
+++ b/test/e2e_node/system/docker_validator.go
@@ -39,7 +39,7 @@ func (d *DockerValidator) Name() string {
 const (
 	dockerEndpoint            = "unix:///var/run/docker.sock"
 	dockerConfigPrefix        = "DOCKER_"
-	maxDockerValidatedVersion = "1.12"
+	maxDockerValidatedVersion = "17.03"
 )
 
 // TODO(random-liu): Add more validating items.
@@ -71,8 +71,9 @@ func (d *DockerValidator) validateDockerInfo(spec *DockerSpec, info types.Info) 
 		}
 	}
 	if !matched {
-		// catch if docker is 1.13+
-		ver := `1\.(1[3-9])\..*|\d{2}\.\d+\.\d+-[a-z]{2}`
+		// If it's of the new Docker version scheme but didn't match above, it
+		// must be a newer version than the most recently validated one.
+		ver := `\d{2}\.\d+\.\d+-[a-z]{2}`
 		r := regexp.MustCompile(ver)
 		if r.MatchString(info.ServerVersion) {
 			d.Reporter.Report(dockerConfigPrefix+"VERSION", info.ServerVersion, good)

--- a/test/e2e_node/system/docker_validator_test.go
+++ b/test/e2e_node/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.1[1-3]\..*`}, // Requires 1.11+
+		Version:     []string{`1\.1[1-3]\..*`, `17\.03\..*`}, // Requires [1.11, 17.03].
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -61,9 +61,13 @@ func TestValidateDockerInfo(t *testing.T) {
 			err:  false,
 			warn: false,
 		},
-		// TODO remove/change warn value once sig-node supports 17.03-0-ce
 		{
 			info: types.Info{Driver: "driver_2", ServerVersion: "17.03.0-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			info: types.Info{Driver: "driver_2", ServerVersion: "17.06.0-ce"},
 			err:  false,
 			warn: true,
 		},

--- a/test/e2e_node/system/types.go
+++ b/test/e2e_node/system/types.go
@@ -159,7 +159,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`1\.1[1-3]\..*`}, // Requires 1.11+
+			Version:     []string{`1\.1[1-3]\..*`, `17\.03\..*`}, // Requires [1.11, 17.03]
 			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper"},
 		},
 	},


### PR DESCRIPTION
Docker 17.03 is 1.13 with bug fixes so they are of the same minor version release. We've validated them both in https://github.com/kubernetes/kubernetes/issues/42926. This PR changes the system spec to support Docker 17.03.

**This should be in 1.8.**

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Kubernetes 1.8 supports docker version 17.03.x.
```

/assign @Random-Liu 