### PR TITLE
Create new targets for running in existing containers (GCB).

### DIFF
--- a/build/package-tarballs.sh
+++ b/build/package-tarballs.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Complete the release with the standard env
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/build/common.sh"
+source "${KUBE_ROOT}/build/lib/release.sh"
+
+kube::build::ensure_tar
+kube::version::get_version_vars
+kube::release::package_tarballs

--- a/build/release-in-a-container.sh
+++ b/build/release-in-a-container.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Complete the release with the standard env
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+# Check and error if not "in-a-container"
+if [[ ! -f /.dockerenv ]]; then
+  echo
+  echo "'make release-in-a-container' can only be used from a docker container."
+  echo
+  exit 1
+fi
+
+# Other dependencies: Your container should contain docker
+if ! type -p docker >/dev/null 2>&1; then
+  echo
+  echo "'make release-in-a-container' requires a container with" \
+       "docker installed."
+  echo
+  exit 1
+fi
+
+
+# First run make cross-in-a-container
+make cross-in-a-container
+
+# at the moment only make test is supported.
+if [[ $KUBE_RELEASE_RUN_TESTS =~ ^[yY]$ ]]; then
+  make test
+fi
+
+$KUBE_ROOT/build/package-tarballs.sh

--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -366,17 +366,23 @@ endif
 
 define RELEASE_HELP_INFO
 # Build a release
+# Use the 'release-in-a-container' target to build the release when already in
+# a container vs. creating a new container to build in using the 'release'
+# target.  Useful for running in GCB.
 #
 # Example:
 #   make release
+#   make release-in-a-container
 endef
-.PHONY: release
+.PHONY: release release-in-a-container
 ifeq ($(PRINT_HELP),y)
-release:
+release release-in-a-container:
 	@echo "$$RELEASE_HELP_INFO"
 else
 release:
 	build/release.sh
+release-in-a-container:
+	build/release-in-a-container.sh
 endif
 
 define RELEASE_SKIP_TESTS_HELP_INFO
@@ -401,19 +407,47 @@ release-skip-tests quick-release:
 	build/release.sh
 endif
 
+define PACKAGE_HELP_INFO
+# Package tarballs
+# Use the 'package-tarballs' target to run the final packaging steps of
+# a release.
+#
+# Example:
+#   make package-tarballs
+endef
+.PHONY: package package-tarballs
+ifeq ($(PRINT_HELP),y)
+package package-tarballs:
+	@echo "$$PACKAGE_HELP_INFO"
+else
+package package-tarballs:
+	build/package-tarballs.sh
+endif
+
 define CROSS_HELP_INFO
 # Cross-compile for all platforms
+# Use the 'cross-in-a-container' target to cross build when already in
+# a container vs. creating a new container to build from (build-image)
+# Useful for running in GCB.
 #
 # Example:
 #   make cross
+#   make cross-in-a-container
 endef
-.PHONY: cross
+.PHONY: cross cross-in-a-container
 ifeq ($(PRINT_HELP),y)
-cross:
+cross cross-in-a-container:
 	@echo "$$CROSS_HELP_INFO"
 else
 cross:
 	hack/make-rules/cross.sh
+cross-in-a-container: KUBE_OUTPUT_SUBPATH = $(OUT_DIR)/dockerized
+cross-in-a-container:
+ifeq (,$(wildcard /.dockerenv))
+	@echo -e "\nThe 'cross-in-a-container' target can only be used from within a docker container.\n"
+else
+	hack/make-rules/cross.sh
+endif
 endif
 
 define CMD_HELP_INFO


### PR DESCRIPTION
Create new targets for running in existing containers (GCB).
    
    1. release-in-a-container - Like 'make release' but in a container.
    2. cross-in-a-container - Like 'make cross' but in a container.
    3. package-tarballs - (NEW) To package tarballs with a docker dependency
    
    'release-in-a-container' is currently only for testing and is not slated to
    be used, but may be useful for testing in some scenarios.
    
    'cross-in-a-container' is meant to be run from the kube-cross image alone.
    'package-tarballs' is a companion target that runs from a docker image
    to package up the tarballs and images (from cross-in-a-container) for a release.

This is an early step to being able to build releases in Container Builder.
This simple solution to a complex problem brought to you by @javier-b-perez.

ref kubernetes/test-infra/issues/4958
ref kubernetes/test-infra/issues/3356