### PR TITLE
Don't referece not-exist addon manager manifests in comment

### DIFF
--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -12,8 +12,6 @@ spec:
   containers:
   - name: kube-addon-manager
     # When updating version also bump it in:
-    # - cluster/images/hyperkube/static-pods/addon-manager-singlenode.json
-    # - cluster/images/hyperkube/static-pods/addon-manager-multinode.json
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
     image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
     command:


### PR DESCRIPTION
**What this PR does / why we need it**:
`addon-manager-multinode.json` and `addon-manager-singlenode.json` have been removed by https://github.com/kubernetes/kubernetes/commit/b814b624474a387eb05172ac8155c79be3fca8b3#diff-89347a70de188b3c15f5ee15323658d2.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
