### PR TITLE
Update file location in e2e test comment

### DIFF
--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -26,7 +26,8 @@ import (
 )
 
 // These tests exercise the Kubernetes expansion syntax $(VAR).
-// For more information, see: docs/design/expansion.md
+// For more information, see:
+// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/expansion.md
 var _ = framework.KubeDescribe("Variable Expansion", func() {
 	f := framework.NewDefaultFramework("var-expansion")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: The location provided, "docs/design/expansion.md" leads to something saying the file has moved with a link. The link goes to a 404 error. The file was moved out of tree to https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/expansion.md and the comment here should be changed

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53270

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
