### PR TITLE
Allow trailing newline in tokenFile

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -218,7 +218,7 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 		if err != nil {
 			return nil, err
 		}
-		mergedConfig.BearerToken = string(tokenBytes)
+		mergedConfig.BearerToken = strings.TrimSpace(string(tokenBytes))
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clientcmd
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -214,11 +215,21 @@ func (config *DirectClientConfig) getUserIdentificationPartialConfig(configAuthI
 	if len(configAuthInfo.Token) > 0 {
 		mergedConfig.BearerToken = configAuthInfo.Token
 	} else if len(configAuthInfo.TokenFile) > 0 {
-		tokenBytes, err := ioutil.ReadFile(configAuthInfo.TokenFile)
+		tokenFile, err := os.Open(configAuthInfo.TokenFile)
 		if err != nil {
 			return nil, err
 		}
-		mergedConfig.BearerToken = strings.TrimSpace(string(tokenBytes))
+		defer tokenFile.Close()
+
+		// read the first line (excluding newline) of the token file as
+		// the Bearer token
+		scanner := bufio.NewScanner(tokenFile)
+		scanner.Scan()
+
+		if err := scanner.Err(); err != nil {
+			return nil, err
+		}
+		mergedConfig.BearerToken = scanner.Text()
 	}
 	if len(configAuthInfo.Impersonate) > 0 {
 		mergedConfig.Impersonate = restclient.ImpersonationConfig{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

When referencing a tokenFile in your kubeconfig user entry (e.g. to be used by
kubectl), the contents of this token file are sent verbatim as the `Bearer` http
header. This causes issues if the tokenFile contains trailing (or leading)
whitespace, such as a single linebreak at the end of the file.

`Unable to connect to the server: net/http: invalid header field value`

It would be reasonable to ask people to not include any leading/trailing
whitespace in their token files. However, some (many? most?) text editors will
add a single linebreak at the end of the line by default. 

This commit removes any leading or trailing whitespace from the token read from
tokenFile, before trying to use it as the bearer token header. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52919

**Special notes for your reviewer**:

I've added a single test to validate the change: `TestTrailingLinebreakTokenFile`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow trailing newline in tokenFile
```

@kubernetes/sig-cli-pr-reviews