### PR TITLE
Return an error if metric cannot be registered

### DIFF
--- a/pkg/util/metrics/BUILD
+++ b/pkg/util/metrics/BUILD
@@ -3,6 +3,7 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
 )
 
 go_library(
@@ -12,6 +13,15 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    library = ":go_default_library",
+    deps = [
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )

--- a/pkg/util/metrics/util.go
+++ b/pkg/util/metrics/util.go
@@ -51,7 +51,9 @@ func registerRateLimiterMetric(ownerName string) error {
 		Help:      fmt.Sprintf("A metric measuring the saturation of the rate limiter for %v", ownerName),
 	})
 	rateLimiterMetrics[ownerName] = metric
-	prometheus.MustRegister(metric)
+	if err := prometheus.Register(metric); err != nil {
+		return fmt.Errorf("error registering rate limiter usage metric: %v", err)
+	}
 	return nil
 }
 

--- a/pkg/util/metrics/util_test.go
+++ b/pkg/util/metrics/util_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
+	testCases := []struct {
+		ownerName   string
+		rateLimiter flowcontrol.RateLimiter
+		err         string
+	}{
+		{
+			ownerName:   "owner_name",
+			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			err:         "",
+		},
+		{
+			ownerName:   "invalid-owner-name",
+			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			err:         "error registering rate limiter usage metric",
+		},
+	}
+
+	for i, tc := range testCases {
+		e := RegisterMetricAndTrackRateLimiterUsage(tc.ownerName, tc.rateLimiter)
+		if e != nil {
+			if tc.err == "" {
+				t.Errorf("[%d] unexpected error: %v", i, e)
+			} else if !strings.Contains(e.Error(), tc.err) {
+				t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

`prometheus.MustRegister` panics if a metric cannot be registered. This PR replaces it with `prometheus.Register`, as it does not panic, and returns the error if the metric cannot be registered.

I also adds lacking tests for `RegisterMetricAndTrackRateLimiterUsage`.

**Which issue this PR fixes**:

Fixes #52872

**Special notes for your reviewer**:

None of the `metrics.RegisterMetricAndTrackRateLimiterUsage` invocations check the returned error, so I plan to submit new PRs to address this.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig instrumentation