### PR TITLE
In DevicePluginHandlerImpl.Allocate(), skips untracked extended resou…

### DIFF
--- a/pkg/kubelet/cm/device_plugin_handler.go
+++ b/pkg/kubelet/cm/device_plugin_handler.go
@@ -166,7 +166,8 @@ func (h *DevicePluginHandlerImpl) Allocate(pod *v1.Pod, container *v1.Container,
 		resource := string(k)
 		needed := int(v.Value())
 		glog.V(3).Infof("needs %d %s", needed, resource)
-		if !deviceplugin.IsDeviceName(k) || needed == 0 {
+		_, registeredResource := h.allDevices[resource]
+		if !registeredResource || needed == 0 {
 			continue
 		}
 		h.Lock()


### PR DESCRIPTION
…rces.

Otherwise, we would fail a Pod allocation request that has an extended
resource not managed by any device plugin.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
https://github.com/kubernetes/kubernetes/issues/53548

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ignore extended resources that are not registered with kubelet during container resource allocation.
```
