### PR TITLE
Avoid unnecessary gcloud call if test was skipped

### DIFF
--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -68,9 +68,13 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 			})
 
 			AfterEach(func() {
-				// Scale down back to only 'nodesNum' nodes, as expected at the start of the test.
-				framework.ExpectNoError(framework.ResizeGroup(nodeGroupName, nodesNum))
-				framework.ExpectNoError(framework.WaitForReadyNodes(f.ClientSet, nodesNum, 15*time.Minute))
+				// Attempt cleanup only if a node group was targeted for scale up.
+				// Otherwise the test was probably skipped and we'll get a gcloud error due to invalid parameters.
+				if len(nodeGroupName) > 0 {
+					// Scale down back to only 'nodesNum' nodes, as expected at the start of the test.
+					framework.ExpectNoError(framework.ResizeGroup(nodeGroupName, nodesNum))
+					framework.ExpectNoError(framework.WaitForReadyNodes(f.ClientSet, nodesNum, 15*time.Minute))
+				}
 			})
 
 			Measure("takes less than 15 minutes", func(b Benchmarker) {


### PR DESCRIPTION
This adds a safeguard to AfterEach to avoid attempting to resize node group with empty name when the test was skipped.

```
1009 04:06:31.866] [BeforeEach] [sig-autoscaling] Autoscaling a service
I1009 04:06:31.866]   /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/autoscaling/autoscaling_timer.go:42
I1009 04:06:31.869] [BeforeEach] from 1 pod and 3 nodes to 8 pods and >=4 nodes
I1009 04:06:31.869]   /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/autoscaling/autoscaling_timer.go:68
I1009 04:06:31.869] Oct  9 04:06:31.869: INFO: test expects 1 node group, found 2
I1009 04:06:31.870] [AfterEach] from 1 pod and 3 nodes to 8 pods and >=4 nodes
I1009 04:06:31.870]   /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/autoscaling/autoscaling_timer.go:74
I1009 04:06:31.870] Oct  9 04:06:31.869: INFO: Skipping dumping logs from cluster
I1009 04:06:32.510] Oct  9 04:06:32.509: INFO: Failed to resize node instance group: ERROR: (gcloud.compute.instance-groups.managed.resize) could not parse resource []
I1009 04:06:32.510] 
I1009 04:06:32.510] Oct  9 04:06:32.509: INFO: Skipping dumping logs from cluster
I1009 04:06:32.510] Oct  9 04:06:32.509: INFO: Unexpected error occurred: exit status 1
```