### PR TITLE
Third party resources should not be part of conformance

### DIFF
--- a/test/e2e/third-party.go
+++ b/test/e2e/third-party.go
@@ -72,7 +72,7 @@ var _ = Describe("ThirdParty resources [Flaky] [Disruptive]", func() {
 	}
 
 	Context("Simple Third Party", func() {
-		It("creating/deleting thirdparty objects works [Conformance]", func() {
+		It("creating/deleting thirdparty objects works", func() {
 			defer func() {
 				if err := f.ClientSet.Extensions().ThirdPartyResources().Delete(rsrc.Name, nil); err != nil {
 					framework.Failf("failed to delete third party resource: %v", err)


### PR DESCRIPTION
They are alpha and were sunset and replaced by CRD.

Fixes #52822

```release-note
Third Party Resource tests in the e2e suite were incorrectly marked as part of the conformance bucket.  They are alpha and are not required for conformance.
```