### PR TITLE
GPU e2e_node test now checks array bounds

### DIFF
--- a/test/e2e_node/gpu_device_plugin.go
+++ b/test/e2e_node/gpu_device_plugin.go
@@ -156,7 +156,11 @@ func getDeviceId(f *framework.Framework, podName string, contName string, restar
 	// Wait till pod has been restarted at least restartCount times.
 	Eventually(func() bool {
 		p, err := f.PodClient().Get(podName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
+
+		if err != nil || len(p.Status.ContainerStatuses) == 0 {
+			return false
+		}
+
 		return p.Status.ContainerStatuses[0].RestartCount >= restartCount
 	}, time.Minute, time.Second).Should(BeTrue())
 	logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, contName)


### PR DESCRIPTION
**What this PR does / why we need it**:
[NVIDIA GPU device plugin e2e_node is consistently failing](https://k8s-testgrid.appspot.com/wg-resource-management#kubelet-serial-gce-e2e). This PR aims to fix that. 

Fixes #53354

**Special notes for your reviewer**:
- PR this was introduced: https://github.com/kubernetes/kubernetes/pull/52250
- @mindprince @jiayingz 

**Release note**:
```release-note
NONE
```
