### PR TITLE
Update log-dump script in release-1.5

### DIFF
--- a/hack/verify-flags/exceptions.txt
+++ b/hack/verify-flags/exceptions.txt
@@ -28,7 +28,7 @@ cluster/juju/layers/kubernetes/reactive/k8s.py:    tlslib.client_key(None, clien
 cluster/lib/logging.sh:      local source_file=${BASH_SOURCE[$frame_no]}
 cluster/lib/logging.sh:    local source_file=${BASH_SOURCE[$stack_skip]}
 cluster/log-dump/log-dump.sh:    local -r node_name="${1}"
-cluster/log-dump/log-dump.sh:  for node_name in "${node_names[@]}"; do
+cluster/log-dump/log-dump.sh:  for node_name in "${nodes_selected_for_logs[@]}"; do
 cluster/log-dump/log-dump.sh:readonly report_dir="${1:-_artifacts}"
 cluster/mesos/docker/km/build.sh:  km_path=$(find-binary km darwin/amd64)
 cluster/photon-controller/templates/salt-master.sh:  api_servers: $MASTER_NAME


### PR DESCRIPTION
As discussed offline - to fix failing log-dump on 1.5 jobs.
I've pretty much replaced the script with the one we have at head, but with logexporter-related code removed.

cc @mwielgus @abgworrall 