### PR TITLE
bug(cli)fix kubectl config unset unexist map key will add this key, s…

### DIFF
--- a/pkg/kubectl/cmd/config/set.go
+++ b/pkg/kubectl/cmd/config/set.go
@@ -152,6 +152,9 @@ func modifyConfig(curr reflect.Value, steps *navigationSteps, propertyValue stri
 
 		needToSetNewMapValue := currMapValue.Kind() == reflect.Invalid
 		if needToSetNewMapValue {
+			if unset {
+				return fmt.Errorf("current map key `%v` is invalid", mapKey.Interface())
+			}
 			currMapValue = reflect.New(mapValueType.Elem()).Elem().Addr()
 			actualCurrValue.SetMapIndex(mapKey, currMapValue)
 		}

--- a/pkg/kubectl/cmd/config/unset.go
+++ b/pkg/kubectl/cmd/config/unset.go
@@ -48,16 +48,16 @@ func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobr
 		Short: i18n.T("Unsets an individual value in a kubeconfig file"),
 		Long:  unset_long,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(options.complete(cmd))
-			cmdutil.CheckErr(options.run())
-			fmt.Fprintf(out, "Property %q unset.\n", options.propertyName)
+			cmdutil.CheckErr(options.complete(cmd, args))
+			cmdutil.CheckErr(options.run(out))
+
 		},
 	}
 
 	return cmd
 }
 
-func (o unsetOptions) run() error {
+func (o unsetOptions) run(out io.Writer) error {
 	err := o.validate()
 	if err != nil {
 		return err
@@ -77,16 +77,21 @@ func (o unsetOptions) run() error {
 		return err
 	}
 
-	return clientcmd.ModifyConfig(o.configAccess, *config, false)
+	if err := clientcmd.ModifyConfig(o.configAccess, *config, false); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "Property %q unset.\n", o.propertyName); err != nil {
+		return err
+	}
+	return nil
 }
 
-func (o *unsetOptions) complete(cmd *cobra.Command) error {
-	endingArgs := cmd.Flags().Args()
-	if len(endingArgs) != 1 {
-		return helpErrorf(cmd, "Unexpected args: %v", endingArgs)
+func (o *unsetOptions) complete(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return helpErrorf(cmd, "Unexpected args: %v", args)
 	}
 
-	o.propertyName = endingArgs[0]
+	o.propertyName = args[0]
 	return nil
 }
 


### PR DESCRIPTION
…hould tell user this key not exist

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fixes #43769

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
cc @kubernetes/sig-cli-pr-reviews

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
