### PR TITLE
[Manual cherrypick #46197 to 1.7] Fix clusterip for ExternalName service test

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -469,7 +469,7 @@ var _ = framework.KubeDescribe("DNS", func() {
 		By("changing the service to type=ClusterIP")
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
 			s.Spec.Type = v1.ServiceTypeClusterIP
-			s.Spec.ClusterIP = "127.1.2.3"
+			s.Spec.ClusterIP = "10.0.0.123"
 			s.Spec.Ports = []v1.ServicePort{
 				{Port: 80, Name: "http", Protocol: "TCP"},
 			}
@@ -484,6 +484,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 		By("creating a third pod to probe DNS")
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, true)
 
-		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, "127.1.2.3")
+		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, "10.0.0.123")
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix failing 1.7 -> 1.8 upgrade suite. See https://github.com/kubernetes/kubernetes/issues/50274 and https://github.com/kubernetes/kubernetes/pull/52759.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/assign @xiangpengzhao @bowei @@abgworrall

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
