### PR TITLE
Allow dns e2e test case for ExternalName to run on aws

### DIFF
--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -400,10 +400,6 @@ var _ = SIGDescribe("DNS", func() {
 	})
 
 	It("should provide DNS for ExternalName services", func() {
-		// TODO(xiangpengzhao): allow AWS when pull-kubernetes-e2e-kops-aws and pull-kubernetes-e2e-gce-etcd3
-		// have the same "service-cluster-ip-range". See: https://github.com/kubernetes/kubernetes/issues/47224
-		framework.SkipUnlessProviderIs("gce")
-
 		// Create a test ExternalName service.
 		By("Creating a test externalName service")
 		serviceName := "dns-test-service-3"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
#52840 uses allocated clusterIP instead of hard-coded one. So we don't need to care about the clusterIP range of the CI job config. Let it run on pull-kubernetes-e2e-kops-aws

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #47224

**Special notes for your reviewer**:
ref: https://github.com/kubernetes/test-infra/pull/4462

/cc @bowei @MrHohn @justinsb 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
