### PR TITLE
add --list option to can-i to show rules review results

### DIFF
--- a/pkg/kubectl/cmd/auth/BUILD
+++ b/pkg/kubectl/cmd/auth/BUILD
@@ -23,10 +23,12 @@ go_library(
         "//pkg/kubectl/cmd/templates:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//pkg/kubectl/resource:go_default_library",
+        "//pkg/printers:go_default_library",
         "//pkg/registry/rbac/reconciliation:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],
 )

--- a/pkg/kubectl/cmd/auth/cani.go
+++ b/pkg/kubectl/cmd/auth/cani.go
@@ -27,21 +27,25 @@ import (
 	"github.com/spf13/cobra"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1alpha1 "k8s.io/apimachinery/pkg/apis/meta/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	authorizationapi "k8s.io/kubernetes/pkg/apis/authorization"
 	internalauthorizationclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/authorization/internalversion"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	"k8s.io/kubernetes/pkg/printers"
 )
 
 // CanIOptions is the start of the data required to perform the operation.  As new fields are added, add them here instead of
 // referencing the cmd.Flags()
 type CanIOptions struct {
-	AllNamespaces bool
-	Quiet         bool
-	Namespace     string
-	SelfSARClient internalauthorizationclient.SelfSubjectAccessReviewsGetter
+	AllNamespaces          bool
+	Quiet                  bool
+	Namespace              string
+	SelfSARClient          internalauthorizationclient.SelfSubjectAccessReviewsGetter
+	SelfSubjectRulesClient internalauthorizationclient.SelfSubjectRulesReviewsGetter
 
+	List           bool
 	Verb           string
 	Resource       schema.GroupVersionResource
 	NonResourceURL string
@@ -93,7 +97,7 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 		Long:    canILong,
 		Example: canIExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(o.Complete(f, args))
+			cmdutil.CheckErr(o.Complete(cmd, f, args))
 			cmdutil.CheckErr(o.Validate())
 
 			allowed, err := o.RunAccessCheck()
@@ -110,12 +114,35 @@ func NewCmdCanI(f cmdutil.Factory, out, err io.Writer) *cobra.Command {
 	cmd.Flags().BoolVar(&o.AllNamespaces, "all-namespaces", o.AllNamespaces, "If true, check the specified action in all namespaces.")
 	cmd.Flags().BoolVarP(&o.Quiet, "quiet", "q", o.Quiet, "If true, suppress output and just return the exit code.")
 	cmd.Flags().StringVar(&o.Subresource, "subresource", "", "SubResource such as pod/log or deployment/scale")
+	cmd.Flags().BoolVar(&o.List, "list", false, "list all the actions I can perform in the namespace or cluster scope")
 	return cmd
 }
 
-func (o *CanIOptions) Complete(f cmdutil.Factory, args []string) error {
+func (o *CanIOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args []string) error {
 	if o.Quiet {
 		o.Out = ioutil.Discard
+	}
+
+	var err error
+	client, err := f.ClientSet()
+	if err != nil {
+		return err
+	}
+	o.SelfSARClient = client.Authorization()
+	o.SelfSubjectRulesClient = client.Authorization()
+
+	o.Namespace = ""
+	if !o.AllNamespaces {
+		o.Namespace, _, err = f.DefaultNamespace()
+		if err != nil {
+			return err
+		}
+	}
+	if o.List {
+		if len(args) > 0 {
+			return errors.New("you may not specify any arguments when listing permissions")
+		}
+		return nil
 	}
 
 	switch len(args) {
@@ -135,21 +162,6 @@ func (o *CanIOptions) Complete(f cmdutil.Factory, args []string) error {
 		return errors.New("you must specify two or three arguments: verb, resource, and optional resourceName")
 	}
 
-	var err error
-	client, err := f.ClientSet()
-	if err != nil {
-		return err
-	}
-	o.SelfSARClient = client.Authorization()
-
-	o.Namespace = ""
-	if !o.AllNamespaces {
-		o.Namespace, _, err = f.DefaultNamespace()
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 
@@ -166,6 +178,10 @@ func (o *CanIOptions) Validate() error {
 }
 
 func (o *CanIOptions) RunAccessCheck() (bool, error) {
+	if o.List {
+		return o.runRulesCheck()
+	}
+
 	var sar *authorizationapi.SelfSubjectAccessReview
 	if o.NonResourceURL == "" {
 		sar = &authorizationapi.SelfSubjectAccessReview{
@@ -237,4 +253,52 @@ func (o *CanIOptions) resourceFor(mapper meta.RESTMapper, resourceArg string) sc
 	}
 
 	return gvr
+}
+
+func (o *CanIOptions) runRulesCheck() (bool, error) {
+	result, err := o.SelfSubjectRulesClient.SelfSubjectRulesReviews().Create(
+		&authorizationapi.SelfSubjectRulesReview{
+			Spec: authorizationapi.SelfSubjectRulesReviewSpec{
+				Namespace: o.Namespace,
+			},
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+
+	table := &metav1alpha1.Table{}
+	table.ColumnDefinitions = []metav1alpha1.TableColumnDefinition{
+		{Name: "VERBS", Type: "string"},
+		{Name: "NON-RESOURCE URLS", Type: "string"},
+		{Name: "RESOURCE NAMES", Type: "string"},
+		{Name: "API GROUPS", Type: "string"},
+		{Name: "RESOURCES", Type: "string"},
+	}
+
+	for _, rule := range result.Status.ResourceRules {
+		table.Rows = append(table.Rows, metav1alpha1.TableRow{
+			Cells: []interface{}{
+				rule.Verbs, "", rule.ResourceNames, rule.APIGroups, rule.Resources,
+			},
+		})
+	}
+	for _, rule := range result.Status.NonResourceRules {
+		table.Rows = append(table.Rows, metav1alpha1.TableRow{
+			Cells: []interface{}{
+				rule.Verbs, rule.NonResourceURLs, "", "", "",
+			},
+		})
+	}
+
+	printers.PrintTable(table, o.Out, printers.PrintOptions{})
+
+	if len(result.Status.EvaluationError) > 0 {
+		return false, fmt.Errorf("error evaluating permissions; reported rules may be incomplete: %v", result.Status.EvaluationError)
+	}
+	if result.Status.Incomplete {
+		return false, fmt.Errorf("reported rules are incomplete")
+	}
+
+	return true, err
 }

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -160,7 +160,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:basic-user"},
 			Rules: []rbac.PolicyRule{
 				// TODO add future selfsubjectrulesreview, project request APIs, project listing APIs
-				rbac.NewRule("create").Groups(authorizationGroup).Resources("selfsubjectaccessreviews").RuleOrDie(),
+				rbac.NewRule("create").Groups(authorizationGroup).Resources("selfsubjectaccessreviews", "selfsubjectrulesreviews").RuleOrDie(),
 			},
 		},
 

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -358,6 +358,7 @@ items:
     - authorization.k8s.io
     resources:
     - selfsubjectaccessreviews
+    - selfsubjectrulesreviews
     verbs:
     - create
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Adds `kubectl auth can-i --list` to see selfsubjectrulesreview results.

@kubernetes/sig-auth-pr-reviews 