### PR TITLE
	modified:   pkg/kubectl/cmd/set/set_image.go

### DIFF
--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -230,6 +230,11 @@ func (o *ImageOptions) Run() error {
 		return nil, err
 	})
 
+	if len(patches) == 0 {
+		fmt.Fprintf(o.Out, "same image specified, no need to change\n")
+		return utilerrors.NewAggregate(allErrs)
+	}
+
 	for _, patch := range patches {
 		info := patch.Info
 		if patch.Err != nil {


### PR DESCRIPTION


**What this PR does / why we need it**:
if user specific same image with current image, the kubectl  command ends up  without any output
for example:
./kubectl set image deployment test *=nginx:1.9.0
deployment "test" image updated
 ./kubectl set image daemonset test *=nginx:1.9.0
(no output)
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
add hint message for users 
./kubectl set image deployment test *=nginx:1.9.0
deployment "test" image updated
 ./kubectl set image daemonset test *=nginx:1.9.0
same image specified, no need to change
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
