### PR TITLE
Make kubedns ip configurable in config file

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -81,6 +81,7 @@ type Networking struct {
 	ServiceSubnet string
 	PodSubnet     string
 	DNSDomain     string
+	DNSIP         string
 }
 
 // Etcd contains elements describing Etcd configuration

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -30,6 +30,8 @@ const (
 	DefaultServiceDNSDomain = "cluster.local"
 	// DefaultServicesSubnet defines default service subnet range
 	DefaultServicesSubnet = "10.96.0.0/12"
+	// DefaultServiceDNSIP sets a blank default for ClusterIP for kubedns
+	DefaultServiceDNSIP       = ""
 	// DefaultKubernetesVersion defines default kubernetes version
 	DefaultKubernetesVersion = "stable-1.8"
 	// DefaultAPIBindPort defines default API port
@@ -66,6 +68,10 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 
 	if obj.Networking.DNSDomain == "" {
 		obj.Networking.DNSDomain = DefaultServiceDNSDomain
+	}
+
+	if obj.Networking.DNSIP == "" {
+		obj.Networking.DNSIP = DefaultServiceDNSIP
 	}
 
 	if len(obj.AuthorizationModes) == 0 {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -76,6 +76,7 @@ type Networking struct {
 	ServiceSubnet string `json:"serviceSubnet"`
 	PodSubnet     string `json:"podSubnet"`
 	DNSDomain     string `json:"dnsDomain"`
+	DNSIP         string `json:"dnsip"`
 }
 
 // Etcd contains elements describing Etcd configuration

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -173,6 +173,7 @@ func autoConvert_v1alpha1_Networking_To_kubeadm_Networking(in *Networking, out *
 	out.ServiceSubnet = in.ServiceSubnet
 	out.PodSubnet = in.PodSubnet
 	out.DNSDomain = in.DNSDomain
+	out.DNSIP = in.DNSIP
 	return nil
 }
 
@@ -185,6 +186,7 @@ func autoConvert_kubeadm_Networking_To_v1alpha1_Networking(in *kubeadm.Networkin
 	out.ServiceSubnet = in.ServiceSubnet
 	out.PodSubnet = in.PodSubnet
 	out.DNSDomain = in.DNSDomain
+	out.DNSIP = in.DNSIP
 	return nil
 }
 

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -132,7 +132,7 @@ func createKubeDNSAddon(deploymentBytes, serviceBytes []byte, client clientset.I
 	return nil
 }
 
-// getDNSIP checks local config or fetches the kubernetes service's ClusterIP and appends a "0" to it in order to get the DNS IP
+// getDNSIP fetches the kubernetes service's ClusterIP and appends a "0" to it in order to get the DNS IP
 func getDNSIP(client clientset.Interface) (net.IP, error) {
 	k8ssvc, err := client.CoreV1().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**: This PR creates a new parameter cfg.Networking.DNSIP that is mapped from the optional config file, which can be used to override the process for determining the IP for kubedns.

**Which issue this PR fixes** https://github.com/kubernetes/kubeadm/issues/433

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
