### PR TITLE
change the pod.status.qosClass description URL

### DIFF
--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2974,7 +2974,7 @@ message PodStatus {
 
   // The Quality of Service (QOS) classification assigned to the pod based on resource requirements
   // See PodQOSClass type for available QOS classes
-  // More info: https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md
+  // More info: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/resource-qos.md
   // +optional
   optional string qosClass = 9;
 }

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2869,7 +2869,7 @@ type PodStatus struct {
 	ContainerStatuses []ContainerStatus `json:"containerStatuses,omitempty" protobuf:"bytes,8,rep,name=containerStatuses"`
 	// The Quality of Service (QOS) classification assigned to the pod based on resource requirements
 	// See PodQOSClass type for available QOS classes
-	// More info: https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md
+	// More info: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/resource-qos.md
 	// +optional
 	QOSClass PodQOSClass `json:"qosClass,omitempty" protobuf:"bytes,9,rep,name=qosClass"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

`pod.status.qosClass` has description URL in swagger specification
which is old. This commit changes that URL to correct location:
https://github.com/kubernetes/kubernetes/blob/master/docs/design/resource-qos.md


**Release note**:
```release-note
NONE
```
