### PR TITLE
Fix volume metric flake

### DIFF
--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -95,6 +95,11 @@ func NewMetricsGrabber(c clientset.Interface, ec clientset.Interface, kubelets b
 	}, nil
 }
 
+// HasRegisteredMaster returns if metrics grabber was able to find a master node
+func (g *MetricsGrabber) HasRegisteredMaster() bool {
+	return g.registeredMaster
+}
+
 func (g *MetricsGrabber) GrabFromKubelet(nodeName string) (KubeletMetrics, error) {
 	nodes, err := g.client.Core().Nodes().List(metav1.ListOptions{FieldSelector: fields.Set{api.ObjectNameField: nodeName}.AsSelector().String()})
 	if err != nil {


### PR DESCRIPTION
* In some environments we don't have access to controller manager's metrics, so we are going to skip that.
* In some cases no metric may be emitted yet and hence nothing might be there in old map.

Fixes https://github.com/kubernetes/kubernetes/issues/52871#event-1260345653

```release-note
NONE
```