### PR TITLE
Automated cherry pick of #53547

### DIFF
--- a/pkg/kubelet/cm/device_plugin_handler.go
+++ b/pkg/kubelet/cm/device_plugin_handler.go
@@ -166,7 +166,8 @@ func (h *DevicePluginHandlerImpl) Allocate(pod *v1.Pod, container *v1.Container,
 		resource := string(k)
 		needed := int(v.Value())
 		glog.V(3).Infof("needs %d %s", needed, resource)
-		if !deviceplugin.IsDeviceName(k) || needed == 0 {
+		_, registeredResource := h.allDevices[resource]
+		if !registeredResource || needed == 0 {
 			continue
 		}
 		h.Lock()


### PR DESCRIPTION
Cherry pick of #53547 on release-1.8.

#53547: In DevicePluginHandlerImpl.Allocate(), skips untracked

```release-note
Ignore extended resources that are not registered with kubelet during container resource allocation.
```