### PR TITLE
Make feature gate enablement checks lock-free

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate_test.go
@@ -135,8 +135,8 @@ func TestFeatureGateFlag(t *testing.T) {
 			t.Errorf("%d: Parse() Expected nil, Got %v", i, err)
 		}
 		for k, v := range test.expect {
-			if f.enabled[k] != v {
-				t.Errorf("%d: expected %s=%v, Got %v", i, k, v, f.enabled[k])
+			if actual := f.enabled.Load().(map[Feature]bool)[k]; actual != v {
+				t.Errorf("%d: expected %s=%v, Got %v", i, k, v, actual)
 			}
 		}
 	}


### PR DESCRIPTION
Since we almost never write to this object after initial creation (basically, just in tests or during API server startup), this is a good candidate for the ["read mostly"](https://golang.org/pkg/sync/atomic/#example_Value_readMostly) pattern which leaves the reads lock-free