### PR TITLE
[Federation] Updates to enable build from an external repo

### DIFF
--- a/federation/cmd/federation-apiserver/app/options/options.go
+++ b/federation/cmd/federation-apiserver/app/options/options.go
@@ -75,7 +75,8 @@ func NewServerRunOptions() *ServerRunOptions {
 }
 
 // AddFlags adds flags for ServerRunOptions fields to be specified via FlagSet.
-func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
+func (s *ServerRunOptions) AddFlags(untypedfs interface{}) {
+	fs := untypedfs.(*pflag.FlagSet)
 	// Add the generic flags.
 	s.GenericServerRunOptions.AddUniversalFlags(fs)
 	s.Etcd.AddFlags(fs)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -61,7 +61,7 @@ import (
 )
 
 // NewAPIServerCommand creates a *cobra.Command object with default parameters
-func NewAPIServerCommand() *cobra.Command {
+func NewAPIServerCommand() interface{} {
 	s := options.NewServerRunOptions()
 	s.AddFlags(pflag.CommandLine)
 	cmd := &cobra.Command{

--- a/federation/cmd/federation-controller-manager/app/controllermanager.go
+++ b/federation/cmd/federation-controller-manager/app/controllermanager.go
@@ -69,7 +69,7 @@ const (
 )
 
 // NewControllerManagerCommand creates a *cobra.Command object with default parameters
-func NewControllerManagerCommand() *cobra.Command {
+func NewControllerManagerCommand() interface{} {
 	s := options.NewCMServer()
 	s.AddFlags(pflag.CommandLine)
 	cmd := &cobra.Command{

--- a/federation/cmd/federation-controller-manager/app/options/options.go
+++ b/federation/cmd/federation-controller-manager/app/options/options.go
@@ -122,7 +122,8 @@ func NewCMServer() *CMServer {
 }
 
 // AddFlags adds flags for a specific CMServer to the specified FlagSet
-func (s *CMServer) AddFlags(fs *pflag.FlagSet) {
+func (s *CMServer) AddFlags(untypedfs interface{}) {
+	fs := untypedfs.(*pflag.FlagSet)
 	fs.IntVar(&s.Port, "port", s.Port, "The port that the controller-manager's http service runs on")
 	fs.Var(componentconfig.IPVar{Val: &s.Address}, "address", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
 	fs.StringVar(&s.FederationName, "federation-name", s.FederationName, "Federation name.")

--- a/federation/cmd/genfeddocs/BUILD
+++ b/federation/cmd/genfeddocs/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//federation/cmd/kubefed/app:go_default_library",
         "//federation/pkg/kubefed:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/cobra/doc:go_default_library",
     ],
 )

--- a/federation/cmd/genfeddocs/gen_fed_docs.go
+++ b/federation/cmd/genfeddocs/gen_fed_docs.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	"k8s.io/kubernetes/cmd/genutils"
 	fedapiservapp "k8s.io/kubernetes/federation/cmd/federation-apiserver/app"
@@ -55,15 +56,15 @@ func main() {
 	case "federation-apiserver":
 		// generate docs for federated-apiserver
 		apiserver := fedapiservapp.NewAPIServerCommand()
-		doc.GenMarkdownTree(apiserver, outDir)
+		doc.GenMarkdownTree(apiserver.(*cobra.Command), outDir)
 	case "federation-controller-manager":
 		// generate docs for kube-controller-manager
 		controllermanager := fedcmapp.NewControllerManagerCommand()
-		doc.GenMarkdownTree(controllermanager, outDir)
+		doc.GenMarkdownTree(controllermanager.(*cobra.Command), outDir)
 	case "kubefed":
 		// generate docs for kubefed
 		kubefed := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, kubefedapp.GetDefaultServerImage(), kubefedapp.DefaultEtcdImage)
-		doc.GenMarkdownTree(kubefed, outDir)
+		doc.GenMarkdownTree(kubefed.(*cobra.Command), outDir)
 	default:
 		fmt.Fprintf(os.Stderr, "Module %s is not supported", module)
 		os.Exit(1)

--- a/federation/cmd/kubefed/app/BUILD
+++ b/federation/cmd/kubefed/app/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kubectl/util/logs:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
 

--- a/federation/cmd/kubefed/app/kubefed.go
+++ b/federation/cmd/kubefed/app/kubefed.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
 	"k8s.io/kubernetes/pkg/version"
 	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+
+	"github.com/spf13/cobra"
 )
 
 const (
@@ -42,5 +44,5 @@ func Run() error {
 	defer logs.FlushLogs()
 
 	cmd := kubefed.NewKubeFedCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr, GetDefaultServerImage(), DefaultEtcdImage)
-	return cmd.Execute()
+	return cmd.(*cobra.Command).Execute()
 }

--- a/federation/pkg/kubefed/kubefed.go
+++ b/federation/pkg/kubefed/kubefed.go
@@ -41,7 +41,7 @@ var (
 )
 
 // NewKubeFedCommand creates the `kubefed` command and its nested children.
-func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultServerImage, defaultEtcdImage string) *cobra.Command {
+func NewKubeFedCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer, defaultServerImage, defaultEtcdImage string) interface{} {
 	// Parent command to which all subcommands are added.
 	cmds := &cobra.Command{
 		Use:   "kubefed",


### PR DESCRIPTION
Facilitates building the binaries into an external repo, but still use all federation packages from core k8s.
We have chosen to enable this in the interim as per [this plan](https://docs.google.com/document/d/1aMwWigMh7gvihqghIdqqwRRU7-LTH1erKGsHv7rCASo), until federation tooling is up and functional.
Vendoring needed packages in k8s.io/federation and still using all packages from k8s.io/kubernetes does not work without hacks. This is the simplest option to have needed binaries built cleanly into k8s/federation.

**Special notes for your reviewer**:
@kubernetes/sig-federation-misc @kubernetes/sig-federation-pr-reviews 

**Release note**:
```None
```
