### PR TITLE
output empty creationTimestamp as null

### DIFF
--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -95,6 +95,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/testing/fuzzer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/testing/roundtrip:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -258,6 +258,10 @@ func (u *Unstructured) GetCreationTimestamp() metav1.Time {
 
 func (u *Unstructured) SetCreationTimestamp(timestamp metav1.Time) {
 	ts, _ := timestamp.MarshalQueryParameter()
+	if len(ts) == 0 || timestamp.Time.IsZero() {
+		RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+		return
+	}
 	u.setNestedField(ts, "metadata", "creationTimestamp")
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
@@ -62,3 +62,24 @@ func TestNilDeletionTimestamp(t *testing.T) {
 	_, ok = metadata["deletionTimestamp"]
 	assert.False(t, ok)
 }
+
+func TestEmptyCreationTimestampIsOmitted(t *testing.T) {
+	var u Unstructured
+	now := metav1.Now()
+
+	// set an initial creationTimestamp and ensure the field exists
+	u.SetCreationTimestamp(now)
+	metadata := u.Object["metadata"].(map[string]interface{})
+	creationTimestamp, exists := metadata["creationTimestamp"]
+	if !exists {
+		t.Fatalf("unexpected missing creationTimestamp")
+	}
+
+	// set an empty timestamp and ensure the field no longer exists
+	u.SetCreationTimestamp(metav1.Time{})
+	metadata = u.Object["metadata"].(map[string]interface{})
+	creationTimestamp, exists = metadata["creationTimestamp"]
+	if exists {
+		t.Errorf("unexpected creation timestamp field: %q", creationTimestamp)
+	}
+}


### PR DESCRIPTION
**Release note**
```release-note
NONE
```

Updates the value of the `creationTimestamp` field to be `null`
when empty, to keep parity between it and `deletionTimestamp`.

Adds a round-trip test to ensure that unstructured objects containing
empty metadata fields are able to be re-converted back into internal
or external objects. Prior to the proposed patch in this PR, an
unstructured object whose `.metadata.creationTimestamp` value had
been set through the metadata accessor to an empty value 
(`metav1.Time{}` in this case), was unable to be re-converted to an
internal or external type using the runtime decoder. Conversion would
fail with the error:

```
unstructured_test.go:177: FromUnstructured failed: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
```

cc @liggitt @fabianofranz 