### PR TITLE
Enable dynamic configue max number of PDs allowed on a node based on machine type

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -477,6 +477,10 @@ func newAWSSDKProvider(creds *credentials.Credentials) *awsSDKProvider {
 	}
 }
 
+func MaxPDCount(node *v1.Node) int {
+	return DefaultMaxEBSVolumes
+}
+
 func (p *awsSDKProvider) addHandlers(regionName string, h *request.Handlers) {
 	h.Sign.PushFrontNamed(request.NamedHandler{
 		Name: "k8s/logger",

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -39,12 +39,17 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"golang.org/x/crypto/pkcs12"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
 	// CloudProviderName is the value used for the --cloud-provider flag
-	CloudProviderName      = "azure"
+	CloudProviderName = "azure"
+	// DefaultMaxAzureVolumes defines the maximum number of PD Volumes for Azure
+	// Larger Azure VMs can actually have much more disks attached.
+	// TODO We should determine the max based on VM size
+	DefaultMaxAzureVolumes = 16
 	rateLimitQPSDefault    = 1.0
 	rateLimitBucketDefault = 5
 	backoffRetriesDefault  = 6
@@ -447,4 +452,9 @@ func initDiskControllers(az *Cloud) error {
 	az.controllerCommon = common
 
 	return nil
+}
+
+// MaxPDCount returns the limits of persistant disks that can be attached to an instance
+func MaxPDCount(node *v1.Node) int {
+	return DefaultMaxAzureVolumes
 }

--- a/plugin/pkg/scheduler/algorithm/predicates/BUILD
+++ b/plugin/pkg/scheduler/algorithm/predicates/BUILD
@@ -49,6 +49,8 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/api/v1/helper:go_default_library",
+        "//pkg/cloudprovider/providers/aws:go_default_library",
+        "//pkg/cloudprovider/providers/gce:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -19,6 +19,8 @@ package predicates
 import (
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"sync"
 
 	"k8s.io/api/core/v1"
@@ -45,6 +47,8 @@ import (
 
 const (
 	MatchInterPodAffinity = "MatchInterPodAffinity"
+	// KubeMaxPDVols defines the maximum number of PD Volumes per kubelet
+	KubeMaxPDVols = "KUBE_MAX_PD_VOLS"
 )
 
 // IMPORTANT NOTE for predicate developers:
@@ -175,7 +179,7 @@ func NoDiskConflict(pod *v1.Pod, meta algorithm.PredicateMetadata, nodeInfo *sch
 
 type MaxPDVolumeCountChecker struct {
 	filter     VolumeFilter
-	maxVolumes int
+	maxPDCount func(*v1.Node) int
 	pvInfo     PersistentVolumeInfo
 	pvcInfo    PersistentVolumeClaimInfo
 
@@ -199,10 +203,10 @@ type VolumeFilter struct {
 // The predicate looks for both volumes used directly, as well as PVC volumes that are backed by relevant volume
 // types, counts the number of unique volumes, and rejects the new pod if it would place the total count over
 // the maximum.
-func NewMaxPDVolumeCountPredicate(filter VolumeFilter, maxVolumes int, pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo) algorithm.FitPredicate {
+func NewMaxPDVolumeCountPredicate(filter VolumeFilter, maxPDCount func(*v1.Node) int, pvInfo PersistentVolumeInfo, pvcInfo PersistentVolumeClaimInfo) algorithm.FitPredicate {
 	c := &MaxPDVolumeCountChecker{
 		filter:               filter,
-		maxVolumes:           maxVolumes,
+		maxPDCount:           maxPDCount,
 		pvInfo:               pvInfo,
 		pvcInfo:              pvcInfo,
 		randomVolumeIDPrefix: rand.String(32),
@@ -298,13 +302,29 @@ func (c *MaxPDVolumeCountChecker) predicate(pod *v1.Pod, meta algorithm.Predicat
 	}
 
 	numNewVolumes := len(newVolumes)
+	maxVolumes := c.getMaxPDCount(nodeInfo.Node())
 
-	if numExistingVolumes+numNewVolumes > c.maxVolumes {
+	if numExistingVolumes+numNewVolumes > maxVolumes {
 		// violates MaxEBSVolumeCount or MaxGCEPDVolumeCount
 		return false, []algorithm.PredicateFailureReason{ErrMaxVolumeCountExceeded}, nil
 	}
 
 	return true, nil, nil
+}
+
+// getMaxVols checks the max PD volumes environment variable, otherwise get the value
+// by calling func maxPDCount() from cloud provider
+func (c *MaxPDVolumeCountChecker) getMaxPDCount(node *v1.Node) int {
+	if rawMaxVols := os.Getenv(KubeMaxPDVols); rawMaxVols != "" {
+		if parsedMaxVols, err := strconv.Atoi(rawMaxVols); err != nil {
+			glog.Errorf("Unable to parse maximum PD volumes value, using default: %v", err)
+		} else if parsedMaxVols <= 0 {
+			glog.Errorf("Maximum PD volumes must be a positive value, using default")
+		} else {
+			return parsedMaxVols
+		}
+	}
+	return c.maxPDCount(node)
 }
 
 // EBSVolumeFilter is a VolumeFilter for filtering AWS ElasticBlockStore Volumes

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -12,6 +12,8 @@ go_library(
     importpath = "k8s.io/kubernetes/plugin/pkg/scheduler/algorithmprovider/defaults",
     deps = [
         "//pkg/cloudprovider/providers/aws:go_default_library",
+        "//pkg/cloudprovider/providers/azure:go_default_library",
+        "//pkg/cloudprovider/providers/gce:go_default_library",
         "//pkg/features:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//plugin/pkg/scheduler/algorithm/predicates:go_default_library",

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -17,12 +17,11 @@ limitations under the License.
 package defaults
 
 import (
-	"os"
-	"strconv"
-
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
@@ -34,19 +33,10 @@ import (
 )
 
 const (
-	// DefaultMaxGCEPDVolumes defines the maximum number of PD Volumes for GCE
-	// GCE instances can have up to 16 PD volumes attached.
-	DefaultMaxGCEPDVolumes = 16
-	// DefaultMaxAzureDiskVolumes defines the maximum number of PD Volumes for Azure
-	// Larger Azure VMs can actually have much more disks attached.
-	// TODO We should determine the max based on VM size
-	DefaultMaxAzureDiskVolumes = 16
 	// ClusterAutoscalerProvider defines the default autoscaler provider
 	ClusterAutoscalerProvider = "ClusterAutoscalerProvider"
 	// StatefulSetKind defines the name of 'StatefulSet' kind
 	StatefulSetKind = "StatefulSet"
-	// KubeMaxPDVols defines the maximum number of PD Volumes per kubelet
-	KubeMaxPDVols = "KUBE_MAX_PD_VOLS"
 )
 
 func init() {
@@ -133,27 +123,21 @@ func defaultPredicates() sets.String {
 		factory.RegisterFitPredicateFactory(
 			"MaxEBSVolumeCount",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				// TODO: allow for generically parameterized scheduler predicates, because this is a bit ugly
-				maxVols := getMaxVols(aws.DefaultMaxEBSVolumes)
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilter, maxVols, args.PVInfo, args.PVCInfo)
+				return predicates.NewMaxPDVolumeCountPredicate(predicates.EBSVolumeFilter, aws.MaxPDCount, args.PVInfo, args.PVCInfo)
 			},
 		),
 		// Fit is determined by whether or not there would be too many GCE PD volumes attached to the node
 		factory.RegisterFitPredicateFactory(
 			"MaxGCEPDVolumeCount",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				// TODO: allow for generically parameterized scheduler predicates, because this is a bit ugly
-				maxVols := getMaxVols(DefaultMaxGCEPDVolumes)
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilter, maxVols, args.PVInfo, args.PVCInfo)
+				return predicates.NewMaxPDVolumeCountPredicate(predicates.GCEPDVolumeFilter, gce.MaxPDCount, args.PVInfo, args.PVCInfo)
 			},
 		),
 		// Fit is determined by whether or not there would be too many Azure Disk volumes attached to the node
 		factory.RegisterFitPredicateFactory(
 			"MaxAzureDiskVolumeCount",
 			func(args factory.PluginFactoryArgs) algorithm.FitPredicate {
-				// TODO: allow for generically parameterized scheduler predicates, because this is a bit ugly
-				maxVols := getMaxVols(DefaultMaxAzureDiskVolumes)
-				return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilter, maxVols, args.PVInfo, args.PVCInfo)
+				return predicates.NewMaxPDVolumeCountPredicate(predicates.AzureDiskVolumeFilter, azure.MaxPDCount, args.PVInfo, args.PVCInfo)
 			},
 		),
 		// Fit is determined by inter-pod affinity.
@@ -260,21 +244,6 @@ func defaultPriorities() sets.String {
 		// Prioritizes nodes that marked with taint which pod can tolerate.
 		factory.RegisterPriorityFunction2("TaintTolerationPriority", priorities.ComputeTaintTolerationPriorityMap, priorities.ComputeTaintTolerationPriorityReduce, 1),
 	)
-}
-
-// getMaxVols checks the max PD volumes environment variable, otherwise returning a default value
-func getMaxVols(defaultVal int) int {
-	if rawMaxVols := os.Getenv(KubeMaxPDVols); rawMaxVols != "" {
-		if parsedMaxVols, err := strconv.Atoi(rawMaxVols); err != nil {
-			glog.Errorf("Unable to parse maximum PD volumes value, using default of %v: %v", defaultVal, err)
-		} else if parsedMaxVols <= 0 {
-			glog.Errorf("Maximum PD volumes must be a positive value, using default of %v", defaultVal)
-		} else {
-			return parsedMaxVols
-		}
-	}
-
-	return defaultVal
 }
 
 func copyAndReplace(set sets.String, replaceWhat, replaceWith string) sets.String {

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -17,51 +17,10 @@ limitations under the License.
 package defaults
 
 import (
-	"os"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
-
-func TestGetMaxVols(t *testing.T) {
-	previousValue := os.Getenv(KubeMaxPDVols)
-	defaultValue := 39
-
-	tests := []struct {
-		rawMaxVols string
-		expected   int
-		test       string
-	}{
-		{
-			rawMaxVols: "invalid",
-			expected:   defaultValue,
-			test:       "Unable to parse maximum PD volumes value, using default value",
-		},
-		{
-			rawMaxVols: "-2",
-			expected:   defaultValue,
-			test:       "Maximum PD volumes must be a positive value, using default value",
-		},
-		{
-			rawMaxVols: "40",
-			expected:   40,
-			test:       "Parse maximum PD volumes value from env",
-		},
-	}
-
-	for _, test := range tests {
-		os.Setenv(KubeMaxPDVols, test.rawMaxVols)
-		result := getMaxVols(defaultValue)
-		if result != test.expected {
-			t.Errorf("%s: expected %v got %v", test.test, test.expected, result)
-		}
-	}
-
-	os.Unsetenv(KubeMaxPDVols)
-	if previousValue != "" {
-		os.Setenv(KubeMaxPDVols, previousValue)
-	}
-}
 
 func TestCopyAndReplace(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
Currently, for cloud provider including gce, aws, and azure, there is a
hardcoded number to limit the max number of PDs allowed on a node.
However, gce has changed this number based on machine type. This PR
allows scheduler to automatically get this number based on the machine
type of the given node.

fixes issue #24317

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Enable dynamic configuration of maximum number of persistent disks allowed on a node based on machine type for scheduler to use to check the feasibility of assigning pod to node.
```
