### PR TITLE
If touchPath has a `'` character in it, return an error

### DIFF
--- a/pkg/kubelet/rkt/rkt_test.go
+++ b/pkg/kubelet/rkt/rkt_test.go
@@ -855,6 +855,28 @@ func TestGetPodStatus(t *testing.T) {
 	}
 }
 
+func TestPodFinishedMarkCommand(t *testing.T) {
+	podDir := "/poddir/fake/tom"
+	rktUID := "rkt-uid-1"
+
+	var testCases = []struct {
+		caseName, touchPath string
+	}{
+		{"correct-1", "/usr/bin/tom/path"},
+		{"incorrect-1", "/usr/bin/tom's/path"},
+	}
+
+	for _, tc := range testCases {
+		_, err := podFinishedMarkCommand(tc.touchPath, podDir, rktUID)
+		if tc.caseName == "correct-1" {
+			assert.NoError(t, err, "the path has no `'` character in it")
+		}
+		if tc.caseName == "incorrect-1" {
+			assert.Errorf(t, err, "the path %s has a `'` character in it", tc.touchPath)
+		}
+	}
+}
+
 func generateCapRetainIsolator(t *testing.T, caps ...string) appctypes.Isolator {
 	retain, err := appctypes.NewLinuxCapabilitiesRetainSet(caps...)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
According to the [notes](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/rkt/rkt.go#LC757), I add the function.

**Release note**:
```NONE```
