### PR TITLE
moved admission interfaces WantsClientCert, WantsAuthorizer and Wants…

### DIFF
--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -219,6 +219,8 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	err = s.Admission.ApplyTo(
 		genericConfig,
 		versionedInformers,
+		nil,
+		nil,
 		pluginInitializer,
 	)
 	if err != nil {

--- a/pkg/kubeapiserver/admission/BUILD
+++ b/pkg/kubeapiserver/admission/BUILD
@@ -12,6 +12,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
     ],
 )
@@ -25,6 +26,7 @@ go_library(
         "//pkg/quota:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],

--- a/pkg/kubeapiserver/admission/init_test.go
+++ b/pkg/kubeapiserver/admission/init_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 )
 
@@ -51,7 +52,7 @@ func (self *WantAuthorizerAdmission) SetAuthorizer(a authorizer.Authorizer) {
 }
 
 var _ admission.Interface = &WantAuthorizerAdmission{}
-var _ WantsAuthorizer = &WantAuthorizerAdmission{}
+var _ genericadmissioninit.WantsAuthorizer = &WantAuthorizerAdmission{}
 
 // TestWantsAuthorizer ensures that the authorizer is injected when the WantsAuthorizer
 // interface is implemented.
@@ -104,21 +105,5 @@ func TestWantsServiceResolver(t *testing.T) {
 	i.SetServiceResolver(fsr).Initialize(sw)
 	if got, ok := sw.got.(*fakeServiceResolver); !ok || got != fsr {
 		t.Errorf("plumbing fail - %v %v#", ok, got)
-	}
-}
-
-type clientCertWanter struct {
-	doNothingAdmission
-	gotCert, gotKey []byte
-}
-
-func (s *clientCertWanter) SetClientCert(cert, key []byte) { s.gotCert, s.gotKey = cert, key }
-
-func TestWantsClientCert(t *testing.T) {
-	i := &PluginInitializer{}
-	ccw := &clientCertWanter{}
-	i.SetClientCert([]byte("cert"), []byte("key")).Initialize(ccw)
-	if string(ccw.gotCert) != "cert" || string(ccw.gotKey) != "key" {
-		t.Errorf("plumbing fail - %v %v", ccw.gotCert, ccw.gotKey)
 	}
 }

--- a/plugin/pkg/admission/security/podsecuritypolicy/BUILD
+++ b/plugin/pkg/admission/security/podsecuritypolicy/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
     ],

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/kubernetes/pkg/api"
@@ -82,7 +83,7 @@ func (plugin *podSecurityPolicyPlugin) Validate() error {
 }
 
 var _ admission.Interface = &podSecurityPolicyPlugin{}
-var _ kubeapiserveradmission.WantsAuthorizer = &podSecurityPolicyPlugin{}
+var _ genericadmissioninit.WantsAuthorizer = &podSecurityPolicyPlugin{}
 var _ kubeapiserveradmission.WantsInternalKubeInformerFactory = &podSecurityPolicyPlugin{}
 
 // NewPlugin creates a new PSP admission plugin.

--- a/plugin/pkg/admission/webhook/BUILD
+++ b/plugin/pkg/admission/webhook/BUILD
@@ -52,6 +52,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],

