### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting BootstrapSigner & TokenCleaner controllers

### DIFF
--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -21,6 +21,8 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/controller/cronjob"
 	"k8s.io/kubernetes/pkg/controller/job"
@@ -42,8 +44,12 @@ func startCronJobController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}] {
 		return false, nil
 	}
-	go cronjob.NewCronJobController(
+	cjc, err := cronjob.NewCronJobController(
 		ctx.ClientBuilder.ClientOrDie("cronjob-controller"),
-	).Run(ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating CronJob controller: %v", err)
+	}
+	go cjc.Run(ctx.Stop)
 	return true, nil
 }

--- a/cmd/kube-controller-manager/app/bootstrap.go
+++ b/cmd/kube-controller-manager/app/bootstrap.go
@@ -16,20 +16,32 @@ limitations under the License.
 
 package app
 
-import "k8s.io/kubernetes/pkg/controller/bootstrap"
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/controller/bootstrap"
+)
 
 func startBootstrapSignerController(ctx ControllerContext) (bool, error) {
-	go bootstrap.NewBootstrapSigner(
+	bsc, err := bootstrap.NewBootstrapSigner(
 		ctx.ClientBuilder.ClientGoClientOrDie("bootstrap-signer"),
 		bootstrap.DefaultBootstrapSignerOptions(),
-	).Run(ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating BootstrapSigner controller: %v", err)
+	}
+	go bsc.Run(ctx.Stop)
 	return true, nil
 }
 
 func startTokenCleanerController(ctx ControllerContext) (bool, error) {
-	go bootstrap.NewTokenCleaner(
+	tcc, err := bootstrap.NewTokenCleaner(
 		ctx.ClientBuilder.ClientGoClientOrDie("token-cleaner"),
 		bootstrap.DefaultTokenCleanerOptions(),
-	).Run(ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating TokenCleaner controller: %v", err)
+	}
+	go tcc.Run(ctx.Stop)
 	return true, nil
 }

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -525,7 +525,7 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 		rootCA = c.rootClientBuilder.ConfigOrDie("tokens-controller").CAData
 	}
 
-	controller := serviceaccountcontroller.NewTokensController(
+	controller, err := serviceaccountcontroller.NewTokensController(
 		ctx.InformerFactory.Core().V1().ServiceAccounts(),
 		ctx.InformerFactory.Core().V1().Secrets(),
 		c.rootClientBuilder.ClientOrDie("tokens-controller"),
@@ -534,6 +534,9 @@ func (c serviceAccountTokenControllerStarter) startServiceAccountTokenController
 			RootCA:         rootCA,
 		},
 	)
+	if err != nil {
+		return true, fmt.Errorf("error creating Tokens controller: %v", err)
+	}
 	go controller.Run(int(ctx.Options.ConcurrentSATokenSyncs), ctx.Stop)
 
 	// start the first set of informers now so that other controllers can start

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -68,6 +68,7 @@ func startServiceController(ctx ControllerContext) (bool, error) {
 		ctx.Options.ClusterName,
 	)
 	if err != nil {
+		// This error shouldn't fail. It lives like this as a legacy.
 		glog.Errorf("Failed to start service controller: %v", err)
 		return false, nil
 	}
@@ -256,7 +257,9 @@ func startResourceQuotaController(ctx ControllerContext) (bool, error) {
 		Registry:                  generic.NewRegistry(quotaConfiguration.Evaluators()),
 	}
 	if resourceQuotaControllerClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("resource_quota_controller", resourceQuotaControllerClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("resource_quota_controller", resourceQuotaControllerClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return true, err
+		}
 	}
 
 	resourceQuotaController, err := resourcequotacontroller.NewResourceQuotaController(resourceQuotaControllerOptions)
@@ -300,12 +303,16 @@ func startNamespaceController(ctx ControllerContext) (bool, error) {
 }
 
 func startServiceAccountController(ctx ControllerContext) (bool, error) {
-	go serviceaccountcontroller.NewServiceAccountsController(
+	sac, err := serviceaccountcontroller.NewServiceAccountsController(
 		ctx.InformerFactory.Core().V1().ServiceAccounts(),
 		ctx.InformerFactory.Core().V1().Namespaces(),
 		ctx.ClientBuilder.ClientOrDie("service-account-controller"),
 		serviceaccountcontroller.DefaultServiceAccountsControllerOptions(),
-	).Run(1, ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating ServiceAccount controller: %v", err)
+	}
+	go sac.Run(1, ctx.Stop)
 	return true, nil
 }
 

--- a/pkg/controller/bootstrap/bootstrapsigner_test.go
+++ b/pkg/controller/bootstrap/bootstrapsigner_test.go
@@ -36,10 +36,14 @@ func init() {
 
 const testTokenID = "abc123"
 
-func newBootstrapSigner() (*BootstrapSigner, *fake.Clientset) {
+func newBootstrapSigner() (*BootstrapSigner, *fake.Clientset, error) {
 	options := DefaultBootstrapSignerOptions()
 	cl := fake.NewSimpleClientset()
-	return NewBootstrapSigner(cl, options), cl
+	bsc, err := NewBootstrapSigner(cl, options)
+	if err != nil {
+		return nil, nil, err
+	}
+	return bsc, cl, nil
 }
 
 func newConfigMap(tokenID, signature string) *v1.ConfigMap {
@@ -60,13 +64,19 @@ func newConfigMap(tokenID, signature string) *v1.ConfigMap {
 }
 
 func TestNoConfigMap(t *testing.T) {
-	signer, cl := newBootstrapSigner()
+	signer, cl, err := newBootstrapSigner()
+	if err != nil {
+		t.Fatalf("error creating BootstrapSigner: %v", err)
+	}
 	signer.signConfigMap()
 	verifyActions(t, []core.Action{}, cl.Actions())
 }
 
 func TestSimpleSign(t *testing.T) {
-	signer, cl := newBootstrapSigner()
+	signer, cl, err := newBootstrapSigner()
+	if err != nil {
+		t.Fatalf("error creating BootstrapSigner: %v", err)
+	}
 
 	cm := newConfigMap("", "")
 	signer.configMaps.Add(cm)
@@ -87,7 +97,10 @@ func TestSimpleSign(t *testing.T) {
 }
 
 func TestNoSignNeeded(t *testing.T) {
-	signer, cl := newBootstrapSigner()
+	signer, cl, err := newBootstrapSigner()
+	if err != nil {
+		t.Fatalf("error creating BootstrapSigner: %v", err)
+	}
 
 	cm := newConfigMap(testTokenID, "eyJhbGciOiJIUzI1NiIsImtpZCI6ImFiYzEyMyJ9..QSxpUG7Q542CirTI2ECPSZjvBOJURUW5a7XqFpNI958")
 	signer.configMaps.Add(cm)
@@ -102,7 +115,10 @@ func TestNoSignNeeded(t *testing.T) {
 }
 
 func TestUpdateSignature(t *testing.T) {
-	signer, cl := newBootstrapSigner()
+	signer, cl, err := newBootstrapSigner()
+	if err != nil {
+		t.Fatalf("error creating BootstrapSigner: %v", err)
+	}
 
 	cm := newConfigMap(testTokenID, "old signature")
 	signer.configMaps.Add(cm)
@@ -123,7 +139,10 @@ func TestUpdateSignature(t *testing.T) {
 }
 
 func TestRemoveSignature(t *testing.T) {
-	signer, cl := newBootstrapSigner()
+	signer, cl, err := newBootstrapSigner()
+	if err != nil {
+		t.Fatalf("error creating BootstrapSigner: %v", err)
+	}
 
 	cm := newConfigMap(testTokenID, "old signature")
 	signer.configMaps.Add(cm)

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -32,14 +32,21 @@ func init() {
 	spew.Config.DisableMethods = true
 }
 
-func newTokenCleaner() (*TokenCleaner, *fake.Clientset) {
+func newTokenCleaner() (*TokenCleaner, *fake.Clientset, error) {
 	options := DefaultTokenCleanerOptions()
 	cl := fake.NewSimpleClientset()
-	return NewTokenCleaner(cl, options), cl
+	tcc, err := NewTokenCleaner(cl, options)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tcc, cl, nil
 }
 
 func TestCleanerNoExpiration(t *testing.T) {
-	cleaner, cl := newTokenCleaner()
+	cleaner, cl, err := newTokenCleaner()
+	if err != nil {
+		t.Fatalf("error creating TokenCleaner: %v", err)
+	}
 
 	secret := newTokenSecret("tokenID", "tokenSecret")
 	cleaner.secrets.Add(secret)
@@ -52,7 +59,10 @@ func TestCleanerNoExpiration(t *testing.T) {
 }
 
 func TestCleanerExpired(t *testing.T) {
-	cleaner, cl := newTokenCleaner()
+	cleaner, cl, err := newTokenCleaner()
+	if err != nil {
+		t.Fatalf("error creating TokenCleaner: %v", err)
+	}
 
 	secret := newTokenSecret("tokenID", "tokenSecret")
 	addSecretExpiration(secret, timeString(-time.Hour))
@@ -71,7 +81,10 @@ func TestCleanerExpired(t *testing.T) {
 }
 
 func TestCleanerNotExpired(t *testing.T) {
-	cleaner, cl := newTokenCleaner()
+	cleaner, cl, err := newTokenCleaner()
+	if err != nil {
+		t.Fatalf("error creating TokenCleaner: %v", err)
+	}
 
 	secret := newTokenSecret("tokenID", "tokenSecret")
 	addSecretExpiration(secret, timeString(time.Hour))

--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -66,14 +66,16 @@ type CronJobController struct {
 	recorder   record.EventRecorder
 }
 
-func NewCronJobController(kubeClient clientset.Interface) *CronJobController {
+func NewCronJobController(kubeClient clientset.Interface) (*CronJobController, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("cronjob_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("cronjob_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 
 	jm := &CronJobController{
@@ -84,12 +86,15 @@ func NewCronJobController(kubeClient clientset.Interface) *CronJobController {
 		recorder:   eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "cronjob-controller"}),
 	}
 
-	return jm
+	return jm, nil
 }
 
-func NewCronJobControllerFromClient(kubeClient clientset.Interface) *CronJobController {
-	jm := NewCronJobController(kubeClient)
-	return jm
+func NewCronJobControllerFromClient(kubeClient clientset.Interface) (*CronJobController, error) {
+	jm, err := NewCronJobController(kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	return jm, nil
 }
 
 // Run the main goroutine responsible for watching and syncing jobs.

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -130,14 +130,16 @@ type DaemonSetsController struct {
 	suspendedDaemonPods      map[string]sets.String
 }
 
-func NewDaemonSetsController(daemonSetInformer extensionsinformers.DaemonSetInformer, historyInformer appsinformers.ControllerRevisionInformer, podInformer coreinformers.PodInformer, nodeInformer coreinformers.NodeInformer, kubeClient clientset.Interface) *DaemonSetsController {
+func NewDaemonSetsController(daemonSetInformer extensionsinformers.DaemonSetInformer, historyInformer appsinformers.ControllerRevisionInformer, podInformer coreinformers.PodInformer, nodeInformer coreinformers.NodeInformer, kubeClient clientset.Interface) (*DaemonSetsController, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(kubeClient.CoreV1().RESTClient()).Events("")})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("daemon_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("daemon_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 	dsc := &DaemonSetsController{
 		kubeClient:    kubeClient,
@@ -201,7 +203,7 @@ func NewDaemonSetsController(daemonSetInformer extensionsinformers.DaemonSetInfo
 	dsc.syncHandler = dsc.syncDaemonSet
 	dsc.enqueueDaemonSet = dsc.enqueue
 	dsc.enqueueDaemonSetRateLimited = dsc.enqueueRateLimited
-	return dsc
+	return dsc, nil
 }
 
 func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {

--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -27,7 +27,10 @@ import (
 
 func TestDaemonSetUpdatesPods(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
 	maxUnavailable := 2
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -66,7 +69,10 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 
 func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -93,7 +99,10 @@ func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 
 func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -119,7 +128,10 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 
 func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, err := newTestController(ds)
+	if err != nil {
+		t.Fatalf("error creating DaemonSets controller: %v", err)
+	}
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -149,7 +161,10 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "No nodes",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
 				return manager
 			}(),
 			ds: func() *extensions.DaemonSet {
@@ -165,7 +180,10 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with ready pods",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -191,7 +209,10 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes, one node without pods",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -214,7 +235,10 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -240,7 +264,10 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents, pod terminating",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, err := newTestController()
+				if err != nil {
+					t.Fatalf("error creating DaemonSets controller: %v", err)
+				}
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -97,14 +97,16 @@ type DeploymentController struct {
 }
 
 // NewDeploymentController creates a new DeploymentController.
-func NewDeploymentController(dInformer extensionsinformers.DeploymentInformer, rsInformer extensionsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, client clientset.Interface) *DeploymentController {
+func NewDeploymentController(dInformer extensionsinformers.DeploymentInformer, rsInformer extensionsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, client clientset.Interface) (*DeploymentController, error) {
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
 	// TODO: remove the wrapper when every clients have moved to use the clientset.
 	eventBroadcaster.StartRecordingToSink(&v1core.EventSinkImpl{Interface: v1core.New(client.CoreV1().RESTClient()).Events("")})
 
 	if client != nil && client.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("deployment_controller", client.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("deployment_controller", client.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 	dc := &DeploymentController{
 		client:        client,
@@ -140,7 +142,7 @@ func NewDeploymentController(dInformer extensionsinformers.DeploymentInformer, r
 	dc.dListerSynced = dInformer.Informer().HasSynced
 	dc.rsListerSynced = rsInformer.Informer().HasSynced
 	dc.podListerSynced = podInformer.Informer().HasSynced
-	return dc
+	return dc, nil
 }
 
 // Run begins watching and syncing.

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -187,10 +187,13 @@ func newFixture(t *testing.T) *fixture {
 	return f
 }
 
-func (f *fixture) newController() (*DeploymentController, informers.SharedInformerFactory) {
+func (f *fixture) newController() (*DeploymentController, informers.SharedInformerFactory, error) {
 	f.client = fake.NewSimpleClientset(f.objects...)
 	informers := informers.NewSharedInformerFactory(f.client, controller.NoResyncPeriodFunc())
-	c := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), f.client)
+	c, err := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), f.client)
+	if err != nil {
+		return nil, nil, err
+	}
 	c.eventRecorder = &record.FakeRecorder{}
 	c.dListerSynced = alwaysReady
 	c.rsListerSynced = alwaysReady
@@ -204,7 +207,7 @@ func (f *fixture) newController() (*DeploymentController, informers.SharedInform
 	for _, pod := range f.podLister {
 		informers.Core().V1().Pods().Informer().GetIndexer().Add(pod)
 	}
-	return c, informers
+	return c, informers, nil
 }
 
 func (f *fixture) runExpectError(deploymentName string, startInformers bool) {
@@ -216,14 +219,17 @@ func (f *fixture) run(deploymentName string) {
 }
 
 func (f *fixture) run_(deploymentName string, startInformers bool, expectError bool) {
-	c, informers := f.newController()
+	c, informers, err := f.newController()
+	if err != nil {
+		f.t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	if startInformers {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 		informers.Start(stopCh)
 	}
 
-	err := c.syncDeployment(deploymentName)
+	err = c.syncDeployment(deploymentName)
 	if !expectError && err != nil {
 		f.t.Errorf("error syncing deployment: %v", err)
 	} else if expectError && err == nil {
@@ -378,7 +384,10 @@ func TestPodDeletionEnqueuesRecreateDeployment(t *testing.T) {
 	f.rsLister = append(f.rsLister, rs)
 	f.objects = append(f.objects, foo, rs)
 
-	c, _ := f.newController()
+	c, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
@@ -411,7 +420,10 @@ func TestPodDeletionDoesntEnqueueRecreateDeployment(t *testing.T) {
 	// return a non-empty list.
 	f.podLister = append(f.podLister, pod1, pod2)
 
-	c, _ := f.newController()
+	c, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
@@ -444,7 +456,10 @@ func TestPodDeletionPartialReplicaSetOwnershipEnqueueRecreateDeployment(t *testi
 	f.rsLister = append(f.rsLister, rs1, rs2)
 	f.objects = append(f.objects, foo, rs1, rs2)
 
-	c, _ := f.newController()
+	c, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
@@ -480,7 +495,10 @@ func TestPodDeletionPartialReplicaSetOwnershipDoesntEnqueueRecreateDeployment(t 
 	// return a non-empty list.
 	f.podLister = append(f.podLister, pod)
 
-	c, _ := f.newController()
+	c, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	enqueued := false
 	c.enqueueDeployment = func(d *extensions.Deployment) {
 		if d.Name == "foo" {
@@ -512,7 +530,10 @@ func TestGetReplicaSetsForDeployment(t *testing.T) {
 	f.objects = append(f.objects, d1, d2, rs1, rs2)
 
 	// Start the fixture.
-	c, informers := f.newController()
+	c, informers, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	informers.Start(stopCh)
@@ -559,7 +580,10 @@ func TestGetReplicaSetsForDeploymentAdoptRelease(t *testing.T) {
 	f.objects = append(f.objects, d, rsAdopt, rsRelease)
 
 	// Start the fixture.
-	c, informers := f.newController()
+	c, informers, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	informers.Start(stopCh)
@@ -603,7 +627,10 @@ func TestGetPodMapForReplicaSets(t *testing.T) {
 	f.objects = append(f.objects, d, rs1, rs2, pod1, pod2, pod3, pod4)
 
 	// Start the fixture.
-	c, informers := f.newController()
+	c, informers, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 	informers.Start(stopCh)
@@ -656,7 +683,10 @@ func TestAddReplicaSet(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	dc.addReplicaSet(rs1)
 	if got, want := dc.queue.Len(), 1; got != want {
@@ -703,7 +733,10 @@ func TestAddReplicaSetOrphan(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	dc.addReplicaSet(rs)
 	if got, want := dc.queue.Len(), 2; got != want {
@@ -728,7 +761,10 @@ func TestUpdateReplicaSet(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	prev := *rs1
 	next := *rs1
@@ -779,7 +815,10 @@ func TestUpdateReplicaSetOrphanWithNewLabels(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	// Change labels and expect all matching controllers to queue.
 	prev := *rs
@@ -806,7 +845,10 @@ func TestUpdateReplicaSetChangeControllerRef(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	// Change ControllerRef and expect both old and new to queue.
 	prev := *rs
@@ -833,7 +875,10 @@ func TestUpdateReplicaSetRelease(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	// Remove ControllerRef and expect all matching controller to sync orphan.
 	prev := *rs
@@ -863,7 +908,10 @@ func TestDeleteReplicaSet(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	dc.deleteReplicaSet(rs1)
 	if got, want := dc.queue.Len(), 1; got != want {
@@ -908,7 +956,10 @@ func TestDeleteReplicaSetOrphan(t *testing.T) {
 
 	// Create the fixture but don't start it,
 	// so nothing happens in the background.
-	dc, _ := f.newController()
+	dc, _, err := f.newController()
+	if err != nil {
+		t.Fatalf("error creating Deployment controller: %v", err)
+	}
 
 	dc.deleteReplicaSet(rs)
 	if got, want := dc.queue.Len(), 0; got != want {

--- a/pkg/controller/deployment/recreate_test.go
+++ b/pkg/controller/deployment/recreate_test.go
@@ -65,7 +65,10 @@ func TestScaleDownOldReplicaSets(t *testing.T) {
 
 		kc := fake.NewSimpleClientset(expected...)
 		informers := informers.NewSharedInformerFactory(kc, controller.NoResyncPeriodFunc())
-		c := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), kc)
+		c, err := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), kc)
+		if err != nil {
+			t.Fatalf("error creating Deployment controller: %v", err)
+		}
 		c.eventRecorder = &record.FakeRecorder{}
 
 		c.scaleDownOldReplicaSetsForRecreate(oldRSs, test.d)

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -399,7 +399,10 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 
 		fake := &fake.Clientset{}
 		informers := informers.NewSharedInformerFactory(fake, controller.NoResyncPeriodFunc())
-		controller := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		controller, err := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		if err != nil {
+			t.Fatalf("error creating Deployment controller: %v", err)
+		}
 
 		controller.eventRecorder = &record.FakeRecorder{}
 		controller.dListerSynced = alwaysReady

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -119,7 +119,9 @@ func New(
 	recorder := broadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: "service-controller"})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("service_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("service_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 
 	s := &ServiceController{

--- a/pkg/controller/serviceaccount/serviceaccounts_controller.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller.go
@@ -61,14 +61,16 @@ func DefaultServiceAccountsControllerOptions() ServiceAccountsControllerOptions 
 }
 
 // NewServiceAccountsController returns a new *ServiceAccountsController.
-func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) *ServiceAccountsController {
+func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInformer, nsInformer coreinformers.NamespaceInformer, cl clientset.Interface, options ServiceAccountsControllerOptions) (*ServiceAccountsController, error) {
 	e := &ServiceAccountsController{
 		client:                  cl,
 		serviceAccountsToEnsure: options.ServiceAccounts,
 		queue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "serviceaccount"),
 	}
 	if cl != nil && cl.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("serviceaccount_controller", cl.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 
 	saInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -86,7 +88,7 @@ func NewServiceAccountsController(saInformer coreinformers.ServiceAccountInforme
 
 	e.syncHandler = e.syncNamespace
 
-	return e
+	return e, nil
 }
 
 // ServiceAccountsController manages ServiceAccount objects inside Namespaces

--- a/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
+++ b/pkg/controller/serviceaccount/serviceaccounts_controller_test.go
@@ -165,12 +165,15 @@ func TestServiceAccountCreation(t *testing.T) {
 		}
 		saInformer := informers.Core().V1().ServiceAccounts()
 		nsInformer := informers.Core().V1().Namespaces()
-		controller := NewServiceAccountsController(
+		controller, err := NewServiceAccountsController(
 			saInformer,
 			nsInformer,
 			client,
 			options,
 		)
+		if err != nil {
+			t.Fatalf("error creating ServiceAccounts controller: %v", err)
+		}
 		controller.saListerSynced = alwaysReady
 		controller.nsListerSynced = alwaysReady
 

--- a/pkg/controller/serviceaccount/tokens_controller_test.go
+++ b/pkg/controller/serviceaccount/tokens_controller_test.go
@@ -586,7 +586,10 @@ func TestTokenCreation(t *testing.T) {
 		secretInformer := informers.Core().V1().Secrets().Informer()
 		secrets := secretInformer.GetStore()
 		serviceAccounts := informers.Core().V1().ServiceAccounts().Informer().GetStore()
-		controller := NewTokensController(informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+		controller, err := NewTokensController(informers.Core().V1().ServiceAccounts(), informers.Core().V1().Secrets(), client, TokensControllerOptions{TokenGenerator: generator, RootCA: []byte("CA Data"), MaxRetries: tc.MaxRetries})
+		if err != nil {
+			t.Fatalf("error creating Tokens controller: %v", err)
+		}
 
 		if tc.ExistingServiceAccount != nil {
 			serviceAccounts.Add(tc.ExistingServiceAccount)

--- a/pkg/util/metrics/util.go
+++ b/pkg/util/metrics/util.go
@@ -34,25 +34,33 @@ const (
 
 var (
 	metricsLock        sync.Mutex
-	rateLimiterMetrics = make(map[string]prometheus.Gauge)
+	rateLimiterMetrics = make(map[string]rateLimiterMetric)
 )
+
+type rateLimiterMetric struct {
+	metric prometheus.Gauge
+	stopCh chan struct{}
+}
 
 func registerRateLimiterMetric(ownerName string) error {
 	metricsLock.Lock()
 	defer metricsLock.Unlock()
 
 	if _, ok := rateLimiterMetrics[ownerName]; ok {
-		glog.Errorf("Metric for %v already registered", ownerName)
-		return fmt.Errorf("Metric for %v already registered", ownerName)
+		return fmt.Errorf("Rate Limiter Metric for %v already registered", ownerName)
 	}
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rate_limiter_use",
 		Subsystem: ownerName,
 		Help:      fmt.Sprintf("A metric measuring the saturation of the rate limiter for %v", ownerName),
 	})
-	rateLimiterMetrics[ownerName] = metric
 	if err := prometheus.Register(metric); err != nil {
 		return fmt.Errorf("error registering rate limiter usage metric: %v", err)
+	}
+	stopCh := make(chan struct{})
+	rateLimiterMetrics[ownerName] = rateLimiterMetric{
+		metric: metric,
+		stopCh: stopCh,
 	}
 	return nil
 }
@@ -60,14 +68,32 @@ func registerRateLimiterMetric(ownerName string) error {
 // RegisterMetricAndTrackRateLimiterUsage registers a metric ownerName_rate_limiter_use in prometheus to track
 // how much used rateLimiter is and starts a goroutine that updates this metric every updatePeriod
 func RegisterMetricAndTrackRateLimiterUsage(ownerName string, rateLimiter flowcontrol.RateLimiter) error {
-	err := registerRateLimiterMetric(ownerName)
-	if err != nil {
+	if err := registerRateLimiterMetric(ownerName); err != nil {
 		return err
 	}
-	go wait.Forever(func() {
+	go wait.Until(func() {
 		metricsLock.Lock()
 		defer metricsLock.Unlock()
-		rateLimiterMetrics[ownerName].Set(rateLimiter.Saturation())
-	}, updatePeriod)
+		rateLimiterMetrics[ownerName].metric.Set(rateLimiter.Saturation())
+	}, updatePeriod, rateLimiterMetrics[ownerName].stopCh)
 	return nil
+}
+
+// UnregisterMetricAndUntrackRateLimiterUsage unregisters a metric ownerName_rate_limiter_use from prometheus and
+// stops the goroutine that updates this metric
+func UnregisterMetricAndUntrackRateLimiterUsage(ownerName string) bool {
+	metricsLock.Lock()
+	defer metricsLock.Unlock()
+
+	rlm, ok := rateLimiterMetrics[ownerName]
+	if !ok {
+		glog.Warningf("Rate Limiter Metric for %v not registered", ownerName)
+		return false
+	}
+
+	close(rlm.stopCh)
+	prometheus.Unregister(rlm.metric)
+	delete(rateLimiterMetrics, ownerName)
+
+	return true
 }

--- a/pkg/util/metrics/util_test.go
+++ b/pkg/util/metrics/util_test.go
@@ -35,6 +35,11 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 			err:         "",
 		},
 		{
+			ownerName:   "owner_name",
+			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			err:         "already registered",
+		},
+		{
 			ownerName:   "invalid-owner-name",
 			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
 			err:         "error registering rate limiter usage metric",
@@ -49,6 +54,30 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 			} else if !strings.Contains(e.Error(), tc.err) {
 				t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
 			}
+		}
+	}
+}
+
+func TestUnregisterMetricAndUntrackRateLimiterUsage(t *testing.T) {
+	RegisterMetricAndTrackRateLimiterUsage("owner_name", flowcontrol.NewTokenBucketRateLimiter(1, 1))
+	testCases := []struct {
+		ownerName string
+		ok        bool
+	}{
+		{
+			ownerName: "owner_name",
+			ok:        true,
+		},
+		{
+			ownerName: "owner_name",
+			ok:        false,
+		},
+	}
+
+	for i, tc := range testCases {
+		ok := UnregisterMetricAndUntrackRateLimiterUsage(tc.ownerName)
+		if tc.ok != ok {
+			t.Errorf("Case[%d] Expected %v, got %v", i, tc.ok, ok)
 		}
 	}
 }

--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller/daemon:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/test/integration/deployment/BUILD
+++ b/test/integration/deployment/BUILD
@@ -35,6 +35,7 @@ go_library(
         "//pkg/controller/deployment:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/controller/replicaset:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/integration/serviceaccount/BUILD
+++ b/test/integration/serviceaccount/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/controller/serviceaccount:go_default_library",
         "//pkg/serviceaccount:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//plugin/pkg/admission/serviceaccount:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	serviceaccountcontroller "k8s.io/kubernetes/pkg/controller/serviceaccount"
 	"k8s.io/kubernetes/pkg/serviceaccount"
+	"k8s.io/kubernetes/pkg/util/metrics"
 	serviceaccountadmission "k8s.io/kubernetes/plugin/pkg/admission/serviceaccount"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -63,13 +64,16 @@ const (
 )
 
 func TestServiceAccountAutoCreate(t *testing.T) {
-	c, _, stopFunc := startServiceAccountTestServer(t)
+	c, _, stopFunc, err := startServiceAccountTestServer(t)
 	defer stopFunc()
+	if err != nil {
+		t.Fatalf("failed to setup ServiceAccounts server: %v", err)
+	}
 
 	ns := "test-service-account-creation"
 
 	// Create namespace
-	_, err := c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -97,14 +101,17 @@ func TestServiceAccountAutoCreate(t *testing.T) {
 }
 
 func TestServiceAccountTokenAutoCreate(t *testing.T) {
-	c, _, stopFunc := startServiceAccountTestServer(t)
+	c, _, stopFunc, err := startServiceAccountTestServer(t)
 	defer stopFunc()
+	if err != nil {
+		t.Fatalf("failed to setup ServiceAccounts server: %v", err)
+	}
 
 	ns := "test-service-account-token-creation"
 	name := "my-service-account"
 
 	// Create namespace
-	_, err := c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -192,13 +199,16 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 }
 
 func TestServiceAccountTokenAutoMount(t *testing.T) {
-	c, _, stopFunc := startServiceAccountTestServer(t)
+	c, _, stopFunc, err := startServiceAccountTestServer(t)
 	defer stopFunc()
+	if err != nil {
+		t.Fatalf("failed to setup ServiceAccounts server: %v", err)
+	}
 
 	ns := "auto-mount-ns"
 
 	// Create "my" namespace
-	_, err := c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
+	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -271,14 +281,17 @@ func TestServiceAccountTokenAutoMount(t *testing.T) {
 }
 
 func TestServiceAccountTokenAuthentication(t *testing.T) {
-	c, config, stopFunc := startServiceAccountTestServer(t)
+	c, config, stopFunc, err := startServiceAccountTestServer(t)
 	defer stopFunc()
+	if err != nil {
+		t.Fatalf("failed to setup ServiceAccounts server: %v", err)
+	}
 
 	myns := "auth-ns"
 	otherns := "other-ns"
 
 	// Create "my" namespace
-	_, err := c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: myns}})
+	_, err = c.Core().Namespaces().Create(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: myns}})
 	if err != nil && !errors.IsAlreadyExists(err) {
 		t.Fatalf("could not create namespace: %v", err)
 	}
@@ -337,7 +350,7 @@ func TestServiceAccountTokenAuthentication(t *testing.T) {
 
 // startServiceAccountTestServer returns a started server
 // It is the responsibility of the caller to ensure the returned stopFunc is called
-func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclient.Config, func()) {
+func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclient.Config, func(), error) {
 	// Listener
 	h := &framework.MasterHolder{Initialized: make(chan struct{})}
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -419,30 +432,38 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 
 	// Start the service account and service account token controllers
 	stopCh := make(chan struct{})
-	tokenController := serviceaccountcontroller.NewTokensController(
-		informers.Core().V1().ServiceAccounts(),
-		informers.Core().V1().Secrets(),
-		rootClientset,
-		serviceaccountcontroller.TokensControllerOptions{TokenGenerator: serviceaccount.JWTTokenGenerator(serviceAccountKey)},
-	)
-	go tokenController.Run(1, stopCh)
-
-	serviceAccountController := serviceaccountcontroller.NewServiceAccountsController(
-		informers.Core().V1().ServiceAccounts(),
-		informers.Core().V1().Namespaces(),
-		rootClientset,
-		serviceaccountcontroller.DefaultServiceAccountsControllerOptions(),
-	)
-	informers.Start(stopCh)
-	internalInformers.Start(stopCh)
-	go serviceAccountController.Run(5, stopCh)
-
 	stop := func() {
 		close(stopCh)
 		apiServer.Close()
 	}
 
-	return rootClientset, clientConfig, stop
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("serviceaccount_tokens_controller")
+	tokenController, err := serviceaccountcontroller.NewTokensController(
+		informers.Core().V1().ServiceAccounts(),
+		informers.Core().V1().Secrets(),
+		rootClientset,
+		serviceaccountcontroller.TokensControllerOptions{TokenGenerator: serviceaccount.JWTTokenGenerator(serviceAccountKey)},
+	)
+	if err != nil {
+		return rootClientset, clientConfig, stop, err
+	}
+	go tokenController.Run(1, stopCh)
+
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("serviceaccount_controller")
+	serviceAccountController, err := serviceaccountcontroller.NewServiceAccountsController(
+		informers.Core().V1().ServiceAccounts(),
+		informers.Core().V1().Namespaces(),
+		rootClientset,
+		serviceaccountcontroller.DefaultServiceAccountsControllerOptions(),
+	)
+	if err != nil {
+		return rootClientset, clientConfig, stop, err
+	}
+	informers.Start(stopCh)
+	internalInformers.Start(stopCh)
+	go serviceAccountController.Run(5, stopCh)
+
+	return rootClientset, clientConfig, stop, nil
 }
 
 func getServiceAccount(c *clientset.Clientset, ns string, name string, shouldWait bool) (*v1.ServiceAccount, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Prevent `BootstrapSigner` and `TokenCleaner` controllers to start if `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
