### PR TITLE
Fix mistype that causes breakage of e2e test.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1345,7 +1345,7 @@ function create-heapster-node() {
   local network=$(make-gcloud-network-argument \
       "${NETWORK_PROJECT}" \
       "${REGION}" \
-      "${NETWORK}"
+      "${NETWORK}" \
       "${SUBNETWORK:-}" \
       "" \
       "${ENABLE_IP_ALIASES:-}" \


### PR DESCRIPTION
**What this PR does / why we need it**:
Mistype in the configuration that breaks configuration with special heapster node.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #52496.