### PR TITLE
Kubeadm: Add some validation for external etcd config

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -677,6 +677,15 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		)
 	} else {
 		// Only check etcd version when external endpoints are specified
+		if cfg.Etcd.CAFile != "" {
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.CAFile})
+		}
+		if cfg.Etcd.CertFile != "" {
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.CertFile})
+		}
+		if cfg.Etcd.KeyFile != "" {
+			checks = append(checks, FileExistingCheck{Path: cfg.Etcd.KeyFile})
+		}
 		checks = append(checks,
 			ExternalEtcdVersionCheck{Etcd: cfg.Etcd},
 		)

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -174,12 +174,34 @@ func (pfct preflightCheckTest) Check() (warning, errors []error) {
 
 func TestRunInitMasterChecks(t *testing.T) {
 	var tests = []struct {
+		name     string
 		cfg      *kubeadmapi.MasterConfiguration
 		expected bool
 	}{
-		{
+		{name: "Test valid advertised address",
 			cfg: &kubeadmapi.MasterConfiguration{
 				API: kubeadmapi.API{AdvertiseAddress: "foo"},
+			},
+			expected: false,
+		},
+		{
+			name: "Test CA file exists if specfied",
+			cfg: &kubeadmapi.MasterConfiguration{
+				Etcd: kubeadmapi.Etcd{CAFile: "/foo"},
+			},
+			expected: false,
+		},
+		{
+			name: "Test Cert file exists if specfied",
+			cfg: &kubeadmapi.MasterConfiguration{
+				Etcd: kubeadmapi.Etcd{CertFile: "/foo"},
+			},
+			expected: false,
+		},
+		{
+			name: "Test Key file exists if specfied",
+			cfg: &kubeadmapi.MasterConfiguration{
+				Etcd: kubeadmapi.Etcd{CertFile: "/foo"},
 			},
 			expected: false,
 		},
@@ -189,9 +211,10 @@ func TestRunInitMasterChecks(t *testing.T) {
 		actual := RunInitMasterChecks(rt.cfg)
 		if (actual == nil) != rt.expected {
 			t.Errorf(
-				"failed RunInitMasterChecks:\n\texpected: %t\n\t  actual: %t",
+				"failed RunInitMasterChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",
 				rt.expected,
-				(actual != nil),
+				(actual == nil),
+				actual,
 			)
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR add file existing check for etcd cert files.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://github.com/kubernetes/kubeadm/issues/342
**Special notes for your reviewer**:
Unlike issue https://github.com/kubernetes/kubeadm/issues/342 said, we already have etcd version check which include extensive validation including file format etc. This PR simply added some file existing check upfront for being more user friendly.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
