### PR TITLE
Use consts defined in api instead of defining another ones.

### DIFF
--- a/pkg/volume/empty_dir/empty_dir_linux.go
+++ b/pkg/volume/empty_dir/empty_dir_linux.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/sys/unix"
+
+	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -37,22 +39,22 @@ type realMountDetector struct {
 	mounter mount.Interface
 }
 
-func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, error) {
+func (m *realMountDetector) GetMountMedium(path string) (v1.StorageMedium, bool, error) {
 	glog.V(5).Infof("Determining mount medium of %v", path)
 	notMnt, err := m.mounter.IsLikelyNotMountPoint(path)
 	if err != nil {
-		return 0, false, fmt.Errorf("IsLikelyNotMountPoint(%q): %v", path, err)
+		return v1.StorageMediumDefault, false, fmt.Errorf("IsLikelyNotMountPoint(%q): %v", path, err)
 	}
 	buf := unix.Statfs_t{}
 	if err := unix.Statfs(path, &buf); err != nil {
-		return 0, false, fmt.Errorf("statfs(%q): %v", path, err)
+		return v1.StorageMediumDefault, false, fmt.Errorf("statfs(%q): %v", path, err)
 	}
 
 	glog.V(5).Infof("Statfs_t of %v: %+v", path, buf)
 	if buf.Type == linuxTmpfsMagic {
-		return mediumMemory, !notMnt, nil
+		return v1.StorageMediumMemory, !notMnt, nil
 	} else if int64(buf.Type) == linuxHugetlbfsMagic {
-		return mediumHugepages, !notMnt, nil
+		return v1.StorageMediumHugePages, !notMnt, nil
 	}
-	return mediumUnknown, !notMnt, nil
+	return v1.StorageMediumDefault, !notMnt, nil
 }

--- a/pkg/volume/empty_dir/empty_dir_test.go
+++ b/pkg/volume/empty_dir/empty_dir_test.go
@@ -66,11 +66,11 @@ func TestCanSupport(t *testing.T) {
 }
 
 type fakeMountDetector struct {
-	medium  storageMedium
+	medium  v1.StorageMedium
 	isMount bool
 }
 
-func (fake *fakeMountDetector) GetMountMedium(path string) (storageMedium, bool, error) {
+func (fake *fakeMountDetector) GetMountMedium(path string) (v1.StorageMedium, bool, error) {
 	return fake.medium, fake.isMount, nil
 }
 
@@ -196,9 +196,9 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 	physicalMounter.ResetLog()
 
 	// Make an unmounter for the volume
-	teardownMedium := mediumUnknown
+	teardownMedium := v1.StorageMediumDefault
 	if config.medium == v1.StorageMediumMemory {
-		teardownMedium = mediumMemory
+		teardownMedium = v1.StorageMediumMemory
 	}
 	unmounterMountDetector := &fakeMountDetector{medium: teardownMedium, isMount: config.shouldBeMountedBeforeTeardown}
 	unmounter, err := plug.(*emptyDirPlugin).newUnmounterInternal(volumeName, types.UID("poduid"), &physicalMounter, unmounterMountDetector)

--- a/pkg/volume/empty_dir/empty_dir_unsupported.go
+++ b/pkg/volume/empty_dir/empty_dir_unsupported.go
@@ -19,6 +19,7 @@ limitations under the License.
 package empty_dir
 
 import (
+	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
@@ -27,6 +28,6 @@ type realMountDetector struct {
 	mounter mount.Interface
 }
 
-func (m *realMountDetector) GetMountMedium(path string) (storageMedium, bool, error) {
-	return mediumUnknown, false, nil
+func (m *realMountDetector) GetMountMedium(path string) (v1.StorageMedium, bool, error) {
+	return v1.StorageMediumDefault, false, nil
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1021,8 +1021,8 @@ type FlockerVolumeSource struct {
 type StorageMedium string
 
 const (
-	StorageMediumDefault   StorageMedium = ""          // use whatever the default is for the node
-	StorageMediumMemory    StorageMedium = "Memory"    // use memory (tmpfs)
+	StorageMediumDefault   StorageMedium = ""          // use whatever the default is for the node, assume anything we don't explicitly handle is this
+	StorageMediumMemory    StorageMedium = "Memory"    // use memory (e.g. tmpfs on linux)
 	StorageMediumHugePages StorageMedium = "HugePages" // use hugepages
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
empty_dir defines some consts. There are already similar consts in api types. So remove the local ones in empty_dir.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
