### PR TITLE
bazel: set --incompatible_comprehension_variables_do_not_leak=false

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -11,3 +11,9 @@ build --sandbox_tmpfs_path=/tmp
 # Ensure that Bazel never runs as root, which can cause unit tests to fail.
 # This flag requires Bazel 0.5.0+
 build --sandbox_fake_username
+
+# rules_go@82483596ec203eb9c1849937636f4cbed83733eb has a typo that
+# inadvertently relies on comprehension variables leaking.
+# TODO(ixdy): Remove this default once rules_go is bumped.
+# Ref kubernetes/kubernetes#52677
+build --incompatible_comprehension_variables_do_not_leak=false


### PR DESCRIPTION
**What this PR does / why we need it**: future-proofing the repo against the upcoming release of bazel 0.6.0. x-ref #52677

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @spxtr @BenTheElder @mikedanese 
