### PR TITLE
Fix broken links in kubeadm after moving proposals to subdirs

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -70,9 +70,9 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 			   and the latter is the Token Secret, which must be kept private at all circumstances.
 			 - The name of the Secret must be named "bootstrap-token-(token-id)".
 
-			You can read more about Bootstrap Tokens in this proposal:
+			You can read more about Bootstrap Tokens here:
 
-			  https://git.k8s.io/community/contributors/design-proposals/bootstrap-discovery.md
+			  https://kubernetes.io/docs/admin/bootstrap-tokens/
 		`),
 
 		// Without this callback, if a user runs just the "token"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
fix incorrect links in kubeadm after kubernetes/community#1010

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes  kubernetes/community#918

**Special notes for your reviewer**:
CC @bgrant0607
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
