### PR TITLE
AllowMissingKeys support in CustomColumnPrinter

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -65,7 +65,7 @@ func AddOutputVarFlagsForMutation(cmd *cobra.Command, output *string) {
 // AddOutputFlags adds output related flags to a command.
 func AddOutputFlags(cmd *cobra.Command) {
 	cmd.Flags().StringP("output", "o", "", "Output format. One of: json|yaml|wide|name|custom-columns=...|custom-columns-file=...|go-template=...|go-template-file=...|jsonpath=...|jsonpath-file=... See custom columns [http://kubernetes.io/docs/user-guide/kubectl-overview/#custom-columns], golang template [http://golang.org/pkg/text/template/#pkg-overview] and jsonpath template [http://kubernetes.io/docs/user-guide/jsonpath].")
-	cmd.Flags().Bool("allow-missing-template-keys", true, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang and jsonpath output formats.")
+	cmd.Flags().Bool("allow-missing-template-keys", true, "If true, ignore any errors in templates when a field or map key is missing in the template. Only applies to golang, jsonpath and custom-column output formats.")
 }
 
 // AddNoHeadersFlags adds no-headers flags to a command.

--- a/pkg/printers/printers.go
+++ b/pkg/printers/printers.go
@@ -105,10 +105,12 @@ func GetStandardPrinter(outputOpts *OutputOptions, noHeaders bool, mapper meta.R
 		printer = jsonpathPrinter
 
 	case "custom-columns":
-		var err error
-		if printer, err = NewCustomColumnsPrinterFromSpec(formatArgument, decoders[0], noHeaders); err != nil {
+		ccPrinter, err := NewCustomColumnsPrinterFromSpec(formatArgument, decoders[0], noHeaders)
+		if err != nil {
 			return nil, err
 		}
+		ccPrinter.AllowMissingKeys(allowMissingTemplateKeys)
+		printer = ccPrinter
 
 	case "custom-columns-file":
 		file, err := os.Open(formatArgument)
@@ -116,9 +118,12 @@ func GetStandardPrinter(outputOpts *OutputOptions, noHeaders bool, mapper meta.R
 			return nil, fmt.Errorf("error reading template %s, %v\n", formatArgument, err)
 		}
 		defer file.Close()
-		if printer, err = NewCustomColumnsPrinterFromTemplate(file, decoders[0]); err != nil {
+		ccPrinter, err := NewCustomColumnsPrinterFromTemplate(file, decoders[0])
+		if err != nil {
 			return nil, err
 		}
+		ccPrinter.AllowMissingKeys(allowMissingTemplateKeys)
+		printer = ccPrinter
 
 	case "wide":
 		fallthrough


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds support for allowing missing keys in CustomColumnPrinter.
The extension API servers can support richer output for their resources in `kubectl get` by annotating their resource types with custom-column spec. Extension API server's objects can have missing keys and those needs to be handled gracefully in `kubectl get` and this change enables that.

