### PR TITLE
Mark the LBaaS v1 of OpenStack cloud provider deprecated

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -520,6 +520,9 @@ func (os *OpenStack) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
 	if lbVersion == "v2" {
 		return &LbaasV2{LoadBalancer{network, compute, os.lbOpts}}, true
 	} else if lbVersion == "v1" {
+		// Since LBaaS v1 is deprecated in the OpenStack Liberty release, so deprecate LBaaSV1 at V1.8, then remove LBaaSV1 after V1.9.
+		// Reference OpenStack doc:	https://docs.openstack.org/mitaka/networking-guide/config-lbaas.html
+		glog.Warningf("The LBaaS v1 of OpenStack cloud provider has been deprecated, Please use LBaaS v2")
 		return &LbaasV1{LoadBalancer{network, compute, os.lbOpts}}, true
 	} else {
 		glog.Warningf("Config error: unrecognised lb-version \"%v\"", lbVersion)

--- a/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_loadbalancer.go
@@ -75,6 +75,8 @@ const (
 	ServiceAnnotationLoadBalancerInternal = "service.beta.kubernetes.io/openstack-internal-load-balancer"
 )
 
+// Deprecated; Since LBaaS v1 is deprecated in the OpenStack Liberty release, Kubernetes deprecated it at V1.8.
+// TODO(FengyunPan): remove LBaaS v1 after kubernetes V1.9.
 // LoadBalancer implementation for LBaaS v1
 type LbaasV1 struct {
 	LoadBalancer


### PR DESCRIPTION
Since LBaaS v1 is deprecated in the OpenStack Liberty release, we
deprecated it on Kubernetes.
Reference OpenStack doc:
https://docs.openstack.org/mitaka/networking-guide/config-lbaas.html
Related to: #52717

**Release note**:
```release-note
Mark the LBaaS v1 of OpenStack cloud provider deprecated.
```
