### PR TITLE
Retry if possible while creating latency pods in density test

### DIFF
--- a/test/e2e/scalability/BUILD
+++ b/test/e2e/scalability/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",


### PR DESCRIPTION
Saw the [last run](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/37) of density test on 5k-node fail due to it:

```
Expected error:
    <*errors.StatusError | 0xc44f2fd7a0>: {
        ErrStatus: {
            TypeMeta: {Kind: "", APIVersion: ""},
            ListMeta: {SelfLink: "", ResourceVersion: "", Continue: ""},
            Status: "Failure",
            Message: "timeout",
            Reason: "",
            Details: nil,
            Code: 500,
        },
    }
    timeout
not to have occurred
```

cc @kubernetes/sig-scalability-misc 