### PR TITLE
Use existing kubelet certificates if certificate rotation is enabled.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -334,6 +334,12 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies) (err error) {
 		var clientCertificateManager certificate.Manager
 		if err == nil {
 			if s.RotateCertificates && utilfeature.DefaultFeatureGate.Enabled(features.RotateKubeletClientCertificate) {
+				if clientConfig.CertFile == "" {
+					clientConfig.CertFile = path.Join(s.CertDirectory, "kubelet.crt")
+				}
+				if clientConfig.KeyFile == "" {
+					clientConfig.KeyFile = path.Join(s.CertDirectory, "kubelet.key")
+				}
 				clientCertificateManager, err = certificate.NewKubeletClientCertificateManager(s.CertDirectory, nodeName, clientConfig.CertData, clientConfig.KeyData, clientConfig.CertFile, clientConfig.KeyFile)
 				if err != nil {
 					return err


### PR DESCRIPTION
**What this PR does / why we need it**:
After upgrading kubelet on 1.7.x node to 1.8.x, it expects to use
/var/run/kubernetes/kubelet-client*.{pem,crt,key} files. Those are present
on newly bootstrapped node, but 1.7 node has certificates as
/var/run/kubernetes/kubelet.{crt,key}. This leads to scenario where kubelet
tries to request new certificates without needed permissions and end up
in Node NotReady wait loop until csr is approved manually.

This allows to re-use in kubelet 1.7.x certificates and rotate them to
new naming schema on expected deadline.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
cc @luxas @pipejakob 

**Release note**:
```release-note
- after upgrade, kubelet 1.8 will re-use correctly 1.7.x certificates if certificate rotation is enabled.
```
