### PR TITLE
`make clean` only removes file generated by `make`

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -309,6 +309,25 @@ clean:
 else
 clean: clean_meta
 	build/make-clean.sh
+	rm -rf Godeps/_workspace # Just until we are sure its gone
+	# TODO(thockin): Remove this when we call clean_generated.
+	rm -f pkg/generated/openapi/zz_generated.openapi.go
+endif
+
+define CLEAN_ALL_HELP_INFO
+# Remove all build artifacts and gitignored files.
+#
+# Example:
+#   make clean_all
+#
+# TODO(thockin): call clean_generated when we stop committing generated code.
+endef
+.PHONY: clean_all
+ifeq ($(PRINT_HELP),y)
+clean_all:
+	@echo "$$CLEAN_HELP_INFO"
+else
+clean_all: clean
 	git clean -Xdf
 endif
 

--- a/hack/jenkins/build.sh
+++ b/hack/jenkins/build.sh
@@ -43,7 +43,7 @@ export KUBE_RELEASE_RUN_TESTS
 # Clean stuff out. Assume the last build left the tree in an odd
 # state.
 rm -rf ~/.kube*
-make clean
+make clean_all
 
 # Uncomment if you want to purge the Docker cache completely each
 # build. It costs about 150s each build to pull the golang image and


### PR DESCRIPTION
**Which issue this PR fixes**:

Fixes #52271 

**What this PR does / why we need it**:

Recently there's been some debate about the expected behavior of `make
clean` in the `Makefile`. Currently, `make clean` will remove all
gitignored files. This can be confusing and unexpected if there are, for
example, intellij project files or vagrant hidden directories you want to
keep on your local workstation.

Convert `make clean` to its previous behavior of only removing files
generated by `make` and add a new command - `make clean_all` - which
removes all gitignored files.

Convert current calls of `make clean` to `make clean_all` to ensure
expected behavior stays the same.

**Release note**:

```release-note
NONE
```
