### PR TITLE
Align imagefs eviction defaults with image gc defaults

### DIFF
--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
@@ -229,7 +229,7 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 		obj.HairpinMode = PromiscuousBridge
 	}
 	if obj.EvictionHard == nil {
-		temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%"
+		temp := "memory.available<100Mi,nodefs.available<10%,nodefs.inodesFree<5%,imagefs.available<15%"
 		obj.EvictionHard = &temp
 	}
 	if obj.EvictionPressureTransitionPeriod == zeroDuration {


### PR DESCRIPTION
**What this PR does / why we need it**:
If a node is configured to use an imagefs for container storage, we should align the default imagefs eviction threshold with the default image-gc threshold.  This PR updates the default imagesfs.available threshold to trigger when below 15% available space, which is same as default image-gc high threshold for 85%.

Fixes https://github.com/kubernetes/kubernetes/issues/53074

**Special notes for your reviewer**:
none, this only impacts nodes running an imagefs otherwise its ignored.

**Release note**:
```release-note
NONE
```
