### PR TITLE
Fix golint errors on test/e2e/e2e.go

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -288,20 +288,20 @@ func gatherTestSuiteMetrics() error {
 	}
 
 	metricsForE2E := (*framework.MetricsForE2E)(&received)
-	metricsJson := metricsForE2E.PrintJSON()
+	metricsJSON := metricsForE2E.PrintJSON()
 	if framework.TestContext.ReportDir != "" {
 		filePath := path.Join(framework.TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")
-		if err := ioutil.WriteFile(filePath, []byte(metricsJson), 0644); err != nil {
+		if err := ioutil.WriteFile(filePath, []byte(metricsJSON), 0644); err != nil {
 			return fmt.Errorf("error writing to %q: %v", filePath, err)
 		}
 	} else {
-		framework.Logf("\n\nTest Suite Metrics:\n%s\n\n", metricsJson)
+		framework.Logf("\n\nTest Suite Metrics:\n%s\n\n", metricsJSON)
 	}
 
 	return nil
 }
 
-// TestE2E checks configuration parameters (specified through flags) and then runs
+// RunE2ETests checks configuration parameters (specified through flags) and then runs
 // E2E tests using the Ginkgo runner.
 // If a "report directory" is specified, one or more JUnit test reports will be
 // generated in this directory, and cluster logs will also be saved.


### PR DESCRIPTION
**What this PR does / why we need it**:

When running golint on test/e2e/e2e.go, the following erros
were faced:

 $ golint e2e.go
 e2e.go:329:2: var metricsJson should be metricsJSON
 e2e.go:342:1: comment on exported function RunE2ETests should be of the form "RunE2ETests ..."

This PR fixes them.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

`NONE`

**Special notes for your reviewer**:

`NONE`

**Release note**:

`NONE`
