### PR TITLE
Revert "Make kubelet touch iptables lock file during initialization"

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -516,16 +516,6 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 	glog.Infof("Hairpin mode set to %q", hairpinMode)
 
-	// TODO(#36485) Remove this workaround once we fix the init-container issue.
-	// Touch iptables lock file, which will be shared among all processes accessing
-	// the iptables.
-	f, err := os.OpenFile(utilipt.LockfilePath16x, os.O_CREATE, 0600)
-	if err != nil {
-		glog.Warningf("Failed to open iptables lock file: %v", err)
-	} else if err = f.Close(); err != nil {
-		glog.Warningf("Failed to close iptables lock file: %v", err)
-	}
-
 	plug, err := network.InitNetworkPlugin(kubeDeps.NetworkPlugins, crOptions.NetworkPluginName, &criNetworkHost{&networkHost{klet}, &network.NoopPortMappingGetter{}}, hairpinMode, kubeCfg.NonMasqueradeCIDR, int(crOptions.NetworkPluginMTU))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**: Revert #47212. #36485 is fixed so this is no longer needed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE

**Special notes for your reviewer**:
/assign @yujuhong @dchen1107 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
