### PR TITLE
Consider kube-apiserver connectivity as part of the kubelet health check

### DIFF
--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -103,6 +103,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/cmd/kubelet/app/BUILD
+++ b/cmd/kubelet/app/BUILD
@@ -103,7 +103,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -263,14 +263,12 @@ func (kl *Kubelet) GetCachedMachineInfo() (*cadvisorapiv1.MachineInfo, error) {
 // reflectors are healthy. If the boolean is false then the reflector errors
 // are returned as well.
 func (kl *Kubelet) ReflectorsHealthy() (bool, []error) {
-	reflectorErrors := make([]error, 0, len(kl.reflectors))
-	allHealthy := true
+	var reflectorErrors []error
 	for _, reflector := range kl.reflectors {
 		if healthy, reflectorError := reflector.Healthy(); !healthy {
 			reflectorErrors = append(reflectorErrors, reflectorError)
-			allHealthy = false
 		}
 	}
 
-	return allHealthy, reflectorErrors
+	return len(reflectorErrors) > 0, reflectorErrors
 }

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -258,3 +258,19 @@ func (kl *Kubelet) GetCachedMachineInfo() (*cadvisorapiv1.MachineInfo, error) {
 	}
 	return kl.machineInfo, nil
 }
+
+// ReflectorsHealthy returns a boolean that is true when all of the kubelet's
+// reflectors are healthy. If the boolean is false then the reflector errors
+// are returned as well.
+func (kl *Kubelet) ReflectorsHealthy() (bool, []error) {
+	reflectorErrors := make([]error, 0, len(kl.reflectors))
+	allHealthy := true
+	for _, reflector := range kl.reflectors {
+		if healthy, reflectorError := reflector.Healthy(); !healthy {
+			reflectorErrors = append(reflectorErrors, reflectorError)
+			allHealthy = false
+		}
+	}
+
+	return allHealthy, reflectorErrors
+}

--- a/pkg/kubelet/server/BUILD
+++ b/pkg/kubelet/server/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/remotecommand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -183,6 +183,7 @@ type HostInterface interface {
 	GetExec(podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error)
 	GetAttach(podFullName string, podUID types.UID, containerName string, streamOpts remotecommandserver.Options) (*url.URL, error)
 	GetPortForward(podName, podNamespace string, podUID types.UID, portForwardOpts portforward.V4Options) (*url.URL, error)
+	ReflectorsHealthy() (bool, []error)
 }
 
 // NewServer initializes and configures a kubelet.Server object to handle HTTP requests.
