### PR TITLE
default fail-swap-on to false for kubelet on kubernetes-worker charm

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -487,6 +487,7 @@ def configure_worker_services(api_servers, dns, cluster_cidr):
     kubelet_opts.add('tls-cert-file', server_cert_path)
     kubelet_opts.add('tls-private-key-file', server_key_path)
     kubelet_opts.add('logtostderr', 'true')
+    kubelet_opts.add('fail-swap-on', 'false')
 
     kube_proxy_opts = FlagManager('kube-proxy')
     kube_proxy_opts.add('cluster-cidr', cluster_cidr)


### PR DESCRIPTION
**What this PR does / why we need it**: default fail-swap-on to false for kubelet on kubernetes-worker charm

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
default fail-swap-on to false for kubelet on kubernetes-worker charm
```
