### PR TITLE
Fix netsh checkIPExists in Chinese

### DIFF
--- a/pkg/util/netsh/netsh.go
+++ b/pkg/util/netsh/netsh.go
@@ -190,9 +190,8 @@ func checkIPExists(ipToCheck string, args []string, runner *runner) (bool, error
 	glog.V(3).Infof("Searching for IP: %v in IP dump: %v", ipToCheck, ipAddressString)
 	showAddressArray := strings.Split(ipAddressString, "\n")
 	for _, showAddress := range showAddressArray {
-		if strings.Contains(showAddress, "IP Address:") {
-			ipFromNetsh := strings.TrimLeft(showAddress, "IP Address:")
-			ipFromNetsh = strings.TrimSpace(ipFromNetsh)
+		if strings.Contains(showAddress, "IP") {
+			ipFromNetsh := getIP(showAddress)
 			if ipFromNetsh == ipToCheck {
 				return true, nil
 			}
@@ -200,4 +199,13 @@ func checkIPExists(ipToCheck string, args []string, runner *runner) (bool, error
 	}
 
 	return false, nil
+}
+
+// getIP gets ip from showAddress (e.g. "IP Address: 10.96.0.4").
+func getIP(showAddress string) string {
+	list := strings.SplitN(showAddress, ":", 2)
+	if len(list) != 2 {
+		return ""
+	}
+	return strings.TrimSpace(list[1])
 }

--- a/pkg/util/netsh/netsh_test.go
+++ b/pkg/util/netsh/netsh_test.go
@@ -438,3 +438,30 @@ func TestCheckIPExists(t *testing.T) {
 		}
 	}
 }
+
+func TestGetIP(t *testing.T) {
+	testcases := []struct {
+		showAddress   string
+		expectAddress string
+	}{
+		{
+			showAddress:   "IP 地址:                           10.96.0.2",
+			expectAddress: "10.96.0.2",
+		},
+		{
+			showAddress:   "IP Address:                           10.96.0.3",
+			expectAddress: "10.96.0.3",
+		},
+		{
+			showAddress:   "IP Address:10.96.0.4",
+			expectAddress: "10.96.0.4",
+		},
+	}
+
+	for _, tc := range testcases {
+		address := getIP(tc.showAddress)
+		if address != tc.expectAddress {
+			t.Errorf("expected address=%q, got %q", tc.expectAddress, address)
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: sakeven <jc5930@sina.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
On Windows in Chinese language, kube-proxy ip dump outputs like this:

```
接口 "vEthernet (KubeProxySwitch)" 的配置
    DHCP 已启用:                          否
    IP 地址:                           10.96.0.2
    子网前缀:                        10.0.0.0/8 (掩码 255.0.0.0)
    IP 地址:                           10.99.233.195
    子网前缀:                        10.0.0.0/8 (掩码 255.0.0.0)
    IP 地址:                           10.109.68.207
    子网前缀:                        10.0.0.0/8 (掩码 255.0.0.0)
    IP 地址:                           10.110.60.68
    子网前缀:                        10.0.0.0/8 (掩码 255.0.0.0)
    IP 地址:                           10.110.252.225
    子网前缀:                        10.0.0.0/8 (掩码 255.0.0.0)
    InterfaceMetric:                      15
```

And here we used ''IP Address:" in English to search IP, so it would never succeed even if ip address was right here. ''IP Address:" in Chinese is "IP 地址: "。

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
