### PR TITLE
Ignore unexported fields in import_known_versions_test

### DIFF
--- a/pkg/master/import_known_versions_test.go
+++ b/pkg/master/import_known_versions_test.go
@@ -106,6 +106,9 @@ func ensureNoTags(t *testing.T, gvk schema.GroupVersionKind, tp reflect.Type, pa
 	case reflect.Struct:
 		for i := 0; i < tp.NumField(); i++ {
 			f := tp.Field(i)
+			if f.PkgPath != "" {
+				continue // Ignore unexported fields
+			}
 			jsonTag := f.Tag.Get("json")
 			protoTag := f.Tag.Get("protobuf")
 			if len(jsonTag) > 0 || len(protoTag) > 0 {


### PR DESCRIPTION
Tests currently fail with:

  "import_known_versions_test.go:122: Unexpected type uint in ..."

**What this PR does / why we need it**:

Running `make test` against the latest (f11a551f64) fails for me with:

```
import_known_versions_test.go:122: Unexpected type uint in schema.GroupVersionKind{Group:"apps", Version:"__internal", Kind:"DaemonSet"}

        import_known_versions_test.go:122: Unexpected type uint in schema.GroupVersionKind{Group:"apps", Version:"__internal", Kind:"DaemonSet"}
        import_known_versions_test.go:124: extensions.DaemonSet:
        import_known_versions_test.go:124:   extensions.DaemonSetSpec:
        import_known_versions_test.go:124:     api.PodTemplateSpec:
        import_known_versions_test.go:124:       api.PodSpec:
        import_known_versions_test.go:124:         []api.Container:
        import_known_versions_test.go:124:           api.Container:
        import_known_versions_test.go:124:             []api.EnvVar:
        import_known_versions_test.go:124:               api.EnvVar:
        import_known_versions_test.go:124:                 *api.EnvVarSource:
        import_known_versions_test.go:124:                   api.EnvVarSource:
        import_known_versions_test.go:124:                     *api.ResourceFieldSelector:
        import_known_versions_test.go:124:                       api.ResourceFieldSelector:
        import_known_versions_test.go:124:                         resource.Quantity:
        import_known_versions_test.go:124:                           resource.infDecAmount:
        import_known_versions_test.go:124:                             *inf.Dec:
        import_known_versions_test.go:124:                               inf.Dec:
        import_known_versions_test.go:124:                                 big.Int:
        import_known_versions_test.go:124:                                   big.nat:
        import_known_versions_test.go:124:                                     big.Word:
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53508

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
