### PR TITLE
Cpumanager works after kubelet restart

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -228,6 +228,12 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				continue
 			}
 
+			// Check whether container is present in state, there may be 2 reasons why it's not present
+			// either container is Be/Bu or kubelet just restarted
+			if _, ok := m.state.GetCPUSet(containerID); !ok {
+				m.AddContainer(pod, &container, containerID)
+			}
+
 			cset := m.state.GetCPUSetOrDefault(containerID)
 			if cset.IsEmpty() {
 				// NOTE: This should not happen outside of tests.

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -151,8 +151,8 @@ func NewManager(
 }
 
 func (m *manager) Start(activePods ActivePodsFunc, podStatusProvider status.PodStatusProvider, containerRuntime runtimeService) {
-	glog.Infof("[cpumanger] starting with %s policy", m.policy.Name())
-	glog.Infof("[cpumanger] reconciling every %v", m.reconcilePeriod)
+	glog.Infof("[cpumanager] starting with %s policy", m.policy.Name())
+	glog.Infof("[cpumanager] reconciling every %v", m.reconcilePeriod)
 
 	m.activePods = activePods
 	m.podStatusProvider = podStatusProvider
@@ -230,7 +230,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 
 			// Check whether container is present in state, there may be 3 reasons why it's not present:
 			// - container is in Be/Bu pod
-			// - kubelet just restarted - state is empty
+			// - kubelet just restarted - state has not been restored properly and is empty
 			// - container has been removed from state by RemoveContainer call (DeletionTimestamp is set)
 			if _, ok := m.state.GetCPUSet(containerID); !ok {
 				if status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -231,7 +231,18 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 			// Check whether container is present in state, there may be 2 reasons why it's not present
 			// either container is Be/Bu or kubelet just restarted
 			if _, ok := m.state.GetCPUSet(containerID); !ok {
-				m.AddContainer(pod, &container, containerID)
+				if status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
+					//if DeletionTimestamp is set, pod has already been removed from state
+					glog.Infof("[cpumanager] reconcileState: found (pod: %s, container: %s, container id: %s) that is not present in state", pod.Name, container.Name, containerID)
+					err := m.AddContainer(pod, &container, containerID)
+					if err != nil {
+						glog.Errorf("[cpumanager] reconcileState: failed to add orphaned container (pod: %s, container: %s, container id: %s, error: %v)", pod.Name, container.Name, containerID, err)
+						failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})
+					}
+				} else {
+					// skip the pods since it's not running and may be deleted soon
+					continue
+				}
 			}
 
 			cset := m.state.GetCPUSetOrDefault(containerID)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -123,6 +123,12 @@ func (p *staticPolicy) AddContainer(s state.State, pod *v1.Pod, container *v1.Co
 	glog.Infof("[cpumanager] static policy: AddContainer (pod: %s, container: %s, container id: %s)", pod.Name, container.Name, containerID)
 	if numCPUs := guaranteedCPUs(pod, container); numCPUs != 0 {
 		// container belongs in an exclusively allocated pool
+
+		if _, ok := s.GetCPUSet(containerID); ok {
+			glog.Infof("[cpumanager] static policy: container: %s, container id: %s already present in state, skipping", container.Name, containerID)
+			return nil
+		}
+
 		cpuset, err := p.allocateCPUs(s, numCPUs)
 		if err != nil {
 			glog.Errorf("[cpumanager] unable to allocate %d CPUs (container id: %s, error: %v)", numCPUs, containerID, err)

--- a/pkg/kubelet/cm/cpumanager/policy_static.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static.go
@@ -125,7 +125,7 @@ func (p *staticPolicy) AddContainer(s state.State, pod *v1.Pod, container *v1.Co
 		// container belongs in an exclusively allocated pool
 
 		if _, ok := s.GetCPUSet(containerID); ok {
-			glog.Infof("[cpumanager] static policy: container: %s, container id: %s already present in state, skipping", container.Name, containerID)
+			glog.Infof("[cpumanager] static policy: container already present in state, skipping (container: %s, container id: %s)", container.Name, containerID)
 			return nil
 		}
 

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -37,8 +37,9 @@ type staticPolicyTest struct {
 	expErr          error
 	expCPUAlloc     bool
 	expCSet         cpuset.CPUSet
-	keepPrevPolicy  bool
-	keepPrevState   bool
+	// Flags to control whether to keep policy and state from previous testCase
+	keepPrevPolicy bool
+	keepPrevState  bool
 }
 
 func TestStaticPolicyName(t *testing.T) {

--- a/pkg/kubelet/cm/cpumanager/state/BUILD
+++ b/pkg/kubelet/cm/cpumanager/state/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "state.go",
+        "state_file.go",
         "state_mem.go",
     ],
     visibility = ["//visibility:public"],

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -37,4 +37,5 @@ type writer interface {
 type State interface {
 	Reader
 	writer
+	UpdateStateFile()
 }

--- a/pkg/kubelet/cm/cpumanager/state/state.go
+++ b/pkg/kubelet/cm/cpumanager/state/state.go
@@ -25,12 +25,14 @@ type Reader interface {
 	GetCPUSet(containerID string) (cpuset.CPUSet, bool)
 	GetDefaultCPUSet() cpuset.CPUSet
 	GetCPUSetOrDefault(containerID string) cpuset.CPUSet
+	GetAllCPUSets() ContainerCpuAssignment
 }
 
 type writer interface {
 	SetCPUSet(containerID string, cpuset cpuset.CPUSet)
 	SetDefaultCPUSet(cpuset cpuset.CPUSet)
 	Delete(containerID string)
+	ClearState()
 }
 
 // State interface provides methods for tracking and setting cpu/pod assignment

--- a/pkg/kubelet/cm/cpumanager/state/state_file.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_file.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package state
+
+import (
+	"encoding/json"
+	"github.com/golang/glog"
+	"io/ioutil"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
+	"os"
+	"sync"
+)
+
+type stateData struct {
+	DefaultCpuSet string            `json:"defaultCpuSet"`
+	Entries       map[string]string `json:"reservedList,omitempty"`
+}
+
+type stateFile struct {
+	sync.RWMutex
+	stateFilePath string
+}
+
+func NewStateFileBackend() *stateFile {
+	return &stateFile{
+		stateFilePath: "/var/lib/kubelet/cpu_manager_state",
+	}
+}
+
+func (sf *stateFile) tryRestoreState() (defaultCPUSet cpuset.CPUSet, assignments map[string]cpuset.CPUSet, err error) {
+	sf.RLock()
+	defer sf.RUnlock()
+
+	// init return values
+	defaultCPUSet = cpuset.NewCPUSet()
+	assignments = make(map[string]cpuset.CPUSet)
+	err = nil
+
+	// used when all parsing is ok
+	tmpAssignments := make(map[string]cpuset.CPUSet)
+	tmpDefaultCPUSet := cpuset.NewCPUSet()
+	tmpContainerCpuSet := cpuset.NewCPUSet()
+
+	var content []byte
+
+	if content, err = ioutil.ReadFile(sf.stateFilePath); os.IsNotExist(err) {
+		// Create file
+		if _, err = os.Create(sf.stateFilePath); err != nil {
+			glog.Errorf("[cpumanager] unable to create state file \"%s\"", sf.stateFilePath)
+			return
+		}
+		glog.Infof("[cpumanager] created empty state file \"%s\"", sf.stateFilePath)
+	} else {
+		// File exists - try to read
+		var readState stateData
+		if err = json.Unmarshal(content, &readState); err != nil {
+			glog.Errorf("[cpumanager] could not unmarshal, corrupted state file - \"%s\"", sf.stateFilePath)
+			return
+		}
+
+		if tmpDefaultCPUSet, err = cpuset.Parse(readState.DefaultCpuSet); err != nil {
+			glog.Errorf("[cpumanager] could not parse state file - [defaultCpuSet:\"%s\"]", readState.DefaultCpuSet)
+			return
+		}
+
+		for containerID, cpuString := range readState.Entries {
+			if tmpContainerCpuSet, err = cpuset.Parse(cpuString); err != nil {
+				glog.Errorf("[cpumanager] could not parse state file - container id: %s, cpuset: \"%s\"", containerID, cpuString)
+				return
+			}
+			tmpAssignments[containerID] = tmpContainerCpuSet
+		}
+
+		assignments = tmpAssignments
+		defaultCPUSet = tmpDefaultCPUSet
+		glog.V(2).Infof("[cpumanager] restored state from state file \"%s\"", sf.stateFilePath)
+		glog.V(4).Infof("[cpumanager] defaultCPUSet: %s", defaultCPUSet.String())
+	}
+	return
+}
+
+func (sf *stateFile) updateStateFile(defaultCPUSet cpuset.CPUSet, assignments map[string]cpuset.CPUSet) error {
+	sf.RLock()
+	defer sf.RUnlock()
+	var content []byte
+	var err error
+
+	writeState := stateData{
+		DefaultCpuSet: defaultCPUSet.String(),
+		Entries: map[string]string{},
+	}
+
+	for containerID, cset := range assignments {
+		writeState.Entries[containerID] = cset.String()
+	}
+
+	if content, err = json.Marshal(writeState); err != nil {
+		glog.Errorf("[cpumanager] could not write parse state to json")
+		return err
+	}
+
+	if err = ioutil.WriteFile(sf.stateFilePath, content, 0666); err != nil {
+		glog.Errorf("[cpumanager] could not write state to file")
+		return err
+	}
+
+	return nil
+
+}

--- a/pkg/kubelet/cm/cpumanager/state/state_mem.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_mem.go
@@ -25,6 +25,15 @@ import (
 
 type ContainerCpuAssignment map[string]cpuset.CPUSet
 
+func (as ContainerCpuAssignment) DeepCopy() ContainerCpuAssignment {
+	ret := make(ContainerCpuAssignment)
+	for key, val := range as {
+		ret[key] = val
+	}
+	return ret
+}
+
+
 type stateMemory struct {
 	sync.RWMutex
 	assignments   ContainerCpuAssignment
@@ -61,7 +70,7 @@ func (s *stateMemory) GetCPUSet(containerID string) (cpuset.CPUSet, bool) {
 func (s *stateMemory) GetAllCPUSets() ContainerCpuAssignment {
 	s.RLock()
 	defer s.RUnlock()
-	return s.assignments
+	return s.assignments.DeepCopy()
 }
 
 func (s *stateMemory) GetDefaultCPUSet() cpuset.CPUSet {


### PR DESCRIPTION
**What this PR does / why we need it**:
Cpumanager after restart looses cpu assignment. Guaranteed pods are being assigned to default cpuset. Implementation has been split as follows:

- [x] File backed `State` implementation #54408
- [x] Enabling of file backed  `State` in policy #54409
- [ ] Reconcile loop can restore state #54410

Part of #52031





