### PR TITLE
Log error when a healthz check fails

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/healthz/healthz.go
@@ -106,9 +106,10 @@ func handleRootHealthz(checks ...HealthzChecker) http.HandlerFunc {
 		failed := false
 		var verboseOut bytes.Buffer
 		for _, check := range checks {
-			if check.Check(r) != nil {
+			if err := check.Check(r); err != nil {
 				// don't include the error since this endpoint is public.  If someone wants more detail
 				// they should have explicit permission to the detailed checks.
+				glog.V(6).Infof("healthz check %v failed: %v", check.Name(), err)
 				fmt.Fprintf(&verboseOut, "[-]%v failed: reason withheld\n", check.Name())
 				failed = true
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we only tell a user that a healthz check failed but we don't display the explicit error of the failed check. This is fine, but we should log the error to make debugging easier.

```release-note
Log error of failed healthz check
```
