### PR TITLE
Adjust defaults of audit webhook backends

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1661,6 +1661,10 @@
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/util/flowcontrol",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/webhook:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This PR:

- increases the default buffer size to contain at lease on the order of magnitude audit events than it's possible to have simultaneous requests (500 AFAIR)
- increase the default batch size. From our load tests .95 size of the log entry is under 2.5KB, therefore 400 entry will sum up to ~1MB request, which sounds reasonable
- increase the initial backoff size. AFAIU, if the initial value is zero, all retries will be used in under 15 seconds (with 0.2 jitter and 1.5 factor), while the backend or a proxy can be unavailable for some reason for 30 seconds and more.
- add throttling to the batching audit webhook

A PR to make these parameters configurable will follow-up

@hzxuzhonghu implemented throttling part of this PR

```release-note
Adjust batching audit webhook default parameters: increase queue size, batch size, and initial backoff. Add throttling to the batching audit webhook. Default rate limit is 10 QPS.
```

/cc @sttts @tallclair @CaoShuFeng @ericchiang @piosz 