### PR TITLE
Fixed intermitant e2e aggregator test on GKE.

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder/strategy.go
@@ -64,7 +64,7 @@ type flunderStrategy struct {
 }
 
 func (flunderStrategy) NamespaceScoped() bool {
-	return false
+	return true
 }
 
 func (flunderStrategy) PrepareForCreate(ctx genericapirequest.Context, obj runtime.Object) {

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -68,7 +68,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 
 		// Testing a 1.7 version of the sample-apiserver
-		TestSampleAPIServer(f, "gcr.io/kubernetes-e2e-test-images/k8s-aggregator-sample-apiserver-amd64:1.7", "sample-system")
+		TestSampleAPIServer(f, "gcr.io/kubernetes-e2e-test-images/k8s-aggregator-sample-apiserver-amd64:1.7v2", "sample-system")
 	})
 })
 


### PR DESCRIPTION
**What this PR does / why we need it**: Issue was caused by another test cleaning up its namespace.
This caused the namespace controller to try to clean up that namespace.
This involves deleting all flunders under that namespace.
However the sample-apiserver was not honoring the namespace filter.
So the flunders for the test would randomly disappear.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #50945 

**Special notes for your reviewer**: Requires we fix the container image to contain this fix to work.

**Release note**:
```release-note NONE
```