--- a/plugin/pkg/admission/webhook/admission.go
+++ b/plugin/pkg/admission/webhook/admission.go
@@ -38,6 +38,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api"
@@ -114,8 +115,8 @@ type GenericAdmissionWebhook struct {
 
 var (
 	_ = admissioninit.WantsServiceResolver(&GenericAdmissionWebhook{})
-	_ = admissioninit.WantsClientCert(&GenericAdmissionWebhook{})
-	_ = admissioninit.WantsExternalKubeClientSet(&GenericAdmissionWebhook{})
+	_ = genericadmissioninit.WantsClientCert(&GenericAdmissionWebhook{})
+	_ = genericadmissioninit.WantsExternalKubeClientSet(&GenericAdmissionWebhook{})
 )
 
 func (a *GenericAdmissionWebhook) SetProxyTransport(pt *http.Transport) {
@@ -140,6 +141,9 @@ func (a *GenericAdmissionWebhook) SetExternalKubeClientSet(client clientset.Inte
 }
 
 func (a *GenericAdmissionWebhook) Validate() error {
+	if a.clientCert == nil || a.clientKey == nil {
+		return fmt.Errorf("the GenericAdmissionWebhook admission plugin requires a client certificate and the private key to be provided")
+	}
 	if a.hookSource == nil {
 		return fmt.Errorf("the GenericAdmissionWebhook admission plugin requires a Kubernetes client to be provided")
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -27,14 +27,21 @@ type pluginInitializer struct {
 	externalClient    kubernetes.Interface
 	externalInformers informers.SharedInformerFactory
 	authorizer        authorizer.Authorizer
+	// serverIdentifyingClientCert used to provide identity when calling out to admission plugins
+	serverIdentifyingClientCert []byte
+	// serverIdentifyingClientKey private key for the client certificate used when calling out to admission plugins
+	serverIdentifyingClientKey []byte
 }
 
 // New creates an instance of admission plugins initializer.
-func New(extClientset kubernetes.Interface, extInformers informers.SharedInformerFactory, authz authorizer.Authorizer) (pluginInitializer, error) {
+// TODO(p0lyn0mial): make the parameters public, this construction seems to be redundant.
+func New(extClientset kubernetes.Interface, extInformers informers.SharedInformerFactory, authz authorizer.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey []byte) (pluginInitializer, error) {
 	return pluginInitializer{
-		externalClient:    extClientset,
-		externalInformers: extInformers,
-		authorizer:        authz,
+		externalClient:              extClientset,
+		externalInformers:           extInformers,
+		authorizer:                  authz,
+		serverIdentifyingClientCert: serverIdentifyingClientCert,
+		serverIdentifyingClientKey:  serverIdentifyingClientKey,
 	}, nil
 }
 
@@ -51,6 +58,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsAuthorizer); ok {
 		wants.SetAuthorizer(i.authorizer)
+	}
+
+	if wants, ok := plugin.(WantsClientCert); ok {
+		wants.SetClientCert(i.serverIdentifyingClientCert, i.serverIdentifyingClientKey)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -40,3 +40,10 @@ type WantsAuthorizer interface {
 	SetAuthorizer(authorizer.Authorizer)
 	admission.Validator
 }
+
+// WantsClientCert defines a fuction that accepts a cert & key for admission
+// plugins that need to make calls and prove their identity.
+type WantsClientCert interface {
+	SetClientCert(cert, key []byte)
+	admission.Validator
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -48,7 +48,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer, err := kubeadmission.New(c, f, nil)
+	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil)
 	if err != nil {
 		return handler, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -73,9 +73,14 @@ func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
 // In addition the method lazily initializes a generic plugin that is appended to the list of pluginInitializers
 // note this method uses:
 //  genericconfig.LoopbackClientConfig
-//  genericconfig.SharedInformerFactory
 //  genericconfig.Authorizer
-func (a *AdmissionOptions) ApplyTo(c *server.Config, informers informers.SharedInformerFactory, pluginInitializers ...admission.PluginInitializer) error {
+func (a *AdmissionOptions) ApplyTo(
+	c *server.Config,
+	informers informers.SharedInformerFactory,
+	serverIdentifyingClientCert []byte,
+	serverIdentifyingClientKey []byte,
+	pluginInitializers ...admission.PluginInitializer,
+) error {
 	pluginNames := a.PluginNames
 	if len(a.PluginNames) == 0 {
 		pluginNames = a.enabledPluginNames()
@@ -90,7 +95,7 @@ func (a *AdmissionOptions) ApplyTo(c *server.Config, informers informers.SharedI
 	if err != nil {
 		return err
 	}
-	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer)
+	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -119,7 +119,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
-	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, admissionInitializer); err != nil {
+	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, admissionInitializer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
moves some admission interfaces to apiserver, hopefully moving the webhook admission in the future will be much easier.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
