### PR TITLE
Fix basic audit in GCE deploy scripts

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -293,6 +293,10 @@ METADATA_CLOBBERS_CONFIG="${METADATA_CLOBBERS_CONFIG:-false}"
 
 ENABLE_BIG_CLUSTER_SUBNETS="${ENABLE_BIG_CLUSTER_SUBNETS:-false}"
 
+if [[ "${ENABLE_APISERVER_BASIC_AUDIT:-}" == "true" ]]; then
+  echo "Warning: Basic audit logging is deprecated and will be removed. Please use advanced auditing instead."
+fi
+
 if [[ -n "${LOGROTATE_FILES_MAX_COUNT:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} LOGROTATE_FILES_MAX_COUNT"
 fi

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -345,6 +345,10 @@ if [[ "${ENABLE_APISERVER_ADVANCED_AUDIT}" == "true" ]]; then
   FEATURE_GATES="${FEATURE_GATES},AdvancedAuditing=true"
 fi
 
+if [[ "${ENABLE_APISERVER_BASIC_AUDIT:-}" == "true" ]]; then
+  echo "Warning: Basic audit logging is deprecated and will be removed. Please use advanced auditing instead."
+fi
+
 ENABLE_BIG_CLUSTER_SUBNETS="${ENABLE_BIG_CLUSTER_SUBNETS:-false}"
 
 if [[ -n "${LOGROTATE_FILES_MAX_COUNT:-}" ]]; then

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1365,6 +1365,12 @@ function start-kube-apiserver {
     # grows at 10MiB/s (~30K QPS), it will rotate after ~6 years if apiserver
     # never restarts. Please manually restart apiserver before this time.
     params+=" --audit-log-maxsize=2000000000"
+    # Disable AdvancedAuditing enabled by default
+    if [[ -z "${FEATURE_GATES:-}" ]]; then
+      FEATURE_GATES="AdvancedAuditing=false"
+    else
+      FEATURE_GATES="${FEATURE_GATES},AdvancedAuditing=false"
+    fi
   elif [[ "${ENABLE_APISERVER_ADVANCED_AUDIT:-}" == "true" ]]; then
     local -r audit_policy_file="/etc/audit_policy.config"
     params+=" --audit-policy-file=${audit_policy_file}"


### PR DESCRIPTION
Fix https://github.com/kubernetes/kubernetes/issues/53154

Since AdvancedAudit feature gate is now enabled by default, we should explicitly disable it when using basic audit.