### PR TITLE
Revert "Add statefulset upgrade tests to be run as part of upgrade testing"

### DIFF
--- a/test/e2e/lifecycle/cluster_upgrade.go
+++ b/test/e2e/lifecycle/cluster_upgrade.go
@@ -200,7 +200,7 @@ var _ = SIGDescribe("etcd Upgrade [Feature:EtcdUpgrade]", func() {
 	})
 })
 
-var _ = Describe("[sig-apps] stateful Upgrade [Feature:ClusterUpgrade]", func() {
+var _ = Describe("[sig-apps] stateful Upgrade [Feature:StatefulUpgrade]", func() {
 	f := framework.NewDefaultFramework("stateful-upgrade")
 
 	// Create the frameworks here because we can only create them


### PR DESCRIPTION
Reverts kubernetes/kubernetes#52582

This causes us to run multiple upgrades. The ginkgo focus flags we use for the upgrade step need to target exactly one upgrade suite.