### PR TITLE
improve the logic setting cgroupparent in RunPodSandbox

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -517,20 +517,34 @@ func (ds *dockerService) ListPodSandbox(filter *runtimeapi.PodSandboxFilter) ([]
 
 // applySandboxLinuxOptions applies LinuxPodSandboxConfig to dockercontainer.HostConfig and dockercontainer.ContainerCreateConfig.
 func (ds *dockerService) applySandboxLinuxOptions(hc *dockercontainer.HostConfig, lc *runtimeapi.LinuxPodSandboxConfig, createConfig *dockertypes.ContainerCreateConfig, image string, separator rune) error {
-	// Apply Cgroup options.
-	cgroupParent, err := ds.GenerateExpectedCgroupParent(lc.CgroupParent)
-	if err != nil {
-		return err
+	if lc == nil {
+		return nil
 	}
-	hc.CgroupParent = cgroupParent
 	// Apply security context.
-	if err = applySandboxSecurityContext(lc, createConfig.Config, hc, ds.network, separator); err != nil {
+	if err := applySandboxSecurityContext(lc, createConfig.Config, hc, ds.network, separator); err != nil {
 		return err
 	}
 
 	// Set sysctls.
 	hc.Sysctls = lc.Sysctls
+	return nil
+}
 
+func (ds *dockerService) applySandboxResources(hc *dockercontainer.HostConfig, lc *runtimeapi.LinuxPodSandboxConfig) error {
+	hc.Resources = dockercontainer.Resources{
+		MemorySwap: DefaultMemorySwap(),
+		CPUShares:  defaultSandboxCPUshares,
+		// Use docker's default cpu quota/period.
+	}
+
+	if lc != nil {
+		// Apply Cgroup options.
+		cgroupParent, err := ds.GenerateExpectedCgroupParent(lc.CgroupParent)
+		if err != nil {
+			return err
+		}
+		hc.CgroupParent = cgroupParent
+	}
 	return nil
 }
 
@@ -563,10 +577,8 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	}
 
 	// Apply linux-specific options.
-	if lc := c.GetLinux(); lc != nil {
-		if err := ds.applySandboxLinuxOptions(hc, lc, createConfig, image, securityOptSep); err != nil {
-			return nil, err
-		}
+	if err := ds.applySandboxLinuxOptions(hc, c.GetLinux(), createConfig, image, securityOptSep); err != nil {
+		return nil, err
 	}
 
 	// Set port mappings.
@@ -574,17 +586,12 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	createConfig.Config.ExposedPorts = exposedPorts
 	hc.PortBindings = portBindings
 
-	// Apply resource options.
-	setSandboxResources(hc)
+	// TODO: Get rid of the dependency on kubelet internal package.
+	hc.OomScoreAdj = qos.PodInfraOOMAdj
 
-	// Apply cgroupsParent derived from the sandbox config.
-	if lc := c.GetLinux(); lc != nil {
-		// Apply Cgroup options.
-		cgroupParent, err := ds.GenerateExpectedCgroupParent(lc.CgroupParent)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cgroup parent in expected syntax for container %q: %v", c.Metadata.Name, err)
-		}
-		hc.CgroupParent = cgroupParent
+	// Apply resource options.
+	if err := ds.applySandboxResources(hc, c.GetLinux()); err != nil {
+		return nil, err
 	}
 
 	// Set security options.
@@ -621,16 +628,6 @@ func sharesHostIpc(container *dockertypes.ContainerJSON) bool {
 		return string(container.HostConfig.IpcMode) == namespaceModeHost
 	}
 	return false
-}
-
-func setSandboxResources(hc *dockercontainer.HostConfig) {
-	hc.Resources = dockercontainer.Resources{
-		MemorySwap: DefaultMemorySwap(),
-		CPUShares:  defaultSandboxCPUshares,
-		// Use docker's default cpu quota/period.
-	}
-	// TODO: Get rid of the dependency on kubelet internal package.
-	hc.OomScoreAdj = qos.PodInfraOOMAdj
 }
 
 func constructPodSandboxCheckpoint(config *runtimeapi.PodSandboxConfig) *PodSandboxCheckpoint {


### PR DESCRIPTION
Signed-off-by: yanxuean <yan.xuean@zte.com.cn>

**What this PR does / why we need it**:
The setting of cgroupparent is too confused!
The old logic is:
1. set CgroupParent correctly
2. reset CgroupParent incorrectly
3. set CgroupParent again  (refer to #42055 )

The login is too confused, and It is sure that there are many people who drop in trap.
We only need to set it in one place.

kubernetes/pkg/kubelet/dockershim/docker_sandbox.go
```
func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig, image string) (*dockertypes.ContainerCreateConfig, error) {
        ....
       // Apply linux-specific options.
	if lc := c.GetLinux(); lc != nil {
		if err := ds.applySandboxLinuxOptions(hc, lc, createConfig, image, securityOptSep); err != nil {
			return nil, err
		}
	}

	// Apply resource options.
        setSandboxResources(hc)      **<-- reset the CgroupParent incorrectly**

       // Apply cgroupsParent derived from the sandbox config.
	if lc := c.GetLinux(); lc != nil {
		// Apply Cgroup options.
		cgroupParent, err := ds.GenerateExpectedCgroupParent(lc.CgroupParent)
		if err != nil {
			return nil, fmt.Errorf("failed to generate cgroup parent in expected syntax for container %q: %v", c.Metadata.Name, err)
		}
		hc.CgroupParent = cgroupParent
	}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
