### PR TITLE
Update Dashboard addon to version 1.8.0 and align /ui redirect with it

### DIFF
--- a/cluster/addons/dashboard/README.md
+++ b/cluster/addons/dashboard/README.md
@@ -1,5 +1,4 @@
 # Kubernetes Dashboard
-==============
 
 Kubernetes Dashboard is a general purpose, web-based UI for Kubernetes clusters.
 It allows users to manage applications running in the cluster, troubleshoot them,

--- a/cluster/addons/dashboard/dashboard-configmap.yaml
+++ b/cluster/addons/dashboard/dashboard-configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    # Allows editing resource and makes sure it is created first.
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: kubernetes-dashboard-settings
+  namespace: kube-system

--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -1,4 +1,13 @@
-apiVersion: extensions/v1beta1
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard
+  namespace: kube-system
+---
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: kubernetes-dashboard
@@ -20,9 +29,8 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3
+        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.8.0
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
             cpu: 100m
             memory: 300Mi
@@ -30,13 +38,29 @@ spec:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 9090
+        - containerPort: 8443
+          protocol: TCP
+        args:
+          - --auto-generate-certificates
+        volumeMounts:
+        - name: kubernetes-dashboard-certs
+          mountPath: /certs
+        - name: tmp-volume
+          mountPath: /tmp
         livenessProbe:
           httpGet:
+            scheme: HTTPS
             path: /
-            port: 9090
+            port: 8443
           initialDelaySeconds: 30
           timeoutSeconds: 30
+      volumes:
+      - name: kubernetes-dashboard-certs
+        secret:
+          secretName: kubernetes-dashboard-certs
+      - name: tmp-volume
+        emptyDir: {}
+      serviceAccountName: kubernetes-dashboard
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/cluster/addons/dashboard/dashboard-rbac.yaml
+++ b/cluster/addons/dashboard/dashboard-rbac.yaml
@@ -1,0 +1,45 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+rules:
+  # Allow Dashboard to create 'kubernetes-dashboard-key-holder' secret.
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["create"]
+  # Allow Dashboard to get, update and delete Dashboard exclusive secrets.
+- apiGroups: [""]
+  resources: ["secrets"]
+  resourceNames: ["kubernetes-dashboard-key-holder", "kubernetes-dashboard-certs"]
+  verbs: ["get", "update", "delete"]
+  # Allow Dashboard to get and update 'kubernetes-dashboard-settings' config map.
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames: ["kubernetes-dashboard-settings"]
+  verbs: ["get", "update"]
+  # Allow Dashboard to get metrics from heapster.
+- apiGroups: [""]
+  resources: ["services"]
+  resourceNames: ["heapster"]
+  verbs: ["proxy"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernetes-dashboard-minimal
+  namespace: kube-system
+  labels:
+    k8s-app: kubernetes-dashboard
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubernetes-dashboard-minimal
+subjects:
+- kind: ServiceAccount
+  name: kubernetes-dashboard
+  namespace: kube-system

--- a/cluster/addons/dashboard/dashboard-secret.yaml
+++ b/cluster/addons/dashboard/dashboard-secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    k8s-app: kubernetes-dashboard
+    # Allows editing resource and makes sure it is created first.
+    addonmanager.kubernetes.io/mode: EnsureExists
+  name: kubernetes-dashboard-certs
+  namespace: kube-system
+type: Opaque

--- a/cluster/addons/dashboard/dashboard-service.yaml
+++ b/cluster/addons/dashboard/dashboard-service.yaml
@@ -11,5 +11,5 @@ spec:
   selector:
     k8s-app: kubernetes-dashboard
   ports:
-  - port: 80
-    targetPort: 9090
+  - port: 443
+    targetPort: 8443

--- a/cluster/centos/deployAddons.sh
+++ b/cluster/centos/deployAddons.sh
@@ -45,19 +45,13 @@ function deploy_dns {
 }
 
 function deploy_dashboard {
-    if ${KUBECTL} get rc -l k8s-app=kubernetes-dashboard --namespace=kube-system | grep kubernetes-dashboard-v &> /dev/null; then
-        echo "Kubernetes Dashboard replicationController already exists"
-    else
-        echo "Creating Kubernetes Dashboard replicationController"
-        ${KUBECTL} create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-controller.yaml
-    fi
+  echo "Deploying Kubernetes Dashboard"
 
-    if ${KUBECTL} get service/kubernetes-dashboard --namespace=kube-system &> /dev/null; then
-        echo "Kubernetes Dashboard service already exists"
-    else
-        echo "Creating Kubernetes Dashboard service"
-        ${KUBECTL} create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-service.yaml
-    fi
+  ${KUBECTL} apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-secret.yaml
+  ${KUBECTL} apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-configmap.yaml
+  ${KUBECTL} apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-rbac.yaml
+  ${KUBECTL} apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-controller.yaml
+  ${KUBECTL} apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-service.yaml
 
   echo
 }

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -792,8 +792,11 @@ function start_kubedashboard {
     if [[ "${ENABLE_CLUSTER_DASHBOARD}" = true ]]; then
         echo "Creating kubernetes-dashboard"
         # use kubectl to create the dashboard
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-controller.yaml
-        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" create -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-service.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-secret.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-configmap.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-rbac.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-controller.yaml
+        ${KUBECTL} --kubeconfig="${CERT_DIR}/admin.kubeconfig" apply -f ${KUBE_ROOT}/cluster/addons/dashboard/dashboard-service.yaml
         echo "kubernetes-dashboard deployment and service successfully deployed."
     fi
 }

--- a/pkg/routes/ui.go
+++ b/pkg/routes/ui.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/server/mux"
 )
 
