### PR TITLE
cmd: genutils: remove entry from .golint_failures

### DIFF
--- a/cmd/genutils/genutils.go
+++ b/cmd/genutils/genutils.go
@@ -22,6 +22,8 @@ import (
 	"path/filepath"
 )
 
+// OutDir creates the absolute path name from path and checks path exists.
+// Returns absolute path including trailing '/' or error if path does not exist.
 func OutDir(path string) (string, error) {
 	outDir, err := filepath.Abs(path)
 	if err != nil {
@@ -34,7 +36,7 @@ func OutDir(path string) (string, error) {
 	}
 
 	if !stat.IsDir() {
-		return "", fmt.Errorf("output directory %s is not a directory\n", outDir)
+		return "", fmt.Errorf("output directory %s is not a directory", outDir)
 	}
 	outDir = outDir + "/"
 	return outDir, nil

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,5 +1,4 @@
 cluster/images/etcd-version-monitor
-cmd/genutils
 cmd/gke-certificates-controller/app
 cmd/hyperkube
 cmd/kube-controller-manager/app


### PR DESCRIPTION
**What this PR does / why we need it**:

`golint` emits warnings

```
exported function OutDir should have comment or be unexported
strings should not be capitalized or end with punctuation or a newline
```

- Add documentation comment to exported function OutDir.
- Remove newline from error string.
- Remove `hack\.golint_failures` entry for `cmd/genutils`

**Special notes for your reviewer**:
   
Don't know which sig to use?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup