### PR TITLE
Add default RBAC cluster role for cloud-controller-manager

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -336,6 +336,18 @@ func ClusterRoles() []rbac.ClusterRole {
 			},
 		},
 		{
+			// a role to use for both out-of-tree or in-tree cloud-controller-manager
+			ObjectMeta: metav1.ObjectMeta{Name: "system:cloud-controller-manager"},
+			Rules: []rbac.PolicyRule{
+				eventsRule(),
+				rbac.NewRule("*").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+				rbac.NewRule("list", "watch", "patch", "update").Groups(legacyGroup).Resources("services").RuleOrDie(),
+				rbac.NewRule("create", "patch", "update").Groups(legacyGroup).Resources("events").RuleOrDie(),
+				rbac.NewRule("create", "get", "list", "watch", "update").Groups(legacyGroup).Resources("endpoints").RuleOrDie(),
+				rbac.NewRule("create").Groups(legacyGroup).Resources("serviceaccounts").RuleOrDie(),
+			},
+		},
+		{
 			// a role to use for the kube-scheduler
 			ObjectMeta: metav1.ObjectMeta{Name: "system:kube-scheduler"},
 			Rules: []rbac.PolicyRule{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -426,6 +426,63 @@ items:
     creationTimestamp: null
     labels:
       kubernetes.io/bootstrapping: rbac-defaults
+    name: system:cloud-controller-manager
+  rules:
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - nodes
+    verbs:
+    - '*'
+  - apiGroups:
+    - ""
+    resources:
+    - services
+    verbs:
+    - list
+    - patch
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - events
+    verbs:
+    - create
+    - patch
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    verbs:
+    - create
+    - get
+    - list
+    - update
+    - watch
+  - apiGroups:
+    - ""
+    resources:
+    - serviceaccounts
+    verbs:
+    - create
+- apiVersion: rbac.authorization.k8s.io/v1
+  kind: ClusterRole
+  metadata:
+    annotations:
+      rbac.authorization.kubernetes.io/autoupdate: "true"
+    creationTimestamp: null
+    labels:
+      kubernetes.io/bootstrapping: rbac-defaults
     name: system:discovery
   rules:
   - nonResourceURLs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a default cluster role for cloud-controller-manager. Should work for both in-tree and out-of-tree cloud providers. In general, supporting a default role _should_ make it easier to adopt out-of-tree cloud providers going forward. Related: https://github.com/kubernetes/kubernetes/issues/48690. 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add a default cluster role `system:cloud-controller-manager' that can be used by cloud controller manager. 
```

cc @jhorwit2 @luxas @wlan0 @prydie @jagosan @kubernetes/sig-auth-pr-reviews
