### PR TITLE
FC plugin: Return target wwn + lun at GetVolumeName()

### DIFF
--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -61,9 +61,12 @@ func (plugin *fcPlugin) GetVolumeName(spec *volume.Spec) (string, error) {
 		return "", err
 	}
 
-	if len(volumeSource.TargetWWNs) != 0 {
+	// API server validates these parameters beforehand but attach/detach
+	// controller creates volumespec without validation. They may be nil
+	// or zero length. We should check again to avoid unexpected conditions.
+	if len(volumeSource.TargetWWNs) != 0 && volumeSource.Lun != nil {
 		// TargetWWNs are the FibreChannel target worldwide names
-		return fmt.Sprintf("%v", volumeSource.TargetWWNs), nil
+		return fmt.Sprintf("%v:%v", volumeSource.TargetWWNs, *volumeSource.Lun), nil
 	} else if len(volumeSource.WWIDs) != 0 {
 		// WWIDs are the FibreChannel World Wide Identifiers
 		return fmt.Sprintf("%v", volumeSource.WWIDs), nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

At volume attach/detach controller, GetVolumeName() is
expected to return unique volume identifier, but FC
plugin didn't return unique identifier if user specified
FC volume using target wwn and lun.

In order to return unique identifier, GetVolumeName()
should use combination of target wwn and lun.

**Which issue this PR fixes** : fixes #52690

**Special notes for your reviewer**:

Should we use same format of unique volume identifier between v1.7 and v1.8 `for the purpose of backward compatibility?`

- At v1.7(before introducing attach/detach function), unique ID was pod's uuid + volume name
```
I0918 22:47:13.113481   44661 reconciler.go:257] operationExecutor.MountVolume started for volume "pv0001" (UniqueName: "kubernetes.io/fc/d6c66980-9ce4-11e7-8bb7-f8bc12550954-pv0001") pod "nginx-pod1" (UID: "d6c66980-9ce4-11e7-8bb7-f8bc12550954")  
I0918 22:47:15.116584   44661 operation_generator.go:476] MountVolume.SetUp succeeded for volume "pv0001" (UniqueName: "kubernetes.io/fc/d6c66980-9ce4-11e7-8bb7-f8bc12550954-pv0001") pod "nginx-pod1" (UID: "d6c66980-9ce4-11e7-8bb7-f8bc12550954")  
```

- At latest master, unique ID is targetWWNs.(if a user specifies a volume using target wwn + lun)
```
I0918 22:23:48.389339    1016 reconciler.go:212] operationExecutor.VerifyControllerAttachedVolume started for volume "pv0001" (UniqueName: "kubernetes.io/fc/[78060e801049abcd]") pod "nginx-pod3" (UID: "8f76b894-9ce1-11e7-b8f4-f8bc12550954")  
```

/cc @jsafrane @rootfs @msau42 @jingxu97 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
