### PR TITLE
clean up old certificate on node after rotate

### DIFF
--- a/pkg/kubelet/certificate/certificate_store.go
+++ b/pkg/kubelet/certificate/certificate_store.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -224,6 +225,11 @@ func (s *fileStore) Update(certData, keyData []byte) (*tls.Certificate, error) {
 	if err := s.updateSymlink(certPath); err != nil {
 		return nil, err
 	}
+
+	if err := s.removeObsolete(pemFilename); err != nil {
+		return nil, err
+	}
+
 	return cert, nil
 }
 
@@ -306,4 +312,23 @@ func loadX509KeyPair(certFile, keyFile string) (*tls.Certificate, error) {
 	}
 	cert.Leaf = certs[0]
 	return &cert, nil
+}
+
+// remove obsolete certificates belong to self, but reserve current one.
+func (s *fileStore) removeObsolete(filename string) error {
+	files, err := utilfile.ReadDirNoStat(s.certDirectory)
+	if err != nil {
+		return fmt.Errorf("unable to read dir %q: %v", s.certDirectory, err)
+	}
+	for _, file := range files {
+		if file == filename || file == s.filename(currentPair) {
+			continue
+		}
+		if strings.HasPrefix(file, s.pairNamePrefix) {
+			if err := os.Remove(path.Join(s.certDirectory, file)); err != nil {
+				return fmt.Errorf("unable to remove %q: %v", s.certDirectory, err)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53027

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add clean up old certificate for kubelet when rotate
```
