### PR TITLE
ip6tables should be set in the noop plugin

### DIFF
--- a/pkg/kubelet/network/testing/BUILD
+++ b/pkg/kubelet/network/testing/BUILD
@@ -35,7 +35,9 @@ go_test(
         "//pkg/kubelet/apis/kubeletconfig:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/network:go_default_library",
+        "//pkg/util/sysctl/testing:go_default_library",
         "//vendor/github.com/golang/mock/gomock:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )


### PR DESCRIPTION

**What this PR does / why we need it**:
The noop plugin currently sets the iptables for IPv4.
This updates that to also set the iptables for IPv6 so
IPv6 can have parity with IPv4.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53147

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
