### PR TITLE
Introduce GCE-specific addons directory

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -419,6 +419,12 @@ function kube::release::package_kube_manifests_tarball() {
   local objects
   objects=$(cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)
   tar c -C "${KUBE_ROOT}/cluster/addons" ${objects} | tar x -C "${gci_dst_dir}"
+  # Merge GCE-specific addons with general purpose addons.
+  local gce_objects
+  gce_objects=$(cd "${KUBE_ROOT}/cluster/gce/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) \( -not -name \*demo\* \))
+  if [[ -n "${gce_objects}" ]]; then
+    tar c -C "${KUBE_ROOT}/cluster/gce/addons" ${gce_objects} | tar x -C "${gci_dst_dir}"
+  fi
 
   kube::release::clean_cruft
 

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -33,6 +33,7 @@ pkg_tar(
     deps = [
         "//cluster/addons",
         "//cluster/gce:gci-trusty-manifests",
+        "//cluster/gce/addons",
         "//cluster/saltbase:gci-trusty-salt-manifests",
     ],
 )

--- a/cluster/gce/BUILD
+++ b/cluster/gce/BUILD
@@ -34,6 +34,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//cluster/gce/addons:all-srcs",
         "//cluster/gce/gci/mounter:all-srcs",
     ],
     tags = ["automanaged"],

--- a/cluster/gce/addons/BUILD
+++ b/cluster/gce/addons/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+filegroup(
+    name = "addon-srcs",
+    srcs = glob(
+        [
+            "**/*.json",
+            "**/*.yaml",
+            "**/*.yaml.in",
+        ],
+        exclude = ["**/*demo*/**"],
+    ),
+)
+
+pkg_tar(
+    name = "addons",
+    extension = "tar.gz",
+    files = [
+        ":addon-srcs",
+    ],
+    mode = "0644",
+    strip_prefix = ".",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/cluster/gce/addons/README.md
+++ b/cluster/gce/addons/README.md
@@ -1,0 +1,7 @@
+# GCE Cluster addons
+
+These cluster add-ons are specific to GCE and GKE clusters. The GCE-specific addon directory is
+merged with the general cluster addon directory at release, so addon paths (relative to the addon
+directory) must be unique across the 2 directory structures.
+
+More details on addons in general can be found [here](../../addons/README.md).


### PR DESCRIPTION
**What this PR does / why we need it**:

GCE & GKE currently rely on the cluster bringup defined in the `cluster/gce` directory, but there isn't a good way of deploying GCE specific manifests. Currently the 2 approaches are, put it in `/cluster/addons`, which implies it should be generally useful (not GCE specific), or it is synthesized by one of the bash scripts in `cluster/gce`.

This PR introduces a straightforward way to have GCE-specific manifests deployed for GCE & GKE, without the need to pollute the general addon space.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53032

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
