### PR TITLE
Remove  TODO: check for defaulting min-available

### DIFF
--- a/pkg/kubectl/pdb.go
+++ b/pkg/kubectl/pdb.go
@@ -18,7 +18,6 @@ package kubectl
 
 import (
 	"fmt"
-	"os"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -165,15 +164,6 @@ func (s *PodDisruptionBudgetV2Generator) StructuredGenerate() (runtime.Object, e
 	selector, err := metav1.ParseToLabelSelector(s.Selector)
 	if err != nil {
 		return nil, err
-	}
-
-	if len(s.MaxUnavailable) == 0 && len(s.MinAvailable) == 0 {
-		s.MinAvailable = "1"
-
-		// This behavior is intended for backward compatibility.
-		// TODO: remove in Kubernetes 1.8
-		fmt.Fprintln(os.Stderr, "Deprecated behavior in kubectl create pdb: Defaulting min-available to 1. "+
-			"Kubernetes 1.8 will remove this default, and one of min-available/max-available must be specified. ")
 	}
 
 	if len(s.MaxUnavailable) > 0 {


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

**What this PR does / why we need it**:
Remove the default for min-available

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Release note**:
```release-note
kubectl create pdb will no longer set the min-available field by default. 
```
