### PR TITLE
context-aware rate-limiting and backoff

### DIFF
--- a/federation/client/clientset_generated/federation_clientset/clientset.go
+++ b/federation/client/clientset_generated/federation_clientset/clientset.go
@@ -124,11 +124,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.autoscalingV1, err = autoscalingv1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -164,11 +164,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.admissionregistration, err = admissionregistrationinternalversion.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -282,9 +282,12 @@ func NewCloud(configReader io.Reader) (cloudprovider.Interface, error) {
 		if az.CloudProviderRateLimitBucket == 0 {
 			az.CloudProviderRateLimitBucket = rateLimitBucketDefault
 		}
-		az.operationPollRateLimiter = flowcontrol.NewTokenBucketRateLimiter(
+		az.operationPollRateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(
 			az.CloudProviderRateLimitQPS,
 			az.CloudProviderRateLimitBucket)
+		if err != nil {
+			return nil, err
+		}
 		glog.V(2).Infof("Azure cloudprovider using rate limit config: QPS=%g, bucket=%d",
 			az.CloudProviderRateLimitQPS,
 			az.CloudProviderRateLimitBucket)

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -467,7 +467,10 @@ func CreateGCECloud(config *CloudConfig) (*GCECloud, error) {
 		glog.Infof("managing multiple zones: %v", config.ManagedZones)
 	}
 
-	operationPollRateLimiter := flowcontrol.NewTokenBucketRateLimiter(10, 100) // 10 qps, 100 bucket size.
+	operationPollRateLimiter, err := flowcontrol.NewTokenBucketRateLimiter(10, 100) // 10 qps, 100 bucket size.
+	if err != nil {
+		return nil, err
+	}
 
 	gce := &GCECloud{
 		service:                  service,

--- a/pkg/cloudprovider/providers/gce/token_source.go
+++ b/pkg/cloudprovider/providers/gce/token_source.go
@@ -106,7 +106,7 @@ func NewAltTokenSource(tokenURL, tokenBody string) oauth2.TokenSource {
 		oauthClient: client,
 		tokenURL:    tokenURL,
 		tokenBody:   tokenBody,
-		throttle:    flowcontrol.NewTokenBucketRateLimiter(tokenURLQPS, tokenURLBurst),
+		throttle:    flowcontrol.MustNewTokenBucketRateLimiter(tokenURLQPS, tokenURLBurst),
 	}
 	return oauth2.ReuseTokenSource(nil, a)
 }

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -592,11 +592,11 @@ func (nc *Controller) addPodEvictorForNewZone(node *v1.Node) {
 		if !nc.useTaintBasedEvictions {
 			nc.zonePodEvictor[zone] =
 				scheduler.NewRateLimitedTimedQueue(
-					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
+					flowcontrol.MustNewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
 		} else {
 			nc.zoneNoExecuteTainer[zone] =
 				scheduler.NewRateLimitedTimedQueue(
-					flowcontrol.NewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
+					flowcontrol.MustNewTokenBucketRateLimiter(nc.evictionLimiterQPS, scheduler.EvictionRateLimiterBurst))
 		}
 		// Init the metric for the new zone.
 		glog.Infof("Initializing eviction metric for zone: %v", zone)

--- a/pkg/controller/node/scheduler/rate_limited_queue.go
+++ b/pkg/controller/node/scheduler/rate_limited_queue.go
@@ -292,7 +292,7 @@ func (q *RateLimitedTimedQueue) SwapLimiter(newQPS float32) {
 	if newQPS <= 0 {
 		newLimiter = flowcontrol.NewFakeNeverRateLimiter()
 	} else {
-		newLimiter = flowcontrol.NewTokenBucketRateLimiter(newQPS, EvictionRateLimiterBurst)
+		newLimiter = flowcontrol.MustNewTokenBucketRateLimiter(newQPS, EvictionRateLimiterBurst)
 	}
 	// If we're currently waiting on limiter, we drain the new one - this is a good approach when Burst value is 1
 	// TODO: figure out if we need to support higher Burst values and decide on the drain logic, should we keep:

--- a/pkg/kubelet/cm/container_manager_unsupported_test.go
+++ b/pkg/kubelet/cm/container_manager_unsupported_test.go
@@ -73,6 +73,22 @@ func (mi *fakeMountInterface) MakeRShared(path string) error {
 	return nil
 }
 
+func (mi *fakeMountInterface) GetFileType(pathname string) (mount.FileType, error) {
+	return mount.FileType("fake"), nil
+}
+
+func (mi *fakeMountInterface) MakeDir(pathname string) error {
+	return nil
+}
+
+func (mi *fakeMountInterface) MakeFile(pathname string) error {
+	return nil
+}
+
+func (mi *fakeMountInterface) ExistsPath(path string) bool {
+	return true
+}
+
 func fakeContainerMgrMountInt() mount.Interface {
 	return &fakeMountInterface{
 		[]mount.MountPoint{

--- a/pkg/kubelet/images/helpers.go
+++ b/pkg/kubelet/images/helpers.go
@@ -33,7 +33,7 @@ func throttleImagePulling(imageService kubecontainer.ImageService, qps float32, 
 	}
 	return &throttledImageService{
 		ImageService: imageService,
-		limiter:      flowcontrol.NewTokenBucketRateLimiter(qps, burst),
+		limiter:      flowcontrol.MustNewTokenBucketRateLimiter(qps, burst),
 	}
 }
 

--- a/pkg/util/async/BUILD
+++ b/pkg/util/async/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/util/async",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )

--- a/pkg/util/async/bounded_frequency_runner.go
+++ b/pkg/util/async/bounded_frequency_runner.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/util/flowcontrol"
 
 	"github.com/golang/glog"
@@ -159,7 +160,7 @@ func construct(name string, fn func(), minInterval, maxInterval time.Duration, b
 	} else {
 		// allow burst updates in short succession
 		qps := float32(time.Second) / float32(minInterval)
-		bfr.limiter = flowcontrol.NewTokenBucketRateLimiterWithClock(qps, burstRuns, timer)
+		bfr.limiter = flowcontrol.MustNewTokenBucketRateLimiterWithClock(qps, burstRuns, clock.RealClock{})
 	}
 	return bfr
 }

--- a/pkg/util/metrics/util_test.go
+++ b/pkg/util/metrics/util_test.go
@@ -31,12 +31,12 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 	}{
 		{
 			ownerName:   "owner_name",
-			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			rateLimiter: flowcontrol.MustNewTokenBucketRateLimiter(1, 1),
 			err:         "",
 		},
 		{
 			ownerName:   "invalid-owner-name",
-			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			rateLimiter: flowcontrol.MustNewTokenBucketRateLimiter(1, 1),
 			err:         "error registering rate limiter usage metric",
 		},
 	}

--- a/plugin/pkg/admission/eventratelimit/BUILD
+++ b/plugin/pkg/admission/eventratelimit/BUILD
@@ -32,7 +32,6 @@ go_library(
     srcs = [
         "admission.go",
         "cache.go",
-        "clock.go",
         "config.go",
         "doc.go",
         "limitenforcer.go",
@@ -50,6 +49,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],

--- a/plugin/pkg/admission/eventratelimit/admission.go
+++ b/plugin/pkg/admission/eventratelimit/admission.go
@@ -19,8 +19,8 @@ package eventratelimit
 import (
 	"io"
 
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apiserver/pkg/admission"
-	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/api"
 	eventratelimitapi "k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit"
 	"k8s.io/kubernetes/plugin/pkg/admission/eventratelimit/apis/eventratelimit/validation"
@@ -41,7 +41,7 @@ func Register(plugins *admission.Plugins) {
 					return nil, errs.ToAggregate()
 				}
 			}
-			return newEventRateLimit(configuration, realClock{})
+			return newEventRateLimit(configuration, clock.RealClock{})
 		})
 }
 
@@ -55,7 +55,7 @@ type eventRateLimitAdmission struct {
 }
 
 // newEventRateLimit configures an admission controller that can enforce event rate limits
-func newEventRateLimit(config *eventratelimitapi.Configuration, clock flowcontrol.Clock) (admission.Interface, error) {
+func newEventRateLimit(config *eventratelimitapi.Configuration, clock clock.Clock) (admission.Interface, error) {
 	limitEnforcers := make([]*limitEnforcer, 0, len(config.Limits))
 	for _, limitConfig := range config.Limits {
 		enforcer, err := newLimitEnforcer(limitConfig, clock)

--- a/plugin/pkg/admission/eventratelimit/cache_test.go
+++ b/plugin/pkg/admission/eventratelimit/cache_test.go
@@ -25,7 +25,10 @@ import (
 )
 
 func TestSingleCache(t *testing.T) {
-	rateLimiter := flowcontrol.NewTokenBucketRateLimiter(1., 1)
+	rateLimiter, err := flowcontrol.NewTokenBucketRateLimiter(1., 1)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter: %v", err)
+	}
 	cache := singleCache{
 		rateLimiter: rateLimiter,
 	}
@@ -40,10 +43,10 @@ func TestSingleCache(t *testing.T) {
 
 func TestLRUCache(t *testing.T) {
 	rateLimiters := []flowcontrol.RateLimiter{
-		flowcontrol.NewTokenBucketRateLimiter(1., 1),
-		flowcontrol.NewTokenBucketRateLimiter(2., 2),
-		flowcontrol.NewTokenBucketRateLimiter(3., 3),
-		flowcontrol.NewTokenBucketRateLimiter(4., 4),
+		flowcontrol.MustNewTokenBucketRateLimiter(1., 1),
+		flowcontrol.MustNewTokenBucketRateLimiter(2., 2),
+		flowcontrol.MustNewTokenBucketRateLimiter(3., 3),
+		flowcontrol.MustNewTokenBucketRateLimiter(4., 4),
 	}
 	nextRateLimiter := 0
 	rateLimiterFactory := func() flowcontrol.RateLimiter {

--- a/plugin/pkg/admission/eventratelimit/limitenforcer.go
+++ b/plugin/pkg/admission/eventratelimit/limitenforcer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/golang-lru"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/api"
@@ -44,9 +45,9 @@ type limitEnforcer struct {
 	keyFunc func(admission.Attributes) string
 }
 
-func newLimitEnforcer(config eventratelimitapi.Limit, clock flowcontrol.Clock) (*limitEnforcer, error) {
+func newLimitEnforcer(config eventratelimitapi.Limit, clock clock.Clock) (*limitEnforcer, error) {
 	rateLimiterFactory := func() flowcontrol.RateLimiter {
-		return flowcontrol.NewTokenBucketRateLimiterWithClock(float32(config.QPS), int(config.Burst), clock)
+		return flowcontrol.MustNewTokenBucketRateLimiterWithClock(float32(config.QPS), int(config.Burst), clock)
 	}
 
 	if config.Type == eventratelimitapi.ServerLimitType {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/clientset.go
@@ -60,11 +60,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.apiextensionsV1beta1, err = apiextensionsv1beta1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/clientset.go
@@ -52,11 +52,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.apiextensions, err = apiextensionsinternalversion.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
@@ -117,6 +117,7 @@ func (f *FakeClock) After(d time.Duration) <-chan time.Time {
 		targetTime: stopTime,
 		destChan:   ch,
 	})
+	f.setTimeLocked(f.time.Add(d))
 	return ch
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
@@ -76,7 +76,8 @@ type FakeClock struct {
 	time time.Time
 
 	// waiters are waiting for the fake time to pass their specified time
-	waiters []fakeClockWaiter
+	waiters        []fakeClockWaiter
+	AdvanceOnAfter bool
 }
 
 type fakeClockWaiter struct {
@@ -117,7 +118,9 @@ func (f *FakeClock) After(d time.Duration) <-chan time.Time {
 		targetTime: stopTime,
 		destChan:   ch,
 	})
-	f.setTimeLocked(f.time.Add(d))
+	if f.AdvanceOnAfter {
+		f.setTimeLocked(f.time.Add(d))
+	}
 	return ch
 }
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
@@ -152,13 +152,18 @@ func newBatchWebhook(configFile string, groupVersion schema.GroupVersion) (*batc
 		return nil, err
 	}
 
+	throttle, err := flowcontrol.NewTokenBucketRateLimiter(defaultBatchThrottleQPS, defaultBatchThrottleBurst)
+	if err != nil {
+		return nil, err
+	}
+
 	return &batchBackend{
 		w:            w,
 		buffer:       make(chan *auditinternal.Event, defaultBatchBufferSize),
 		maxBatchSize: defaultBatchMaxSize,
 		maxBatchWait: defaultBatchMaxWait,
 		shutdownCh:   make(chan struct{}),
-		throttle:     flowcontrol.NewTokenBucketRateLimiter(defaultBatchThrottleQPS, defaultBatchThrottleBurst),
+		throttle:     throttle,
 	}, nil
 }
 

--- a/staging/src/k8s.io/client-go/kubernetes/clientset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/clientset.go
@@ -364,11 +364,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.admissionregistrationV1alpha1, err = admissionregistrationv1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -69,6 +69,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/client-go/rest/client.go
+++ b/staging/src/k8s.io/client-go/rest/client.go
@@ -112,7 +112,10 @@ func NewRESTClient(baseURL *url.URL, versionedAPIPath string, config ContentConf
 
 	var throttle flowcontrol.RateLimiter
 	if maxQPS > 0 && rateLimiter == nil {
-		throttle = flowcontrol.NewTokenBucketRateLimiter(maxQPS, maxBurst)
+		throttle, err = flowcontrol.NewTokenBucketRateLimiter(maxQPS, maxBurst)
+		if err != nil {
+			return nil, err
+		}
 	} else if rateLimiter != nil {
 		throttle = rateLimiter
 	}

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -173,6 +174,8 @@ func (t *fakeLimiter) QPS() float32 {
 func (t *fakeLimiter) Stop() {}
 
 func (t *fakeLimiter) Accept() {}
+
+func (t *fakeLimiter) AcceptContext(_ context.Context) error { return nil }
 
 type fakeCodec struct{}
 

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -131,6 +131,7 @@ func NewRequest(client HTTPClient, verb string, baseURL *url.URL, versionedAPIPa
 		serializers: serializers,
 		backoffMgr:  backoff,
 		throttle:    throttle,
+		ctx:         context.Background(),
 	}
 	switch {
 	case len(content.AcceptContentTypes) > 0:
@@ -391,7 +392,9 @@ func (r *Request) Body(obj interface{}) *Request {
 // Context adds a context to the request. Contexts are only used for
 // timeouts, deadlines, and cancellations.
 func (r *Request) Context(ctx context.Context) *Request {
-	r.ctx = ctx
+	if ctx != nil {
+		r.ctx = ctx
+	}
 	return r
 }
 
@@ -453,14 +456,28 @@ func (r Request) finalURLTemplate() url.URL {
 	return *url
 }
 
-func (r *Request) tryThrottle() {
-	now := time.Now()
-	if r.throttle != nil {
-		r.throttle.Accept()
+func (r *Request) doBackoff() error {
+	if r.err = r.backoffMgr.SleepContext(r.ctx, r.backoffMgr.CalculateBackoff(r.URL())); r.err != nil {
+		return r.err
 	}
+	return nil
+}
+
+func (r *Request) tryThrottle() error {
+	if r.throttle == nil {
+		return nil
+	}
+
+	now := time.Now()
+	if r.err = r.throttle.AcceptContext(r.ctx); r.err != nil {
+		return r.err
+	}
+
 	if latency := time.Since(now); latency > longThrottleLatency {
 		glog.V(4).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
 	}
+
+	return nil
 }
 
 // Watch attempts to begin watching the requested location.
@@ -480,15 +497,17 @@ func (r *Request) Watch() (watch.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-	if r.ctx != nil {
-		req = req.WithContext(r.ctx)
-	}
+	req = req.WithContext(r.ctx)
+
 	req.Header = r.headers
 	client := r.client
 	if client == nil {
 		client = http.DefaultClient
 	}
-	r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+
+	if err := r.doBackoff(); err != nil {
+		return nil, err
+	}
 	resp, err := client.Do(req)
 	updateURLMetrics(r, resp, err)
 	if r.baseURL != nil {
@@ -545,22 +564,27 @@ func (r *Request) Stream() (io.ReadCloser, error) {
 		return nil, r.err
 	}
 
-	r.tryThrottle()
+	if err := r.tryThrottle(); err != nil {
+		return nil, err
+	}
 
 	url := r.URL().String()
 	req, err := http.NewRequest(r.verb, url, nil)
 	if err != nil {
 		return nil, err
 	}
-	if r.ctx != nil {
-		req = req.WithContext(r.ctx)
-	}
+
+	req = req.WithContext(r.ctx)
 	req.Header = r.headers
 	client := r.client
 	if client == nil {
 		client = http.DefaultClient
 	}
-	r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+
+	if err := r.doBackoff(); err != nil {
+		return nil, err
+	}
+
 	resp, err := client.Do(req)
 	updateURLMetrics(r, resp, err)
 	if r.baseURL != nil {
@@ -630,17 +654,19 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 		if err != nil {
 			return err
 		}
-		if r.ctx != nil {
-			req = req.WithContext(r.ctx)
-		}
+		req = req.WithContext(r.ctx)
 		req.Header = r.headers
 
-		r.backoffMgr.Sleep(r.backoffMgr.CalculateBackoff(r.URL()))
+		if err := r.doBackoff(); err != nil {
+			return err
+		}
 		if retries > 0 {
 			// We are retrying the request that we already send to apiserver
 			// at least once before.
 			// This request should also be throttled with the client-internal throttler.
-			r.tryThrottle()
+			if err := r.tryThrottle(); err != nil {
+				return err
+			}
 		}
 		resp, err := client.Do(req)
 		updateURLMetrics(r, resp, err)
@@ -690,7 +716,9 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 				}
 
 				glog.V(4).Infof("Got a Retry-After %s response for attempt %d to %v", seconds, retries, url)
-				r.backoffMgr.Sleep(time.Duration(seconds) * time.Second)
+				if r.err = r.backoffMgr.SleepContext(r.ctx, time.Duration(seconds)*time.Second); r.err != nil {
+					return true
+				}
 				return false
 			}
 			fn(req, resp)
@@ -711,7 +739,10 @@ func (r *Request) request(fn func(*http.Request, *http.Response)) error {
 //  * If the server responds with a status: *errors.StatusError or *errors.UnexpectedObjectError
 //  * http.Client.Do errors are returned directly.
 func (r *Request) Do() Result {
-	r.tryThrottle()
+
+	if err := r.tryThrottle(); err != nil {
+		return Result{err: err}
+	}
 
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {
@@ -725,7 +756,9 @@ func (r *Request) Do() Result {
 
 // DoRaw executes the request but does not process the response body.
 func (r *Request) DoRaw() ([]byte, error) {
-	r.tryThrottle()
+	if err := r.tryThrottle(); err != nil {
+		return nil, err
+	}
 
 	var result Result
 	err := r.request(func(req *http.Request, resp *http.Response) {

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1118,6 +1118,11 @@ func (b *testBackoffManager) Sleep(d time.Duration) {
 	b.sleeps = append(b.sleeps, d)
 }
 
+func (b *testBackoffManager) SleepContext(ctx context.Context, d time.Duration) error {
+	b.sleeps = append(b.sleeps, d)
+	return nil
+}
+
 func TestCheckRetryClosesBody(t *testing.T) {
 	count := 0
 	ch := make(chan struct{})

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1095,7 +1095,7 @@ func TestBackoffLifecycle(t *testing.T) {
 	// which are used in the server implementation returning StatusOK above.
 	seconds := []int{0, 1, 2, 4, 8, 0, 1, 2, 4, 0}
 	request := c.Verb("POST").Prefix("backofftest").Suffix("abc")
-	clock := clock.FakeClock{}
+	clock := clock.FakeClock{AdvanceOnAfter: true}
 	request.backoffMgr = &URLBackoff{
 		// Use a fake backoff here to avoid flakes and speed the test up.
 		Backoff: flowcontrol.NewFakeBackOff(

--- a/staging/src/k8s.io/client-go/tools/record/events_cache.go
+++ b/staging/src/k8s.io/client-go/tools/record/events_cache.go
@@ -140,7 +140,7 @@ func (f *EventSourceObjectSpamFilter) Filter(event *v1.Event) bool {
 
 	// verify we have a rate limiter for this record
 	if record.rateLimiter == nil {
-		record.rateLimiter = flowcontrol.NewTokenBucketRateLimiterWithClock(f.qps, f.burst, f.clock)
+		record.rateLimiter = flowcontrol.MustNewTokenBucketRateLimiterWithClock(f.qps, f.burst, f.clock)
 	}
 
 	// ensure we have available rate

--- a/staging/src/k8s.io/client-go/util/flowcontrol/BUILD
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/BUILD
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "backoff_test.go",
+        "ratelimit_test.go",
         "throttle_test.go",
     ],
     importpath = "k8s.io/client-go/util/flowcontrol",
@@ -21,11 +22,12 @@ go_library(
     name = "go_default_library",
     srcs = [
         "backoff.go",
+        "ratelimit.go",
+        "sleep.go",
         "throttle.go",
     ],
     importpath = "k8s.io/client-go/util/flowcontrol",
     deps = [
-        "//vendor/github.com/juju/ratelimit:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//vendor/k8s.io/client-go/util/integer:go_default_library",
     ],
@@ -42,4 +44,13 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_xtest",
+    srcs = ["sleep_test.go"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/client-go/util/flowcontrol/ratelimit.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/ratelimit.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flowcontrol
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+)
+
+type Limiter interface {
+	TakeAvailable(int64) int64
+	Capacity() int64
+	Available() int64
+	Wait(int64)
+	WaitContext(context.Context, int64) error
+}
+
+func NewBucketLimiter(rate float64, capacity int64) (Limiter, error) {
+	return NewBucketLimiterWithClock(rate, capacity, clock.RealClock{})
+}
+
+func NewBucketLimiterWithClock(rate float64, capacity int64, clock clock.Clock) (Limiter, error) {
+	fill, quantum, err := calculateQuantum(rate, capacity)
+	if err != nil {
+		return nil, err
+	}
+	return &bucketLimiter{
+		rate:      rate,
+		capacity:  capacity,
+		available: capacity,
+		fill:      fill,
+		quantum:   quantum,
+		start:     clock.Now(),
+		clock:     clock,
+		mtx:       new(sync.Mutex),
+	}, nil
+}
+
+type bucketLimiter struct {
+	rate      float64
+	capacity  int64
+	fill      time.Duration
+	quantum   int64
+	available int64
+	ticks     int64
+	start     time.Time
+	clock     clock.Clock
+	mtx       *sync.Mutex
+}
+
+func (bl *bucketLimiter) TakeAvailable(count int64) int64 {
+	if count <= 0 {
+		return 0
+	}
+
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+
+	bl.adjust(bl.clock.Now())
+
+	if bl.available <= 0 {
+		return 0
+	}
+
+	if count > bl.available {
+		count = bl.available
+	}
+
+	bl.available -= count
+	return count
+}
+
+func (bl *bucketLimiter) Capacity() int64 {
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+	return bl.capacity
+}
+
+func (bl *bucketLimiter) Available() int64 {
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+	bl.adjust(bl.clock.Now())
+	return bl.available
+}
+
+func (bl *bucketLimiter) Wait(count int64) {
+	bl.WaitContext(context.Background(), count)
+}
+
+func (bl *bucketLimiter) WaitContext(ctx context.Context, count int64) error {
+	if count <= 0 {
+		return nil
+	}
+	if d := bl.take(count); d > 0 {
+		return SleepContext(ctx, bl.clock, d)
+	}
+	return nil
+}
+
+func (bl *bucketLimiter) take(count int64) time.Duration {
+	bl.mtx.Lock()
+	defer bl.mtx.Unlock()
+
+	now := bl.clock.Now()
+	current := bl.adjust(now)
+
+	bl.available -= count
+
+	if bl.available >= 0 {
+		return 0
+	}
+
+	tick := current + (bl.quantum-bl.available-1)/bl.quantum
+	stop := bl.start.Add(time.Duration(tick) * bl.fill)
+
+	return stop.Sub(now)
+}
+
+func (bl *bucketLimiter) adjust(now time.Time) int64 {
+	current := int64(now.Sub(bl.start) / bl.fill)
+
+	if bl.available >= bl.capacity {
+		return current
+	}
+
+	bl.available += (current - bl.ticks) * bl.quantum
+	if bl.available > bl.capacity {
+		bl.available = bl.capacity
+	}
+	bl.ticks = current
+
+	return current
+}
+
+func calculateQuantum(rate float64, capacity int64) (time.Duration, int64, error) {
+	for quantum := int64(1); quantum < 1<<50; quantum = nextQuantum(quantum) {
+		fill := time.Duration(1e9 * float64(quantum) / rate)
+		if fill <= 0 {
+			continue
+		}
+
+		if delta := math.Abs(1e9*float64(quantum)/float64(fill) - rate); delta/rate <= 0.01 {
+			return fill, quantum, nil
+		}
+	}
+	return 0, 0, errors.New("bucket limiter: unable to find appropriate quantum")
+}
+
+func nextQuantum(quantum int64) int64 {
+	next := quantum * 11 / 10
+	if next == quantum {
+		return next + 1
+	}
+	return next
+}

--- a/staging/src/k8s.io/client-go/util/flowcontrol/ratelimit_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/ratelimit_test.go
@@ -1,0 +1,38 @@
+package flowcontrol
+
+import "testing"
+
+func TestLimiter(t *testing.T) {
+	valid := []struct {
+		rate     float64
+		capacity int64
+	}{
+		{10, 100},
+	}
+
+	for _, tt := range valid {
+		if _, err := NewBucketLimiter(tt.rate, tt.capacity); err != nil {
+			t.Fatalf("%v,%v: %v", tt.rate, tt.capacity, err)
+		}
+	}
+}
+
+func TestLimiterTakeAvailable(t *testing.T) {
+	bl, err := NewBucketLimiter(1, 3)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter")
+	}
+
+	t.Logf("available: %v", bl.Available())
+
+	for i := 0; i < 3; i++ {
+		if val := bl.TakeAvailable(1); val != 1 {
+			t.Errorf("unable to take %v/3: %v", i+1, val)
+		}
+	}
+
+	if val := bl.TakeAvailable(1); val != 0 {
+		t.Errorf("invalid take: %v", val)
+	}
+
+}

--- a/staging/src/k8s.io/client-go/util/flowcontrol/sleep.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/sleep.go
@@ -24,12 +24,10 @@ import (
 )
 
 func SleepContext(ctx context.Context, clock clock.Clock, d time.Duration) error {
-	t := clock.NewTimer(d)
 	select {
-	case <-t.C():
+	case <-clock.After(d):
 		return nil
 	case <-ctx.Done():
-		t.Stop()
 		return ctx.Err()
 	}
 }

--- a/staging/src/k8s.io/client-go/util/flowcontrol/sleep.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/sleep.go
@@ -14,21 +14,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package eventratelimit
+package flowcontrol
 
 import (
+	"context"
 	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
 )
 
-// realClock implements flowcontrol.Clock in terms of standard time functions.
-type realClock struct{}
-
-// Now is identical to time.Now.
-func (realClock) Now() time.Time {
-	return time.Now()
-}
-
-// Sleep is identical to time.Sleep.
-func (realClock) Sleep(d time.Duration) {
-	time.Sleep(d)
+func SleepContext(ctx context.Context, clock clock.Clock, d time.Duration) error {
+	t := clock.NewTimer(d)
+	select {
+	case <-t.C():
+		return nil
+	case <-ctx.Done():
+		t.Stop()
+		return ctx.Err()
+	}
 }

--- a/staging/src/k8s.io/client-go/util/flowcontrol/sleep_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/sleep_test.go
@@ -1,0 +1,55 @@
+package flowcontrol_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func TestSleepContext(t *testing.T) {
+	clock := clock.NewFakeClock(time.Now())
+	ctx := context.Background()
+
+	ch := make(chan struct{})
+	var err error
+	go func() {
+		defer close(ch)
+		err = flowcontrol.SleepContext(ctx, clock, time.Minute)
+	}()
+
+	time.Sleep(time.Second / 20)
+	clock.Step(time.Hour * 2)
+
+	<-ch
+
+	if err != nil {
+		t.Error("unexpected error")
+	}
+
+	if clock.HasWaiters() {
+		t.Error("unexpected waiters")
+	}
+}
+
+func TestSleepContext_preempted(t *testing.T) {
+	clock := clock.NewFakeClock(time.Now())
+	ctx, cancel := context.WithCancel(context.Background())
+
+	ch := make(chan struct{})
+	var err error
+	go func() {
+		defer close(ch)
+		err = flowcontrol.SleepContext(ctx, clock, time.Minute)
+	}()
+
+	cancel()
+
+	<-ch
+
+	if err != ctx.Err() {
+		t.Error("expected error not returned")
+	}
+}

--- a/staging/src/k8s.io/client-go/util/flowcontrol/sleep_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/sleep_test.go
@@ -13,6 +13,7 @@ func TestSleepContext(t *testing.T) {
 	duration := time.Minute
 	start := time.Now()
 	clock := clock.NewFakeClock(start)
+	clock.AdvanceOnAfter = true
 	ctx := context.Background()
 
 	err := flowcontrol.SleepContext(ctx, clock, duration)

--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
@@ -25,7 +25,10 @@ import (
 
 func TestMultithreadedThrottling(t *testing.T) {
 	// Bucket with 100QPS and no burst
-	r := NewTokenBucketRateLimiter(100, 1)
+	r, err := NewTokenBucketRateLimiter(100, 1)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter: %v", err)
+	}
 
 	// channel to collect 100 tokens
 	taken := make(chan bool, 100)
@@ -74,10 +77,13 @@ func TestMultithreadedThrottling(t *testing.T) {
 }
 
 func TestBasicThrottle(t *testing.T) {
-	r := NewTokenBucketRateLimiter(1, 3)
+	r, err := NewTokenBucketRateLimiter(1, 3)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter: %v", err)
+	}
 	for i := 0; i < 3; i++ {
 		if !r.TryAccept() {
-			t.Error("unexpected false accept")
+			t.Errorf("unexpected false accept %v", i)
 		}
 	}
 	if r.TryAccept() {
@@ -86,7 +92,10 @@ func TestBasicThrottle(t *testing.T) {
 }
 
 func TestIncrementThrottle(t *testing.T) {
-	r := NewTokenBucketRateLimiter(1, 1)
+	r, err := NewTokenBucketRateLimiter(1, 1)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter: %v", err)
+	}
 	if !r.TryAccept() {
 		t.Error("unexpected false accept")
 	}
@@ -103,7 +112,10 @@ func TestIncrementThrottle(t *testing.T) {
 }
 
 func TestThrottle(t *testing.T) {
-	r := NewTokenBucketRateLimiter(10, 5)
+	r, err := NewTokenBucketRateLimiter(10, 5)
+	if err != nil {
+		t.Fatalf("unable to create rate limiter: %v", err)
+	}
 
 	// Should consume 5 tokens immediately, then
 	// the remaining 11 should take at least 1 second (0.1s each)
@@ -128,7 +140,10 @@ func TestRateLimiterSaturation(t *testing.T) {
 		{10, 3, 0.3},
 	}
 	for i, tt := range tests {
-		rl := NewTokenBucketRateLimiter(1, tt.capacity)
+		rl, err := NewTokenBucketRateLimiter(1, tt.capacity)
+		if err != nil {
+			t.Fatalf("unable to create rate limiter: %v", err)
+		}
 		for i := 0; i < tt.take; i++ {
 			rl.Accept()
 		}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/clientset.go
@@ -52,11 +52,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.example, err = exampleinternalversion.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/clientset.go
@@ -60,11 +60,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.exampleV1, err = examplev1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -149,11 +149,14 @@ var newClientsetForConfigTemplate = `
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *$.Config|raw$) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = $.flowcontrolNewTokenBucketRateLimiter|raw$(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = $.flowcontrolNewTokenBucketRateLimiter|raw$(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 $range .allGroups$    cs.$.LowerCaseGroupVersion$, err =$.PackageName$.NewForConfig(&configShallowCopy)
 	if err!=nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/clientset.go
@@ -60,11 +60,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.apiregistrationV1beta1, err = apiregistrationv1beta1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/internalclientset/clientset.go
@@ -52,11 +52,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.apiregistration, err = apiregistrationinternalversion.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset_generated/clientset/clientset.go
@@ -68,11 +68,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.metricsV1alpha1, err = metricsv1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/client.go
@@ -43,8 +43,12 @@ func New(client rest.Interface) CustomMetricsClient {
 
 func NewForConfig(c *rest.Config) (CustomMetricsClient, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	configShallowCopy.APIPath = "/apis"
 	if configShallowCopy.UserAgent == "" {

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/internalversion/clientset.go
@@ -52,11 +52,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.wardle, err = wardleinternalversion.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/clientset/versioned/clientset.go
@@ -60,11 +60,14 @@ func (c *Clientset) Discovery() discovery.DiscoveryInterface {
 // NewForConfig creates a new Clientset for the given config.
 func NewForConfig(c *rest.Config) (*Clientset, error) {
 	configShallowCopy := *c
+	var err error
 	if configShallowCopy.RateLimiter == nil && configShallowCopy.QPS > 0 {
-		configShallowCopy.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		configShallowCopy.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(configShallowCopy.QPS, configShallowCopy.Burst)
+		if err != nil {
+			return nil, err
+		}
 	}
 	var cs Clientset
-	var err error
 	cs.wardleV1alpha1, err = wardlev1alpha1.NewForConfig(&configShallowCopy)
 	if err != nil {
 		return nil, err

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -964,10 +964,14 @@ func (c *allClient) createPrerequisites(mapper meta.RESTMapper, ns string, prere
 }
 
 func newClient(config restclient.Config) (*allClient, error) {
+	var err error
 	config.ContentConfig.NegotiatedSerializer = legacyscheme.Codecs
 	config.ContentConfig.ContentType = "application/json"
 	config.Timeout = 30 * time.Second
-	config.RateLimiter = flowcontrol.NewTokenBucketRateLimiter(3, 10)
+	config.RateLimiter, err = flowcontrol.NewTokenBucketRateLimiter(3, 10)
+	if err != nil {
+		return nil, err
+	}
 
 	transport, err := restclient.TransportFor(&config)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently `rest.Request` ignores its context when rate-limiting and backing off.  This can cause problems when attempting to shut down gracefully.  boz/kail#10 is an example of this.

High-level changes:

 * `flowcontrol.RateLimiter`: add `AcceptContext()`
 * `rest/BackoffManager`: add `SleepContext()`
 * `flowcontrol.Limiter`: new context-aware bucket limiter based off of juju's
 * `rest.Request`: return immediately when context is done.

**Special notes for your reviewer**:

There are no tests right now.  I want to make sure this is the right approach before spending time on them.

**Release note**:
```release-note
NONE
```
/hold
/release-note