### PR TITLE
conversion-gen: make staging dirs independent of living in vendor/

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -685,7 +685,8 @@ $(foreach dir, $(CONVERSION_DIRS),  \
     $(META_DIR)/$(dir)/$(CONVERSIONS_META)):
 	TAGS=$$(grep --color=never -h '^// *+k8s:conversion-gen=' $</*.go   \
 	    | cut -f2- -d=                                                  \
-	    | sed 's|$(PRJ_SRC_PATH)/||');                                  \
+	    | sed 's|$(PRJ_SRC_PATH)/||'                                    \
+	    | sed 's|^k8s.io/|vendor/k8s.io/|');                            \
 	mkdir -p $(@D);                                                     \
 	echo "conversions__$< := $$(echo $${TAGS})" >$@.tmp;                \
 	if ! cmp -s $@.tmp $@; then                                         \

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
+// +k8s:conversion-gen=k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1beta1 is the v1beta1 version of the API.

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/doc.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/apis/testapigroup
+// +k8s:conversion-gen=k8s.io/apimachinery/pkg/apis/testapigroup
 // +k8s:openapi-gen=false
 // +k8s:defaulter-gen=TypeMeta
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/apiserver
+// +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/apiserver
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1alpha1 is the v1alpha1 version of the API.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/audit
+// +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/audit
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/audit
+// +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/audit
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/doc.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/apis/example
+// +k8s:conversion-gen=k8s.io/apiserver/pkg/apis/example
 // +k8s:openapi-gen=false
 // +k8s:defaulter-gen=TypeMeta
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/doc.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration
+// +k8s:conversion-gen=k8s.io/kube-aggregator/pkg/apis/apiregistration
 // +k8s:openapi-gen=true
 
 // Package v1beta1 contains the API Registration API, which is responsible for

--- a/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/custom_metrics/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/metrics/pkg/apis/custom_metrics
+// +k8s:conversion-gen=k8s.io/metrics/pkg/apis/custom_metrics
 // +k8s:openapi-gen=true
 
 package v1beta1

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/metrics/pkg/apis/metrics
+// +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
 
 package v1alpha1

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/metrics/pkg/apis/metrics
+// +k8s:conversion-gen=k8s.io/metrics/pkg/apis/metrics
 // +k8s:openapi-gen=true
 
 package v1beta1


### PR DESCRIPTION
The `+k8s:conversion-gen` tags included the package directory inside of kube's vendor dir. This
makes them invalid when we publish staging repos.

Without this PR our sample-apiserver example code-generation is broken once published.