### PR TITLE
Skip basic statefulset functionality e2e tests for 1.6-1.8 upgrade tests

### DIFF
--- a/test/e2e/statefulset.go
+++ b/test/e2e/statefulset.go
@@ -92,6 +92,7 @@ var _ = framework.KubeDescribe("StatefulSet", func() {
 		})
 
 		It("should provide basic identity", func() {
+			framework.SkipUnlessServerVersionLT(version.MustParseSemantic("v1.8.0-alpha.0"), f.ClientSet.Discovery())
 			By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 3
 			framework.SetStatefulSetInitializedAnnotation(ss, "false")
@@ -214,6 +215,7 @@ var _ = framework.KubeDescribe("StatefulSet", func() {
 		})
 
 		It("should not deadlock when a pod's predecessor fails", func() {
+			framework.SkipUnlessServerVersionLT(version.MustParseSemantic("v1.8.0-alpha.0"), f.ClientSet.Discovery())
 			By("Creating statefulset " + ssName + " in namespace " + ns)
 			*(ss.Spec.Replicas) = 2
 			framework.SetStatefulSetInitializedAnnotation(ss, "false")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR skips basic statefulset functionality e2e tests for passing 1.6-1.8 upgrade tests.
The tests are:
`[k8s.io] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should not deadlock when a pod's predecessor fails`

`[k8s.io] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should provide basic identity`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52808 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/assign @foxish @enisoc 
