### PR TITLE
Fixes the flaky TestDevicePluginReRegistration.

### DIFF
--- a/pkg/kubelet/deviceplugin/manager_test.go
+++ b/pkg/kubelet/deviceplugin/manager_test.go
@@ -70,6 +70,13 @@ func TestDevicePluginReRegistration(t *testing.T) {
 	p1.Register(socketName, testResourceName)
 	// Wait for the first callback to be issued.
 	<-callbackChan
+	// Wait till the endpoint is added to the manager.
+	for i := 0; i < 20; i++ {
+		if len(m.Devices()) > 0 {
+			break
+		}
+		time.Sleep(1)
+	}
 	devices := m.Devices()
 	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
 


### PR DESCRIPTION
In the current test, there is a race that the new device plugin endpoint
may not be added to the device plugin manager endpoints at the time when
we call manager.Devices(). Added the checking and waiting for endpoint
updates before calling manager.Devices() in the test.

Tested:
go test -race -count 500 k8s.io/kubernetes/pkg/kubelet/deviceplugin -run
TestDevicePluginReRegistration -timeout 5h

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/52560

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
