### PR TITLE
cmd: cloud-controller-manager: remove golint_failures entry

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -56,7 +56,7 @@ import (
 )
 
 const (
-	// Jitter used when starting controller managers
+	// ControllerStartJitter is the jitter value used when starting controller managers.
 	ControllerStartJitter = 1.0
 )
 

--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -31,7 +31,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// CloudControllerMangerServer is the main context object for the controller manager.
+// CloudControllerManagerServer is the main context object for the controller manager.
 type CloudControllerManagerServer struct {
 	componentconfig.KubeControllerManagerConfiguration
 

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -1,6 +1,4 @@
 cluster/images/etcd-version-monitor
-cmd/cloud-controller-manager/app
-cmd/cloud-controller-manager/app/options
 cmd/genutils
 cmd/gke-certificates-controller/app
 cmd/hyperkube


### PR DESCRIPTION
**What this PR does / why we need it**:

`cmd/cloud-controller-manager/app` and  `cmd/cloud-controller-manager/app/options` currently appear in `.golint_failures`. We can lint these packages.

`golint` emits the following two warnings
```
comment on exported type CloudControllerManagerServer should be of the form "CloudControllerManagerServer ..."
comment on exported const ControllerStartJitter should be of the form "ControllerStartJitter ..."
```

Fix the documentation comments and remove entries from `.golint_failures`

**Special notes for your reviewer**:

Don't know which sig to label this PR with?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/kind cleanup
