### PR TITLE
kubeadm-reset: notify about a non-default certificates directory

### DIFF
--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -133,6 +133,9 @@ func (r *Reset) Run(out io.Writer) error {
 	}
 
 	// Remove contents from the config and pki directories
+	if r.certsDir != kubeadmapiext.DefaultCertificatesDir {
+		fmt.Printf("[reset] WARNING: Cleaning a non-default certificates directory: %q\n", r.certsDir)
+	}
 	resetConfigDir(kubeadmconstants.KubernetesDir, r.certsDir)
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The `kubeadm reset` command requires super-user access.
When passing non-default path to the `kubeadm reset` command via `--cert-dir `, the user should be at least warned that a non-standard directory is being cleaned completely.

**Which issue this PR fixes**
/approve no-issue

**Special notes for your reviewer**:
If you think that this can be amended (or even improved as a whole) in some way, please let me know.

**Release note**:
```release-note
Make sure that "kubeadm reset" notifies about cleaning the directory specified by "--cert-dir" with a warning.
```
Lubomir I. Ivanov (VMWare)
