### PR TITLE
Fix sed command to not try shell redirection

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -114,23 +114,20 @@ func masterUpgradeKubernetesAnywhere(v string) error {
 	backupConfigPath := filepath.Join(kaPath, ".config.bak")
 	updatedConfigPath := filepath.Join(kaPath, fmt.Sprintf(".config-%s", v))
 
-	// backup .config to .config.bak
-	if err := os.Rename(originalConfigPath, backupConfigPath); err != nil {
+	// modify config with specified k8s version
+	if _, _, err := RunCmd("sed",
+		"-i.bak", // writes original to .config.bak
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		originalConfigPath); err != nil {
 		return err
 	}
+
 	defer func() {
 		// revert .config.bak to .config
 		if err := os.Rename(backupConfigPath, originalConfigPath); err != nil {
 			Logf("Could not rename %s back to %s", backupConfigPath, originalConfigPath)
 		}
 	}()
-
-	// modify config with specified k8s version
-	if _, _, err := RunCmd("sed",
-		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
-		backupConfigPath, ">", originalConfigPath); err != nil {
-		return err
-	}
 
 	// invoke ka upgrade
 	if _, _, err := RunCmd("make", "-C", TestContext.KubernetesAnywherePath,


### PR DESCRIPTION
RunCmd uses Go's os/exec library to run commands directly. Since these
are not run through a shell, we can't use shell syntax for piping or
file redirection. The proper way to do that is to create a Command
object and set the Std{in,out,err} pipes appropriately. Luckily sed
can handle the behavior we need without having to manually set this up.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

fixes https://github.com/kubernetes/kubeadm/issues/472

