### PR TITLE
Explicit HTTP link for the local proxy server

### DIFF
--- a/pkg/kubectl/cmd/proxy.go
+++ b/pkg/kubectl/cmd/proxy.go
@@ -152,7 +152,7 @@ func RunProxy(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error {
 	if err != nil {
 		glog.Fatal(err)
 	}
-	fmt.Fprintf(out, "Starting to serve on %s\n", l.Addr().String())
+	fmt.Fprintf(out, "Starting to serve on http://%s\n", l.Addr().String())
 	glog.Fatal(server.ServeOnListener(l))
 	return nil
 }


### PR DESCRIPTION
In iTerm2 (and others likely too) terminal it's easy to just click on a link to open it in a browser. This would make the link explicit and thus clickable - a tiny usability improvement for me.

**What this PR does / why we need it**:

It is a small usability improvement for the proxy command. It makes it easier to open the proxy page in the browser.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