-const dashboardPath = "/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy"
+const dashboardPath = "/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/"
 
 // UIRedirect redirects /ui to the kube-ui proxy path.
 type UIRedirect struct{}

--- a/test/e2e/ui/BUILD
+++ b/test/e2e/ui/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )

--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -23,6 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -36,6 +37,7 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 		uiServiceName = "kubernetes-dashboard"
 		uiAppName     = uiServiceName
 		uiNamespace   = metav1.NamespaceSystem
+		uiRedirect    = "/ui"
 
 		serverStartTimeout = 1 * time.Minute
 	)
@@ -63,20 +65,20 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 			ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
 			defer cancel()
 
-			// Query against the proxy URL for the kube-ui service.
+			// Query against the proxy URL for the kubernetes-dashboard service.
 			err := proxyRequest.Namespace(uiNamespace).
 				Context(ctx).
-				Name(uiServiceName).
+				Name(utilnet.JoinSchemeNamePort("https", uiServiceName, "")).
 				Timeout(framework.SingleCallTimeout).
 				Do().
 				StatusCode(&status).
 				Error()
 			if err != nil {
 				if ctx.Err() != nil {
-					framework.Failf("Request to kube-ui failed: %v", err)
+					framework.Failf("Request to kubernetes-dashboard failed: %v", err)
 					return true, err
 				}
-				framework.Logf("Request to kube-ui failed: %v", err)
+				framework.Logf("Request to kubernetes-dashboard failed: %v", err)
 			} else if status != http.StatusOK {
 				framework.Logf("Unexpected status from kubernetes-dashboard: %v", status)
 			}
@@ -88,7 +90,7 @@ var _ = SIGDescribe("Kubernetes Dashboard", func() {
 		By("Checking that the ApiServer /ui endpoint redirects to a valid server.")
 		var status int
 		err = f.ClientSet.CoreV1().RESTClient().Get().
-			AbsPath("/ui").
+			AbsPath(uiRedirect).
 			Timeout(framework.SingleCallTimeout).
 			Do().
 			StatusCode(&status).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: In Dashboard 1.8.0 we have introduced a couple of changes (security, settings, new resources etc.) and fixed a lot of bugs. You can check release notes at https://github.com/kubernetes/dashboard/releases/tag/v1.8.0.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Updated Dashboard add-on to version 1.8.0: The Dashboard add-on now deploys with https enabled. The Dashboard can be accessed via kubectl proxy at http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/. The /ui redirect is deprecated and will be removed in 1.10.
```
