### PR TITLE
oidc client auth: better error when refresh response is missing id_token

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -258,7 +258,11 @@ func (p *oidcAuthProvider) idToken() (string, error) {
 
 	idToken, ok := token.Extra("id_token").(string)
 	if !ok {
-		return "", fmt.Errorf("token response did not contain an id_token")
+		// id_token isn't a required part of a refresh token response, so some
+		// providers (Okta) don't return this value.
+		//
+		// See https://github.com/kubernetes/kubernetes/issues/36847
+		return "", fmt.Errorf("token response did not contain an id_token, either the scope \"openid\" wasn't requested upon login, or the provider doesn't support id_tokens as part of the refresh response.")
 	}
 
 	// Create a new config to persist.


### PR DESCRIPTION
/kind cleanup
@kubernetes/sig-auth-pr-reviews 

Updates https://github.com/kubernetes/kubernetes/issues/36847

```release-notes
none
```