### PR TITLE
Don't try to migrate to new roles and rolebinding within 1.7 upgrades

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/errors"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/proxy"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/apiconfig"
@@ -62,9 +63,12 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.MasterC
 		errs = append(errs, err)
 	}
 
-	// Create/update RBAC rules that makes the bootstrap tokens able to get their CSRs approved automatically
-	if err := nodebootstraptoken.AutoApproveNodeBootstrapTokens(client, k8sVersion); err != nil {
-		errs = append(errs, err)
+	// Not needed for 1.7 upgrades
+	if k8sVersion.AtLeast(constants.MinimumCSRAutoApprovalClusterRolesVersion) {
+		// Create/update RBAC rules that makes the bootstrap tokens able to get their CSRs approved automatically
+		if err := nodebootstraptoken.AutoApproveNodeBootstrapTokens(client, k8sVersion); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// TODO: Is this needed to do here? I think that updating cluster info should probably be separate from a normal upgrade
@@ -72,9 +76,12 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.MasterC
 	// if err := clusterinfo.CreateBootstrapConfigMapIfNotExists(client, kubeadmconstants.GetAdminKubeConfigPath()); err != nil {
 	// 	return err
 	//}
-	// Create/update RBAC rules that makes the cluster-info ConfigMap reachable
-	if err := clusterinfo.CreateClusterInfoRBACRules(client); err != nil {
-		errs = append(errs, err)
+	// Not needed for 1.7 upgrades
+	if k8sVersion.AtLeast(constants.UseEnableBootstrapTokenAuthFlagVersion) {
+		// Create/update RBAC rules that makes the cluster-info ConfigMap reachable
+		if err := clusterinfo.CreateClusterInfoRBACRules(client); err != nil {
+			errs = append(errs, err)
+		}
 	}
 
 	// TODO: This call is deprecated


### PR DESCRIPTION
**What this PR does / why we need it**:

If user uses kubeadm 1.8.0 to upgrade within 1.7.x versions, don't try to migrate to new RBAC rules and names. It will lead to errors like described in kubernetes/kubeadm#475

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: kubernetes/kubeadm#475

**Special notes for your reviewer**:

**Release note**:
```release-note
kubeadm 1.8 now properly handles upgrades from to 1.7.x to newer release in 1.7 branch
```