### PR TITLE
Version should be quoted so jq doesn't interpret it as numeric

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -117,7 +117,7 @@ func masterUpgradeKubernetesAnywhere(v string) error {
 	// modify config with specified k8s version
 	if _, _, err := RunCmd("sed",
 		"-i.bak", // writes original to .config.bak
-		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%q/`, v),
 		originalConfigPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes: #https://github.com/kubernetes/kubeadm/issues/477