### PR TITLE
Normalize RepoTags before checking for match

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/helpers_test.go
+++ b/pkg/kubelet/dockershim/libdocker/helpers_test.go
@@ -102,6 +102,14 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			Output: true,
 		},
 		{
+			Inspected: dockertypes.ImageInspect{
+				ID:       "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoTags: []string{"docker.io/busybox:latest"},
+			},
+			Image:  "docker.io/library/busybox:latest",
+			Output: true,
+		},
+		{
 			// RepoDigest match is is required
 			Inspected: dockertypes.ImageInspect{
 				ID:          "",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

on projectatomic-based docker, we get "docker.io/library/busybox:latest"
when someone uses an unqualified name like "busybox". Though when we
inspect, the RepoTag will still say "docker.io/busybox:latest", So
we have reparse the tag, normalize it and try again. Please see the
additional test case.

Signed-off-by: Andy Goldstein <andy.goldstein@gmail.com>

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #52110

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixes an issue pulling pod specs referencing unqualified images from docker.io on centos/fedora/rhel
```
