### PR TITLE
apiextensions/examples: remove unnecessary function

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
@@ -26,7 +26,6 @@ import (
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
 	// Uncomment the following line to load the gcp plugin (only required to authenticate against GKE clusters).
@@ -38,11 +37,12 @@ import (
 )
 
 func main() {
+	masterURL := flag.String("master", "", "The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.")
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kube config. Only required if out-of-cluster.")
 	flag.Parse()
 
-	// Create the client config. Use kubeconfig if given, otherwise assume in-cluster.
-	config, err := buildConfig(*kubeconfig)
+	// Create the client config. Use masterURL and kubeconfig if given, otherwise assume in-cluster.
+	config, err := clientcmd.BuildConfigFromFlags(*masterURL, *kubeconfig)
 	if err != nil {
 		panic(err)
 	}
@@ -120,11 +120,4 @@ func main() {
 		panic(err)
 	}
 	fmt.Printf("LIST: %#v\n", exampleList)
-}
-
-func buildConfig(kubeconfig string) (*rest.Config, error) {
-	if kubeconfig != "" {
-		return clientcmd.BuildConfigFromFlags("", kubeconfig)
-	}
-	return rest.InClusterConfig()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The `BuildConfigFromFlags` function already calls the `InClusterConfig` function.

**Special notes for your reviewer**:

If this function was added to bypass [the warning](https://github.com/kubernetes/client-go/blob/master/tools/clientcmd/client_config.go#L529), then maybe we should instead add a comment.

/cc @sttts @nikhita
