### PR TITLE
cmd: kubectl: remove golint_failures entry

### DIFF
--- a/cmd/kubectl/app/kubectl.go
+++ b/cmd/kubectl/app/kubectl.go
@@ -31,6 +31,8 @@ import (
 WARNING: this logic is duplicated, with minor changes, in cmd/hyperkube/kubectl.go
 Any salient changes here will need to be manually reflected in that file.
 */
+
+// Run runs the kubectl program (creates and executes a new cobra command).
 func Run() error {
 	logs.InitLogs()
 	defer logs.FlushLogs()

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -9,7 +9,6 @@ cmd/kube-proxy/app
 cmd/kubeadm/app
 cmd/kubeadm/app/apis/kubeadm
 cmd/kubeadm/app/apis/kubeadm/v1alpha1
-cmd/kubectl/app
 cmd/kubelet/app
 cmd/kubelet/app/options
 cmd/kubemark

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -117,7 +117,7 @@ func masterUpgradeKubernetesAnywhere(v string) error {
 	// modify config with specified k8s version
 	if _, _, err := RunCmd("sed",
 		"-i.bak", // writes original to .config.bak
-		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%q/`, v),
 		originalConfigPath); err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
       
`.golint_failures` currently has an entry for `cmd/kubectl/app`. We can lint this package and remove the entry. There is only one `golint` warning; comment on exported function Run should be of the form "Run..."
    
Fix documentation comment and remove `cmd/kubectl/app` from `.golint_failures`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig cli
/kind cleanup
