### PR TITLE
Add cos as an alias for gci in the upgrade script

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -253,6 +253,11 @@ function setup-base-image() {
   if [[ "${env_os_distro}" == "false" ]]; then
     echo "== Ensuring that new Node base OS image matched the existing Node base OS image"
     NODE_OS_DISTRIBUTION=$(get-node-os "${NODE_NAMES[0]}")
+
+    if [[ "${NODE_OS_DISTRIBUTION}" == "cos" ]]; then
+        NODE_OS_DISTRIBUTION="gci"
+    fi
+    
     source "${KUBE_ROOT}/cluster/gce/${NODE_OS_DISTRIBUTION}/node-helper.sh"
     # Reset the node image based on current os distro
     set-node-image


### PR DESCRIPTION
This was causing some issues when upgrading from a GCI image. This is the same conversion happening in config-defaults.sh.

https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-stable2-stable1-upgrade-cluster-new/205

The node image was being left at COS, and when we  went to build the kube-env, we only check against "gci". This caused us to not fully construct the environment for nodes and then they couldn't fully come up after an upgrade.

I've already fixed the CI test suites to explicitly specify "gci", but this auto-detection logic should be fixed too.

Fixes: #52930