### PR TITLE
Add ping6 option for e2e ext connectivity test for IPv6-only clusters

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4503,15 +4503,22 @@ func LaunchWebserverPod(f *Framework, podName, nodeName string) (ip string) {
 	return
 }
 
+type PingCommand string
+
+const (
+	IPv4PingCommand PingCommand = "ping"
+	IPv6PingCommand PingCommand = "ping6"
+)
+
 // CheckConnectivityToHost launches a pod to test connectivity to the specified
 // host. An error will be returned if the host is not reachable from the pod.
 //
 // An empty nodeName will use the schedule to choose where the pod is executed.
-func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, timeout int) error {
+func CheckConnectivityToHost(f *Framework, nodeName, podName, host string, pingCmd PingCommand, timeout int) error {
 	contName := fmt.Sprintf("%s-container", podName)
 
 	command := []string{
-		"ping",
+		string(pingCmd),
 		"-c", "3", // send 3 pings
 		"-W", "2", // wait at most 2 seconds for a reply
 		"-w", strconv.Itoa(timeout),

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -45,10 +45,16 @@ var _ = SIGDescribe("Networking", func() {
 		}
 	})
 
-	It("should provide Internet connection for containers", func() {
+	It("should provide Internet connection for containers [Feature:Networking-IPv4]", func() {
 		By("Running container which tries to ping 8.8.8.8")
 		framework.ExpectNoError(
-			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", 30))
+			framework.CheckConnectivityToHost(f, "", "ping-test", "8.8.8.8", framework.IPv4PingCommand, 30))
+	})
+
+	It("should provide Internet connection for containers [Feature:Networking-IPv6][Experimental]", func() {
+		By("Running container which tries to ping google.com")
+		framework.ExpectNoError(
+			framework.CheckConnectivityToHost(f, "", "ping-test", "google.com", framework.IPv6PingCommand, 30))
 	})
 
 	// First test because it has no dependencies on variables created later on.


### PR DESCRIPTION
e2e tests provide only an (IPv4) ping test for external connectivity.

We need a way to conditionally run a ping6 external connectivity check,
and disable the (IPv4) ping-based external connectivity check,
for end-to-end testing on IPv6-only clusters.

This feature will be needed for creating gating IPv6 CI tests.

fixes #53383

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This adds an IPv6 (ping6) version of the external connectivity ping check to the e2e test suite,
and adds "Feature:" flags for selecting whether the IPv4 or IPv6 (or both) versions
of the connectivity test should be run. We need this change to be able to use the
e2e test suite in upstream gating IPv6 CI tests on IPv6-only clusters (at least until
dual-stack operation is fully supported in Kubernetes).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53383

**Special notes for your reviewer**:
Please let me know if there are better tags to use for selecting IPv4 vs IPv6 testing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
