### PR TITLE
Eliminate extra CRI call during processing cpu set

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -176,11 +176,16 @@ func (m *manager) AddContainer(p *v1.Pod, c *v1.Container, containerID string) e
 	cpus := m.state.GetCPUSetOrDefault(containerID)
 	m.Unlock()
 
-	err = m.updateContainerCPUSet(containerID, cpus)
-	if err != nil {
-		glog.Errorf("[cpumanager] AddContainer error: %v", err)
-		return err
+	if !cpus.IsEmpty() {
+		err = m.updateContainerCPUSet(containerID, cpus)
+		if err != nil {
+			glog.Errorf("[cpumanager] AddContainer error: %v", err)
+			return err
+		}
+	} else {
+		glog.V(5).Infof("[cpumanager] update container resources is skipped due to cpu set is empty")
 	}
+
 	return nil
 }
 

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -180,7 +180,7 @@ func TestCPUManagerAdd(t *testing.T) {
 			description: "cpu manager add - container update error",
 			regErr:      nil,
 			updateErr:   fmt.Errorf("fake update error"),
-			expErr:      fmt.Errorf("fake update error"),
+			expErr:      nil,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Encountered this during `kubernetes/frakti` node e2e test.

When cpuset is not set, there's still plenty of `runtime.UpdateContainerResources` been called, which seems unnecessary.

cc @ConnorDoyle Make sense? Fixes: #53304

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Only do UpdateContainerResources when cpuset is set 
```
