### PR TITLE
cmd: hyperkube: remove entry for golint_failures

### DIFF
--- a/cmd/hyperkube/hyperkube.go
+++ b/cmd/hyperkube/hyperkube.go
@@ -243,7 +243,7 @@ func (hk *HyperKube) MakeSymlinks(command string) error {
 	}
 
 	if errs {
-		return errors.New("Error creating one or more symlinks.")
+		return errors.New("error creating one or more symlinks")
 	}
 	return nil
 }

--- a/cmd/hyperkube/kube-aggregator.go
+++ b/cmd/hyperkube/kube-aggregator.go
@@ -39,10 +39,7 @@ func NewKubeAggregator() *Server {
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunAggregator(stopCh); err != nil {
-				return err
-			}
-			return nil
+			return o.RunAggregator(stopCh)
 		},
 		RespectsStopCh: true,
 	}

--- a/cmd/hyperkube/kubectl.go
+++ b/cmd/hyperkube/kubectl.go
@@ -23,7 +23,7 @@ import (
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
-// Create a Server that implements the kubectl command
+// NewKubectlServer creates a server that implements the kubectl command.
 func NewKubectlServer() *Server {
 	cmd := cmd.NewKubectlCommand(cmdutil.NewFactory(nil), os.Stdin, os.Stdout, os.Stderr)
 	localFlags := cmd.LocalFlags()

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -160,6 +160,7 @@ func AddFlags(options *Options, fs *pflag.FlagSet) {
 	utilfeature.DefaultFeatureGate.AddFlag(fs)
 }
 
+// NewOptions creates a new Options structure.
 func NewOptions() (*Options, error) {
 	o := &Options{
 		config:      new(componentconfig.KubeProxyConfiguration),
@@ -202,6 +203,7 @@ func (o *Options) Validate(args []string) error {
 	return nil
 }
 
+// Run does the actual work.
 func (o *Options) Run() error {
 	config := o.config
 
@@ -210,13 +212,13 @@ func (o *Options) Run() error {
 	}
 
 	if len(o.ConfigFile) > 0 {
-		if c, err := o.loadConfigFromFile(o.ConfigFile); err != nil {
+		c, err := o.loadConfigFromFile(o.ConfigFile)
+		if err != nil {
 			return err
-		} else {
-			config = c
-			// Make sure we apply the feature gate settings in the config file.
-			utilfeature.DefaultFeatureGate.Set(config.FeatureGates)
 		}
+		config = c
+		// Make sure we apply the feature gate settings in the config file.
+		utilfeature.DefaultFeatureGate.Set(config.FeatureGates)
 	}
 
 	proxyServer, err := NewProxyServer(config, o.CleanupAndExit, o.scheme, o.master)
@@ -301,6 +303,7 @@ func (o *Options) loadConfig(data []byte) (*componentconfig.KubeProxyConfigurati
 	return config, nil
 }
 
+// ApplyDefaults
 func (o *Options) ApplyDefaults(in *componentconfig.KubeProxyConfiguration) (*componentconfig.KubeProxyConfiguration, error) {
 	external, err := o.scheme.ConvertToVersion(in, v1alpha1.SchemeGroupVersion)
 	if err != nil {
@@ -319,7 +322,7 @@ func (o *Options) ApplyDefaults(in *componentconfig.KubeProxyConfiguration) (*co
 	return out, nil
 }
 
-// NewProxyCommand creates a *cobra.Command object with default parameters
+// NewProxyCommand creates a *cobra.Command object with default parameters.
 func NewProxyCommand() *cobra.Command {
 	opts, err := NewOptions()
 	if err != nil {

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,7 +1,6 @@
 cluster/images/etcd-version-monitor
 cmd/genutils
 cmd/gke-certificates-controller/app
-cmd/hyperkube
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app
 cmd/kubeadm/app


### PR DESCRIPTION
**What this PR does / why we need it**:

`cmd/hyperkube` currently appears in `.golint_failures`. We can lint this package, there is only one warning; comment on exported function NewKubectlServer should be of the form "NewKubectlServer ..."

Fix documentation comment and remove `cmd/hyperkube` entry from `.golint_failures`.

**Special notes for your reviewer**:

Don't know which sig to label this PR with?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/kind cleanup
