### PR TITLE
[cli] not print empty list when api-server is not accessable

### DIFF
--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -563,7 +563,7 @@ func (options *GetOptions) printGeneric(printer printers.ResourcePrinter, r *res
 	singleItemImplied := false
 	infos, err := r.IntoSingleItemImplied(&singleItemImplied).Infos()
 	if err != nil {
-		if singleItemImplied {
+		if singleItemImplied || len(infos) == 0 {
 			return err
 		}
 		errs = append(errs, err)


### PR DESCRIPTION
When running command `kubectl get pods -o yaml`, an empty list
is output even when the api-server is not accessable. This would
make users think that there is no items of such resource.

Before this change:
```
$ kubectl get pods; systemctl stop kube-apiserver; #cache the discovery api group info
$ kubectl get pods -o json
{
    "apiVersion": "v1",
    "items": [],
    "kind": "List",
    "metadata": {
        "resourceVersion": "",
        "selfLink": ""
    }
}
The connection to the server 172.16.116.128:443 was refused - did you specify the right host or port?
```

After this change
```
$ kubectl get pods -o json
The connection to the server 172.16.116.128:443 was refused - did you specify the right host or port?
```
**Release note**:
```
NONE
```
