### PR TITLE
revamp replicaset kubectl command tests

### DIFF
--- a/hack/testdata/frontend-replicaset.yaml
+++ b/hack/testdata/frontend-replicaset.yaml
@@ -1,22 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-    # app: guestbook
-    # tier: frontend
+  labels:
+    app: guestbook
+    tier: frontend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   template:
     metadata:
       labels:

--- a/hack/testdata/redis-slave-replicaset.yaml
+++ b/hack/testdata/redis-slave-replicaset.yaml
@@ -1,23 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
+  labels:
+    app: redis
+    role: slave
+    tier: backend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: slave
-  #   tier: backend
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:

--- a/hack/testdata/replicaset-with-initializer.yaml
+++ b/hack/testdata/replicaset-with-initializer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: nginx

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -589,7 +589,7 @@ func (f *ring0Factory) CanBeExposed(kind schema.GroupKind) error {
 func (f *ring0Factory) CanBeAutoscaled(kind schema.GroupKind) error {
 	switch kind {
 	case api.Kind("ReplicationController"), extensions.Kind("ReplicaSet"),
-		extensions.Kind("Deployment"), apps.Kind("Deployment"):
+		apps.Kind("ReplicaSet"), extensions.Kind("Deployment"), apps.Kind("Deployment"):
 		// nothing to do here
 	default:
 		return fmt.Errorf("cannot autoscale a %v", kind)

--- a/test/fixtures/doc-yaml/user-guide/replicaset/frontend.yaml
+++ b/test/fixtures/doc-yaml/user-guide/replicaset/frontend.yaml
@@ -1,22 +1,18 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: frontend
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-    # app: guestbook
-    # tier: frontend
+  labels:
+    app: guestbook
+    tier: frontend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 3
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   matchLabels:
-  #     app: guestbook
-  #     tier: frontend
+    selector:
+      matchLabels:
+        app: guestbook
+        tier: frontend
   template:
     metadata:
       labels:

--- a/test/fixtures/doc-yaml/user-guide/replicaset/redis-slave.yaml
+++ b/test/fixtures/doc-yaml/user-guide/replicaset/redis-slave.yaml
@@ -1,23 +1,20 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta2
 kind: ReplicaSet
 metadata:
   name: redis-slave
-  # these labels can be applied automatically
-  # from the labels in the pod template if not set
-  # labels:
-  #   app: redis
-  #   role: slave
-  #   tier: backend
+  labels:
+    app: redis
+    role: slave
+    tier: backend
 spec:
   # this replicas value is default
   # modify it according to your case
   replicas: 2
-  # selector can be applied automatically
-  # from the labels in the pod template if not set
-  # selector:
-  #   app: guestbook
-  #   role: slave
-  #   tier: backend
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR revamps existing replicaset kubectl command tests by changing YAML file to use `apps/v1beta2` API version.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #52118

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```