### PR TITLE
deviceplugin: close grpc conn at stop

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
+++ b/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
@@ -66,16 +66,11 @@ func (m *Stub) Start() error {
 	m.server = grpc.NewServer([]grpc.ServerOption{}...)
 	pluginapi.RegisterDevicePluginServer(m.server, m)
 
-	go m.server.Serve(sock)
-	// Wait till grpc server is ready.
-	for i := 0; i < 10; i++ {
-		services := m.server.GetServiceInfo()
-		if len(services) > 1 {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-	log.Println("Starting to serve on", m.socket)
+	go func() {
+		err := m.server.Serve(sock)
+		log.Printf("failed to serve on %s, err: %v", m.socket, err)
+	}()
+	log.Println("starting to serve on", m.socket)
 
 	return nil
 }
@@ -114,7 +109,6 @@ func (m *Stub) Register(kubeletEndpoint, resourceName string) error {
 
 // ListAndWatch lists devices and update that list according to the Update call
 func (m *Stub) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAndWatchServer) error {
-	log.Println("ListAndWatch")
 	var devs []*pluginapi.Device
 
 	for _, d := range m.devs {
@@ -143,8 +137,6 @@ func (m *Stub) Update(devs []*pluginapi.Device) {
 
 // Allocate does a mock allocation
 func (m *Stub) Allocate(ctx context.Context, r *pluginapi.AllocateRequest) (*pluginapi.AllocateResponse, error) {
-	log.Printf("Allocate, %+v", r)
-
 	var response pluginapi.AllocateResponse
 	return &response, nil
 }

--- a/pkg/kubelet/cm/deviceplugin/endpoint_test.go
+++ b/pkg/kubelet/cm/deviceplugin/endpoint_test.go
@@ -17,7 +17,8 @@ limitations under the License.
 package deviceplugin
 
 import (
-	"path"
+	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -26,12 +27,18 @@ import (
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
 )
 
-var (
-	esocketName = "mock.sock"
-)
+// tmpSocketFile returns an unique name for unix domain socket
+func tmpSocketFile(t *testing.T, tmpDir string) string {
+	socket, err := ioutil.TempFile(tmpDir, "mock.sock")
+	require.NoError(t, err)
+	addr := socket.Name()
+	socket.Close()
+	os.Remove(addr)
+	return addr
+}
 
 func TestNewEndpoint(t *testing.T) {
-	socket := path.Join("/tmp", esocketName)
+	socket := tmpSocketFile(t, "/tmp")
 
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
@@ -42,7 +49,7 @@ func TestNewEndpoint(t *testing.T) {
 }
 
 func TestList(t *testing.T) {
-	socket := path.Join("/tmp", esocketName)
+	socket := tmpSocketFile(t, "/tmp")
 
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},
@@ -67,7 +74,7 @@ func TestList(t *testing.T) {
 }
 
 func TestListAndWatch(t *testing.T) {
-	socket := path.Join("/tmp", esocketName)
+	socket := tmpSocketFile(t, "/tmp")
 
 	devs := []*pluginapi.Device{
 		{ID: "ADeviceId", Health: pluginapi.Healthy},


### PR DESCRIPTION
Also remove useless loop in device_plugin_stub, it doesnt do anything
except looping for full 10s in most case. It fixes some errors but i
think its because of connection not closed properly. Removing the loop
also cut test runtime from 60s to 6s on my machine.

With this `go test -count 20 -race` run successfully on my machine
without any errors.

**Release note**:
```release-note
NONE
```
