### PR TITLE
Remove redundant examples for kubectl rollout

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout.go
+++ b/pkg/kubectl/cmd/rollout/rollout.go
@@ -30,13 +30,6 @@ var (
 	rollout_long = templates.LongDesc(`
 		Manage the rollout of a resource.` + rollout_valid_resources)
 
-	rollout_example = templates.Examples(`
-		# Rollback to the previous deployment
-		kubectl rollout undo deployment/abc
-		
-		# Check the rollout status of a daemonset
-		kubectl rollout status daemonset/foo`)
-
 	rollout_valid_resources = dedent.Dedent(`
 		Valid resource types include:
 
@@ -49,13 +42,12 @@ var (
 func NewCmdRollout(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 
 	cmd := &cobra.Command{
-		Use:     "rollout SUBCOMMAND",
-		Short:   i18n.T("Manage the rollout of a resource"),
-		Long:    rollout_long,
-		Example: rollout_example,
-		Run:     cmdutil.DefaultSubCommandRun(errOut),
+		Use:   "rollout SUBCOMMAND",
+		Short: i18n.T("Manage the rollout of a resource"),
+		Long:  rollout_long,
+		Run:   cmdutil.DefaultSubCommandRun(errOut),
 	}
-	// subcommands
+	// add subcommands
 	cmd.AddCommand(NewCmdRolloutHistory(f, out))
 	cmd.AddCommand(NewCmdRolloutPause(f, out))
 	cmd.AddCommand(NewCmdRolloutResume(f, out))


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

**What this PR does / why we need it**:
There are redundant examples for kubectl rollout because subcomands supply their own example.
I think we don't need give examples for kubectl rollout and remove these examples.

**Which issue this PR fixes**:
 fixes #52824

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
