### PR TITLE
Add group by default to kubeadm token create

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -120,7 +120,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 	createCmd.Flags().StringSliceVar(&usages,
 		"usages", kubeadmconstants.DefaultTokenUsages, "The ways in which this token can be used. Valid options: [signing,authentication].")
 	createCmd.Flags().StringSliceVar(&extraGroups,
-		"groups", []string{},
+		"groups", []string{kubeadmconstants.V18NodeBootstrapTokenAuthGroup},
 		fmt.Sprintf("Extra groups that this token will authenticate as when used for authentication. Must match %q.", bootstrapapi.BootstrapGroupPattern))
 	createCmd.Flags().StringVar(&description,
 		"description", "", "A human friendly description of how this token is used.")


### PR DESCRIPTION
Changes the default when creating tokens to include the group that is used during `kubeadm init`.  The most likely use of this function is to create/recreate tokens to use with `kubeadm join` so let's make that a default.

fixes https://github.com/kubernetes/kubeadm/issues/483


```release-note
Change `kubeadm create token` to default to the group that almost everyone will want to use.  The group is system:bootstrappers:kubeadm:default-node-token and is the group that kubeadm sets up, via an RBAC binding, for auto-approval (system:certificates.k8s.io:certificatesigningrequests:nodeclient).
```

This is a cherry pick candidate for 1.8.1.
