### PR TITLE
Automated cherry pick of #48326

### DIFF
--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -138,7 +138,9 @@ func (a *azureFileProvisioner) Provision() (*v1.PersistentVolume, error) {
 
 	var sku, location, account string
 
-	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 75)
+	// File share name has a length limit of 63, and it cannot contain two consecutive '-'s.
+	name := volume.GenerateVolumeName(a.options.ClusterName, a.options.PVName, 63)
+	name = strings.Replace(name, "--", "-", -1)
 	capacity := a.options.PVC.Spec.Resources.Requests[v1.ResourceName(v1.ResourceStorage)]
 	requestBytes := capacity.Value()
 	requestGB := int(volume.RoundUpSize(requestBytes, 1024*1024*1024))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Azure file share name has a length limit of 63, but currently the code is using data volume's limit 75.

**Which issue this PR fixes**
cherry-pick fix of https://github.com/kubernetes/kubernetes/pull/48326
With current implementation, when the cluster name is long, the resulting file share name could have a length of 75.

Also function GenerateVolumeName would produce double '-' when clusterName containing '-' is to be truncated.

In both cases, service would reject the creating file share request.

**Special notes for your reviewer**:
Please refer to:
https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-shares--directories--files--and-metadata#share-names

Share names must be from 3 through 63 characters long.
The name cannot contain two consecutive hyphens.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix the issue: could not create an azure file when k8s cluster name lenght > 15 
```
