### PR TITLE
Let node test subcommand be an arg

### DIFF
--- a/test/e2e_node/jenkins/conformance/conformance-jenkins.sh
+++ b/test/e2e_node/jenkins/conformance/conformance-jenkins.sh
@@ -32,7 +32,7 @@ TIMEOUT=${TIMEOUT:-"45m"}
 
 mkdir -p ${ARTIFACTS}
 
-go run test/e2e_node/runner/remote/run_remote.go  conformance \
+go run test/e2e_node/runner/remote/run_remote.go  --test-suite=conformance \
   --logtostderr --vmodule=*=4 --ssh-env="gce" --ssh-user="$GCE_USER" \
   --zone="$GCE_ZONE" --project="$GCE_PROJECT" --hosts="$GCE_HOSTS" \
   --images="$GCE_IMAGES" --image-project="$GCE_IMAGE_PROJECT" \

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -45,7 +45,7 @@ import (
 )
 
 var testArgs = flag.String("test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
-var testSuite = flag.String("test-suite", "", "Test suite the runner initializes with.")
+var testSuite = flag.String("test-suite", "default", "Test suite the runner initializes with. Currently support default|conformance")
 var instanceNamePrefix = flag.String("instance-name-prefix", "", "prefix for instance names")
 var zone = flag.String("zone", "", "gce zone the hosts live in")
 var project = flag.String("project", "", "gce project the hosts live in")
@@ -150,9 +150,11 @@ func main() {
 	case "conformance":
 		suite = remote.InitConformanceRemote()
 	// TODO: Add subcommand for node soaking, node conformance, cri validation.
-	default:
+	case "default":
 		// Use node e2e suite by default if no subcommand is specified.
 		suite = remote.InitNodeE2ERemote()
+	default:
+		glog.Fatalf("--test-suite must be one of default or conformance")
 	}
 
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -45,6 +45,7 @@ import (
 )
 
 var testArgs = flag.String("test_args", "", "Space-separated list of arguments to pass to Ginkgo test runner.")
+var testSuite = flag.String("test-suite", "", "Test suite the runner initializes with.")
 var instanceNamePrefix = flag.String("instance-name-prefix", "", "prefix for instance names")
 var zone = flag.String("zone", "", "gce zone the hosts live in")
 var project = flag.String("project", "", "gce project the hosts live in")
@@ -143,14 +144,9 @@ type internalGCEImage struct {
 	tests     []string
 }
 
-// parseFlags parse subcommands and flags
-func parseFlags() {
-	if len(os.Args) <= 1 {
-		glog.Fatalf("Too few flags specified: %v", os.Args)
-	}
-	// Parse subcommand.
-	subcommand := os.Args[1]
-	switch subcommand {
+func main() {
+	flag.Parse()
+	switch *testSuite {
 	case "conformance":
 		suite = remote.InitConformanceRemote()
 	// TODO: Add subcommand for node soaking, node conformance, cri validation.
@@ -158,12 +154,6 @@ func parseFlags() {
 		// Use node e2e suite by default if no subcommand is specified.
 		suite = remote.InitNodeE2ERemote()
 	}
-	// Parse test flags.
-	flag.CommandLine.Parse(os.Args[2:])
-}
-
-func main() {
-	parseFlags()
 
 	rand.Seed(time.Now().UTC().UnixNano())
 	if *buildOnly {


### PR DESCRIPTION
Currently node-test will strip off the 1st arg if subcommand is not specified, i.e. both [Jenkins](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/e2e-node-jenkins.sh#L44) and [kubetest](https://github.com/kubernetes/test-infra/blob/master/kubetest/e2e.go#L524) -- make it a flag will be clearer.

/assign @Random-Liu @yguo0905 