### PR TITLE
Minor fix: make sure that glusterfsPlugin implements interface ExpandableVolumePlugin

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -60,6 +60,7 @@ var _ volume.VolumePlugin = &glusterfsPlugin{}
 var _ volume.PersistentVolumePlugin = &glusterfsPlugin{}
 var _ volume.DeletableVolumePlugin = &glusterfsPlugin{}
 var _ volume.ProvisionableVolumePlugin = &glusterfsPlugin{}
+var _ volume.ExpandableVolumePlugin = &glusterfsPlugin{}
 var _ volume.Provisioner = &glusterfsVolumeProvisioner{}
 var _ volume.Deleter = &glusterfsVolumeDeleter{}
 


### PR DESCRIPTION
Attempting an assignment to make sure that `glusterfsPlugin`  implements interface `ExpandableVolumePlugin`, just as we did for `DeletableVolumePlugin`, `PersistentVolumePlugin`


**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/assign @gnufied 
