### PR TITLE
Provide aggregated validation errors for version and kind

### DIFF
--- a/pkg/kubectl/cmd/util/openapi/validation/validation.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation.go
@@ -43,9 +43,9 @@ func (v *SchemaValidation) ValidateBytes(data []byte) error {
 		return err
 	}
 
-	gvk, err := getObjectKind(obj)
-	if err != nil {
-		return err
+	gvk, errs := getObjectKind(obj)
+	if errs != nil {
+		return utilerrors.NewAggregate(errs)
 	}
 
 	if strings.HasSuffix(gvk.Kind, "List") {
@@ -61,15 +61,15 @@ func (v *SchemaValidation) validateList(object interface{}) []error {
 		return []error{errors.New("invalid object to validate")}
 	}
 
-	errs := []error{}
+	allErrors := []error{}
 	for _, item := range fields["items"].([]interface{}) {
-		if gvk, err := getObjectKind(item); err != nil {
-			errs = append(errs, err)
+		if gvk, errs := getObjectKind(item); errs != nil {
+			allErrors = append(allErrors, errs...)
 		} else {
-			errs = append(errs, v.validateResource(item, gvk)...)
+			allErrors = append(allErrors, v.validateResource(item, gvk)...)
 		}
 	}
-	return errs
+	return allErrors
 }
 
 func (v *SchemaValidation) validateResource(obj interface{}, gvk schema.GroupVersionKind) []error {
@@ -99,29 +99,39 @@ func parse(data []byte) (interface{}, error) {
 	return obj, nil
 }
 
-func getObjectKind(object interface{}) (schema.GroupVersionKind, error) {
+func getObjectKind(object interface{}) (schema.GroupVersionKind, []error) {
+	var listErrors []error
 	fields := object.(map[string]interface{})
 	if fields == nil {
-		return schema.GroupVersionKind{}, errors.New("invalid object to validate")
+		listErrors = append(listErrors, errors.New("invalid object to validate"))
+		return schema.GroupVersionKind{}, listErrors
 	}
+
+	var group string
+	var version string
 	apiVersion := fields["apiVersion"]
 	if apiVersion == nil {
-		return schema.GroupVersionKind{}, errors.New("apiVersion not set")
-	}
-	if _, ok := apiVersion.(string); !ok {
-		return schema.GroupVersionKind{}, errors.New("apiVersion isn't string type")
-	}
-	gv, err := schema.ParseGroupVersion(apiVersion.(string))
-	if err != nil {
-		return schema.GroupVersionKind{}, err
+		listErrors = append(listErrors, errors.New("apiVersion not set"))
+	} else if _, ok := apiVersion.(string); !ok {
+		listErrors = append(listErrors, errors.New("apiVersion isn't string type"))
+	} else {
+		gv, err := schema.ParseGroupVersion(apiVersion.(string))
+		if err != nil {
+			listErrors = append(listErrors, err)
+		} else {
+			group = gv.Group
+			version = gv.Version
+		}
 	}
 	kind := fields["kind"]
 	if kind == nil {
-		return schema.GroupVersionKind{}, errors.New("kind not set")
+		listErrors = append(listErrors, errors.New("kind not set"))
+	} else if _, ok := kind.(string); !ok {
+		listErrors = append(listErrors, errors.New("kind isn't string type"))
 	}
-	if _, ok := kind.(string); !ok {
-		return schema.GroupVersionKind{}, errors.New("kind isn't string type")
+	if listErrors != nil {
+		return schema.GroupVersionKind{}, listErrors
 	}
 
-	return schema.GroupVersionKind{Group: gv.Group, Version: gv.Version, Kind: kind.(string)}, nil
+	return schema.GroupVersionKind{Group: group, Version: version, Kind: kind.(string)}, nil
 }


### PR DESCRIPTION
Currently the validation checks is done individually for version and
kind group. For example, if user provided yaml file is missing apiVersion
and kind fields, first they will receive error on apiVersion. Once user
update the file and try to recreate, an error on missing kind is displayed.
The behavior is same for wrong types of the fields.
These errors should be aggregated and displayed.

Examples of current validation:
1
test.yaml is missing apiVersion and kind:
$kubectl.sh create -f /home/sahdev/go/src/bugfixes/test.yaml
error: error validating "/home/sahdev/go/src/bugfixes/test.yaml": error validating data: apiVersion not set; if you choose to ignore these errors, turn validation off with --validate=false
2.
test.yaml is fixed for apiVersion but missing kind:
$kubectl.sh create -f /home/sahdev/go/src/bugfixes/test.yaml
error: error validating "/home/sahdev/go/src/bugfixes/test.yaml": error validating data: kind not set; if you choose to ignore these errors, turn validation off with --validate=false

Examples with aggregated validation: 
1.
error: error validating "/home/sahdev/go/src/bugfixes/test.yaml": error validating data: [apiVersion not set, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false
2.
error: error validating "/home/sahdev/go/src/bugfixes/testmix.yaml": error validating data: [apiVersion isn't string type, kind not set]; if you choose to ignore these errors, turn validation off with --validate=false

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
To provide aggregated validations to user for version and kind group.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54098

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
