### PR TITLE
Allow version arg to be optional in "kubeadm upgrade apply"

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -80,11 +80,26 @@ func NewCmdApply(parentFlags *cmdUpgradeFlags) *cobra.Command {
 			err = runPreflightChecks(flags.parent.ignorePreflightErrorsSet)
 			kubeadmutil.CheckErr(err)
 
-			err = cmdutil.ValidateExactArgNumber(args, []string{"version"})
-			kubeadmutil.CheckErr(err)
+			// If the version is specified in config file, pick up that value.
+			if flags.parent.cfgPath != "" {
+				cfg, err := upgrade.FetchConfigurationFromFile(flags.parent.cfgPath)
+				kubeadmutil.CheckErr(err)
 
-			// It's safe to use args[0] here as the slice has been validated above
-			flags.newK8sVersionStr = args[0]
+				if cfg.KubernetesVersion != "" {
+					flags.newK8sVersionStr = cfg.KubernetesVersion
+				}
+			}
+
+			// If the new version is already specified in config file, version arg is optional.
+			if flags.newK8sVersionStr == "" {
+				err = cmdutil.ValidateExactArgNumber(args, []string{"version"})
+				kubeadmutil.CheckErr(err)
+			}
+
+			// If option was specified in both args and config file, args will overwrite the config file.
+			if len(args) == 1 {
+				flags.newK8sVersionStr = args[0]
+			}
 
 			// Default the flags dynamically, based on each others' value
 			err = SetImplicitFlags(flags)

--- a/cmd/kubeadm/app/phases/upgrade/configuration.go
+++ b/cmd/kubeadm/app/phases/upgrade/configuration.go
@@ -52,6 +52,23 @@ func FetchConfiguration(client clientset.Interface, w io.Writer, cfgPath string)
 	return versionedcfg, nil
 }
 
+// FetchConfigurationFromFile fetch configuration from a file
+func FetchConfigurationFromFile(cfgPath string) (*kubeadmapiext.MasterConfiguration, error) {
+	// Load the configuration from a file or the cluster
+	configBytes, err := ioutil.ReadFile(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// Take the versioned configuration populated from the configmap, default it and validate
+	// Return the internal version of the API object
+	versionedcfg, err := bytesToValidatedMasterConfig(configBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode configuration: %v", err)
+	}
+	return versionedcfg, nil
+}
+
 // loadConfigurationBytes loads the configuration byte slice from either a file or the cluster ConfigMap
 func loadConfigurationBytes(client clientset.Interface, w io.Writer, cfgPath string) ([]byte, error) {
 	if cfgPath != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR make the version arg optional if --config is specified and .KuberneteVersion is available.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://github.com/kubernetes/kubeadm/issues/460

**Special notes for your reviewer**:
```release-note
Allow version arg in kubeadm upgrade apply to be optional if config file already have version info
```