### PR TITLE
PodSecurityPolicy admission ignores mirror pods

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -124,6 +124,11 @@ func (c *podSecurityPolicyPlugin) Admit(a admission.Attributes) error {
 		return nil
 	}
 
+	// Ignore mirror pods, as they are run regardless of the admission decision.
+	if _, isMirrorPod := pod.Annotations[api.MirrorPodAnnotationKey]; isMirrorPod {
+		return nil
+	}
+
 	// get all constraints that are usable by the user
 	glog.V(4).Infof("getting pod security policies for pod %s (generate: %s)", pod.Name, pod.GenerateName)
 	var saInfo user.Info


### PR DESCRIPTION
**What this PR does / why we need it**:
Mirror pods are ignored by the PodSecurityPolicy admission controller.

**Which issue this PR fixes**: fixes #53467

```release-note
The PodSecurityPolicy admission controller no longer handles mirror pods.
```
