### PR TITLE
[WIP] Convert federated jobs to use sync controller

### DIFF
--- a/federation/pkg/federatedtypes/BUILD
+++ b/federation/pkg/federatedtypes/BUILD
@@ -32,6 +32,7 @@ go_library(
         "daemonset.go",
         "deployment.go",
         "hpa.go",
+        "job.go",
         "namespace.go",
         "qualifiedname.go",
         "registry.go",

--- a/federation/pkg/federatedtypes/BUILD
+++ b/federation/pkg/federatedtypes/BUILD
@@ -54,6 +54,7 @@ go_library(
         "//pkg/controller/namespace/deletion:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/autoscaling/v1:go_default_library",
+        "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/federation/pkg/federatedtypes/job.go
+++ b/federation/pkg/federatedtypes/job.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +build ignore
+package federatedtypes
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	pkgruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	kubeclientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	federationclientset "k8s.io/kubernetes/federation/client/clientset_generated/federation_clientset"
+	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
+)
+
+const (
+	JobKind                     = "job"
+	JobControllerName           = "jobs"
+	FedJobPreferencesAnnotation = "federation.kubernetes.io/job-preferences"
+)
+
+func init() {
+	//RegisterFederatedType(JobKind, JobControllerName, []schema.GroupVersionResource{extensionsv1.SchemeGroupVersion.WithResource(JobControllerName)}, NewJobAdapter)
+}
+
+type JobAdapter struct {
+	//*jobSchedulingAdapter
+	client federationclientset.Interface
+}
+
+func NewJobAdapter(client federationclientset.Interface, config *restclient.Config, adapterSpecificArgs map[string]interface{}) bool {
+	//return &JobAdapter{client}
+	return true
+}
+
+func (a *JobAdapter) Kind() string {
+	return JobKind
+}
+
+func (a *JobAdapter) ObjectType() pkgruntime.Object {
+	return &batchv1.Job{}
+}
+
+func (a *JobAdapter) IsExpectedType(obj interface{}) bool {
+	_, ok := obj.(*batchv1.Job)
+	return ok
+}
+
+func (a *JobAdapter) Copy(obj pkgruntime.Object) pkgruntime.Object {
+	job := obj.(*batchv1.Job)
+	return &batchv1.Job{
+		ObjectMeta: fedutil.DeepCopyRelevantObjectMeta(job.ObjectMeta),
+		Spec:       *fedutil.DeepCopyApiTypeOrPanic(&job.Spec).(*batchv1.JobSpec),
+	}
+}
+
+func (a *JobAdapter) Equivalent(obj1, obj2 pkgruntime.Object) bool {
+	return fedutil.ObjectMetaAndSpecEquivalent(obj1, obj2)
+}
+
+func (a *JobAdapter) QualifiedName(obj pkgruntime.Object) QualifiedName {
+	job := obj.(*batchv1.Job)
+	return QualifiedName{Namespace: job.Namespace, Name: job.Name}
+}
+
+func (a *JobAdapter) ObjectMeta(obj pkgruntime.Object) *metav1.ObjectMeta {
+	return &obj.(*batchv1.Job).ObjectMeta
+}
+
+func (a *JobAdapter) FedCreate(obj pkgruntime.Object) (pkgruntime.Object, error) {
+	job := obj.(*batchv1.Job)
+	return a.client.BatchV1().Jobs(job.Namespace).Create(job)
+}
+
+func (a *JobAdapter) FedDelete(qualifiedName QualifiedName, options *metav1.DeleteOptions) error {
+	return a.client.BatchV1().Jobs(qualifiedName.Namespace).Delete(qualifiedName.Name, options)
+}
+
+func (a *JobAdapter) FedGet(qualifiedName QualifiedName) (pkgruntime.Object, error) {
+	return a.client.BatchV1().Jobs(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
+}
+
+func (a *JobAdapter) FedList(namespace string, options metav1.ListOptions) (pkgruntime.Object, error) {
+	return a.client.BatchV1().Jobs(namespace).List(options)
+}
+
+func (a *JobAdapter) FedUpdate(obj pkgruntime.Object) (pkgruntime.Object, error) {
+	job := obj.(*batchv1.Job)
+	return a.client.BatchV1().Jobs(job.Namespace).Update(job)
+}
+
+func (a *JobAdapter) FedWatch(namespace string, options metav1.ListOptions) (watch.Interface, error) {
+	return a.client.BatchV1().Jobs(namespace).Watch(options)
+}
+
+func (a *JobAdapter) ClusterCreate(client kubeclientset.Interface, obj pkgruntime.Object) (pkgruntime.Object, error) {
+	job := obj.(*batchv1.Job)
+	return client.BatchV1().Jobs(job.Namespace).Create(job)
+}
+
+func (a *JobAdapter) ClusterDelete(client kubeclientset.Interface, qualifiedName QualifiedName, options *metav1.DeleteOptions) error {
+	return client.BatchV1().Jobs(qualifiedName.Namespace).Delete(qualifiedName.Name, options)
+}
+
+func (a *JobAdapter) ClusterGet(client kubeclientset.Interface, qualifiedName QualifiedName) (pkgruntime.Object, error) {
+	return client.BatchV1().Jobs(qualifiedName.Namespace).Get(qualifiedName.Name, metav1.GetOptions{})
+}
+
+func (a *JobAdapter) ClusterList(client kubeclientset.Interface, namespace string, options metav1.ListOptions) (pkgruntime.Object, error) {
+	return client.BatchV1().Jobs(namespace).List(options)
+}
+
+func (a *JobAdapter) ClusterUpdate(client kubeclientset.Interface, obj pkgruntime.Object) (pkgruntime.Object, error) {
+	job := obj.(*batchv1.Job)
+	return client.Batch().Jobs(job.Namespace).Update(job)
+}
+
+func (a *JobAdapter) ClusterWatch(client kubeclientset.Interface, namespace string, options metav1.ListOptions) (watch.Interface, error) {
+	return client.Batch().Jobs(namespace).Watch(options)
+}
+
+func (a *JobAdapter) EquivalentIgnoringSchedule(obj1, obj2 pkgruntime.Object) bool {
+	job1 := obj1.(*batchv1.Job)
+	job2 := a.Copy(obj2).(*batchv1.Job)
+	//job2.Spec.Replicas = job1.Spec.Replicas // why do we need to copy Replicas address?
+	return fedutil.ObjectMetaAndSpecEquivalent(job1, job2)
+}
+
+func (a *JobAdapter) NewTestObject(namespace string) pkgruntime.Object {
+	parallelism := int32(3)
+	completions := int32(3)
+	zero := int64(0)
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "test-job-",
+			Namespace:    namespace,
+		},
+		Spec: batchv1.JobSpec{
+			Parallelism: &parallelism,
+			Completions: &completions,
+			Template: apiv1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"foo": "bar"},
+				},
+				Spec: apiv1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []apiv1.Container{
+						{
+							Name:  "busybox",
+							Image: "busybox",
+							Command: []string{
+								"echo",
+								"Hello FederatedType Jobs!",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/federation/pkg/federatedtypes/job.go
+++ b/federation/pkg/federatedtypes/job.go
@@ -72,7 +72,7 @@ func (a *JobAdapter) Copy(obj pkgruntime.Object) pkgruntime.Object {
 	job := obj.(*batchv1.Job)
 	return &batchv1.Job{
 		ObjectMeta: fedutil.DeepCopyRelevantObjectMeta(job.ObjectMeta),
-		Spec:       *fedutil.DeepCopyApiTypeOrPanic(&job.Spec).(*batchv1.JobSpec),
+		Spec:       *job.Spec.DeepCopy(),
 	}
 }
 

--- a/federation/pkg/federatedtypes/job.go
+++ b/federation/pkg/federatedtypes/job.go
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +build ignore
 package federatedtypes
 
 import (


### PR DESCRIPTION
This implements the FederatedTypeAdapter for jobs but does not incorporate scheduling yet. The test job created for integration tests specifies the `ManualSelector: true` field in order to allow integration tests to pass, but it still needs to be implemented as part of the scheduling for jobs.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Simplify jobs controller to use common interface.

<!--**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
-->

**Special notes for your reviewer**:
Not ready for review yet.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
