### PR TITLE
Improve success messages from `kubectl label`

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -232,7 +232,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		}
 
 		var outputObj runtime.Object
-		dataChangeMsg := "not labeled"
+		dataChangeMsg := "no labels changed"
 		if o.dryrun || o.local || o.list {
 			err = labelFunc(info.Object, o.overwrite, o.resourceVersion, o.newLabels, o.removeLabels)
 			if err != nil {
@@ -270,7 +270,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 				return err
 			}
 			if !reflect.DeepEqual(oldData, newData) {
-				dataChangeMsg = "labeled"
+				dataChangeMsg = "labels updated"
 			}
 			patchBytes, err := jsonpatch.CreateMergePatch(oldData, newData)
 			createdPatch := err == nil

--- a/pkg/kubectl/cmd/label_test.go
+++ b/pkg/kubectl/cmd/label_test.go
@@ -400,7 +400,7 @@ func TestLabelForResourceFromFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "labeled") {
+	if !strings.Contains(buf.String(), "labels updated") {
 		t.Errorf("did not set labels: %s", buf.String())
 	}
 }
@@ -433,7 +433,7 @@ func TestLabelLocal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(buf.String(), "labeled") {
+	if !strings.Contains(buf.String(), "labels updated") {
 		t.Errorf("did not set labels: %s", buf.String())
 	}
 }
@@ -488,7 +488,7 @@ func TestLabelMultipleObjects(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if strings.Count(buf.String(), "labeled") != len(pods.Items) {
+	if strings.Count(buf.String(), "labels updated") != len(pods.Items) {
 		t.Errorf("not all labels are set: %s", buf.String())
 	}
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

The messages "not labeled" and "labeled" are hard to decipher for
someone not fluent in Kubernetes lingo. From just these two words, it is
easy to miss that "to label" is meant as a verb, and that "not labeled"
means that, for example, no update was necessary as the requested value
is already set.

This changes the messages (both for the changed and un-changed result)
to use "label" in the more common noun form.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

I am not sure that my messages are the best possible messages. I think they are an improvement, but would be happy about suggestions. I tried to keep them short. I'm especially unsure about changed vs. updated.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
