### PR TITLE
Automated cherry pick of #53161

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/helpers_test.go
+++ b/pkg/kubelet/dockershim/libdocker/helpers_test.go
@@ -102,6 +102,14 @@ func TestMatchImageTagOrSHA(t *testing.T) {
 			Output: true,
 		},
 		{
+			Inspected: dockertypes.ImageInspect{
+				ID:       "sha256:9bbdf247c91345f0789c10f50a57e36a667af1189687ad1de88a6243d05a2227",
+				RepoTags: []string{"docker.io/busybox:latest"},
+			},
+			Image:  "docker.io/library/busybox:latest",
+			Output: true,
+		},
+		{
 			// RepoDigest match is is required
 			Inspected: dockertypes.ImageInspect{
 				ID:          "",


### PR DESCRIPTION
Cherry pick of #53161 on release-1.8.

#53161: Normalize RepoTags before checking for match