### PR TITLE
[release-1.6] Disable invalid test case from dns externalName e2e test

### DIFF
--- a/test/e2e/dns.go
+++ b/test/e2e/dns.go
@@ -487,6 +487,8 @@ var _ = framework.KubeDescribe("DNS", func() {
 
 		validateTargetedProbeOutput(f, pod2, []string{wheezyFileName, jessieFileName}, "bar.example.com.")
 
+		/* Below test case is disabled for v1.6 due to https://github.com/kubernetes/kubernetes/issues/35354.
+		   It is enabled for v1.8+ where the fix is in place.
 		// Test changing type from ExternalName to ClusterIP
 		By("changing the service to type=ClusterIP")
 		_, err = framework.UpdateService(f.ClientSet, f.Namespace.Name, serviceName, func(s *v1.Service) {
@@ -507,5 +509,6 @@ var _ = framework.KubeDescribe("DNS", func() {
 		pod3 := createDNSPod(f.Namespace.Name, wheezyProbeCmd, jessieProbeCmd, false)
 
 		validateTargetedProbeOutput(f, pod3, []string{wheezyFileName, jessieFileName}, "127.1.2.3")
+		*/
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the same fix as https://github.com/kubernetes/kubernetes/pull/52875 for 1.7.

[gke-gci-1.6-gci-1.8-upgrade-master](https://k8s-testgrid.appspot.com/release-1.8-upgrade-skew#gke-gci-1.6-gci-1.8-upgrade-master&sort-by-flakiness=&width=20) and [gke-gci-1.6-gci-1.8-upgrade-cluster](https://k8s-testgrid.appspot.com/release-1.8-upgrade-skew#gke-gci-1.6-gci-1.8-upgrade-cluster&sort-by-flakiness=&width=20)
are still failing `[k8s.io] DNS should provide DNS for ExternalName services`.

Given that https://github.com/kubernetes/kubernetes/issues/35354 isn't fixed in 1.6, and the fix https://github.com/kubernetes/kubernetes/pull/46197 seems rather huge to be cherrypicked, I consider it is reasonable to remove the invalid testcase from 1.6 to stop multiple testsuites from bleeding.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: From #50274

**Special notes for your reviewer**:
/assign @bowei @xiangpengzhao 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
