### PR TITLE
generators: allow +groupName everywhere in doc.go

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -250,7 +250,7 @@ func applyGroupOverrides(universe types.Universe, customArgs *clientgenargs.Cust
 	changes := make(map[clientgentypes.GroupVersion]clientgentypes.GroupVersion)
 	for gv, inputDir := range customArgs.GroupVersionToInputPath {
 		p := universe.Package(inputDir)
-		if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+		if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 			newGV := clientgentypes.GroupVersion{
 				Group:   clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0]),
 				Version: gv.Version,

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -102,7 +102,7 @@ func (g *genFakeForType) GenerateType(c *generator.Context, t *types.Type, w io.
 
 	// allow user to define a group name that's different from the one parsed from the directory.
 	p := c.Universe.Package(path.Vendorless(g.inputPackage))
-	if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+	if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 		groupName = override[0]
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -80,7 +80,7 @@ func (g *genGroup) GenerateType(c *generator.Context, t *types.Type, w io.Writer
 	}
 	// allow user to define a group name that's different from the one parsed from the directory.
 	p := c.Universe.Package(path.Vendorless(g.inputPackage))
-	if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+	if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 		groupName = override[0]
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -165,7 +165,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
 		// group when generating.
-		if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+		if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 			gv.Group = clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0])
 		}
 

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -111,7 +111,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
 		// group when generating.
-		if override := types.ExtractCommentTags("+", p.DocComments)["groupName"]; override != nil {
+		if override := types.ExtractCommentTags("+", p.Comments)["groupName"]; override != nil {
 			gv.Group = clientgentypes.Group(strings.SplitN(override[0], ".", 2)[0])
 		}
 


### PR DESCRIPTION
... not only directly above the package directive.

Avoiding confusion as in https://github.com/kubernetes/kubernetes/issues/53498.