### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting Deployment controller

### DIFF
--- a/pkg/controller/deployment/recreate_test.go
+++ b/pkg/controller/deployment/recreate_test.go
@@ -65,7 +65,7 @@ func TestScaleDownOldReplicaSets(t *testing.T) {
 
 		kc := fake.NewSimpleClientset(expected...)
 		informers := informers.NewSharedInformerFactory(kc, controller.NoResyncPeriodFunc())
-		c := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), kc)
+		c, _ := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), kc)
 		c.eventRecorder = &record.FakeRecorder{}
 
 		c.scaleDownOldReplicaSetsForRecreate(oldRSs, test.d)

--- a/pkg/controller/deployment/sync_test.go
+++ b/pkg/controller/deployment/sync_test.go
@@ -399,7 +399,7 @@ func TestDeploymentController_cleanupDeployment(t *testing.T) {
 
 		fake := &fake.Clientset{}
 		informers := informers.NewSharedInformerFactory(fake, controller.NoResyncPeriodFunc())
-		controller := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), fake)
+		controller, _ := NewDeploymentController(informers.Extensions().V1beta1().Deployments(), informers.Extensions().V1beta1().ReplicaSets(), informers.Core().V1().Pods(), fake)
 
 		controller.eventRecorder = &record.FakeRecorder{}
 		controller.dListerSynced = alwaysReady

--- a/test/integration/deployment/BUILD
+++ b/test/integration/deployment/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/controller/deployment:go_default_library",
         "//pkg/controller/deployment/util:go_default_library",
         "//pkg/controller/replicaset:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -30,8 +30,11 @@ import (
 )
 
 func TestNewDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, err := dcSetup(t)
 	defer closeFn()
+	if err != nil {
+		t.Fatalf("failed to setup deployment controller: %v", err)
+	}
 	name := "test-new-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
@@ -41,7 +44,6 @@ func TestNewDeployment(t *testing.T) {
 	tester.deployment.Spec.MinReadySeconds = 4
 
 	tester.deployment.Annotations = map[string]string{"test": "should-copy-to-replica-set", v1.LastAppliedConfigAnnotation: "should-not-copy-to-replica-set"}
-	var err error
 	tester.deployment, err = c.ExtensionsV1beta1().Deployments(ns.Name).Create(tester.deployment)
 	if err != nil {
 		t.Fatalf("failed to create deployment %s: %v", tester.deployment.Name, err)
@@ -141,8 +143,11 @@ func TestDeploymentSelectorImmutability(t *testing.T) {
 
 // Paused deployment should not start new rollout
 func TestPausedDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, err := dcSetup(t)
 	defer closeFn()
+	if err != nil {
+		t.Fatalf("failed to setup deployment controller: %v", err)
+	}
 	name := "test-paused-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
@@ -153,7 +158,6 @@ func TestPausedDeployment(t *testing.T) {
 	tgps := int64(1)
 	tester.deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &tgps
 
-	var err error
 	tester.deployment, err = c.ExtensionsV1beta1().Deployments(ns.Name).Create(tester.deployment)
 	if err != nil {
 		t.Fatalf("failed to create deployment %s: %v", tester.deployment.Name, err)
@@ -242,8 +246,11 @@ func TestPausedDeployment(t *testing.T) {
 
 // Paused deployment can be scaled
 func TestScalePausedDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, err := dcSetup(t)
 	defer closeFn()
+	if err != nil {
+		t.Fatalf("failed to setup deployment controller: %v", err)
+	}
 	name := "test-scale-paused-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
@@ -253,7 +260,6 @@ func TestScalePausedDeployment(t *testing.T) {
 	tgps := int64(1)
 	tester.deployment.Spec.Template.Spec.TerminationGracePeriodSeconds = &tgps
 
-	var err error
 	tester.deployment, err = c.ExtensionsV1beta1().Deployments(ns.Name).Create(tester.deployment)
 	if err != nil {
 		t.Fatalf("failed to create deployment %s: %v", tester.deployment.Name, err)
@@ -323,8 +329,11 @@ func TestScalePausedDeployment(t *testing.T) {
 
 // Deployment rollout shouldn't be blocked on hash collisions
 func TestDeploymentHashCollision(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, err := dcSetup(t)
 	defer closeFn()
+	if err != nil {
+		t.Fatalf("failed to setup deployment controller: %v", err)
+	}
 	name := "test-hash-collision-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
@@ -332,7 +341,6 @@ func TestDeploymentHashCollision(t *testing.T) {
 	replicas := int32(1)
 	tester := &deploymentTester{t: t, c: c, deployment: newDeployment(name, ns.Name, replicas)}
 
-	var err error
 	tester.deployment, err = c.ExtensionsV1beta1().Deployments(ns.Name).Create(tester.deployment)
 	if err != nil {
 		t.Fatalf("failed to create deployment %s: %v", tester.deployment.Name, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Prevent `Deployment` controller to start if `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
