### PR TITLE
Replace deprecate aws functions

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	gcfg "gopkg.in/gcfg.v1"
+	"gopkg.in/gcfg.v1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -174,8 +174,8 @@ const (
 // The major consequence is that it is then not considered for AWS zone discovery for dynamic volume creation.
 var awsTagNameMasterRoles = sets.NewString("kubernetes.io/role/master", "k8s.io/role/master")
 
-// Maps from backend protocol to ELB protocol
-var backendProtocolMapping = map[string]string{
+// Maps from backend protocol to ELB protocol with SSL/HTTPS
+var backendSSLProtocolMapping = map[string]string{
 	"https": "https",
 	"http":  "https",
 	"ssl":   "ssl",
@@ -538,8 +538,11 @@ func (p *awsSDKProvider) Compute(regionName string) (EC2, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
-
-	service := ec2.New(session.New(awsConfig))
+	newSession, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	service := ec2.New(newSession)
 
 	p.addHandlers(regionName, &service.Handlers)
 
@@ -555,8 +558,11 @@ func (p *awsSDKProvider) LoadBalancing(regionName string) (ELB, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
-
-	elbClient := elb.New(session.New(awsConfig))
+	newSession, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	elbClient := elb.New(newSession)
 
 	p.addHandlers(regionName, &elbClient.Handlers)
 
@@ -569,8 +575,11 @@ func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
-
-	client := autoscaling.New(session.New(awsConfig))
+	newSession, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	client := autoscaling.New(newSession)
 
 	p.addHandlers(regionName, &client.Handlers)
 
@@ -578,7 +587,11 @@ func (p *awsSDKProvider) Autoscaling(regionName string) (ASG, error) {
 }
 
 func (p *awsSDKProvider) Metadata() (EC2Metadata, error) {
-	client := ec2metadata.New(session.New(&aws.Config{}))
+	newSession, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		return nil, err
+	}
+	client := ec2metadata.New(newSession)
 	p.addAPILoggingHandlers(&client.Handlers)
 	return client, nil
 }
@@ -589,21 +602,15 @@ func (p *awsSDKProvider) KeyManagement(regionName string) (KMS, error) {
 		Credentials: p.creds,
 	}
 	awsConfig = awsConfig.WithCredentialsChainVerboseErrors(true)
-
-	kmsClient := kms.New(session.New(awsConfig))
+	newSession, err := session.NewSession(awsConfig)
+	if err != nil {
+		return nil, err
+	}
+	kmsClient := kms.New(newSession)
 
 	p.addHandlers(regionName, &kmsClient.Handlers)
 
 	return kmsClient, nil
-}
-
-// stringPointerArray creates a slice of string pointers from a slice of strings
-// Deprecated: consider using aws.StringSlice - but note the slightly different behaviour with a nil input
-func stringPointerArray(orig []string) []*string {
-	if orig == nil {
-		return nil
-	}
-	return aws.StringSlice(orig)
 }
 
 func newEc2Filter(name string, values ...string) *ec2.Filter {
@@ -779,11 +786,15 @@ func (s *awsSdkEC2) ModifyInstanceAttribute(request *ec2.ModifyInstanceAttribute
 func init() {
 	registerMetrics()
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		newSession, err := session.NewSession(&aws.Config{})
+		if err != nil {
+			return nil, err
+		}
 		creds := credentials.NewChainCredentials(
 			[]credentials.Provider{
 				&credentials.EnvProvider{},
 				&ec2rolecreds.EC2RoleProvider{
-					Client: ec2metadata.New(session.New(&aws.Config{})),
+					Client: ec2metadata.New(newSession),
 				},
 				&credentials.SharedCredentialsProvider{},
 			})
@@ -2762,7 +2773,7 @@ func buildListener(port v1.ServicePort, annotations map[string]string, sslPorts 
 			protocol = "ssl"
 			instanceProtocol = "tcp"
 		} else {
-			protocol = backendProtocolMapping[instanceProtocol]
+			protocol = backendSSLProtocolMapping[instanceProtocol]
 			if protocol == "" {
 				return nil, fmt.Errorf("Invalid backend protocol %s for %s in %s", instanceProtocol, certID, ServiceAnnotationLoadBalancerBEProtocol)
 			}

--- a/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
+++ b/pkg/cloudprovider/providers/aws/aws_loadbalancer.go
@@ -82,9 +82,9 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 
 		// We are supposed to specify one subnet per AZ.
 		// TODO: What happens if we have more than one subnet per AZ?
-		createRequest.Subnets = stringPointerArray(subnetIDs)
+		createRequest.Subnets = aws.StringSlice(subnetIDs)
 
-		createRequest.SecurityGroups = stringPointerArray(securityGroupIDs)
+		createRequest.SecurityGroups = aws.StringSlice(securityGroupIDs)
 
 		// Get additional tags set by the user
 		tags := getLoadBalancerAdditionalTags(annotations)
@@ -166,7 +166,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 				// This call just replaces the security groups, unlike e.g. subnets (!)
 				request := &elb.ApplySecurityGroupsToLoadBalancerInput{}
 				request.LoadBalancerName = aws.String(loadBalancerName)
-				request.SecurityGroups = stringPointerArray(securityGroupIDs)
+				request.SecurityGroups = aws.StringSlice(securityGroupIDs)
 				glog.V(2).Info("Applying updated security groups to load balancer")
 				_, err := c.elb.ApplySecurityGroupsToLoadBalancer(request)
 				if err != nil {
@@ -197,10 +197,10 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 					if elbProtocolsAreEqual(actual.InstanceProtocol, expected.InstanceProtocol) {
 						continue
 					}
-					if orZero(actual.InstancePort) != orZero(expected.InstancePort) {
+					if aws.Int64Value(actual.InstancePort) != aws.Int64Value(expected.InstancePort) {
 						continue
 					}
-					if orZero(actual.LoadBalancerPort) != orZero(expected.LoadBalancerPort) {
+					if aws.Int64Value(actual.LoadBalancerPort) != aws.Int64Value(expected.LoadBalancerPort) {
 						continue
 					}
 					if awsArnEquals(actual.SSLCertificateId, expected.SSLCertificateId) {
@@ -287,7 +287,7 @@ func (c *Cloud) ensureLoadBalancer(namespacedName types.NamespacedName, loadBala
 					foundBackends[instancePort] = true
 					// This is an existing ELB backend so we need to determine
 					// if the state changed
-					setPolicy = (currentState != proxyProtocol)
+					setPolicy = currentState != proxyProtocol
 				}
 
 				if setPolicy {
@@ -389,10 +389,10 @@ func (c *Cloud) ensureLoadBalancerHealthCheck(loadBalancer *elb.LoadBalancerDesc
 	expectedTarget := protocol + ":" + strconv.FormatInt(int64(port), 10) + path
 
 	if expectedTarget == aws.StringValue(actual.Target) &&
-		expectedHealthyThreshold == orZero(actual.HealthyThreshold) &&
-		expectedUnhealthyThreshold == orZero(actual.UnhealthyThreshold) &&
-		expectedTimeout == orZero(actual.Timeout) &&
-		expectedInterval == orZero(actual.Interval) {
+		expectedHealthyThreshold == aws.Int64Value(actual.HealthyThreshold) &&
+		expectedUnhealthyThreshold == aws.Int64Value(actual.UnhealthyThreshold) &&
+		expectedTimeout == aws.Int64Value(actual.Timeout) &&
+		expectedInterval == aws.Int64Value(actual.Interval) {
 		return nil
 	}
 

--- a/pkg/cloudprovider/providers/aws/aws_utils.go
+++ b/pkg/cloudprovider/providers/aws/aws_utils.go
@@ -42,9 +42,3 @@ func stringSetFromPointers(in []*string) sets.String {
 	}
 	return out
 }
-
-// orZero returns the value, or 0 if the pointer is nil
-// Deprecated: prefer aws.Int64Value
-func orZero(v *int64) int64 {
-	return aws.Int64Value(v)
-}

--- a/pkg/cloudprovider/providers/aws/tags.go
+++ b/pkg/cloudprovider/providers/aws/tags.go
@@ -152,13 +152,13 @@ func (t *awsTagging) hasClusterTag(tags []*ec2.Tag) bool {
 // Ensure that a resource has the correct tags
 // If it has no tags, we assume that this was a problem caused by an error in between creation and tagging,
 // and we add the tags.  If it has a different cluster's tags, that is an error.
-func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags []*ec2.Tag) error {
+func (t *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecycle ResourceLifecycle, additionalTags map[string]string, observedTags []*ec2.Tag) error {
 	actualTagMap := make(map[string]string)
 	for _, tag := range observedTags {
 		actualTagMap[aws.StringValue(tag.Key)] = aws.StringValue(tag.Value)
 	}
 
-	expectedTags := c.buildTags(lifecycle, additionalTags)
+	expectedTags := t.buildTags(lifecycle, additionalTags)
 
 	addTags := make(map[string]string)
 	for k, expected := range expectedTags {
@@ -178,7 +178,7 @@ func (c *awsTagging) readRepairClusterTags(client EC2, resourceID string, lifecy
 		return nil
 	}
 
-	if err := c.createTags(client, resourceID, lifecycle, addTags); err != nil {
+	if err := t.createTags(client, resourceID, lifecycle, addTags); err != nil {
 		return fmt.Errorf("error adding missing tags to resource %q: %q", resourceID, err)
 	}
 


### PR DESCRIPTION
1. Replace deprecate aws functions
2. Delete unused functions
3. Rename variables
```release-note
NONE
```
