### PR TITLE
Address code-gen issue 7 nil pointer when incorrect pkg name

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -291,7 +291,11 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		// Make sure our peer-packages are added and fully parsed.
 		for _, pp := range peerPkgs {
 			context.AddDir(pp)
-			getManualConversionFunctions(context, context.Universe[pp], manualConversions)
+			p := context.Universe[pp]
+			if nil == p {
+				glog.Fatalf("failed to find pkg: %s", pp)
+			}
+			getManualConversionFunctions(context, p, manualConversions)
 		}
 
 		unsafeEquality := TypesEqual(memoryEquivalentTypes)


### PR DESCRIPTION
**What this PR does / why we need it**:
When using the code-gen tool, if the comments in the ```doc.go``` file has a misspelled pkg name, it ends with a nil pointer. This can be difficult to debug. This PR fixes that by logging an error and continuing. 
https://github.com/kubernetes/code-generator/issues/7

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I was not sure whether just exiting here would be correct behaviour as reading the code , I noticed in other places it continues if the pkg is nil.
Also perhaps I should use the ```glog.V(5).info```  ?

```release-note
`NONE`
```
