### PR TITLE
Add a negotiate method media type for use in explicit contexts

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate.go
@@ -40,6 +40,8 @@ func MediaTypesForSerializer(ns runtime.NegotiatedSerializer) (mediaTypes, strea
 	return mediaTypes, streamMediaTypes
 }
 
+// NegotiateOutputMediaType negotiates the output structured media type and a serializer, or
+// returns an error.
 func NegotiateOutputMediaType(req *http.Request, ns runtime.NegotiatedSerializer, restrictions EndpointRestrictions) (MediaTypeOptions, runtime.SerializerInfo, error) {
 	mediaType, ok := NegotiateMediaTypeOptions(req.Header.Get("Accept"), AcceptedMediaTypesForEndpoint(ns), restrictions)
 	if !ok {
@@ -54,11 +56,13 @@ func NegotiateOutputMediaType(req *http.Request, ns runtime.NegotiatedSerializer
 	return mediaType, info, nil
 }
 
+// NegotiateOutputSerializer returns a serializer for the output.
 func NegotiateOutputSerializer(req *http.Request, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
 	_, info, err := NegotiateOutputMediaType(req, ns, DefaultEndpointRestrictions)
 	return info, err
 }
 
+// NegotiateOutputStreamSerializer returns a stream serializer for the given request.
 func NegotiateOutputStreamSerializer(req *http.Request, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
 	mediaType, ok := NegotiateMediaTypeOptions(req.Header.Get("Accept"), AcceptedMediaTypesForEndpoint(ns), DefaultEndpointRestrictions)
 	if !ok || mediaType.Accepted.Serializer.StreamSerializer == nil {
@@ -68,9 +72,15 @@ func NegotiateOutputStreamSerializer(req *http.Request, ns runtime.NegotiatedSer
 	return mediaType.Accepted.Serializer, nil
 }
 
+// NegotiateInputSerializer returns the input serializer for the provided request.
 func NegotiateInputSerializer(req *http.Request, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
-	mediaTypes := ns.SupportedMediaTypes()
 	mediaType := req.Header.Get("Content-Type")
+	return NegotiateInputSerializerForMediaType(mediaType, ns)
+}
+
+// NegotiateInputSerializerForMediaType returns the appropriate serializer for the given media type or an error.
+func NegotiateInputSerializerForMediaType(mediaType string, ns runtime.NegotiatedSerializer) (runtime.SerializerInfo, error) {
+	mediaTypes := ns.SupportedMediaTypes()
 	if len(mediaType) == 0 {
 		mediaType = mediaTypes[0].MediaType
 	}


### PR DESCRIPTION
There are more cases now where we want to negotiate from contexts where we have a media type but no request.