### PR TITLE
Add no-negcache flag to kube-dns

### DIFF
--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -163,6 +163,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/__PILLAR__DNS__DOMAIN__/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -163,6 +163,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/{{ pillar['dns_domain'] }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -163,6 +163,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/$DNS_DOMAIN/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -121,6 +121,7 @@ spec:
         - --
         - -k
         - --cache-size=1000
+        - --no-negcache
         - --log-facility=-
         - --server=/{{ .DNSDomain }}/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the [`--no-negcache`](https://linux.die.net/man/8/dnsmasq) flag to prevent dnsmasq from caching negative (NXDOMAIN) responses. More details on why this is desirable [here](https://github.com/kubernetes/dns/issues/121).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/dns#121

**Special notes for your reviewer**:
Thanks to @rsmitty (https://rsmitty.github.io/KubeDNS-Tweaks/) and @coresolve (https://github.com/kubernetes/dns/issues/121#issuecomment-334045196) for pointing us in the right direction.

**Release note**:
```release-note
Add --no-negcache flag to kube-dns to prevent caching of NXDOMAIN responses.
```
