### PR TITLE
Add Flag to specify the address-type to use for ssh-tunnels

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -63,6 +63,7 @@ type ServerRunOptions struct {
 	ServiceNodePortRange      utilnet.PortRange
 	SSHKeyfile                string
 	SSHUser                   string
+	SSHPreferredAddressTypes  []string
 
 	ProxyClientCertFile string
 	ProxyClientKeyFile  string
@@ -111,7 +112,8 @@ func NewServerRunOptions() *ServerRunOptions {
 			EnableHttps: true,
 			HTTPTimeout: time.Duration(5) * time.Second,
 		},
-		ServiceNodePortRange: kubeoptions.DefaultServiceNodePortRange,
+		SSHPreferredAddressTypes: []string{string(api.NodeExternalIP)},
+		ServiceNodePortRange:     kubeoptions.DefaultServiceNodePortRange,
 	}
 	// Overwrite the default for storage data format.
 	s.Etcd.DefaultStorageMediaType = "application/vnd.kubernetes.protobuf"
@@ -158,6 +160,9 @@ func (s *ServerRunOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.SSHKeyfile, "ssh-keyfile", s.SSHKeyfile,
 		"If non-empty, use secure SSH proxy to the nodes, using this user keyfile")
+
+	fs.StringSliceVar(&s.SSHPreferredAddressTypes, "ssh-preferred-address-types", s.SSHPreferredAddressTypes,
+		"List of the preferred NodeAddressTypes to use for the SSH proxy to the nodes. Possible values: "+strings.Join(AllNodeAddressTypes.Names(), ", "))
 
 	fs.Int64Var(&s.MaxConnectionBytesPerSec, "max-connection-bytes-per-sec", s.MaxConnectionBytesPerSec, ""+
 		"If non-zero, throttle each user connection to this number of bytes/sec. "+

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -91,10 +91,11 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
-		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
-		MasterCount:            5,
-		EndpointReconcilerType: string(reconcilers.MasterCountReconcilerType),
-		AllowPrivileged:        false,
+		SSHPreferredAddressTypes: []string{string(kapi.NodeExternalIP)},
+		ServiceNodePortRange:     kubeoptions.DefaultServiceNodePortRange,
+		MasterCount:              5,
+		EndpointReconcilerType:   string(reconcilers.MasterCountReconcilerType),
+		AllowPrivileged:          false,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -230,6 +230,9 @@ func CreateNodeDialer(s *options.ServerRunOptions) (tunneler.Tunneler, *http.Tra
 		if s.KubeletConfig.ReadOnlyPort == 0 {
 			return nil, nil, fmt.Errorf("must enable kubelet readonly port if proxy ssh-tunneling is specified")
 		}
+		if len(s.SSHPreferredAddressTypes) == 0 {
+			return nil, nil, fmt.Errorf("a ssh-preferred-address-types must be specified if proxy ssh-tunneling is specified")
+		}
 		// Set up the nodeTunneler
 		// TODO(cjcullen): If we want this to handle per-kubelet ports or other
 		// kubelet listen-addresses, we need to plumb through options.
@@ -238,7 +241,7 @@ func CreateNodeDialer(s *options.ServerRunOptions) (tunneler.Tunneler, *http.Tra
 			Host:   net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(s.KubeletConfig.ReadOnlyPort), 10)),
 			Path:   "healthz",
 		}
-		nodeTunneler = tunneler.New(s.SSHUser, s.SSHKeyfile, healthCheckPath, installSSHKey)
+		nodeTunneler = tunneler.New(s.SSHUser, s.SSHKeyfile, healthCheckPath, installSSHKey, s.SSHPreferredAddressTypes)
 
 		// Use the nodeTunneler's dialer when proxying to pods, services, and nodes
 		proxyDialerFn = nodeTunneler.Dial

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -383,7 +383,7 @@ func (m *Master) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.
 }
 
 func (m *Master) installTunneler(nodeTunneler tunneler.Tunneler, nodeClient corev1client.NodeInterface) {
-	nodeTunneler.Run(nodeAddressProvider{nodeClient}.externalAddresses)
+	nodeTunneler.Run(nodeAddressProvider{nodeClient}.preferredAddresses)
 	m.GenericAPIServer.AddHealthzChecks(healthz.NamedCheck("SSH Tunnel Check", tunneler.TunnelSyncHealthChecker(nodeTunneler)))
 	prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "apiserver_proxy_tunnel_sync_latency_secs",
@@ -436,10 +436,12 @@ type nodeAddressProvider struct {
 	nodeClient corev1client.NodeInterface
 }
 
-func (n nodeAddressProvider) externalAddresses() ([]string, error) {
-	preferredAddressTypes := []apiv1.NodeAddressType{
-		apiv1.NodeExternalIP,
+func (n nodeAddressProvider) preferredAddresses(preferredAddressTypes []string) ([]string, error) {
+	nodeAddressTypes := []apiv1.NodeAddressType{}
+	for _, v := range preferredAddressTypes {
+		nodeAddressTypes = append(nodeAddressTypes, apiv1.NodeAddressType(v))
 	}
+
 	nodes, err := n.nodeClient.List(metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -447,7 +449,7 @@ func (n nodeAddressProvider) externalAddresses() ([]string, error) {
 	addrs := []string{}
 	for ix := range nodes.Items {
 		node := &nodes.Items[ix]
-		addr, err := nodeutil.GetPreferredNodeAddress(node, preferredAddressTypes)
+		addr, err := nodeutil.GetPreferredNodeAddress(node, nodeAddressTypes)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -270,7 +270,7 @@ func TestGetNodeAddresses(t *testing.T) {
 
 	// Fail case (no addresses associated with nodes)
 	nodes, _ := fakeNodeClient.List(metav1.ListOptions{})
-	addrs, err := addressProvider.externalAddresses()
+	addrs, err := addressProvider.preferredAddresses([]string{string(api.NodeExternalIP)})
 
 	assert.Error(err, "addresses should have caused an error as there are no addresses.")
 	assert.Equal([]string(nil), addrs)
@@ -281,7 +281,7 @@ func TestGetNodeAddresses(t *testing.T) {
 		nodes.Items[index].Status.Addresses = []apiv1.NodeAddress{{Type: apiv1.NodeExternalIP, Address: "127.0.0.1"}}
 		fakeNodeClient.Update(&nodes.Items[index])
 	}
-	addrs, err = addressProvider.externalAddresses()
+	addrs, err = addressProvider.preferredAddresses([]string{string(api.NodeExternalIP)})
 	assert.NoError(err, "addresses should not have returned an error.")
 	assert.Equal([]string{"127.0.0.1", "127.0.0.1"}, addrs)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since 1.7 SSH-Tunnels are only created with the ExternalIP (hard coded). This does not work on every environment.
This PR adds a flag so a user can specify the AddressType to use for SSH tunnels. Default is still ExternalIP.
I decided against the `kubelet-preferred-address-types` as the address-type coming from `kubelet-preferred-address-types` might not be reachable on the node where the tunnel is opened.

```release-note
Add flag to specify node address type to be used for SSH tunnels
```
