### PR TITLE
Fix broken statefulset e2e test

### DIFF
--- a/test/e2e/testing-manifests/statefulset/cockroachdb/service.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/service.yaml
@@ -1,28 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  # This service is meant to be used by clients of the database. It exposes a ClusterIP that will
-  # automatically load balance connections to the different database pods.
-  name: cockroachdb-public
-  labels:
-    app: cockroachdb
-spec:
-  ports:
-  # The main port, served by gRPC, serves Postgres-flavor SQL, internode
-  # traffic and the cli.
-  - port: 26257
-    targetPort: 26257
-    name: grpc
-  # The secondary port serves the UI as well as health and debug endpoints.
-  - port: 8080
-    targetPort: 8080
-    name: http
-  selector:
-    app: cockroachdb
----
-apiVersion: v1
-kind: Service
-metadata:
   # This service only exists to create DNS entries for each pod in the stateful
   # set such that they can resolve each other's IP addresses. It does not
   # create a load-balanced ClusterIP and should not be used directly by clients

--- a/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/cockroachdb/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
               # We don't join cockroachdb in order to avoid a node attempting
               # to join itself, which currently doesn't work
               # (https://github.com/cockroachdb/cockroach/issues/9625).
-              CRARGS+=("--join" "cockroachdb-public")
+              CRARGS+=("--join" "cockroachdb-0.cockroachdb,cockroachdb-1.cockroachdb,cockroachdb-2.cockroachdb")
             fi
             exec /cockroach/cockroach ${CRARGS[*]}
       # No pre-stop hook is required, a SIGTERM plus some time is all that's


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the CockroachDB statefulset e2e test.

This was broken back in #43637 when the logic in
`(*StatefulSetTester).CreateStatefulSet` switched from using
`generated.ReadOrDie` to read the entire service.yaml file and pass it
to kubectl to using `manifest.SvcFromManifest`, which assumes that the
file contains only a single service.

To fix the test, just remove the second service, which isn't needed to test the Statefulset functionality.

**Which issue this PR fixes**:

Fixes #52750

**Special notes for your reviewer**:

N/A

**Release note**:
```release-note
NONE
```
