### PR TITLE
Move make clean to a static list

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -309,7 +309,7 @@ clean:
 else
 clean: clean_meta
 	build/make-clean.sh
-	git clean -Xdf
+	hack/make-rules/clean.sh
 endif
 
 define CLEAN_META_HELP_INFO

--- a/hack/make-rules/clean.sh
+++ b/hack/make-rules/clean.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
+source "${KUBE_ROOT}/hack/lib/util.sh"
+
+CLEAN_PATTERNS=(
+  "_tmp"
+  "doc_tmp"
+  ".*/zz_generated.openapi.go"
+  "test/e2e/generated/bindata.go"
+)
+
+for pattern in ${CLEAN_PATTERNS[@]}; do
+  for match in $(find "${KUBE_ROOT}" -iregex "^${KUBE_ROOT}/${pattern}$"); do
+    echo "Removing ${match#${KUBE_ROOT}\/} .."
+    rm -rf "${match#${KUBE_ROOT}\/}"
+  done
+done
+
+# ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
**What this PR does / why we need it**:
#51911 changed the functionality of `make clean` to use `git clean` to remove ignored files. This had unintended consequences, wiping things out like etcd. This changes it back to a static list, managed via a bash script. It's not optimal, but the static list of patterns is more up to date then it was keeping it in the make file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52271

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
