### PR TITLE
Extends TestPodContainerDeviceAllocation() to expose issue #53548

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -490,6 +490,10 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		resourceQuantity: *resource.NewQuantity(int64(1), resource.DecimalSI),
 		devs:             []string{"dev3", "dev4"},
 	}
+	nonDeviceRes := TestResource{
+		resourceName:     "domain3.com/resource3",
+		resourceQuantity: *resource.NewQuantity(int64(1), resource.DecimalSI),
+	}
 	testResources := make([]TestResource, 2)
 	testResources = append(testResources, res1)
 	testResources = append(testResources, res2)
@@ -505,9 +509,10 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 
 	testPods := []*v1.Pod{
 		makePod(v1.ResourceList{
-			v1.ResourceName(res1.resourceName): res1.resourceQuantity,
-			v1.ResourceName("cpu"):             res1.resourceQuantity,
-			v1.ResourceName(res2.resourceName): res2.resourceQuantity}),
+			v1.ResourceName(res1.resourceName):         res1.resourceQuantity,
+			v1.ResourceName("cpu"):                     res1.resourceQuantity,
+			v1.ResourceName(res2.resourceName):         res2.resourceQuantity,
+			v1.ResourceName(nonDeviceRes.resourceName): nonDeviceRes.resourceQuantity}),
 		makePod(v1.ResourceList{
 			v1.ResourceName(res1.resourceName): res2.resourceQuantity}),
 		makePod(v1.ResourceList{
@@ -522,7 +527,7 @@ func TestPodContainerDeviceAllocation(t *testing.T) {
 		expErr                    error
 	}{
 		{
-			description:               "Successfull allocation of two Res1 resources and one Res2 resource",
+			description:               "Successfull allocation of two Res1 resources, one Res2 resource, and a non device resource",
 			testPod:                   testPods[0],
 			expectedContainerOptsLen:  []int{3, 2, 2},
 			expectedAllocatedResName1: 2,


### PR DESCRIPTION
that container allocation request may fail if it requests some
extended resource not managed by any device plugin.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Unit test to expose https://github.com/kubernetes/kubernetes/issues/53548

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
