### PR TITLE
add ApproximatePodTemplateForObject factory method

### DIFF
--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -454,6 +454,10 @@ func (f *FakeFactory) AttachablePodForObject(ob runtime.Object, timeout time.Dur
 	return nil, nil
 }
 
+func (f *FakeFactory) ApproximatePodTemplateForObject(obj runtime.Object) (*api.PodTemplateSpec, error) {
+	return f.ApproximatePodTemplateForObject(obj)
+}
+
 func (f *FakeFactory) UpdatePodSpecForObject(obj runtime.Object, fn func(*api.PodSpec) error) (bool, error) {
 	return false, nil
 }
@@ -716,6 +720,10 @@ func (f *fakeAPIFactory) AttachablePodForObject(object runtime.Object, timeout t
 		}
 		return nil, fmt.Errorf("cannot attach to %v: not implemented", gvks[0])
 	}
+}
+
+func (f *fakeAPIFactory) ApproximatePodTemplateForObject(obj runtime.Object) (*api.PodTemplateSpec, error) {
+	return f.Factory.ApproximatePodTemplateForObject(obj)
 }
 
 func (f *fakeAPIFactory) Validator(validate bool) (validation.Schema, error) {

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -231,6 +231,11 @@ type ObjectMappingFactory interface {
 	// AttachablePodForObject returns the pod to which to attach given an object.
 	AttachablePodForObject(object runtime.Object, timeout time.Duration) (*api.Pod, error)
 
+	// ApproximatePodTemplateForObject returns a pod template object for the provided source.
+	// It may return both an error and a object. It attempt to return the best possible template
+	// available at the current time.
+	ApproximatePodTemplateForObject(runtime.Object) (*api.PodTemplateSpec, error)
+
 	// Returns a schema that can validate objects stored on disk.
 	Validator(validate bool) (validation.Schema, error)
 	// SwaggerSchema returns the schema declaration for the provided group version kind.

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"reflect"
 	"sort"
 	"sync"
 	"time"
@@ -352,6 +353,28 @@ func (f *ring1Factory) StatusViewer(mapping *meta.RESTMapping) (kubectl.StatusVi
 		return nil, err
 	}
 	return kubectl.StatusViewerFor(mapping.GroupVersionKind.GroupKind(), clientset)
+}
+
+func (f *ring1Factory) ApproximatePodTemplateForObject(object runtime.Object) (*api.PodTemplateSpec, error) {
+	switch t := object.(type) {
+	case *api.Pod:
+		return &api.PodTemplateSpec{
+			ObjectMeta: t.ObjectMeta,
+			Spec:       t.Spec,
+		}, nil
+	case *api.ReplicationController:
+		return t.Spec.Template, nil
+	case *extensions.ReplicaSet:
+		return &t.Spec.Template, nil
+	case *extensions.DaemonSet:
+		return &t.Spec.Template, nil
+	case *extensions.Deployment:
+		return &t.Spec.Template, nil
+	case *batch.Job:
+		return &t.Spec.Template, nil
+	}
+
+	return nil, fmt.Errorf("unable to extract pod template from type %v", reflect.TypeOf(object))
 }
 
 func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout time.Duration) (*api.Pod, error) {


### PR DESCRIPTION
Makes it possible to get at a pod spec template even if an object is scaled to zero, for use with commands that care about pod templates.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Related downstream patch and use-case: https://github.com/openshift/origin/pull/16379

cc @smarterclayton 
