### PR TITLE
Validate that cronjob names are 52 characters or less

### DIFF
--- a/pkg/apis/batch/validation/BUILD
+++ b/pkg/apis/batch/validation/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/labels"
+	apimachineryvalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/api"
 	apivalidation "k8s.io/kubernetes/pkg/api/validation"
@@ -162,6 +163,13 @@ func ValidateCronJob(scheduledJob *batch.CronJob) field.ErrorList {
 	// CronJobs and rcs have the same name validation
 	allErrs := apivalidation.ValidateObjectMeta(&scheduledJob.ObjectMeta, true, apivalidation.ValidateReplicationControllerName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateCronJobSpec(&scheduledJob.Spec, field.NewPath("spec"))...)
+	if len(scheduledJob.ObjectMeta.Name) > apimachineryvalidation.DNS1035LabelMaxLength-11 {
+		// The cronjob controller appends a 11-character suffix to the cronjob (`-$TIMESTAMP`) when
+		// creating a job. The job name length limit is 63 characters.
+		// Therefore cronjob names must have length <= 63-11=52. If we don't validate this here,
+		// then job creation will fail later.
+		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata").Child("name"), scheduledJob.ObjectMeta.Name, "must be no more than 52 characters"))
+	}
 	return allErrs
 }
 

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -520,6 +520,22 @@ func TestValidateCronJob(t *testing.T) {
 				},
 			},
 		},
+		"metadata.name: must be no more than 52 characters": {
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "10000000002000000000300000000040000000005000000000123",
+				Namespace: metav1.NamespaceDefault,
+				UID:       types.UID("1a2b3c"),
+			},
+			Spec: batch.CronJobSpec{
+				Schedule:          "* * * * ?",
+				ConcurrencyPolicy: batch.AllowConcurrent,
+				JobTemplate: batch.JobTemplateSpec{
+					Spec: batch.JobSpec{
+						Template: validPodTemplateSpec,
+					},
+				},
+			},
+		},
 		"spec.jobTemplate.spec.manualSelector: Unsupported value": {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "mycronjob",


### PR DESCRIPTION
**What this PR does / why we need it**:

Right now when you create a cronjob with a name longer than 52 characters, creation will succeed but the cronjob controller will create Job objects with names longer than 63 characters. Jobs cannot have names longer than 63 characters, so the cronjob will never be able to run any jobs.

**Which issue this PR fixes** : Fixes #50850 

**Special notes for your reviewer**:

**Release note**:
```release-note
Validate that cronjob names are 52 characters or less
```
