### PR TITLE
Disable invalid test case from dns externalName e2e test

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -465,6 +465,8 @@ var _ = framework.KubeDescribe("DNS", func() {
 
 		validateTargetedProbeOutput(f, pod2, []string{wheezyFileName, jessieFileName}, "bar.example.com.")
 
+		/* Below test case is disabled for v1.7 due to https://github.com/kubernetes/kubernetes/issues/35354.
+		   It is enabled for v1.8+ where the fix is in place.
 		// Test changing type from ExternalName to ClusterIP
 		By("changing the service to type=ClusterIP")
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
@@ -485,5 +487,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, true)
 
 		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, "10.0.0.123")
+		*/
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
[gke-gci-1.7-gci-master-upgrade-master](https://k8s-testgrid.appspot.com/master-upgrade#gke-gci-1.7-gci-master-upgrade-master&sort-by-failures=) and [gke-gci-1.7-gci-master-upgrade-cluster-parallel](https://k8s-testgrid.appspot.com/master-upgrade#gke-gci-1.7-gci-master-upgrade-cluster-parallel&sort-by-failures=)
are still failing `[k8s.io] DNS should provide DNS for ExternalName services`.

Given that https://github.com/kubernetes/kubernetes/issues/35354 isn't fixed in 1.7, and the fix https://github.com/kubernetes/kubernetes/pull/46197 seems rather huge to be cherrypicked, I consider it is reasonable to remove the invalid testcase from 1.7 to stop multiple testsuites from bleeding.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: From #50274

**Special notes for your reviewer**:
I know this is not a great fix but am hoping this is acceptable :(
/assign @bowei @xiangpengzhao 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
