### PR TITLE
In autoscaling integration test, use allocatable instead of capacity for node memory

### DIFF
--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -80,12 +80,12 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				// Calculate the CPU request of the service.
 				// This test expects that 8 pods will not fit in 'nodesNum' nodes, but will fit in >='nodesNum'+1 nodes.
 				// Make it so that 'nodesNum' pods fit perfectly per node (in practice other things take space, so less than that will fit).
-				nodeCpus := nodes.Items[0].Status.Capacity[v1.ResourceCPU]
+				nodeCpus := nodes.Items[0].Status.Allocatable[v1.ResourceCPU]
 				nodeCpuMillis := (&nodeCpus).MilliValue()
 				cpuRequestMillis := int64(nodeCpuMillis / nodesNum)
 
 				// Start the service we want to scale and wait for it to be up and running.
-				nodeMemoryBytes := nodes.Items[0].Status.Capacity[v1.ResourceMemory]
+				nodeMemoryBytes := nodes.Items[0].Status.Allocatable[v1.ResourceMemory]
 				nodeMemoryMB := (&nodeMemoryBytes).Value() / 1024 / 1024
 				memRequestMB := nodeMemoryMB / 10 // Ensure each pod takes not more than 10% of node's total memory.
 				replicas := 1


### PR DESCRIPTION
This makes the remaining cluster autoscaling test (integration test of HPA and CA working together to scale up the cluster) use node allocatable resources when computing how much memory we need to consume in order to trigger scale up/prevent scale down. Follow up to #52650 as that one is already merging.

cc @wasylkowski 