### PR TITLE
bazel: set --incompatible_disallow_set_constructor=false to fix breakage

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -17,6 +17,8 @@ build --sandbox_fake_username
 # TODO(ixdy): Remove this default once rules_go is bumped.
 # Ref kubernetes/kubernetes#52677
 build --incompatible_comprehension_variables_do_not_leak=false
+# TODO(ixdy): remove the following once repo-infra is bumped.
+build --incompatible_disallow_set_constructor=false
 
 # Enable go race detection.
 test --features=race


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The build is broken with bazel 0.6.0. I have a proper fix ready, but it'll lock us to bazel 0.6.0+, which I don't want to do quite yet, hence this workaround.

x-ref #52677

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @mikedanese @spxtr @BenTheElder 
cc @apelisse 