### PR TITLE
[fluentd-gcp addon] Remove audit logs from the fluentd configuration

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -170,15 +170,6 @@ data:
       tag kube-apiserver
     </source>
 
-    # Audit logs in JSON format.
-    <source>
-      type tail
-      format json
-      path /var/log/kube-apiserver-audit.log
-      pos_file /var/log/gcp-kube-apiserver-audit.log.pos
-      tag kube-apiserver-audit
-    </source>
-
     # Example:
     # I0204 06:55:31.872680       5 servicecontroller.go:277] LB already exists and doesn't need update for service kube-system/kube-ui
     <source>
@@ -395,7 +386,7 @@ data:
       num_threads 2
     </match>
 metadata:
-  name: fluentd-gcp-config-v1.2.1
+  name: fluentd-gcp-config-v1.2.2
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -117,7 +117,7 @@ spec:
           path: /usr/lib64
       - name: config-volume
         configMap:
-          name: fluentd-gcp-config-v1.2.1
+          name: fluentd-gcp-config-v1.2.2
       - name: ssl-certs
         hostPath:
           path: /etc/ssl/certs


### PR DESCRIPTION
Since this approach is deprecated, remove support for basic auditing from the fluentd configuration

```releate-note
[fluentd-gcp addon] Default configuration no longer supports basic audit logging.
```