### PR TITLE
Added testcase for manager_test.go

### DIFF
--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -90,6 +90,13 @@ func TestDevicePluginReRegistration(t *testing.T) {
 	p2.Stop()
 }
 
+func TestCheckpointFile(t *testing.T) {
+	m, err := NewManagerImpl(socketName, func(n string, a, u, r []*pluginapi.Device) {})
+	require.NoError(t, err)
+	result := m.CheckpointFile()
+	require.Equal(t, "/tmp/device_plugin/kubelet_internal_checkpoint", result)
+}
+
 func setup(t *testing.T, devs []*pluginapi.Device, callback MonitorCallback) (Manager, *Stub) {
 	m, err := NewManagerImpl(socketName, callback)
 	require.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**: New testcase on deviceplugin for manager_test.go

**Release note**:

```release-note
   NONE
```
