### PR TITLE
Fix FC WaitForAttach not mounting a volume

### DIFF
--- a/pkg/volume/fc/fc_util.go
+++ b/pkg/volume/fc/fc_util.go
@@ -219,6 +219,10 @@ func (util *FCUtil) AttachDisk(b fcDiskMounter) (string, error) {
 	}
 	// mount it
 	globalPDPath := util.MakeGlobalPDName(*b.fcDisk)
+	if err := os.MkdirAll(globalPDPath, 0750); err != nil {
+		return devicePath, fmt.Errorf("fc: failed to mkdir %s, error", globalPDPath)
+	}
+
 	noMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
 	if err != nil {
 		return devicePath, fmt.Errorf("Heuristic determination of mount point failed:%v", err)
@@ -226,10 +230,6 @@ func (util *FCUtil) AttachDisk(b fcDiskMounter) (string, error) {
 	if !noMnt {
 		glog.Infof("fc: %s already mounted", globalPDPath)
 		return devicePath, nil
-	}
-
-	if err := os.MkdirAll(globalPDPath, 0750); err != nil {
-		return devicePath, fmt.Errorf("fc: failed to mkdir %s, error", globalPDPath)
 	}
 
 	err = b.mounter.FormatAndMount(devicePath, globalPDPath, b.fsType, nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

WaitForAttach failed consistently with this error:

Heuristic determination of mount point failed:stat
/var/lib/kubelet/plugins/kubernetes.io/fc/wwn-lun-0:
no such file or directory

We should create dir at first to avoid the error.

**Which issue this PR fixes** : fixes #52674

**Special notes for your reviewer**:

@rootfs @jsafrane 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
