### PR TITLE
Allow to use version labels in kubeadm upgrade apply command.

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//cmd/kubeadm/app/preflight:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
+        "//cmd/kubeadm/app/util/config:go_default_library",
         "//cmd/kubeadm/app/util/dryrun:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//pkg/api:go_default_library",
@@ -41,7 +42,6 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/phases/upgrade:go_default_library",
-        "//pkg/util/version:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/upgrade/apply_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply_test.go
@@ -19,8 +19,6 @@ package upgrade
 import (
 	"reflect"
 	"testing"
-
-	"k8s.io/kubernetes/pkg/util/version"
 )
 
 func TestSetImplicitFlags(t *testing.T) {
@@ -38,7 +36,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             false,
 				force:              false,
 				nonInteractiveMode: false,
@@ -53,7 +50,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             false,
 				force:              false,
 				nonInteractiveMode: true,
@@ -68,7 +64,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             true,
 				force:              false,
 				nonInteractiveMode: true,
@@ -83,7 +78,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             false,
 				force:              true,
 				nonInteractiveMode: true,
@@ -98,7 +92,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             true,
 				force:              true,
 				nonInteractiveMode: true,
@@ -113,7 +106,6 @@ func TestSetImplicitFlags(t *testing.T) {
 			},
 			expectedFlags: applyFlags{
 				newK8sVersionStr:   "v1.8.0",
-				newK8sVersion:      version.MustParseSemantic("v1.8.0"),
 				dryRun:             true,
 				force:              true,
 				nonInteractiveMode: true,
@@ -127,45 +119,6 @@ func TestSetImplicitFlags(t *testing.T) {
 				newK8sVersionStr: "",
 			},
 			errExpected: true,
-		},
-		{ // if the new version is invalid; it should error out
-			flags: &applyFlags{
-				newK8sVersionStr: "foo",
-			},
-			expectedFlags: applyFlags{
-				newK8sVersionStr: "foo",
-			},
-			errExpected: true,
-		},
-		{ // if the new version is valid but without the "v" prefix; it parse and prepend v
-			flags: &applyFlags{
-				newK8sVersionStr: "1.8.0",
-			},
-			expectedFlags: applyFlags{
-				newK8sVersionStr: "v1.8.0",
-				newK8sVersion:    version.MustParseSemantic("v1.8.0"),
-			},
-			errExpected: false,
-		},
-		{ // valid version should succeed
-			flags: &applyFlags{
-				newK8sVersionStr: "v1.8.1",
-			},
-			expectedFlags: applyFlags{
-				newK8sVersionStr: "v1.8.1",
-				newK8sVersion:    version.MustParseSemantic("v1.8.1"),
-			},
-			errExpected: false,
-		},
-		{ // valid version should succeed
-			flags: &applyFlags{
-				newK8sVersionStr: "1.8.0-alpha.3",
-			},
-			expectedFlags: applyFlags{
-				newK8sVersionStr: "v1.8.0-alpha.3",
-				newK8sVersion:    version.MustParseSemantic("v1.8.0-alpha.3"),
-			},
-			errExpected: false,
 		},
 	}
 	for _, rt := range tests {

--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -59,7 +59,7 @@ func NewDaemonSetPrepuller(client clientset.Interface, waiter apiclient.Waiter, 
 
 // CreateFunc creates a DaemonSet for making the image available on every relevant node
 func (d *DaemonSetPrepuller) CreateFunc(component string) error {
-	image := images.GetCoreImage(component, d.cfg.ImageRepository, d.cfg.KubernetesVersion, d.cfg.UnifiedControlPlaneImage)
+	image := images.GetCoreImage(component, d.cfg.GetControlPlaneImageRepository(), d.cfg.KubernetesVersion, d.cfg.UnifiedControlPlaneImage)
 	ds := buildPrePullDaemonSet(component, image)
 
 	// Create the DaemonSet in the API Server

--- a/cmd/kubeadm/app/util/config/masterconfig.go
+++ b/cmd/kubeadm/app/util/config/masterconfig.go
@@ -45,24 +45,10 @@ func SetInitDynamicDefaults(cfg *kubeadmapi.MasterConfiguration) error {
 	}
 	cfg.API.AdvertiseAddress = ip.String()
 
-	// Requested version is automatic CI build, thus use KubernetesCI Image Repository for core images
-	if kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion) {
-		cfg.CIImageRepository = kubeadmconstants.DefaultCIImageRepository
-	}
-	// Validate version argument
-	ver, err := kubeadmutil.KubernetesReleaseVersion(cfg.KubernetesVersion)
+	// Resolve possible version labels and validate version string
+	err = NormalizeKubernetesVersion(cfg)
 	if err != nil {
 		return err
-	}
-	cfg.KubernetesVersion = ver
-
-	// Parse the given kubernetes version and make sure it's higher than the lowest supported
-	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
-	if err != nil {
-		return fmt.Errorf("couldn't parse kubernetes version %q: %v", cfg.KubernetesVersion, err)
-	}
-	if k8sVersion.LessThan(kubeadmconstants.MinimumControlPlaneVersion) {
-		return fmt.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= %s. Current version: %s", kubeadmconstants.MinimumControlPlaneVersion.String(), cfg.KubernetesVersion)
 	}
 
 	if cfg.Token == "" {
@@ -122,4 +108,31 @@ func ConfigFileAndDefaultsToInternalConfig(cfgPath string, defaultversionedcfg *
 		return nil, err
 	}
 	return internalcfg, nil
+}
+
+// NormalizeKubernetesVersion resolves version labels, sets alternative
+// image registry if requested for CI builds, and validates minimal
+// version that kubeadm supports.
+func NormalizeKubernetesVersion(cfg *kubeadmapi.MasterConfiguration) error {
+	// Requested version is automatic CI build, thus use KubernetesCI Image Repository for core images
+	if kubeadmutil.KubernetesIsCIVersion(cfg.KubernetesVersion) {
+		cfg.CIImageRepository = kubeadmconstants.DefaultCIImageRepository
+	}
+
+	// Parse and validate the version argument and resolve possible CI version labels
+	ver, err := kubeadmutil.KubernetesReleaseVersion(cfg.KubernetesVersion)
+	if err != nil {
+		return err
+	}
+	cfg.KubernetesVersion = ver
+
+	// Parse the given kubernetes version and make sure it's higher than the lowest supported
+	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
+	if err != nil {
+		return fmt.Errorf("couldn't parse kubernetes version %q: %v", cfg.KubernetesVersion, err)
+	}
+	if k8sVersion.LessThan(kubeadmconstants.MinimumControlPlaneVersion) {
+		return fmt.Errorf("this version of kubeadm only supports deploying clusters with the control plane version >= %s. Current version: %s", kubeadmconstants.MinimumControlPlaneVersion.String(), cfg.KubernetesVersion)
+	}
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

kubeadm upgrade apply now is able to utilize all possible combinations
of version argument, including labels (latest, stable-1.8, ci/latest-1.9)
as well as specific builds (v1.8.0-rc.1, ci/v1.9.0-alpha.1.123_01234567889)

As side effect, specifying exact build to deploy from CI area is now also
possible in kubeadm init command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/kubeadm#451

**Special notes for your reviewer**:
cc @luxas 

**Release note**:
```release-note
- kubeadm init can now deploy exact build from CI area by specifying ID with "ci/" prefix. Example: "ci/v1.9.0-alpha.1.123+01234567889"
- kubeadm upgrade apply supports all standard ways of specifying version via labels. Examples: stable-1.8, latest-1.8, ci/latest-1.9 and similar.
```
