### PR TITLE
Improve deb and rpm packaging in bazel build

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -86,6 +86,12 @@ grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
     stamp = 1,
 )
 
+genrule(
+    name = "cni_package_version",
+    outs = ["cni_version"],
+    cmd = "echo 0.5.1 >$@",
+)
+
 release_filegroup(
     name = "docker-artifacts",
     srcs = [":%s.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +

--- a/build/debs/10-kubeadm.conf
+++ b/build/debs/10-kubeadm.conf
@@ -4,7 +4,10 @@ Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manife
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
+# Value should match Docker daemon settings.
+# Defaults are "cgroupfs" for Debian/Ubuntu/OpenSUSE and "systemd" for Fedora/CentOS/RHEL
+Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=cgroupfs"
 Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
 Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true"
 ExecStart=
-ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CGROUP_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS

--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -73,7 +73,7 @@ deb_data(
             "dir": "/usr/bin",
         },
         {
-            "files": ["kubeadm-10.conf"],
+            "files": ["10-kubeadm.conf"],
             "mode": "644",
             "dir": "/etc/systemd/system/kubelet.service.d",
         },
@@ -132,7 +132,7 @@ k8s_deb(
     name = "kubelet",
     depends = [
         "iptables (>= 1.4.21)",
-        "kubernetes-cni (>= 0.3.0.1)",
+        "kubernetes-cni (>= 0.5.1)",
         "iproute2",
         "socat",
         "util-linux",
@@ -149,8 +149,9 @@ The node agent of Kubernetes, the container cluster manager
 k8s_deb(
     name = "kubeadm",
     depends = [
-        "kubelet (>= 1.4.0)",
-        "kubectl (>= 1.4.0)",
+        "kubelet (>= 1.8.0)",
+        "kubectl (>= 1.8.0)",
+        "kubernetes-cni (>= 0.5.1)",
     ],
     description = """Kubernetes Cluster Bootstrapping Tool
 The Kubernetes command line tool for bootstrapping a Kubernetes cluster.
@@ -163,7 +164,7 @@ k8s_deb(
     description = """Kubernetes Packaging of CNI
 The Container Networking Interface tools for provisioning container networks.
 """,
-    version_file = "//build:os_package_version",
+    version_file = "//build:cni_package_version",
 )
 
 filegroup(

--- a/build/rpms/10-kubeadm.conf
+++ b/build/rpms/10-kubeadm.conf
@@ -4,6 +4,10 @@ Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manife
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"
 Environment="KUBELET_AUTHZ_ARGS=--authorization-mode=Webhook --client-ca-file=/etc/kubernetes/pki/ca.crt"
+# Value should match Docker daemon settings.
+# Defaults are "cgroupfs" for Debian/Ubuntu/OpenSUSE and "systemd" for Fedora/CentOS/RHEL
 Environment="KUBELET_CGROUP_ARGS=--cgroup-driver=systemd"
+Environment="KUBELET_CADVISOR_ARGS=--cadvisor-port=0"
+Environment="KUBELET_CERTIFICATE_ARGS=--rotate-certificates=true"
 ExecStart=
-ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CGROUP_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_AUTHZ_ARGS $KUBELET_CGROUP_ARGS $KUBELET_CADVISOR_ARGS $KUBELET_CERTIFICATE_ARGS $KUBELET_EXTRA_ARGS

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -45,7 +45,7 @@ pkg_rpm(
         "@kubernetes_cni//file",
     ],
     spec_file = "kubernetes-cni.spec",
-    version_file = "//build:os_package_version",
+    version_file = "//build:cni_package_version",
 )
 
 filegroup(

--- a/build/rpms/kubeadm.spec
+++ b/build/rpms/kubeadm.spec
@@ -2,15 +2,15 @@ Name: kubeadm
 Version: OVERRIDE_THIS
 Release: 00
 License: ASL 2.0
-Summary: Container Cluster Manager
-Requires: kubelet >= %{version}
-Requires: kubectl >= %{version}
-Requires: kubernetes-cni
+Summary: Container Cluster Manager - Kubernetes Cluster Bootstrapping Tool
+Requires: kubelet >= 1.8.0
+Requires: kubectl >= 1.8.0
+Requires: kubernetes-cni >= 0.5.1
 
 URL: https://kubernetes.io
 
 %description
-Command-line utility for administering a Kubernetes cluster.
+Command-line utility for deploying a Kubernetes cluster.
 
 %install
 install -m 755 -d %{buildroot}%{_bindir}

--- a/build/rpms/kubectl.spec
+++ b/build/rpms/kubectl.spec
@@ -2,7 +2,7 @@ Name: kubectl
 Version: OVERRIDE_THIS
 Release: 00
 License: ASL 2.0
-Summary: Container Cluster Manager
+Summary: Container Cluster Manager - Kubernetes client tools
 
 URL: https://kubernetes.io
 

--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -2,7 +2,7 @@ Name: kubelet
 Version: OVERRIDE_THIS
 Release: 00
 License: ASL 2.0
-Summary: Container Cluster Manager
+Summary: Container Cluster Manager - Kubernetes Node Agent
 
 URL: https://kubernetes.io
 

--- a/build/rpms/kubernetes-cni.spec
+++ b/build/rpms/kubernetes-cni.spec
@@ -2,7 +2,7 @@ Name: kubernetes-cni
 Version: OVERRIDE_THIS
 Release: 00
 License: ASL 2.0
-Summary: Container Cluster Manager
+Summary: Container Cluster Manager - CNI plugins
 
 URL: https://kubernetes.io
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- kubernetes-cni package now has proper version (0.5.1)
- Synchronize post-1.8 version of 10-kubeadm.conf file from release
  repository.
- Fix dependencies
- Improve descriptions in produced packages

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This PR will be safe to cherry-pick to 1.8 branch. After that we will be able to generate from bazel automatically usable packages for both 1.8 and master branch out of bazel builds.
cc @ixdy @mikedanese @luxas 

**Release note**:
```release-note
- Improved generation of deb and rpm packages in bazel build
```
