### PR TITLE
In autoscaling tests, improve setting pdbs for kube-system pods

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -1480,8 +1480,7 @@ func addKubeSystemPdbs(f *framework.Framework) (func(), error) {
 		{label: "kube-dns-autoscaler", min_available: 0},
 		{label: "metrics-server", min_available: 0},
 		{label: "kubernetes-dashboard", min_available: 0},
-		{label: "l7-default-backend", min_available: 0},
-		{label: "heapster", min_available: 0},
+		{label: "glbc", min_available: 0},
 	}
 	for _, pdbData := range pdbsToAdd {
 		By(fmt.Sprintf("Create PodDisruptionBudget for %v", pdbData.label))


### PR DESCRIPTION
This fixes selector for l7-default-backend pod and removes Heapster's PDB (it's harmless but pointless as CA won't be able to evict it due to other constraints).