### PR TITLE
Fix running e2e with 'Completed' kube-system pods.

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -647,10 +647,7 @@ func WaitForPodsRunningReady(c clientset.Interface, ns string, minPods, allowedN
 			case res && err == nil:
 				nOk++
 			case pod.Status.Phase == v1.PodSucceeded:
-				Logf("The status of Pod %s is Succeeded which is unexpected", pod.ObjectMeta.Name)
-				badPods = append(badPods, pod)
-				// it doesn't make sense to wait for this pod
-				return false, errors.New("unexpected Succeeded pod state")
+				continue
 			case pod.Status.Phase != v1.PodFailed:
 				Logf("The status of Pod %s is %s (Ready = false), waiting for it to be either Running (with Ready = true) or Failed", pod.ObjectMeta.Name, pod.Status.Phase)
 				notReady++


### PR DESCRIPTION
Currently e2e runner fails during BeforeSuite execution if there are pods in `kube-system` namespace in 'Completed' state.

Exactly this issue was fixed previously in #37325 by adding new option "_skipSucceeded_" to ignore 'Completed' pods. Then, in https://github.com/kubernetes/kubernetes/commit/2e3cd93fc8c8a1fb481610598ef2f31c463f7955#diff-eb7b79470992813ea1905e96c298b47bL557  that option was removed and code was adjusted to ignore 'Completed' pods all the time. But in 0bf96a3ca4ab45763a98c11436a201bbc6ec9b5f that code was accidentally removed as redundant.

This fix restores removed code.