### PR TITLE
StatefulSet: Fix auto-heal of Pod hostname/subdomain fields.

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -401,8 +401,8 @@ func TestStatefulPodControlUpdatePodConflictFailure(t *testing.T) {
 	fakeClient := &fake.Clientset{}
 	indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 	updatedPod := newStatefulSetPod(set, 0)
-	updatedPod.Annotations[podapi.PodHostnameAnnotation] = "wrong"
-	updatedPod.Spec.Hostname = "wrong"
+	updatedPod.Annotations[podapi.PodHostnameAnnotation] = ""
+	updatedPod.Spec.Hostname = ""
 	indexer.Add(updatedPod)
 	podLister := corelisters.NewPodLister(indexer)
 	control := NewRealStatefulPodControl(fakeClient, nil, podLister, nil, recorder)

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -79,16 +79,14 @@ func TestIdentityMatches(t *testing.T) {
 		t.Error("identity matches for a Pod with the wrong namespace")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodHostnameAnnotation)
 	pod.Spec.Hostname = ""
 	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no hostname")
+		t.Error("identity matches for a Pod with no hostname field")
 	}
 	pod = newStatefulSetPod(set, 1)
-	delete(pod.Annotations, podapi.PodSubdomainAnnotation)
 	pod.Spec.Subdomain = ""
 	if identityMatches(set, pod) {
-		t.Error("identity matches for a Pod with no subdomain")
+		t.Error("identity matches for a Pod with no subdomain field")
 	}
 }
 


### PR DESCRIPTION
This is a followup to #52557, which was a backport of #51199.

The original fix was incomplete. It doesn't trigger unless we change the consistency check to look at the fields.
