### PR TITLE
Add permisions for Metrics Server to read resources on cluster level

### DIFF
--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -1,0 +1,42 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metrics-server
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "extensions"
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metrics-server
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system


### PR DESCRIPTION
**What this PR does / why we need it**:
Add permisions for Metrics Server to read resources on cluster level.

**Which issue this PR fixes**:
fixes https://github.com/kubernetes-incubator/metrics-server/issues/16

**Release note**:
```release-note
Fix permissions for Metrics Server.
```
