### PR TITLE
Remove touch-lock init container from kube-proxy

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -28,16 +28,6 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/kube-proxy-ds-ready: "true"
-      initContainers:
-      - name: touch-lock
-        image: busybox
-        command: ['/bin/touch', '/run/xtables.lock']
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /run
-          name: run
-          readOnly: false
       containers:
       - name: kube-proxy
         image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}
@@ -73,7 +63,5 @@ spec:
       - name: xtables-lock
         hostPath:
           path: /run/xtables.lock
-      - name: run
-        hostPath:
-          path: /run
+          type: FileOrCreate
       serviceAccountName: kube-proxy

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -65,16 +65,6 @@ metadata:
 spec:
   {{pod_priority}}
   hostNetwork: true
-  initContainers:
-  - name: touch-lock
-    image: busybox
-    command: ['/bin/touch', '/run/xtables.lock']
-    securityContext:
-      privileged: true
-    volumeMounts:
-    - mountPath: /run
-      name: run
-      readOnly: false
   containers:
   - name: kube-proxy
     image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}
@@ -120,9 +110,6 @@ spec:
   - hostPath:
       path: /var/log
     name: varlog
-  - hostPath:
-      path: /run
-    name: run
   - hostPath:
       path: /run/xtables.lock
       type: FileOrCreate


### PR DESCRIPTION
**What this PR does / why we need it**: Ack https://github.com/kubernetes/kubeadm/issues/298, touch-lock init container is no longer needed after we have https://github.com/kubernetes/kubernetes/pull/46597.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE

**Special notes for your reviewer**:
/assign @bowei @cmluciano 
cc @dixudx 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
