### PR TITLE
restore e2fsprogs in hyperkube image

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -21,6 +21,7 @@ RUN ln -s /bin/sh /bin/bash
 
 RUN echo CACHEBUST>/dev/null && clean-install \
     iptables \
+    e2fsprogs \
     ebtables \
     ethtool \
     ca-certificates \

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=gcr.io/google-containers
 IMAGE?=debian-hyperkube-base
-TAG=0.2
+TAG=0.3
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.2
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.3
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes defaults to the ext4 filesystem if no filesystem is specified. Unformatted filesystems are not able to be mounted without these tools.

The default ext{2,3,4} tools and mkfs.* utilities should be included in the hyperkube image.

**Which issue this PR fixes**: Fixes #52789 #50802

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
