### PR TITLE
Fix url for Saltstack administration document

### DIFF
--- a/cluster/saltbase/README.md
+++ b/cluster/saltbase/README.md
@@ -1,7 +1,7 @@
 # SaltStack configuration
 
 This is the root of the SaltStack configuration for Kubernetes. A high
-level overview for the Kubernetes SaltStack configuration can be found [in the docs tree.](https://kubernetes.io/docs/admin/salt.md)
+level overview for the Kubernetes SaltStack configuration can be found [in the docs tree.](https://kubernetes.io/docs/admin/salt/)
 
 This SaltStack configuration currently applies to default
 configurations for Debian-on-GCE, Fedora-on-Vagrant, Ubuntu-on-AWS and


### PR DESCRIPTION
Got an 404 not found error on `https://kubernetes.io/docs/admin/salt.md`

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Fixed a wrong url in document

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

NONE

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```