### PR TITLE
Start certificate rotation in the background with valid bootstrap certs

### DIFF
--- a/pkg/kubelet/certificate/BUILD
+++ b/pkg/kubelet/certificate/BUILD
@@ -48,9 +48,12 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )

--- a/pkg/kubelet/certificate/certificate_manager.go
+++ b/pkg/kubelet/certificate/certificate_manager.go
@@ -276,7 +276,7 @@ func getCurrentCertificateOrBootstrap(
 		return nil, false, fmt.Errorf("unable to parse certificate data: %v", err)
 	}
 	bootstrapCert.Leaf = certs[0]
-	return &bootstrapCert, true, nil
+	return &bootstrapCert, false, nil
 }
 
 // shouldRotate looks at how close the current certificate is to expiring and


### PR DESCRIPTION
Fixes hang portion of #53237 when starting a kubelet with a valid kubeconfig

```release-note
Resolves an issue with kubelet hanging on startup when using --rotate-certificates
```