### PR TITLE
[cluster-monitoring addon] Update monitoring-influxdb-grafana to latest version

### DIFF
--- a/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/grafana-service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: monitoring-grafana
   namespace: kube-system
-  labels: 
+  labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "Grafana"
@@ -11,9 +11,9 @@ spec:
   # On production clusters, consider setting up auth for grafana, and
   # exposing Grafana either using a LoadBalancer or a public IP.
   # type: LoadBalancer
-  ports: 
+  ports:
     - port: 80
-      targetPort: 3000
-  selector: 
+      protocol: TCP
+      targetPort: ui
+  selector:
     k8s-app: influxGrafana
-

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -1,44 +1,52 @@
-apiVersion: v1
-kind: ReplicationController
+kind: Deployment
+apiVersion: extensions/v1beta1
 metadata:
   name: monitoring-influxdb-grafana-v4
   namespace: kube-system
-  labels: 
+  labels:
     k8s-app: influxGrafana
     version: v4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-spec: 
+spec:
   replicas: 1
-  selector: 
-    k8s-app: influxGrafana
-    version: v4
-  template: 
-    metadata: 
-      labels: 
+  selector:
+    matchLabels:
+      k8s-app: influxGrafana
+      version: v4
+  template:
+    metadata:
+      labels:
         k8s-app: influxGrafana
         version: v4
-        kubernetes.io/cluster-service: "true"
-    spec: 
-      containers: 
-        - image: gcr.io/google_containers/heapster-influxdb-amd64:v1.1.1
-          name: influxdb
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: "CriticalAddonsOnly"
+        operator: "Exists"
+      containers:
+        - name: influxdb
+          image: gcr.io/google_containers/heapster-influxdb-amd64:v1.3.3
           resources:
-            # keep request = limit to keep this container in guaranteed class
             limits:
               cpu: 100m
               memory: 500Mi
             requests:
               cpu: 100m
               memory: 500Mi
-          ports: 
-            - containerPort: 8083
-            - containerPort: 8086
+          ports:
+            - name: http
+              containerPort: 8083
+            - name: api
+              containerPort: 8086
           volumeMounts:
           - name: influxdb-persistent-storage
             mountPath: /data
-        - image: gcr.io/google_containers/heapster-grafana-amd64:v4.0.2
-          name: grafana
+        - name: grafana
+          image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.3
           env:
           resources:
             # keep request = limit to keep this container in guaranteed class
@@ -64,6 +72,9 @@ spec:
               value: Admin
             - name: GF_SERVER_ROOT_URL
               value: /api/v1/proxy/namespaces/kube-system/services/monitoring-grafana/
+          ports:
+          - name: ui
+            containerPort: 3000
           volumeMounts:
           - name: grafana-persistent-storage
             mountPath: /var
@@ -72,4 +83,3 @@ spec:
         emptyDir: {}
       - name: grafana-persistent-storage
         emptyDir: {}
-

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-service.yaml
@@ -3,18 +3,17 @@ kind: Service
 metadata:
   name: monitoring-influxdb
   namespace: kube-system
-  labels: 
+  labels:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     kubernetes.io/name: "InfluxDB"
-spec: 
-  ports: 
+spec:
+  ports:
     - name: http
       port: 8083
       targetPort: 8083
     - name: api
       port: 8086
       targetPort: 8086
-  selector: 
+  selector:
     k8s-app: influxGrafana
-


### PR DESCRIPTION
**What this PR does / why we need it**:
In cluster-monitoring addon, the `monitoring-influxdb-grafana` part of the content is too old, so I modified some file to update, this has been tested on v1.7.7, v1.8.0.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Update Influxdb image to latest version.
Update Grafana image to latest version.
Change influxdb-grafana-controller resource to Deployment.
```
