### PR TITLE
Add client and server versions to the e2e.test output.

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -60,6 +60,7 @@ go_library(
         "//pkg/controller/node:go_default_library",
         "//pkg/kubectl/util/logs:go_default_library",
         "//pkg/quota/evaluator/core:go_default_library",
+        "//pkg/version:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
+	"k8s.io/kubernetes/pkg/version"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
@@ -225,6 +226,19 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 			framework.Logf("Dumping network health container logs from all nodes...")
 		}
 		framework.LogContainersInPodsWithLabels(c, metav1.NamespaceSystem, framework.ImagePullerLabels, "nethealth", logFunc)
+	}
+
+	// Log the version of the server and this client.
+	framework.Logf("Client version: %s", version.Get().GitVersion)
+
+	dc := c.DiscoveryClient
+
+	serverVersion, serverErr := dc.ServerVersion()
+	if serverErr != nil {
+		framework.Logf("Unexpected server error retrieving version: %v", serverErr)
+	}
+	if serverVersion != nil {
+		framework.Logf("Server version: %s", serverVersion.GitVersion)
 	}
 
 	// Reference common test to make the import valid.


### PR DESCRIPTION
Fixes #53502.

```release-note
NONE
```

Sample output:
```
Oct  6 15:02:44.001: INFO: Client version: v1.9.0-alpha.1.737+3b1b19a1e2a9a4-dirty
Oct  6 15:02:44.039: INFO: Server version: v1.8.0
```

/assign @timothysc 