### PR TITLE
Add .aws to .gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,3 +125,6 @@ zz_generated.openapi.go
 
 /bazel-*
 *.pyc
+
+# aws credential
+.aws


### PR DESCRIPTION
Upon migrate kops-aws presubmit to prow, now that workspace will be inside kubernetes, however it needs `./.aws/credentials` to run the job inside aws. 

Currently bazel build will toss a `-dirty` tag, i.e. https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-e2e-kops-aws-prow/5/

(If this is the right way to go)

/assign @ixdy @BenTheElder @zmerlynn 