### PR TITLE
fix case proposed replica num is bigger than both ScaleUpLimit and MaxReplicas

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -419,7 +419,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 		scaleUpLimit := calculateScaleUpLimit(currentReplicas)
 
 		switch {
-		case desiredReplicas > scaleUpLimit:
+		case desiredReplicas > scaleUpLimit && desiredReplicas < hpa.Spec.MaxReplicas:
 			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "ScaleUpLimit", "the desired replica count is increasing faster than the maximum scale rate")
 			desiredReplicas = scaleUpLimit
 

--- a/pkg/controller/podautoscaler/horizontal_test.go
+++ b/pkg/controller/podautoscaler/horizontal_test.go
@@ -1083,6 +1083,26 @@ func TestMaxReplicas(t *testing.T) {
 	tc.runTest(t)
 }
 
+// Test for case "proposed replica num is bigger than both ScaleUpLimit and MaxReplicas"
+func TestScaleUpLimitExceedMaxReplicas(t *testing.T) {
+	tc := testCase{
+		minReplicas:         1,
+		maxReplicas:         6,
+		initialReplicas:     2,
+		desiredReplicas:     6,
+		CPUTarget:           50,
+		reportedLevels:      []uint64{900, 900, 900},
+		reportedCPURequests: []resource.Quantity{resource.MustParse("0.1"), resource.MustParse("0.1"), resource.MustParse("0.1")},
+		useMetricsAPI:       true,
+		expectedConditions: statusOkWithOverrides(autoscalingv2.HorizontalPodAutoscalerCondition{
+			Type:   autoscalingv2.ScalingLimited,
+			Status: v1.ConditionTrue,
+			Reason: "TooManyReplicas",
+		}),
+	}
+	tc.runTest(t)
+}
+
 func TestSuperfluousMetrics(t *testing.T) {
 	tc := testCase{
 		minReplicas:         2,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
In current hpa controller code logic, if proposed replica numbers is bigger than the `scaleUpLimit`, the desired replica number will be the `scaleUpLimit`. As the scaleUpLimit is calculated by `currentReplicas*scaleUpLimitFactor`, it may be bigger than the `hpa.Spec.MaxReplicas`. which results in the final replica number is bigger than the `hpa.Spec.MaxReplicas`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```