### PR TITLE
Add docs for secret literal and file combinations

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -49,10 +49,11 @@ var (
 		A single secret may package one or more key/value pairs.
 
 		When creating a secret based on a file, the key will default to the basename of the file, and the value will
-		default to the file content.  If the basename is an invalid key, you may specify an alternate key.
+		default to the file content. If the basename is an invalid key or you wish to chose your own, you may specify
+		an alternate key.
 
 		When creating a secret based on a directory, each file whose basename is a valid key in the directory will be
-		packaged into the secret.  Any directory entries except regular files are ignored (e.g. subdirectories,
+		packaged into the secret. Any directory entries except regular files are ignored (e.g. subdirectories,
 		symlinks, devices, pipes, etc).`))
 
 	secretExample = templates.Examples(i18n.T(`
@@ -64,6 +65,9 @@ var (
 
 	  # Create a new secret named my-secret with key1=supersecret and key2=topsecret
 	  kubectl create secret generic my-secret --from-literal=key1=supersecret --from-literal=key2=topsecret
+
+	  # Create a new secret named my-secret using a combination of a file and a literal
+	  kubectl create secret generic my-secret --from-file=ssh-privatekey=~/.ssh/id_rsa --from-literal=passphrase=topsecret
 
 	  # Create a new secret named my-secret from an env file
 	  kubectl create secret generic my-secret --from-env-file=path/to/bar.env`))
@@ -127,11 +131,10 @@ var (
 
 		Dockercfg secrets are used to authenticate against Docker registries.
 
-		When using the Docker command line to push images, you can authenticate to a given registry by running
+		When using the Docker command line to push images, you can authenticate to a given registry by running:
+			'$ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
 
-		    $ docker login DOCKER_REGISTRY_SERVER --username=DOCKER_USER --password=DOCKER_PASSWORD --email=DOCKER_EMAIL'.
-
-    That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
+    	That produces a ~/.dockercfg file that is used by subsequent 'docker push' and 'docker pull' commands to
 		authenticate to the registry. The email address is optional.
 
 		When creating applications, you may have a Docker registry that requires authentication.  In order for the
@@ -208,7 +211,8 @@ var (
 	secretForTLSLong = templates.LongDesc(i18n.T(`
 		Create a TLS secret from the given public/private key pair.
 
-		The public/private key pair must exist before hand. The public key certificate must be .PEM encoded and match the given private key.`))
+		The public/private key pair must exist before hand. The public key certificate must be .PEM encoded and match
+		the given private key.`))
 
 	secretForTLSExample = templates.Examples(i18n.T(`
 	  # Create a new TLS secret named tls-secret with the given key pair:


### PR DESCRIPTION
Adds documentation to the help for generic secret creation that specifies how to create a secret using values from both a literal and a file. Also cleans up some of the formatting.