### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting DaemonSets controller

### DIFF
--- a/pkg/controller/daemon/update_test.go
+++ b/pkg/controller/daemon/update_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestDaemonSetUpdatesPods(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, _ := newTestController(ds)
 	maxUnavailable := 2
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -66,7 +66,7 @@ func TestDaemonSetUpdatesPods(t *testing.T) {
 
 func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, _ := newTestController(ds)
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -93,7 +93,7 @@ func TestDaemonSetUpdatesWhenNewPosIsNotReady(t *testing.T) {
 
 func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, _ := newTestController(ds)
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -119,7 +119,7 @@ func TestDaemonSetUpdatesAllOldPodsNotReady(t *testing.T) {
 
 func TestDaemonSetUpdatesNoTemplateChanged(t *testing.T) {
 	ds := newDaemonSet("foo")
-	manager, podControl, _ := newTestController(ds)
+	manager, podControl, _, _ := newTestController(ds)
 	maxUnavailable := 3
 	addNodes(manager.nodeStore, 0, 5, nil)
 	manager.dsStore.Add(ds)
@@ -149,7 +149,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "No nodes",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, _ := newTestController()
 				return manager
 			}(),
 			ds: func() *extensions.DaemonSet {
@@ -165,7 +165,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with ready pods",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, _ := newTestController()
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -191,7 +191,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes, one node without pods",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, _ := newTestController()
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -214,7 +214,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, _ := newTestController()
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),
@@ -240,7 +240,7 @@ func TestGetUnavailableNumbers(t *testing.T) {
 		{
 			name: "Two nodes with pods, MaxUnavailable in percents, pod terminating",
 			Manager: func() *daemonSetsController {
-				manager, _, _ := newTestController()
+				manager, _, _, _ := newTestController()
 				addNodes(manager.nodeStore, 0, 2, nil)
 				return manager
 			}(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Prevent `DaemonSets` controller to start if `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
