### PR TITLE
bug(cli):fix kubectl rollout status not recoginze resource namespace

### DIFF
--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -124,7 +124,7 @@ func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []stri
 	}
 
 	// check if deployment's has finished the rollout
-	status, done, err := statusViewer.Status(cmdNamespace, info.Name, revision)
+	status, done, err := statusViewer.Status(info.Namespace, info.Name, revision)
 	if err != nil {
 		return err
 	}
@@ -149,7 +149,7 @@ func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []stri
 	return intr.Run(func() error {
 		_, err := watch.Until(0, w, func(e watch.Event) (bool, error) {
 			// print deployment's status
-			status, done, err := statusViewer.Status(cmdNamespace, info.Name, revision)
+			status, done, err := statusViewer.Status(info.Namespace, info.Name, revision)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Fixes #42364

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
cc @kubernetes/sig-cli-pr-reviews

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
