### PR TITLE
PodSecurityPolicy: teach fuzzer about fsGroup/supplementalGroups strategies

### DIFF
--- a/pkg/apis/extensions/fuzzer/fuzzer.go
+++ b/pkg/apis/extensions/fuzzer/fuzzer.go
@@ -57,10 +57,31 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 		},
 		func(psp *extensions.PodSecurityPolicySpec, c fuzz.Continue) {
 			c.FuzzNoCustom(psp) // fuzz self without calling this function again
-			runAsUserRules := []extensions.RunAsUserStrategy{extensions.RunAsUserStrategyMustRunAsNonRoot, extensions.RunAsUserStrategyMustRunAs, extensions.RunAsUserStrategyRunAsAny}
+
+			runAsUserRules := []extensions.RunAsUserStrategy{
+				extensions.RunAsUserStrategyMustRunAsNonRoot,
+				extensions.RunAsUserStrategyMustRunAs,
+				extensions.RunAsUserStrategyRunAsAny,
+			}
 			psp.RunAsUser.Rule = runAsUserRules[c.Rand.Intn(len(runAsUserRules))]
-			seLinuxRules := []extensions.SELinuxStrategy{extensions.SELinuxStrategyRunAsAny, extensions.SELinuxStrategyMustRunAs}
+
+			seLinuxRules := []extensions.SELinuxStrategy{
+				extensions.SELinuxStrategyMustRunAs,
+				extensions.SELinuxStrategyRunAsAny,
+			}
 			psp.SELinux.Rule = seLinuxRules[c.Rand.Intn(len(seLinuxRules))]
+
+			supplementalGroupsRules := []extensions.SupplementalGroupsStrategyType{
+				extensions.SupplementalGroupsStrategyRunAsAny,
+				extensions.SupplementalGroupsStrategyMustRunAs,
+			}
+			psp.SupplementalGroups.Rule = supplementalGroupsRules[c.Rand.Intn(len(supplementalGroupsRules))]
+
+			fsGroupRules := []extensions.FSGroupStrategyType{
+				extensions.FSGroupStrategyMustRunAs,
+				extensions.FSGroupStrategyRunAsAny,
+			}
+			psp.FSGroup.Rule = fsGroupRules[c.Rand.Intn(len(fsGroupRules))]
 		},
 		func(s *extensions.Scale, c fuzz.Continue) {
 			c.FuzzNoCustom(s) // fuzz self without calling this function again


### PR DESCRIPTION
**What this PR does / why we need it**:
At present, fuzzer for PSP doesn't take into account `fsGroup`/`supplementalGroups` strategies. This PR teach fuzzer about these strategies in order to have ability to catch more possible errors.

**Special notes for your reviewer**:
Let me know if you think that we need to cover more (all?) fields in the PSP.

**Release note**:
```release-note
NONE
```

PTAL @pweil- @sttts 
CC @simo5
