### PR TITLE
Allow kubelet metrics tests to run on gke

### DIFF
--- a/test/e2e/storage/volume_metrics.go
+++ b/test/e2e/storage/volume_metrics.go
@@ -62,10 +62,6 @@ var _ = SIGDescribe("[Serial] Volume metrics", func() {
 		if err != nil {
 			framework.Failf("Error creating metrics grabber : %v", err)
 		}
-
-		if !metricsGrabber.HasRegisteredMaster() {
-			framework.Skipf("Environment does not support getting controller-manager metrics - skipping")
-		}
 	})
 
 	AfterEach(func() {
@@ -74,6 +70,10 @@ var _ = SIGDescribe("[Serial] Volume metrics", func() {
 
 	It("should create prometheus metrics for volume provisioning and attach/detach", func() {
 		var err error
+
+		if !metricsGrabber.HasRegisteredMaster() {
+			framework.Skipf("Environment does not support getting controller-manager metrics - skipping")
+		}
 
 		controllerMetrics, err := metricsGrabber.GrabFromControllerManager()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
On GKE, you can still access kubelet metrics, so allow the kubelet metrics test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
NONE
