### PR TITLE
Strip tokens from `kubeadm-config` config map

### DIFF
--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -40,6 +40,9 @@ func UploadConfiguration(cfg *kubeadmapi.MasterConfiguration, client clientset.I
 	externalcfg := &kubeadmapiext.MasterConfiguration{}
 	api.Scheme.Convert(cfg, externalcfg, nil)
 
+	// Removes sensitive info from the data that will be stored in the config map
+	externalcfg.Token = ""
+
 	cfgYaml, err := yaml.Marshal(*externalcfg)
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -64,6 +64,7 @@ func TestUploadConfiguration(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &kubeadmapi.MasterConfiguration{
 				KubernetesVersion: "1.7.3",
+				Token:             "1234567",
 			}
 			client := clientsetfake.NewSimpleClientset()
 			if tt.errOnCreate != nil {
@@ -107,6 +108,10 @@ func TestUploadConfiguration(t *testing.T) {
 
 				if decodedCfg.KubernetesVersion != cfg.KubernetesVersion {
 					t.Errorf("Decoded value doesn't match, decoded = %#v, expected = %#v", decodedCfg.KubernetesVersion, cfg.KubernetesVersion)
+				}
+
+				if decodedCfg.Token != "" {
+					t.Errorf("Decoded value contains token (sensitive info), decoded = %#v, expected = empty", decodedCfg.Token)
 				}
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
When kubeadm 1.8 create a cluster stores a `kubeadm-config` config map with all the info used for initialising the cluster.
This PR removes the kubeadm join token - which is a sensitive information - from this config map.

**Which issue this PR fixes** 
[#485](https://github.com/kubernetes/kubeadm/issues/485)

**Special notes for your reviewer**:
This fixes all the subcommands that touch `kubeadm-config` config map, namely:
- kubeadm init
- kubeadm config upload
- kubeadm upgrade


```release-note
kubeadm: Strip bootstrap tokens from the `kubeadm-config` ConfigMap
```