### PR TITLE
kubeadm: Let kubelets in the cluster rotate their certificates

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -382,6 +382,11 @@ func (i *Init) Run(out io.Writer) error {
 		return err
 	}
 
+	// Create/update RBAC rules that makes the nodes to rotate certificates and get their CSRs approved automatically
+	if err := nodebootstraptokenphase.AutoApproveNodeCertificateRotation(client, k8sVersion); err != nil {
+		return err
+	}
+
 	// Create the cluster-info ConfigMap with the associated RBAC rules
 	if err := clusterinfophase.CreateBootstrapConfigMapIfNotExists(client, adminKubeConfigPath); err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
+++ b/cmd/kubeadm/app/phases/bootstraptoken/node/tlsbootstrap.go
@@ -38,8 +38,12 @@ const (
 	// TODO: This value should be defined in an other, generic authz package instead of here
 	// Starting from v1.8, CSRAutoApprovalClusterRoleName is automatically created by the API server on startup
 	CSRAutoApprovalClusterRoleName = "system:certificates.k8s.io:certificatesigningrequests:nodeclient"
+	// NodeSelfCSRAutoApprovalClusterRoleName is a role defined in default 1.8 RBAC policies for automatic CSR approvals for automatically rotated node certificates
+	NodeSelfCSRAutoApprovalClusterRoleName = "system:certificates.k8s.io:certificatesigningrequests:selfnodeclient"
 	// NodeAutoApproveBootstrapClusterRoleBinding defines the name of the ClusterRoleBinding that makes the csrapprover approve node CSRs
 	NodeAutoApproveBootstrapClusterRoleBinding = "kubeadm:node-autoapprove-bootstrap"
+	// NodeAutoApproveCertificateRotationClusterRoleBinding defines name of the ClusterRoleBinding that makes the csrapprover approve node auto rotated CSRs
+	NodeAutoApproveCertificateRotationClusterRoleBinding = "kubeadm:node-autoapprove-certificate-rotation"
 )
 
 // AllowBootstrapTokensToPostCSRs creates RBAC rules in a way the makes Node Bootstrap Tokens able to post CSRs
@@ -87,4 +91,31 @@ func AutoApproveNodeBootstrapTokens(client clientset.Interface, k8sVersion *vers
 			},
 		},
 	})
+}
+
+// AutoApproveNodeCertificateRotation creates RBAC rules in a way that makes Node certificate rotation CSR auto-approved by the csrapprover controller
+func AutoApproveNodeCertificateRotation(client clientset.Interface, k8sVersion *version.Version) error {
+
+	// Create autorotation cluster role binding only if we deploying or upgrading to version that supports it.
+	if k8sVersion.AtLeast(constants.MinimumCSRAutoApprovalClusterRolesVersion) {
+		fmt.Println("[bootstraptoken] Configured RBAC rules to allow certificate rotation for all node client certificates in the cluster")
+
+		return apiclient.CreateOrUpdateClusterRoleBinding(client, &rbac.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: NodeAutoApproveCertificateRotationClusterRoleBinding,
+			},
+			RoleRef: rbac.RoleRef{
+				APIGroup: rbac.GroupName,
+				Kind:     "ClusterRole",
+				Name:     NodeSelfCSRAutoApprovalClusterRoleName,
+			},
+			Subjects: []rbac.Subject{
+				{
+					Kind: "Group",
+					Name: constants.NodesGroup,
+				},
+			},
+		})
+	}
+	return nil
 }

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -66,6 +66,11 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.MasterC
 		errs = append(errs, err)
 	}
 
+	// Create/update RBAC rules that makes the 1.8.0+ nodes to rotate certificates and get their CSRs approved automatically
+	if err := nodebootstraptoken.AutoApproveNodeCertificateRotation(client, k8sVersion); err != nil {
+		errs = append(errs, err)
+	}
+
 	// TODO: Is this needed to do here? I think that updating cluster info should probably be separate from a normal upgrade
 	// Create the cluster-info ConfigMap with the associated RBAC rules
 	// if err := clusterinfo.CreateBootstrapConfigMapIfNotExists(client, kubeadmconstants.GetAdminKubeConfigPath()); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
As of 1.8.0 kubelet in kubeadm configuration ships with enabled feature
of node certificate autorotation, it makes sense to enable automatic
certificate rotation csr signing. It will help to avoid issues like
described in #53231 and #53237.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53237.

**Special notes for your reviewer**:
We need that patch to be applied both to master branch and cherry-pick into 1.8, so kubeadm in 1.8.1 release will create correct role bindings on upgrades between 1.7 -> 1.8 and initialization of new clusters with 1.8.x

cc @luxas @liggitt @pipejakob 

**Release note**:
```release-note
kubeadm allows the kubelets in the cluster to automatically renew their client certificates
```
