### PR TITLE
kubectl: fix golint warnings

### DIFF
--- a/federation/pkg/kubefed/cluster.go
+++ b/federation/pkg/kubefed/cluster.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubefed
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/kubectl"
+)
+
+const (
+	// ServiceAccountNameAnnotation annotation for service account name.
+	ServiceAccountNameAnnotation = "federation.kubernetes.io/servive-account-name"
+	// ClusterRoleNameAnnotation annotation for cluster role name.
+	ClusterRoleNameAnnotation = "federation.kubernetes.io/cluster-role-name"
+)
+
+// ClusterGeneratorV1Beta1 supports stable generation of a
+// federation/cluster resource.
+type ClusterGeneratorV1Beta1 struct {
+	// Name of the cluster context (required)
+	Name string
+	// ClientCIDR is the CIDR range in which the Kubernetes APIServer
+	// is available for the client (optional)
+	ClientCIDR string
+	// ServerAddress is the APIServer address of the Kubernetes cluster
+	// that is being registered (required)
+	ServerAddress string
+	// SecretName is the name of the secret that stores the credentials
+	// for the Kubernetes cluster that is being registered (optional)
+	SecretName string
+	// ServiceAccountName is the name of the service account that is
+	// created in the cluster being registered. If this is provided,
+	// then ClusterRoleName must also be provided (optional)
+	ServiceAccountName string
+	// ClusterRoleName is the name of the cluster role and cluster role
+	// binding that are created in the cluster being registered. If this
+	// is provided, then ServiceAccountName must also be provided
+	// (optional)
+	ClusterRoleName string
+}
+
+// Ensure it supports the generator pattern that uses parameter
+// injection.
+var _ kubectl.Generator = &ClusterGeneratorV1Beta1{}
+
+// Ensure it supports the generator pattern that uses parameters
+// specified during construction.
+var _ kubectl.StructuredGenerator = &ClusterGeneratorV1Beta1{}
+
+// Generate returns a cluster resource using the specified parameters.
+func (s ClusterGeneratorV1Beta1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
+	err := kubectl.ValidateParams(s.ParamNames(), genericParams)
+	if err != nil {
+		return nil, err
+	}
+	clustergen := &ClusterGeneratorV1Beta1{}
+	params := map[string]string{}
+	for key, value := range genericParams {
+		strVal, isString := value.(string)
+		if !isString {
+			return nil, fmt.Errorf("expected string, saw %v for '%s'", value, key)
+		}
+		params[key] = strVal
+	}
+	clustergen.Name = params["name"]
+	clustergen.ClientCIDR = params["client-cidr"]
+	clustergen.ServerAddress = params["server-address"]
+	clustergen.SecretName = params["secret"]
+	clustergen.ServiceAccountName = params["service-account-name"]
+	clustergen.ClusterRoleName = params["cluster-role-name"]
+	return clustergen.StructuredGenerate()
+}
+
+// ParamNames returns the set of supported input parameters when using
+// the parameter injection generator pattern.
+func (s ClusterGeneratorV1Beta1) ParamNames() []kubectl.GeneratorParam {
+	return []kubectl.GeneratorParam{
+		{
+			Name:     "name",
+			Required: true,
+		},
+		{
+			Name:     "client-cidr",
+			Required: false,
+		},
+		{
+			Name:     "server-address",
+			Required: true,
+		},
+		{
+			Name:     "secret",
+			Required: false,
+		},
+		{
+			Name:     "service-account-name",
+			Required: false,
+		},
+		{
+			Name:     "cluster-role-name",
+			Required: false,
+		},
+	}
+}
+
+// StructuredGenerate outputs a federation cluster resource object
+// using the configured fields.
+func (s ClusterGeneratorV1Beta1) StructuredGenerate() (runtime.Object, error) {
+	if err := s.validate(); err != nil {
+		return nil, err
+	}
+	if s.ClientCIDR == "" {
+		s.ClientCIDR = "0.0.0.0/0"
+	}
+	if s.SecretName == "" {
+		s.SecretName = s.Name
+	}
+	cluster := &federationapi.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: s.Name,
+		},
+		Spec: federationapi.ClusterSpec{
+			ServerAddressByClientCIDRs: []federationapi.ServerAddressByClientCIDR{
+				{
+					ClientCIDR:    s.ClientCIDR,
+					ServerAddress: s.ServerAddress,
+				},
+			},
+			SecretRef: &v1.LocalObjectReference{
+				Name: s.SecretName,
+			},
+		},
+	}
+
+	annotations := make(map[string]string)
+	if s.ServiceAccountName != "" {
+		annotations[ServiceAccountNameAnnotation] = s.ServiceAccountName
+	}
+	if s.ClusterRoleName != "" {
+		annotations[ClusterRoleNameAnnotation] = s.ClusterRoleName
+	}
+	if len(annotations) == 1 {
+		return nil, fmt.Errorf("Either both or neither of ServiceAccountName and ClusterRoleName must be provided.")
+	}
+	if len(annotations) > 0 {
+		cluster.SetAnnotations(annotations)
+	}
+
+	return cluster, nil
+}
+
+// validate validates required fields are set to support structured
+// generation.
+func (s ClusterGeneratorV1Beta1) validate() error {
+	if len(s.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+	if len(s.ServerAddress) == 0 {
+		return fmt.Errorf("server address must be specified")
+	}
+	return nil
+}

--- a/pkg/kubectl/apply.go
+++ b/pkg/kubectl/apply.go
@@ -174,8 +174,8 @@ func CreateApplyAnnotation(info *resource.Info, codec runtime.Encoder) error {
 	return SetOriginalConfiguration(info, modified)
 }
 
-// Create the annotation used by kubectl apply only when createAnnotation is true
-// Otherwise, only update the annotation when it already exists
+// CreateOrUpdateAnnotation creates the annotation used by kubectl apply if createAnnotation is true.
+// Otherwise, only update the annotation when it already exists.
 func CreateOrUpdateAnnotation(createAnnotation bool, info *resource.Info, codec runtime.Encoder) error {
 	if createAnnotation {
 		return CreateApplyAnnotation(info, codec)

--- a/pkg/kubectl/autoscale.go
+++ b/pkg/kubectl/autoscale.go
@@ -25,8 +25,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+// HorizontalPodAutoscalerV1 implements the Generate interface.
 type HorizontalPodAutoscalerV1 struct{}
 
+// ParamNames returns the list of parameters that this generator uses.
 func (HorizontalPodAutoscalerV1) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"default-name", true},
@@ -40,6 +42,7 @@ func (HorizontalPodAutoscalerV1) ParamNames() []GeneratorParam {
 	}
 }
 
+// Generate creates an API object given a set of parameters.
 func (HorizontalPodAutoscalerV1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
 	return generateHPA(genericParams)
 }
@@ -58,7 +61,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	if !found || len(name) == 0 {
 		name, found = params["default-name"]
 		if !found || len(name) == 0 {
-			return nil, fmt.Errorf("'name' is a required parameter.")
+			return nil, fmt.Errorf("'name' is a required parameter")
 		}
 	}
 	minString, found := params["min"]
@@ -71,7 +74,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 	maxString, found := params["max"]
 	if !found {
-		return nil, fmt.Errorf("'max' is a required parameter.")
+		return nil, fmt.Errorf("'max' is a required parameter")
 	}
 	max, err := strconv.Atoi(maxString)
 	if err != nil {
@@ -79,7 +82,7 @@ func generateHPA(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 
 	if min > max {
-		return nil, fmt.Errorf("'max' must be greater than or equal to 'min'.")
+		return nil, fmt.Errorf("'max' must be greater than or equal to 'min'")
 	}
 
 	cpuString, found := params["cpu-percent"]

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -388,7 +388,7 @@ func findNewName(args []string, oldRc *api.ReplicationController) string {
 		return args[1]
 	}
 	if oldRc != nil {
-		newName, _ := kubectl.GetNextControllerAnnotation(oldRc)
+		newName, _ := kubectl.NextControllerAnnotation(oldRc)
 		return newName
 	}
 	return ""

--- a/pkg/kubectl/configmap.go
+++ b/pkg/kubectl/configmap.go
@@ -201,7 +201,7 @@ func handleConfigMapFromFileSources(configMap *v1.ConfigMap, fileSources []strin
 		}
 		if info.IsDir() {
 			if strings.Contains(fileSource, "=") {
-				return fmt.Errorf("cannot give a key name for a directory path.")
+				return fmt.Errorf("cannot give a key name for a directory path")
 			}
 			fileList, err := ioutil.ReadDir(filePath)
 			if err != nil {
@@ -266,7 +266,7 @@ func addKeyFromLiteralToConfigMap(configMap *v1.ConfigMap, keyName, data string)
 		return fmt.Errorf("%q is not a valid key name for a ConfigMap: %s", keyName, strings.Join(errs, ";"))
 	}
 	if _, entryExists := configMap.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, configMap.Data)
+		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v", keyName, configMap.Data)
 	}
 	configMap.Data[keyName] = data
 	return nil

--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -41,8 +41,11 @@ import (
 )
 
 const (
+	// Interval is the default poll interval.
 	Interval = time.Second * 1
-	Timeout  = time.Minute * 5
+
+	// Timeout is the default time to wait for termination.
+	Timeout = time.Minute * 5
 )
 
 // A Reaper terminates an object as gracefully as possible.
@@ -54,19 +57,23 @@ type Reaper interface {
 	Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error
 }
 
+// NoSuchReaperError implements the error interface.
 type NoSuchReaperError struct {
 	kind schema.GroupKind
 }
 
+// Error returns an error message string.
 func (n *NoSuchReaperError) Error() string {
 	return fmt.Sprintf("no reaper has been implemented for %v", n.kind)
 }
 
+// IsNoSuchReaperError returns true if err is of type NoSuchReaperError.
 func IsNoSuchReaperError(err error) bool {
 	_, ok := err.(*NoSuchReaperError)
 	return ok
 }
 
+// ReaperFor returns a Reaper for the resource specified by kind.
 func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, error) {
 	switch kind {
 	case api.Kind("ReplicationController"):
@@ -94,35 +101,49 @@ func ReaperFor(kind schema.GroupKind, c internalclientset.Interface) (Reaper, er
 	return nil, &NoSuchReaperError{kind}
 }
 
+// ReaperForReplicationController returns an ReplicationControllerReaper for rcClient.
 func ReaperForReplicationController(rcClient coreclient.ReplicationControllersGetter, timeout time.Duration) (Reaper, error) {
 	return &ReplicationControllerReaper{rcClient, Interval, timeout}, nil
 }
 
+// ReplicationControllerReaper implements the Reaper interface.
 type ReplicationControllerReaper struct {
 	client                coreclient.ReplicationControllersGetter
 	pollInterval, timeout time.Duration
 }
+
+// ReplicaSetReaper implements the Reaper interface.
 type ReplicaSetReaper struct {
 	client                extensionsclient.ReplicaSetsGetter
 	pollInterval, timeout time.Duration
 }
+
+// DaemonSetReaper implements the Reaper interface.
 type DaemonSetReaper struct {
 	client                extensionsclient.DaemonSetsGetter
 	pollInterval, timeout time.Duration
 }
+
+// JobReaper implements the Reaper interface.
 type JobReaper struct {
 	client                batchclient.JobsGetter
 	podClient             coreclient.PodsGetter
 	pollInterval, timeout time.Duration
 }
+
+// DeploymentReaper implements the Reaper interface.
 type DeploymentReaper struct {
 	dClient               extensionsclient.DeploymentsGetter
 	rsClient              extensionsclient.ReplicaSetsGetter
 	pollInterval, timeout time.Duration
 }
+
+// PodReaper implements the Reaper interface.
 type PodReaper struct {
 	client coreclient.PodsGetter
 }
+
+// StatefulSetReaper implements the Reaper interface.
 type StatefulSetReaper struct {
 	client                appsclient.StatefulSetsGetter
 	podClient             coreclient.PodsGetter
@@ -146,6 +167,7 @@ func getOverlappingControllers(rcClient coreclient.ReplicationControllerInterfac
 	return matchingRCs, nil
 }
 
+// Stop a given object within a namespace.
 func (reaper *ReplicationControllerReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	rc := reaper.client.ReplicationControllers(namespace)
 	scaler := &ReplicationControllerScaler{reaper.client}
@@ -215,6 +237,7 @@ func getOverlappingReplicaSets(c extensionsclient.ReplicaSetInterface, rs *exten
 	return overlappingRSs, exactMatchRSs, nil
 }
 
+// Stop a given object within a namespace.
 func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	rsc := reaper.client.ReplicaSets(namespace)
 	scaler := &ReplicaSetScaler{reaper.client}
@@ -279,6 +302,7 @@ func (reaper *ReplicaSetReaper) Stop(namespace, name string, timeout time.Durati
 	return rsc.Delete(name, deleteOptions)
 }
 
+// Stop a given object within a namespace.
 func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	ds, err := reaper.client.DaemonSets(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
@@ -316,6 +340,7 @@ func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duratio
 	return reaper.client.DaemonSets(namespace).Delete(name, deleteOptions)
 }
 
+// Stop a given object within a namespace.
 func (reaper *StatefulSetReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	statefulsets := reaper.client.StatefulSets(namespace)
 	scaler := &StatefulSetScaler{reaper.client}
@@ -344,6 +369,7 @@ func (reaper *StatefulSetReaper) Stop(namespace, name string, timeout time.Durat
 	return statefulsets.Delete(name, deleteOptions)
 }
 
+// Stop a given object within a namespace.
 func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	jobs := reaper.client.Jobs(namespace)
 	pods := reaper.podClient.Pods(namespace)
@@ -389,6 +415,7 @@ func (reaper *JobReaper) Stop(namespace, name string, timeout time.Duration, gra
 	return jobs.Delete(name, deleteOptions)
 }
 
+// Stop a given object within a namespace.
 func (reaper *DeploymentReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	deployments := reaper.dClient.Deployments(namespace)
 	rsReaper := &ReplicaSetReaper{reaper.rsClient, reaper.pollInterval, reaper.timeout}
@@ -477,6 +504,7 @@ func (reaper *DeploymentReaper) updateDeploymentWithRetries(namespace, name stri
 	return deployment, err
 }
 
+// Stop a given object within a namespace.
 func (reaper *PodReaper) Stop(namespace, name string, timeout time.Duration, gracePeriod *metav1.DeleteOptions) error {
 	pods := reaper.client.Pods(namespace)
 	_, err := pods.Get(name, metav1.GetOptions{})

--- a/pkg/kubectl/deployment.go
+++ b/pkg/kubectl/deployment.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// BaseDeploymentGenerator: implement the common functionality of
+// BaseDeploymentGenerator implements the common functionality of
 // DeploymentBasicGeneratorV1 and DeploymentBasicAppsGeneratorV1. To reduce
 // confusion, it's best to keep this struct in the same file as those
 // generators.

--- a/pkg/kubectl/generate.go
+++ b/pkg/kubectl/generate.go
@@ -51,6 +51,7 @@ type StructuredGenerator interface {
 	StructuredGenerate() (runtime.Object, error)
 }
 
+// IsZero returns true if i is nil or the zero value for its type.
 func IsZero(i interface{}) bool {
 	if i == nil {
 		return true
@@ -98,7 +99,7 @@ func AnnotateFlags(cmd *cobra.Command, generators map[string]Generator) {
 	}
 }
 
-//  EnsureFlagsValid ensures that no invalid flags are being used against a generator.
+// EnsureFlagsValid ensures that no invalid flags are being used against a generator.
 func EnsureFlagsValid(cmd *cobra.Command, generators map[string]Generator, generatorInUse string) error {
 	AnnotateFlags(cmd, generators)
 
@@ -136,6 +137,7 @@ func MakeParams(cmd *cobra.Command, params []GeneratorParam) map[string]interfac
 	return result
 }
 
+// MakeProtocols flattens protocols map into form "key1/val1,key2/val2, ..."
 func MakeProtocols(protocols map[string]string) string {
 	out := []string{}
 	for key, value := range protocols {
@@ -144,6 +146,8 @@ func MakeProtocols(protocols map[string]string) string {
 	return strings.Join(out, ",")
 }
 
+// ParseProtocols builds a map out of protocols.
+// protocols is of form "port1/protocol1,port2/protocol2, ..."
 func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	protocolsString, isString := protocols.(string)
 	if !isString {
@@ -170,6 +174,7 @@ func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	return portProtocolMap, nil
 }
 
+// MakeLabels flattens labels map into form "key1=val1,key2=val2, ..."
 func MakeLabels(labels map[string]string) string {
 	out := []string{}
 	for key, value := range labels {
@@ -202,10 +207,12 @@ func ParseLabels(labelSpec interface{}) (map[string]string, error) {
 	return labels, nil
 }
 
+// GetBool returns the boolean value represented by the string in params map for key.
+// If key is not in map, returns defValue.
 func GetBool(params map[string]string, key string, defValue bool) (bool, error) {
-	if val, found := params[key]; !found {
+	val, found := params[key]
+	if !found {
 		return defValue, nil
-	} else {
-		return strconv.ParseBool(val)
 	}
+	return strconv.ParseBool(val)
 }

--- a/pkg/kubectl/history.go
+++ b/pkg/kubectl/history.go
@@ -45,14 +45,16 @@ import (
 )
 
 const (
+	// ChangeCauseAnnotation change-cause annotation.
 	ChangeCauseAnnotation = "kubernetes.io/change-cause"
 )
 
-// HistoryViewer provides an interface for resources have historical information.
+// HistoryViewer provides an interface for resources that have historical information.
 type HistoryViewer interface {
 	ViewHistory(namespace, name string, revision int64) (string, error)
 }
 
+// HistoryViewerFor returns a HistoryViewer for a resource specified by kind.
 func HistoryViewerFor(kind schema.GroupKind, c clientset.Interface) (HistoryViewer, error) {
 	switch kind {
 	case extensions.Kind("Deployment"), apps.Kind("Deployment"):
@@ -65,11 +67,12 @@ func HistoryViewerFor(kind schema.GroupKind, c clientset.Interface) (HistoryView
 	return nil, fmt.Errorf("no history viewer has been implemented for %q", kind)
 }
 
+// DeploymentHistoryViewer implements the HistoryViewer interface.
 type DeploymentHistoryViewer struct {
 	c clientset.Interface
 }
 
-// ViewHistory returns a revision-to-replicaset map as the revision history of a deployment
+// ViewHistory returns a revision-to-replicaset map as the revision history of a deployment.
 // TODO: this should be a describer
 func (h *DeploymentHistoryViewer) ViewHistory(namespace, name string, revision int64) (string, error) {
 	versionedExtensionsClient := versionedExtensionsClientV1beta1(h.c)
@@ -147,11 +150,12 @@ func printTemplate(template *v1.PodTemplateSpec) (string, error) {
 	return buf.String(), nil
 }
 
+// DaemonSetHistoryViewer implements the HistoryViewer interface.
 type DaemonSetHistoryViewer struct {
 	c clientset.Interface
 }
 
-// ViewHistory returns a revision-to-history map as the revision history of a deployment
+// ViewHistory returns a revision-to-history map as the revision history of a deployment.
 // TODO: this should be a describer
 func (h *DaemonSetHistoryViewer) ViewHistory(namespace, name string, revision int64) (string, error) {
 	versionedAppsClient := versionedAppsClientV1beta1(h.c)
@@ -211,6 +215,7 @@ func (h *DaemonSetHistoryViewer) ViewHistory(namespace, name string, revision in
 	})
 }
 
+// StatefulSetHistoryViewer implements the HistoryViewer interface.
 type StatefulSetHistoryViewer struct {
 	c clientset.Interface
 }
@@ -226,7 +231,7 @@ func getOwner(revision apps.ControllerRevision) *metav1.OwnerReference {
 	return nil
 }
 
-// ViewHistory returns a list of the revision history of a statefulset
+// ViewHistory returns a revision-to-history map as the revision history of a deployment.
 // TODO: this should be a describer
 // TODO: needs to implement detailed revision view
 func (h *StatefulSetHistoryViewer) ViewHistory(namespace, name string, revision int64) (string, error) {
@@ -263,7 +268,7 @@ func (h *StatefulSetHistoryViewer) ViewHistory(namespace, name string, revision 
 	})
 }
 
-// controlledHistories returns all ControllerRevisions controlled by the given API object
+// controlledHistories returns all ControllerRevisions controlled by the given API object.
 func controlledHistories(apps clientappsv1beta1.AppsV1beta1Interface, extensions clientextensionsv1beta1.ExtensionsV1beta1Interface, namespace, name, kind string) (runtime.Object, []*appsv1beta1.ControllerRevision, error) {
 	var obj runtime.Object
 	var labelSelector *metav1.LabelSelector
@@ -310,7 +315,7 @@ func controlledHistories(apps clientappsv1beta1.AppsV1beta1Interface, extensions
 	return obj, result, nil
 }
 
-// applyHistory returns a specific revision of DaemonSet by applying the given history to a copy of the given DaemonSet
+// applyHistory returns a specific revision of DaemonSet by applying the given history to a copy of the given DaemonSet.
 func applyHistory(ds *extensionsv1beta1.DaemonSet, history *appsv1beta1.ControllerRevision) (*extensionsv1beta1.DaemonSet, error) {
 	obj, err := legacyscheme.Scheme.New(ds.GroupVersionKind())
 	if err != nil {
@@ -348,7 +353,7 @@ func tabbedString(f func(io.Writer) error) (string, error) {
 	return str, nil
 }
 
-// getChangeCause returns the change-cause annotation of the input object
+// getChangeCause returns the change-cause annotation of the input object.
 func getChangeCause(obj runtime.Object) string {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// A set of common functions needed by cmd/kubectl and pkg/kubectl packages.
+// Package kubectl provides a set of common functions needed by the cmd/kubectl and pkg/kubectl packages.
 package kubectl
 
 import (

--- a/pkg/kubectl/quota.go
+++ b/pkg/kubectl/quota.go
@@ -97,8 +97,8 @@ func (g *ResourceQuotaGeneratorV1) StructuredGenerate() (runtime.Object, error) 
 }
 
 // validate validates required fields are set to support structured generation
-func (r *ResourceQuotaGeneratorV1) validate() error {
-	if len(r.Name) == 0 {
+func (g *ResourceQuotaGeneratorV1) validate() error {
+	if len(g.Name) == 0 {
 		return fmt.Errorf("name must be specified")
 	}
 	return nil

--- a/pkg/kubectl/resource_filter.go
+++ b/pkg/kubectl/resource_filter.go
@@ -32,6 +32,7 @@ type FilterFunc func(runtime.Object, printers.PrintOptions) bool
 // Filters is a collection of filter funcs
 type Filters []FilterFunc
 
+// NewResourceFilter returns single element filter list containing filterPods().
 func NewResourceFilter() Filters {
 	return []FilterFunc{
 		filterPods,
@@ -69,7 +70,7 @@ func (f Filters) Filter(obj runtime.Object, opts *printers.PrintOptions) (bool, 
 	return false, nil
 }
 
-// check if the object is unstructured. If so, let's attempt to convert it to a type we can understand.
+// DecodeUnknownObject attempts to convert object, if is unstructured, to a type we can understand.
 func DecodeUnknownObject(obj runtime.Object) (runtime.Object, error) {
 	var err error
 

--- a/pkg/kubectl/rolling_updater.go
+++ b/pkg/kubectl/rolling_updater.go
@@ -43,7 +43,7 @@ import (
 
 const (
 	kubectlAnnotationPrefix    = "kubectl.kubernetes.io/"
-	sourceIdAnnotation         = kubectlAnnotationPrefix + "update-source-id"
+	sourceIDAnnotation         = kubectlAnnotationPrefix + "update-source-id"
 	desiredReplicasAnnotation  = kubectlAnnotationPrefix + "desired-replicas"
 	originalReplicasAnnotation = kubectlAnnotationPrefix + "original-replicas"
 	nextControllerAnnotation   = kubectlAnnotationPrefix + "next-controller-id"
@@ -123,7 +123,7 @@ type RollingUpdater struct {
 	scaleAndWait func(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error)
 	//getOrCreateTargetController gets and validates an existing controller or
 	//makes a new one.
-	getOrCreateTargetController func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error)
+	getOrCreateTargetController func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error)
 	// cleanup performs post deployment cleanup tasks for newRc and oldRc.
 	cleanup func(oldRc, newRc *api.ReplicationController, config *RollingUpdaterConfig) error
 	// getReadyPods returns the amount of old and new ready pods.
@@ -175,8 +175,8 @@ func (r *RollingUpdater) Update(config *RollingUpdaterConfig) error {
 
 	// Find an existing controller (for continuing an interrupted update) or
 	// create a new one if necessary.
-	sourceId := fmt.Sprintf("%s:%s", oldRc.Name, oldRc.UID)
-	newRc, existed, err := r.getOrCreateTargetController(config.NewRc, sourceId)
+	sourceID := fmt.Sprintf("%s:%s", oldRc.Name, oldRc.UID)
+	newRc, existed, err := r.getOrCreateTargetController(config.NewRc, sourceID)
 	if err != nil {
 		return err
 	}
@@ -447,14 +447,14 @@ func (r *RollingUpdater) readyPods(oldRc, newRc *api.ReplicationController, minR
 }
 
 // getOrCreateTargetControllerWithClient looks for an existing controller with
-// sourceId. If found, the existing controller is returned with true
+// sourceID. If found, the existing controller is returned with true
 // indicating that the controller already exists. If the controller isn't
 // found, a new one is created and returned along with false indicating the
 // controller was created.
 //
-// Existing controllers are validated to ensure their sourceIdAnnotation
-// matches sourceId; if there's a mismatch, an error is returned.
-func (r *RollingUpdater) getOrCreateTargetControllerWithClient(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+// Existing controllers are validated to ensure their sourceIDAnnotation
+// matches sourceID; if there's a mismatch, an error is returned.
+func (r *RollingUpdater) getOrCreateTargetControllerWithClient(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 	existingRc, err := r.existingController(controller)
 	if err != nil {
 		if !errors.IsNotFound(err) {
@@ -470,17 +470,17 @@ func (r *RollingUpdater) getOrCreateTargetControllerWithClient(controller *api.R
 			controller.Annotations = map[string]string{}
 		}
 		controller.Annotations[desiredReplicasAnnotation] = fmt.Sprintf("%d", controller.Spec.Replicas)
-		controller.Annotations[sourceIdAnnotation] = sourceId
+		controller.Annotations[sourceIDAnnotation] = sourceID
 		controller.Spec.Replicas = 0
 		newRc, err := r.rcClient.ReplicationControllers(r.ns).Create(controller)
 		return newRc, false, err
 	}
 	// Validate and use the existing controller.
 	annotations := existingRc.Annotations
-	source := annotations[sourceIdAnnotation]
+	source := annotations[sourceIDAnnotation]
 	_, ok := annotations[desiredReplicasAnnotation]
-	if source != sourceId || !ok {
-		return nil, false, fmt.Errorf("Missing/unexpected annotations for controller %s, expected %s : %s", controller.Name, sourceId, annotations)
+	if source != sourceID || !ok {
+		return nil, false, fmt.Errorf("missing/unexpected annotations for controller %s, expected %s : %s", controller.Name, sourceID, annotations)
 	}
 	return existingRc, true, nil
 }
@@ -506,7 +506,7 @@ func (r *RollingUpdater) cleanupWithClients(oldRc, newRc *api.ReplicationControl
 		return err
 	}
 	applyUpdate := func(rc *api.ReplicationController) {
-		delete(rc.Annotations, sourceIdAnnotation)
+		delete(rc.Annotations, sourceIDAnnotation)
 		delete(rc.Annotations, desiredReplicasAnnotation)
 	}
 	if newRc, err = updateRcWithRetries(r.rcClient, r.ns, newRc, applyUpdate); err != nil {
@@ -541,6 +541,8 @@ func (r *RollingUpdater) cleanupWithClients(oldRc, newRc *api.ReplicationControl
 	}
 }
 
+// Rename renames a ReplicationController. First deletes RC and its orphaned pods
+// then creates an RC with the newName.
 func Rename(c coreclient.ReplicationControllersGetter, rc *api.ReplicationController, newName string) error {
 	oldName := rc.Name
 	rc.Name = newName
@@ -569,6 +571,7 @@ func Rename(c coreclient.ReplicationControllersGetter, rc *api.ReplicationContro
 	return err
 }
 
+// LoadExistingNextReplicationController gets the next RC for namespace and newName.
 func LoadExistingNextReplicationController(c coreclient.ReplicationControllersGetter, namespace, newName string) (*api.ReplicationController, error) {
 	if len(newName) == 0 {
 		return nil, nil
@@ -580,6 +583,7 @@ func LoadExistingNextReplicationController(c coreclient.ReplicationControllersGe
 	return newRc, err
 }
 
+// NewControllerConfig is the configuration for a new RC.
 type NewControllerConfig struct {
 	Namespace        string
 	OldName, NewName string
@@ -589,6 +593,8 @@ type NewControllerConfig struct {
 	PullPolicy       api.PullPolicy
 }
 
+// CreateNewControllerFromCurrentController creates a new RC from an existing RC
+// with the new configuration in cfg.
 func CreateNewControllerFromCurrentController(rcClient coreclient.ReplicationControllersGetter, codec runtime.Codec, cfg *NewControllerConfig) (*api.ReplicationController, error) {
 	containerIndex := 0
 	// load the old RC into the "new" RC
@@ -642,6 +648,7 @@ func CreateNewControllerFromCurrentController(rcClient coreclient.ReplicationCon
 	return newRc, nil
 }
 
+// AbortRollingUpdate aborts a rolling update.
 func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	// Swap the controllers
 	tmp := c.OldRc
@@ -651,7 +658,7 @@ func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	if c.NewRc.Annotations == nil {
 		c.NewRc.Annotations = map[string]string{}
 	}
-	c.NewRc.Annotations[sourceIdAnnotation] = fmt.Sprintf("%s:%s", c.OldRc.Name, c.OldRc.UID)
+	c.NewRc.Annotations[sourceIDAnnotation] = fmt.Sprintf("%s:%s", c.OldRc.Name, c.OldRc.UID)
 
 	// Use the original value since the replica count change from old to new
 	// could be asymmetric. If we don't know the original count, we can't safely
@@ -666,11 +673,13 @@ func AbortRollingUpdate(c *RollingUpdaterConfig) error {
 	return nil
 }
 
-func GetNextControllerAnnotation(rc *api.ReplicationController) (string, bool) {
+// NextControllerAnnotation gets the annotation for the next RC.
+func NextControllerAnnotation(rc *api.ReplicationController) (string, bool) {
 	res, found := rc.Annotations[nextControllerAnnotation]
 	return res, found
 }
 
+// SetNextControllerAnnotation sets the annotation for the next RC.
 func SetNextControllerAnnotation(rc *api.ReplicationController, name string) {
 	if rc.Annotations == nil {
 		rc.Annotations = map[string]string{}
@@ -678,6 +687,7 @@ func SetNextControllerAnnotation(rc *api.ReplicationController, name string) {
 	rc.Annotations[nextControllerAnnotation] = name
 }
 
+// UpdateExistingReplicationController updates an existing RC.
 func UpdateExistingReplicationController(rcClient coreclient.ReplicationControllersGetter, podClient coreclient.PodsGetter, oldRc *api.ReplicationController, namespace, newName, deploymentKey, deploymentValue string, out io.Writer) (*api.ReplicationController, error) {
 	if _, found := oldRc.Spec.Selector[deploymentKey]; !found {
 		SetNextControllerAnnotation(oldRc, newName)
@@ -692,6 +702,7 @@ func UpdateExistingReplicationController(rcClient coreclient.ReplicationControll
 	return updateRcWithRetries(rcClient, namespace, oldRc, applyUpdate)
 }
 
+// AddDeploymentKeyToReplicationController adds a deployment key to an RC.
 func AddDeploymentKeyToReplicationController(oldRc *api.ReplicationController, rcClient coreclient.ReplicationControllersGetter, podClient coreclient.PodsGetter, deploymentKey, deploymentValue, namespace string, out io.Writer) (*api.ReplicationController, error) {
 	var err error
 	// First, update the template label.  This ensures that any newly created pods will have the new label
@@ -823,6 +834,7 @@ func updatePodWithRetries(podClient coreclient.PodsGetter, namespace string, pod
 	return pod, err
 }
 
+// FindSourceController finds an existing RC with annotation for source ID namespace/name.
 func FindSourceController(r coreclient.ReplicationControllersGetter, namespace, name string) (*api.ReplicationController, error) {
 	list, err := r.ReplicationControllers(namespace).List(metav1.ListOptions{})
 	if err != nil {
@@ -830,9 +842,9 @@ func FindSourceController(r coreclient.ReplicationControllersGetter, namespace, 
 	}
 	for ix := range list.Items {
 		rc := &list.Items[ix]
-		if rc.Annotations != nil && strings.HasPrefix(rc.Annotations[sourceIdAnnotation], name) {
+		if rc.Annotations != nil && strings.HasPrefix(rc.Annotations[sourceIDAnnotation], name) {
 			return rc, nil
 		}
 	}
-	return nil, fmt.Errorf("couldn't find a replication controller with source id == %s/%s", namespace, name)
+	return nil, fmt.Errorf("couldn't find a replication controller with source ID == %s/%s", namespace, name)
 }

--- a/pkg/kubectl/rolling_updater_test.go
+++ b/pkg/kubectl/rolling_updater_test.go
@@ -85,7 +85,7 @@ func newRc(replicas int, desired int) *api.ReplicationController {
 		Name:      "foo-v2",
 		Annotations: map[string]string{
 			desiredReplicasAnnotation: fmt.Sprintf("%d", desired),
-			sourceIdAnnotation:        "foo-v1:7764ae47-9092-11e4-8393-42010af018ff",
+			sourceIDAnnotation:        "foo-v1:7764ae47-9092-11e4-8393-42010af018ff",
 		},
 	}
 	return rc
@@ -810,7 +810,7 @@ Scaling foo-v2 up to 2
 				rc.Status.Replicas = rc.Spec.Replicas
 				return rc, nil
 			},
-			getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+			getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 				// Simulate a create vs. update of an existing controller.
 				return test.newRc, test.newRcExists, nil
 			},
@@ -862,7 +862,7 @@ func TestUpdate_progressTimeout(t *testing.T) {
 			// Do nothing.
 			return rc, nil
 		},
-		getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+		getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 			return newRc, false, nil
 		},
 		cleanup: func(oldRc, newRc *api.ReplicationController, config *RollingUpdaterConfig) error {
@@ -906,7 +906,7 @@ func TestUpdate_assignOriginalAnnotation(t *testing.T) {
 		scaleAndWait: func(rc *api.ReplicationController, retry *RetryParams, wait *RetryParams) (*api.ReplicationController, error) {
 			return rc, nil
 		},
-		getOrCreateTargetController: func(controller *api.ReplicationController, sourceId string) (*api.ReplicationController, bool, error) {
+		getOrCreateTargetController: func(controller *api.ReplicationController, sourceID string) (*api.ReplicationController, bool, error) {
 			return newRc, false, nil
 		},
 		cleanup: func(oldRc, newRc *api.ReplicationController, config *RollingUpdaterConfig) error {
@@ -1235,7 +1235,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "foo",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "bar:1234",
+				sourceIDAnnotation: "bar:1234",
 			},
 		},
 	}
@@ -1244,7 +1244,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "bar",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "foo:12345",
+				sourceIDAnnotation: "foo:12345",
 			},
 		},
 	}
@@ -1253,7 +1253,7 @@ func TestFindSourceController(t *testing.T) {
 			Namespace: metav1.NamespaceDefault,
 			Name:      "baz",
 			Annotations: map[string]string{
-				sourceIdAnnotation: "baz:45667",
+				sourceIDAnnotation: "baz:45667",
 			},
 		},
 	}

--- a/pkg/kubectl/run.go
+++ b/pkg/kubectl/run.go
@@ -236,7 +236,7 @@ func getName(params map[string]string) (string, error) {
 	if !found || len(name) == 0 {
 		name, found = params["default-name"]
 		if !found || len(name) == 0 {
-			return "", fmt.Errorf("'name' is a required parameter.")
+			return "", fmt.Errorf("'name' is a required parameter")
 		}
 	}
 	return name, nil

--- a/pkg/kubectl/secret.go
+++ b/pkg/kubectl/secret.go
@@ -203,7 +203,7 @@ func handleFromFileSources(secret *v1.Secret, fileSources []string) error {
 		}
 		if info.IsDir() {
 			if strings.Contains(fileSource, "=") {
-				return fmt.Errorf("cannot give a key name for a directory path.")
+				return fmt.Errorf("cannot give a key name for a directory path")
 			}
 			fileList, err := ioutil.ReadDir(filePath)
 			if err != nil {
@@ -263,7 +263,7 @@ func addKeyFromLiteralToSecret(secret *v1.Secret, keyName string, data []byte) e
 	}
 
 	if _, entryExists := secret.Data[keyName]; entryExists {
-		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v.", keyName, secret.Data)
+		return fmt.Errorf("cannot add key %s, another key by that name already exists: %v", keyName, secret.Data)
 	}
 	secret.Data[keyName] = data
 	return nil

--- a/pkg/kubectl/service.go
+++ b/pkg/kubectl/service.go
@@ -87,7 +87,7 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 	}
 	selectorString, found := params["selector"]
 	if !found || len(selectorString) == 0 {
-		return nil, fmt.Errorf("'selector' is a required parameter.")
+		return nil, fmt.Errorf("'selector' is a required parameter")
 	}
 	selector, err := ParseLabels(selectorString)
 	if err != nil {
@@ -107,7 +107,7 @@ func generate(genericParams map[string]interface{}) (runtime.Object, error) {
 	if !found || len(name) == 0 {
 		name, found = params["default-name"]
 		if !found || len(name) == 0 {
-			return nil, fmt.Errorf("'name' is a required parameter.")
+			return nil, fmt.Errorf("'name' is a required parameter")
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently code in `pkg/kubectl` generates various `golint` warnings. The majority of these are for documentation and punctuation on error strings. 

This PR fixes the majority of the `golint` warnings for `pkg/kubectl` excluding subdirectories. Also, since there is an outstanding effort to move generators to a sub package this PR does not fix warnings around generator code.

**Special notes for your reviewer**:

This work was previously submitted as numerous small PR's but on request from @soltysh these have been closed and combined into a single big PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
