### PR TITLE
federation/pkg/federation-controller/util: fix swallowed errors

### DIFF
--- a/federation/pkg/federation-controller/util/cluster_util.go
+++ b/federation/pkg/federation-controller/util/cluster_util.go
@@ -68,7 +68,8 @@ func BuildClusterConfig(c *federation_v1beta1.Cluster) (*restclient.Config, erro
 			if c.Spec.SecretRef.Name == "" {
 				return nil, fmt.Errorf("found secretRef but no secret name for cluster %s", c.Name)
 			}
-			secret, err := getSecret(c.Spec.SecretRef.Name)
+			var secret *api.Secret
+			secret, err = getSecret(c.Spec.SecretRef.Name)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What this PR does / why we need it**: The re-declaration of `err` inside the `if` block causes it to be lost before the check on line 93, even though it is reassigned on lines 95 and 90. By declaring the secret variable on line 71 I was able to ditch the `:=` assignment on line 72, meaning we can keep the `err` variable previously defined before the block on line 47.

```release-note NONE
```
