### PR TITLE
Cleanup: Simplify DeleteContainer function

### DIFF
--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -115,7 +115,7 @@ type Runtime interface {
 	// "100" or "all") to tail the log.
 	GetContainerLogs(pod *v1.Pod, containerID ContainerID, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) (err error)
 	// Delete a container. If the container is still running, an error is returned.
-	DeleteContainer(containerID ContainerID) error
+	DeleteContainer(containerID string) error
 	// ImageService provides methods to image-related methods.
 	ImageService
 	// UpdatePodCIDR sends a new podCIDR to the runtime.

--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -439,7 +439,7 @@ func (f *FakeRuntime) GarbageCollect(gcPolicy ContainerGCPolicy, ready bool, evi
 	return f.Err
 }
 
-func (f *FakeRuntime) DeleteContainer(containerID ContainerID) error {
+func (f *FakeRuntime) DeleteContainer(containerID string) error {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -145,7 +145,7 @@ func (r *Mock) GarbageCollect(gcPolicy ContainerGCPolicy, ready bool, evictNonDe
 	return args.Error(0)
 }
 
-func (r *Mock) DeleteContainer(containerID ContainerID) error {
+func (r *Mock) DeleteContainer(containerID string) error {
 	args := r.Called(containerID)
 	return args.Error(0)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -657,7 +657,7 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 			}
 			// prune all other init containers that match this container name
 			glog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
+			if err := m.DeleteContainer(status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
 			}
@@ -689,7 +689,7 @@ func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *
 			count++
 			// Purge all init containers that match this container name
 			glog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
+			if err := m.DeleteContainer(status.ID.ID); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
 				continue
 			}
@@ -803,13 +803,13 @@ func (m *kubeGenericRuntimeManager) RunInContainer(id kubecontainer.ContainerID,
 	return append(stdout, stderr...), err
 }
 
-// removeContainer removes the container and the container logs.
+// DeleteContainer removes the container and the container logs.
 // Notice that we remove the container logs first, so that container will not be removed if
 // container logs are failed to be removed, and kubelet will retry this later. This guarantees
 // that container logs to be removed with the container.
 // Notice that we assume that the container should only be removed in non-running state, and
 // it will not write container logs anymore in that state.
-func (m *kubeGenericRuntimeManager) removeContainer(containerID string) error {
+func (m *kubeGenericRuntimeManager) DeleteContainer(containerID string) error {
 	glog.V(4).Infof("Removing container %q", containerID)
 	// Call internal container post-stop lifecycle hook.
 	if err := m.internalLifecycle.PostStopContainer(containerID); err != nil {
@@ -848,9 +848,4 @@ func (m *kubeGenericRuntimeManager) removeContainerLog(containerID string) error
 			containerID, legacySymlink, err)
 	}
 	return nil
-}
-
-// DeleteContainer removes a container.
-func (m *kubeGenericRuntimeManager) DeleteContainer(containerID kubecontainer.ContainerID) error {
-	return m.removeContainer(containerID.ID)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_test.go
@@ -58,7 +58,7 @@ func TestRemoveContainer(t *testing.T) {
 
 	containerId := fakeContainers[0].Id
 	fakeOS := m.osInterface.(*containertest.FakeOS)
-	err = m.removeContainer(containerId)
+	err = m.DeleteContainer(containerId)
 	assert.NoError(t, err)
 	// Verify container log is removed
 	expectedContainerLogPath := filepath.Join(podLogsRootDirectory, "12345678", "foo_0.log")

--- a/pkg/kubelet/kuberuntime/kuberuntime_gc.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_gc.go
@@ -122,7 +122,7 @@ func (cgc *containerGC) removeOldestN(containers []containerGCInfo, toRemove int
 	// Remove from oldest to newest (last to first).
 	numToKeep := len(containers) - toRemove
 	for i := len(containers) - 1; i >= numToKeep; i-- {
-		if err := cgc.manager.removeContainer(containers[i].id); err != nil {
+		if err := cgc.manager.DeleteContainer(containers[i].id); err != nil {
 			glog.Errorf("Failed to remove container %q: %v", containers[i].id, err)
 		}
 	}

--- a/pkg/kubelet/rkt/rkt.go
+++ b/pkg/kubelet/rkt/rkt.go
@@ -1958,7 +1958,7 @@ func (r *Runtime) getKubernetesDirective(serviceFilePath string) (podService pod
 	return podService, fmt.Errorf("failed to parse pod from file %s", serviceFilePath)
 }
 
-func (r *Runtime) DeleteContainer(containerID kubecontainer.ContainerID) error {
+func (r *Runtime) DeleteContainer(containerID string) error {
 	return fmt.Errorf("unimplemented")
 }
 


### PR DESCRIPTION
Came across this while working on #53233
We only ever use the ID field of the ContainerID passed in, so just use the string ID instead of the whole struct.
/release-note-none
This has no associated issue