@@ -258,6 +259,7 @@ func (s *Server) InstallDefaultHandlers() {
 	healthz.InstallHandler(s.restfulCont,
 		healthz.PingHealthz,
 		healthz.NamedCheck("syncloop", s.syncLoopHealthCheck),
+		healthz.NamedCheck("reflectorHealthCheck", s.reflectorHealthCheck),
 	)
 	ws := new(restful.WebService)
 	ws.
@@ -429,6 +431,21 @@ func (s *Server) syncLoopHealthCheck(req *http.Request) error {
 		return fmt.Errorf("sync Loop took longer than expected")
 	}
 	return nil
+}
+
+// Checks if any of the kubelet's reflectors have reported any errors
+func (s *Server) reflectorHealthCheck(req *http.Request) error {
+	healthy, reflectorErrors := s.host.ReflectorsHealthy()
+	if healthy {
+		return nil
+	}
+
+	reflectorErrorStrings := make([]string, 0, len(reflectorErrors))
+	for _, reflectorError := range reflectorErrors {
+		reflectorErrorStrings = append(reflectorErrorStrings, reflectorError.Error())
+	}
+
+	return fmt.Errorf("Reflector errors: %s", strings.Join(reflectorErrorStrings, ", "))
 }
 
 // getContainerLogs handles containerLogs request against the Kubelet

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/errors"
 	remotecommandconsts "k8s.io/apimachinery/pkg/util/remotecommand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -435,17 +436,8 @@ func (s *Server) syncLoopHealthCheck(req *http.Request) error {
 
 // Checks if any of the kubelet's reflectors have reported any errors
 func (s *Server) reflectorHealthCheck(req *http.Request) error {
-	healthy, reflectorErrors := s.host.ReflectorsHealthy()
-	if healthy {
-		return nil
-	}
-
-	reflectorErrorStrings := make([]string, 0, len(reflectorErrors))
-	for _, reflectorError := range reflectorErrors {
-		reflectorErrorStrings = append(reflectorErrorStrings, reflectorError.Error())
-	}
-
-	return fmt.Errorf("Reflector errors: %s", strings.Join(reflectorErrorStrings, ", "))
+	_, reflectorErrors := s.host.ReflectorsHealthy()
+	return errors.NewAggregate(reflectorErrors)
 }
 
 // getContainerLogs handles containerLogs request against the Kubelet

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -83,6 +83,7 @@ type fakeKubelet struct {
 	loopEntryTime                      time.Time
 	plegHealth                         bool
 	redirectURL                        *url.URL
+	reflectorsHealthyFunc              func() (bool, []error)
 }
 
 func (fk *fakeKubelet) ResyncInterval() time.Duration {
@@ -180,6 +181,10 @@ func (_ *fakeKubelet) GetCgroupStats(cgroupName string) (*statsapi.ContainerStat
 	return nil, nil, nil
 }
 
+func (fk *fakeKubelet) ReflectorsHealthy() (bool, []error) {
+	return fk.reflectorsHealthyFunc()
+}
+
 type fakeAuth struct {
 	authenticateFunc func(*http.Request) (user.Info, bool, error)
 	attributesFunc   func(user.Info, *http.Request) authorizer.Attributes
@@ -209,6 +214,9 @@ func newServerTest() *serverTestFramework {
 	fw.fakeKubelet = &fakeKubelet{
 		hostnameFunc: func() string {
 			return "127.0.0.1"
+		},
+		reflectorsHealthyFunc: func() (bool, []error) {
+			return true, []error{}
 		},
 		podByNameFunc: func(namespace, name string) (*v1.Pod, bool) {
 			return &v1.Pod{
@@ -564,6 +572,21 @@ func TestHealthCheck(t *testing.T) {
 		return "fake"
 	}
 	assertHealthIsOk(t, fw.testHTTPServer.URL+"/healthz")
+}
+
+func TestReflectorsHealthCheck(t *testing.T) {
+	fw := newServerTest()
+	defer fw.testHTTPServer.Close()
+	fw.fakeKubelet.reflectorsHealthyFunc = func() (bool, []error) {
+		return true, []error{}
+	}
+
+	assertHealthIsOk(t, fw.testHTTPServer.URL+"/healthz")
+
+	fw.fakeKubelet.reflectorsHealthyFunc = func() (bool, []error) {
+		return false, []error{fmt.Errorf("fake reflector error")}
+	}
+	assertHealthFails(t, fw.testHTTPServer.URL+"/healthz", http.StatusInternalServerError)
 }
 
 func assertHealthFails(t *testing.T, httpURL string, expectedErrorCode int) {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -71,6 +71,10 @@ type Reflector struct {
 	lastSyncResourceVersion string
 	// lastSyncResourceVersionMutex guards read/write access to lastSyncResourceVersion
 	lastSyncResourceVersionMutex sync.RWMutex
+
+	// If the last API list/watch request returned an error then it will be set here.
+	// This is used to determine if the Reflector is currently healthy.
+	listWatchError error
 }
 
 var (
@@ -109,13 +113,14 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	r := &Reflector{
 		name: name,
 		// we need this to be unique per process (some names are still the same)but obvious who it belongs to
-		metrics:       newReflectorMetrics(makeValidPromethusMetricName(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
-		listerWatcher: lw,
-		store:         store,
-		expectedType:  reflect.TypeOf(expectedType),
-		period:        time.Second,
-		resyncPeriod:  resyncPeriod,
-		clock:         &clock.RealClock{},
+		metrics:        newReflectorMetrics(makeValidPromethusMetricName(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
+		listerWatcher:  lw,
+		store:          store,
+		expectedType:   reflect.TypeOf(expectedType),
+		period:         time.Second,
+		resyncPeriod:   resyncPeriod,
+		clock:          &clock.RealClock{},
+		listWatchError: nil,
 	}
 	return r
 }
@@ -248,6 +253,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 	start := r.clock.Now()
 	list, err := r.listerWatcher.List(options)
 	if err != nil {
+		r.listWatchError = err
 		return fmt.Errorf("%s: Failed to list %v: %v", r.name, r.expectedType, err)
 	}
 	r.metrics.listDuration.Observe(time.Since(start).Seconds())
@@ -313,6 +319,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 				glog.V(1).Infof("%s: Watch for %v closed with unexpected EOF: %v", r.name, r.expectedType, err)
 			default:
 				utilruntime.HandleError(fmt.Errorf("%s: Failed to watch %v: %v", r.name, r.expectedType, err))
+				r.listWatchError = err
 			}
 			// If this is "connection refused" error, it means that most likely apiserver is not responsive.
 			// It doesn't make sense to re-list all objects because most likely we will be able to restart
@@ -328,6 +335,7 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 			}
 			return nil
 		}
+		r.listWatchError = nil
 
 		if err := r.watchHandler(w, &resourceVersion, resyncerrc, stopCh); err != nil {
 			if err != errorStopRequested {
@@ -439,4 +447,16 @@ func (r *Reflector) setLastSyncResourceVersion(v string) {
 	if err == nil {
 		r.metrics.lastResourceVersion.Set(float64(rv))
 	}
+}
+
+// Healthy returns a boolean that will be false if the Reflector has most
+// recently recevied an error response on its list/watch attempts.
+// If the Reflector is unhealthy and the boolean return value is false then the
+// last observed error will also be returned.
+func (r *Reflector) Healthy() (bool, error) {
+	if r.listWatchError != nil {
+		return false, r.listWatchError
+	}
+
+	return true, nil
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_test.go
@@ -354,6 +354,76 @@ func TestReflectorListAndWatchWithErrors(t *testing.T) {
 	}
 }
 
+func TestReflectorHealthy(t *testing.T) {
+	mkPod := func(id string, rv string) *v1.Pod {
+		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: id, ResourceVersion: rv}}
+	}
+	mkList := func(rv string, pods ...*v1.Pod) *v1.PodList {
+		list := &v1.PodList{ListMeta: metav1.ListMeta{ResourceVersion: rv}}
+		for _, pod := range pods {
+			list.Items = append(list.Items, *pod)
+		}
+		return list
+	}
+	table := []struct {
+		list     *v1.PodList
+		listErr  error
+		events   []watch.Event
+		watchErr error
+	}{
+		{
+			list:     mkList("5", mkPod("bar", "3"), mkPod("qux", "5")),
+			watchErr: fmt.Errorf("a watch error"),
+		}, {
+			list: mkList("1"),
+			events: []watch.Event{
+				{Type: watch.Added, Object: mkPod("foo", "2")},
+				{Type: watch.Added, Object: mkPod("bar", "3")},
+			},
+			watchErr: nil,
+		},
+	}
+
+	s := NewFIFO(MetaNamespaceKeyFunc)
+	for _, item := range table {
+		watchRet, watchErr := item.events, item.watchErr
+		watchCount := 0
+		var r *Reflector
+		lw := &testLW{
+			ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
+				return item.list, item.listErr
+			},
+			WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
+				healthy, err := r.Healthy()
+				if watchCount == 0 && !healthy {
+					t.Errorf("Reflector not healthy when it should be, got error %v", err)
+				}
+				watchCount = watchCount + 1
+
+				if watchErr != nil {
+					return nil, watchErr
+				}
+				watchErr = fmt.Errorf("second watch")
+				fw := watch.NewFake()
+				go func() {
+					for _, e := range watchRet {
+						fw.Action(e.Type, e.Object)
+					}
+					fw.Stop()
+				}()
+				return fw, nil
+			},
+		}
+
+		r = NewReflector(lw, &v1.Pod{}, s, 0)
+		r.ListAndWatch(wait.NeverStop)
+		healthy, _ := r.Healthy()
+		if watchErr != nil && healthy {
+			t.Errorf("Reflector healthy when it should not be, expected error %v", watchErr)
+		}
+	}
+}
+
 func TestReflectorResync(t *testing.T) {
 	iteration := 0
 	stopCh := make(chan struct{})


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR will cause the kubelet's `/healthz` endpoint to return an unhealthy status when either of its two `cache.Reflector` instances are "unhealthy" due to hitting errors talking to the kube-apiserver.

A Reflector is considered unhealthy when it hits a single error talking to the kube-apiserver in its list/watch loop. It's then considered healthy again as soon as it makes a single successful request. So if a kubelet has connectivity issues talking to the API server then the kubelet's `/healthz` will start failing, but if the connectivity issues are subsequently fixed then the kubelet's `/healthz` will go back to OK.

For context on why including API connectivity in kubelet health is desirable, I currently work with an on-premises Kubernetes setup that relies on monitoring the kubelet `/healthz` endpoint on every worker node to fire warnings and alerts when certain percentages of workers are unhealthy. Recently we encountered a problem where some of our kubelets began to fail to connect to the kube-apiserver, but every kubelet's `/healthz` continued to report OK. Our monitoring failed to alert us to the problem and we were blind to the issue until we dove into the kubelet logs on individual worker nodes and discovered the connectivity errors.

**Which issue this PR fixes**:

Fixes part of #50928.

**Special notes for your reviewer**:

If this is a good approach then I'd soon like to open additional PRs to consider kube-apiserver connectivity as part of the health check of more consumers of `cache.Reflector`, with the goal of fixing all of #50928.

**Release note**:
```release-note
Active kube-apiserver connectivity errors now cause the kubelet health check to fail
```
