### PR TITLE
vendor/k8s.io/client-go/tools/record: Fix two swallowed errors in tests

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -120,6 +120,9 @@ func TestEventf(t *testing.T) {
 		},
 	}
 	testRef, err := ref.GetPartialReference(scheme.Scheme, testPod, "spec.containers[2]")
+	if err != nil {
+		t.Fatal(err)
+	}
 	testRef2, err := ref.GetPartialReference(scheme.Scheme, testPod2, "spec.containers[3]")
 	if err != nil {
 		t.Fatal(err)
@@ -641,6 +644,9 @@ func TestMultiSinkCache(t *testing.T) {
 		},
 	}
 	testRef, err := ref.GetPartialReference(scheme.Scheme, testPod, "spec.containers[2]")
+	if err != nil {
+		t.Fatal(err)
+	}
 	testRef2, err := ref.GetPartialReference(scheme.Scheme, testPod2, "spec.containers[3]")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes two dropped errors in client-go.

```release-note NONE
```
