### PR TITLE
Automated cherry pick of #53353

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -606,15 +606,6 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *v1.Node) {
 					node.Status.Capacity[k] = v
 				}
 			}
-			// Remove stale extended resources.
-			for k := range node.Status.Capacity {
-				if v1helper.IsExtendedResourceName(k) {
-					if _, ok := currentCapacity[k]; !ok {
-						glog.V(2).Infof("delete capacity for %s", k)
-						delete(node.Status.Capacity, k)
-					}
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #53353 on release-1.8.

#53353: Fixes a regression introduced by PR 52290 that extended

```release-note
Fixes a regression caused by device plugin that extended resource capacity may drop to zero after kubelet restarts.
```