### PR TITLE
TestIoHandler should not run on unsupported platforms

### DIFF
--- a/pkg/volume/azure_dd/azure_common_test.go
+++ b/pkg/volume/azure_dd/azure_common_test.go
@@ -119,6 +119,9 @@ func (handler *fakeIOHandler) ReadFile(filename string) ([]byte, error) {
 }
 
 func TestIoHandler(t *testing.T) {
+	if runtime.GOOS != "windows" && runtime.GOOS != "linux" {
+		t.Skipf("TestIoHandler not supported on GOOS=%s", runtime.GOOS)
+	}
 	disk, err := findDiskByLun(lun, &fakeIOHandler{}, mount.NewOsExec())
 	if runtime.GOOS == "windows" {
 		if err != nil {


### PR DESCRIPTION
Fix for failing test on darwin/osx. Skip the test on unsupported (non-windows and non-linux) platforms.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
`make test WHAT=./pkg/volume/azure_dd` doesn't pass on my OSX setup (10.12.6, go1.9, docker 17.06.2) on master. Our [docs on unit tests](https://github.com/kubernetes/community/blob/master/contributors/devel/testing.md#unit-tests)  say they should pass on OS X. This PR allows it to pass.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
