### PR TITLE
fluentd-elasticsearch add-on: Rename Docker image tag

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -16,7 +16,7 @@
 
 PREFIX = gcr.io/google-containers
 IMAGE = elasticsearch
-TAG = v5.6.2-1
+TAG = v5.6.2
 
 build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: gcr.io/google-containers/elasticsearch:v5.6.2-1
+      - image: gcr.io/google-containers/elasticsearch:v5.6.2
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class


### PR DESCRIPTION
As @crassirostris requested in #53307 - rename tag of Docker image gcr.io/google-containers/elasticsearch to drop -1 suffix.