### PR TITLE
Mark Cluster Autoscaler as GA (1.0.0)

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v0.7.0-beta2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This is basically the same version as 0.7.0(-beta2). However to reduce confusion among users we decided to name the first GA version of CA as 1.0.0.

```release-note
Cluster Autoscaler 1.0.0
```
