### PR TITLE
fix kubectl copy file into correct dir when tail slash is missing in remote file spec

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -143,7 +143,7 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 
 	// TODO: Improve error messages by first testing if 'tar' is present in the container?
 	cmdArr := []string{"tar", "xf", "-"}
-	destDir := path.Dir(dest.File)
+	destDir := path.Clean(dest.File)
 	if len(destDir) > 0 {
 		cmdArr = append(cmdArr, "-C", destDir)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
without this PR:
1. `kubectl cp a tomcat-179433334-2f0b4:/tmp/b` will copy file `a` into remote `/tmp/` unexpectedly
2. `kubectl cp a tomcat-179433334-2f0b4:/tmp/b/` will copy file `a` into remote `/tmp/b/` as expected

with this PR:
both `kubectl cp a tomcat-179433334-2f0b4:/tmp/b` and `kubectl cp a tomcat-179433334-2f0b4:/tmp/b/` will copy file  `a` into remote `/tmp/b/` as expected

```release-note
NONE
```
