### PR TITLE
Fix the defaultServerImage name of hyperkube in kubefed

### DIFF
--- a/federation/cmd/kubefed/app/kubefed.go
+++ b/federation/cmd/kubefed/app/kubefed.go
@@ -19,6 +19,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/kubernetes/federation/pkg/kubefed"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
@@ -34,7 +35,7 @@ const (
 )
 
 func GetDefaultServerImage() string {
-	return fmt.Sprintf("%s:%s", hyperkubeImageName, version.Get())
+	return fmt.Sprintf("%s:%s", hyperkubeImageName, strings.Replace(version.Get().String(), "+", "_", 1))
 }
 
 func Run() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the issue mentioned in https://github.com/kubernetes/kubernetes/issues/53430

Docker images cannot contain special characters like '+' in the tags. So while uploading the federation container images we replace '+' character by '_'. This should have been taken care by kubefed too while consuming the federation container image.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53430

**Special notes for your reviewer**:
This PR fixes the "invalid reference format" issue for the docker image. But am not sure if the version of hyperkube image is available in registry. The version is got from `version.Get()`. So if a user has built the kubefed from source it may be possible that the hyperkube version referenced by that commit is not available in registry. Ideally this issue should not arise on released versions of kubefed.

We need to cherry-pick this fix to all previous supported k8s versions too.

**Release note**:
```release-note
NONE
```

/cc @kubernetes/sig-multicluster-bugs 