### PR TITLE
Fixes a regression introduced by PR 52290 that extended resource

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -608,15 +608,6 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 					node.Status.Capacity[k] = v
 				}
 			}
-			// Remove stale extended resources.
-			for k := range node.Status.Capacity {
-				if v1helper.IsExtendedResourceName(k) {
-					if _, ok := currentCapacity[k]; !ok {
-						glog.V(2).Infof("delete capacity for %s", k)
-						delete(node.Status.Capacity, k)
-					}
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
capacity may temporarily drop to zero after kubelet restarts and PODs restarted during
that time window could fail to be scheduled.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/53342

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Don't remove extended resource capacities that are not registered with kubelet from node status.
```