### PR TITLE
Remove / at the end of paths on swagger.json

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -59654,7 +59654,7 @@
      }
     ]
    },
-   "/version/": {
+   "/version": {
     "get": {
      "description": "get the code version",
      "consumes": [

--- a/federation/apis/openapi-spec/swagger.json
+++ b/federation/apis/openapi-spec/swagger.json
@@ -10409,7 +10409,7 @@
      }
     ]
    },
-   "/version/": {
+   "/version": {
     "get": {
      "description": "get the code version",
      "consumes": [


### PR DESCRIPTION
**What this PR does / why we need it**:

As the original openapi spec[1] and the other paths on the same
swagger.json, the swagger.json doesn't need to contain / at the
end of paths. This PR removes it.

This issue was detected during the implementation of [2] because
these APIs are considered as untested even but some of them are
tested.

[1]: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#pathsObject
[2]: https://github.com/kubernetes/kubernetes/pull/50627

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

`NONE`

**Special notes for your reviewer**:

`NONE`

**Release note**:

`NONE`
