### PR TITLE
Change ImageGCManage to consume ImageFS stats from StatsProvider

### DIFF
--- a/pkg/kubelet/images/BUILD
+++ b/pkg/kubelet/images/BUILD
@@ -17,7 +17,7 @@ go_library(
         "types.go",
     ],
     deps = [
-        "//pkg/kubelet/cadvisor:go_default_library",
+        "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/events:go_default_library",
         "//pkg/util/parsers:go_default_library",
@@ -40,10 +40,10 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//pkg/kubelet/cadvisor/testing:go_default_library",
+        "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",
-        "//vendor/github.com/google/cadvisor/info/v2:go_default_library",
+        "//pkg/kubelet/server/stats/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -730,7 +730,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.containerDeletor = newPodContainerDeletor(klet.containerRuntime, integer.IntMax(containerGCPolicy.MaxPerPodContainer, minDeadContainerInPod))
 
 	// setup imageManager
-	imageManager, err := images.NewImageGCManager(klet.containerRuntime, kubeDeps.CAdvisorInterface, kubeDeps.Recorder, nodeRef, imageGCPolicy)
+	imageManager, err := images.NewImageGCManager(klet.containerRuntime, klet.StatsProvider, kubeDeps.Recorder, nodeRef, imageGCPolicy)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize image manager: %v", err)
 	}


### PR DESCRIPTION
Fixes #53083.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Change ImageGCManage to consume ImageFS stats from StatsProvider
```

/assign @Random-Liu 
