### PR TITLE
Avoid fetching entire discovery tree when possible

### DIFF
--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"io"
 
 	"github.com/spf13/cobra"
@@ -109,17 +108,15 @@ func createDeployment(f cmdutil.Factory, cmdOut, cmdErr io.Writer,
 	if err != nil {
 		return err
 	}
-	resourcesList, err := clientset.Discovery().ServerResources()
-	// ServerResources ignores errors for old servers do not expose discovery
-	if err != nil {
-		return fmt.Errorf("failed to discover supported resources: %v", err)
-	}
 
 	generatorName := cmdutil.GetFlagString(cmd, "generator")
 
 	// It is possible we have to modify the user-provided generator name if
 	// the server does not have support for the requested generator.
-	generatorName = cmdutil.FallbackGeneratorNameIfNecessary(generatorName, resourcesList, cmdErr)
+	generatorName, err = cmdutil.FallbackGeneratorNameIfNecessary(generatorName, clientset.Discovery(), cmdErr)
+	if err != nil {
+		return err
+	}
 
 	imageNames := cmdutil.GetFlagStringSlice(cmd, "image")
 	generator, ok := generatorFromName(generatorName, imageNames, deploymentName)

--- a/pkg/kubectl/cmd/util/cached_discovery.go
+++ b/pkg/kubectl/cmd/util/cached_discovery.go
@@ -67,7 +67,7 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 	if err == nil {
 		cachedResources := &metav1.APIResourceList{}
 		if err := runtime.DecodeInto(api.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
-			glog.V(6).Infof("returning cached discovery info from %v", filename)
+			glog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedResources, nil
 		}
 	}
@@ -114,7 +114,7 @@ func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 	if err == nil {
 		cachedGroups := &metav1.APIGroupList{}
 		if err := runtime.DecodeInto(api.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
-			glog.V(6).Infof("returning cached discovery info from %v", filename)
+			glog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedGroups, nil
 		}
 	}


### PR DESCRIPTION
For specific commands, we use discovery to determine whether a particular resource is available.

We should avoid fetching the entire discovery tree to check a single resource group version. As the number of groups grows, the performance hit and potential to encounter an error also grows.

```release-note
NONE
```