### PR TITLE
Add support for skeleton in GetSigner

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -3450,6 +3450,11 @@ func GetSigner(provider string) (ssh.Signer, error) {
 		if len(keyfile) == 0 {
 			keyfile = "id_rsa"
 		}
+	case "skeleton":
+		keyfile = os.Getenv("KUBE_SSH_KEY")
+		if len(keyfile) == 0 {
+			keyfile = "id_rsa"
+		}
 	default:
 		return nil, fmt.Errorf("GetSigner(...) not implemented for %s", provider)
 	}


### PR DESCRIPTION
Adding support for skeleton to GetSigner to be able to run
e2e tests against a bare metal multinode cluster.
Closes #35613