### PR TITLE
Skip e2e check for logs API path if provider is skeleton

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -70,7 +70,7 @@ var _ = SIGDescribe("Networking", func() {
 			{path: "/version"},
 			// TODO: test proxy links here
 		}
-		if !framework.ProviderIs("gke") {
+		if !framework.ProviderIs("gke", "skeleton") {
 			tests = append(tests, struct{ path string }{path: "/logs"})
 		}
 		for _, test := range tests {


### PR DESCRIPTION
There is a networking e2e test with the It() description:
```
   "should provide unchanging, static URL paths for kubernetes api services"
```
This test performs GETs from the Kubernetes API using various paths,
including "/logs". This test for a GET using path "/logs" should be
skipped for provider type "skeleton", since this path is unsupported.

This change adds "skeleton" to the list of providers for which
this test case should be skipped.

fixes #53529

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This change adds "skeleton" to the list of providers for which
the test for an API GET using the "/logs" path should be skipped.
This is needed because, as far as I can tell, the "skeleton" provider
doesn't support the "/logs" api path.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53529

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
