### PR TITLE
bazel: make //cmd/kubectl:kubectl binary publicly visible

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -35,15 +35,6 @@ package_group(
 )
 
 package_group(
-    name = "COMMON_release",
-    packages = [
-        "//build",
-        "//build/debs",
-        "//build/rpms",
-    ],
-)
-
-package_group(
     name = "COMMON_testing",
     packages = [
         "//hack",
@@ -395,5 +386,5 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
-    visibility = ["//build/visible_to:COMMON_release"],
+    visibility = ["//visibility:public"],
 )

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -19,9 +19,7 @@ go_binary(
         ],
     }),
     library = ":go_default_library",
-    visibility = [
-        "//build/visible_to:COMMON_release",
-    ],
+    visibility = ["//visibility:public"],
     x_defs = version_x_defs(),
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**: making the `kubectl` binary visible to the release rules only seems unnecessarily restrictive (x-ref https://github.com/bazelbuild/bazel/issues/3744) - I think making this publicly visible should be fine.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @monopole 
cc @achew22