### PR TITLE
Enable autoscaling test of scale down to 0 in GKE

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -619,8 +619,20 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		framework.ExpectNoError(waitForAllCaPodsReadyInNamespace(f, c))
 	})
 
-	It("Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]", func() {
-		framework.SkipUnlessAtLeast(len(originalSizes), 2, "At least 2 node groups are needed for scale-to-0 tests")
+	It("Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingXScaleDown]", func() {
+		// Determine whether we want to run & adjust the setup if necessary
+		if len(originalSizes) < 2 {
+			if framework.ProviderIs("gke") {
+				const extraPoolName = "extra-pool"
+				addNodePool(extraPoolName, "n1-standard-4", 1)
+				defer deleteNodePool(extraPoolName)
+				err := enableAutoscaler(extraPoolName, 0, 1)
+				framework.ExpectNoError(err)
+			} else {
+				framework.Skipf("At least 2 node groups are needed for scale-to-0 tests")
+			}
+		}
+
 		By("Find smallest node group and manually scale it to a single node")
 		minMig := ""
 		minSize := nodeCount


### PR DESCRIPTION
This change will cause "Should be able to scale a node group down to 0[Feature:ClusterSizeAutoscalingScaleDown]" test scenario to run in GKE jobs. It affects only cluster size autoscaling test suite.