### PR TITLE
Add UT for DefaultServiceIPRange

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -114,6 +114,7 @@ go_test(
         "import_known_versions_test.go",
         "master_openapi_test.go",
         "master_test.go",
+        "services_test.go",
     ],
     features = ["-race"],
     importpath = "k8s.io/kubernetes/pkg/master",

--- a/pkg/master/services.go
+++ b/pkg/master/services.go
@@ -27,7 +27,6 @@ import (
 
 // DefaultServiceIPRange takes a the serviceIPRange flag and returns the defaulted service ip range (if  needed),
 // api server service IP, and an error
-// TODO move this out of the genericapiserver package
 func DefaultServiceIPRange(passedServiceClusterIPRange net.IPNet) (net.IPNet, net.IP, error) {
 	serviceClusterIPRange := passedServiceClusterIPRange
 	if passedServiceClusterIPRange.IP == nil {
@@ -40,7 +39,7 @@ func DefaultServiceIPRange(passedServiceClusterIPRange net.IPNet) (net.IPNet, ne
 		serviceClusterIPRange = *defaultServiceClusterIPRange
 	}
 	if size := ipallocator.RangeSize(&serviceClusterIPRange); size < 8 {
-		return net.IPNet{}, net.IP{}, fmt.Errorf("The service cluster IP range must be at least %d IP addresses", 8)
+		return net.IPNet{}, net.IP{}, fmt.Errorf("the service cluster IP range must be at least %d IP addresses", 8)
 	}
 
 	// Select the first valid IP from ServiceClusterIPRange to use as the GenericAPIServer service IP.

--- a/pkg/master/services_test.go
+++ b/pkg/master/services_test.go
@@ -71,7 +71,6 @@ func TestDefaultServiceIPRange(t *testing.T) {
 	for _, testCase := range testCases {
 		ipNet, ip, err := DefaultServiceIPRange(testCase.ipNet)
 
-<<<<<<< HEAD
 		if testCase.stopError != nil && err != nil && testCase.stopError.Error() == err.Error() {
 			continue
 		}

--- a/pkg/master/services_test.go
+++ b/pkg/master/services_test.go
@@ -71,6 +71,7 @@ func TestDefaultServiceIPRange(t *testing.T) {
 	for _, testCase := range testCases {
 		ipNet, ip, err := DefaultServiceIPRange(testCase.ipNet)
 
+<<<<<<< HEAD
 		if testCase.stopError != nil && err != nil && testCase.stopError.Error() == err.Error() {
 			continue
 		}

--- a/pkg/master/services_test.go
+++ b/pkg/master/services_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package master
+
+import (
+	"fmt"
+	"net"
+	"reflect"
+	"testing"
+)
+
+func TestDefaultServiceIPRange(t *testing.T) {
+
+	_, normalIpNet, err := net.ParseCIDR("192.168.1.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, badIpNet, err := net.ParseCIDR("192.168.1.0/30")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, defaultIpNet, err := net.ParseCIDR("10.0.0.0/24")
+	if err != nil {
+		t.Fatal(err)
+	}
+	emptyIpNet := net.IPNet{}
+
+	testCases := []struct {
+		name        string
+		ipNet       net.IPNet
+		resultIpNet net.IPNet
+		resultIp    string
+		stopError   error
+	}{
+		{
+			name:        "normal ipNet",
+			ipNet:       *normalIpNet,
+			resultIpNet: *normalIpNet,
+			resultIp:    "192.168.1.1",
+			stopError:   nil,
+		},
+		{
+			name:        "empty ipNet",
+			ipNet:       emptyIpNet,
+			resultIpNet: *defaultIpNet,
+			resultIp:    "10.0.0.1",
+			stopError:   nil,
+		},
+		{
+			name:        "bad ipNet",
+			ipNet:       *badIpNet,
+			resultIpNet: net.IPNet{},
+			resultIp:    "<nil>",
+			stopError:   fmt.Errorf("the service cluster IP range must be at least %d IP addresses", 8),
+		},
+	}
+	for _, testCase := range testCases {
+		ipNet, ip, err := DefaultServiceIPRange(testCase.ipNet)
+
+		if testCase.stopError != nil && err != nil && testCase.stopError.Error() == err.Error() {
+			continue
+		}
+
+		if testCase.stopError != nil && err == nil {
+			t.Errorf("case %v, expected error: %v, but get nil", testCase.name, testCase.stopError)
+		}
+
+		if testCase.stopError == nil && err != nil {
+			t.Errorf("case %v, unexpected error: %v", testCase.name, err)
+		}
+
+		if !reflect.DeepEqual(testCase.resultIpNet, ipNet) {
+			t.Errorf("want ipNet: %v, get: %v", testCase.resultIpNet, ipNet)
+		}
+
+		if !reflect.DeepEqual(testCase.resultIp, ip.String()) {
+			t.Errorf("want ip: %v, get: %v", testCase.resultIp, ip.String())
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
1. Add UT for DefaultServiceIPRange
2. Remove unused TODO  because the code has already move out of the genericapiserver package

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
