### PR TITLE
removes k8s.io/kubernetes/pkg/api dependency from the webhook plugin.

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -484,6 +484,7 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 		certBytes,
 		keyBytes,
 		kubeClientConfig,
+		api.Scheme,
 		pluginInitializer)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to initialize admission: %v", err)

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -218,6 +218,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		nil,
 		nil,
 		kubeClientConfig,
+		api.Scheme,
 		pluginInitializer,
 	)
 	if err != nil {

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -85,7 +85,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 		whiteList: whiteList,
 	}
 
-	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil)
+	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/webhook/BUILD
+++ b/plugin/pkg/admission/webhook/BUILD
@@ -11,7 +11,6 @@ go_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/api:go_default_library",
         "//pkg/apis/admission/install:go_default_library",
         "//pkg/kubeapiserver/admission:go_default_library",
         "//pkg/kubeapiserver/admission/configuration:go_default_library",

--- a/plugin/pkg/admission/webhook/admission.go
+++ b/plugin/pkg/admission/webhook/admission.go
@@ -41,7 +41,6 @@ import (
 	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/api"
 	admissioninit "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/kubeapiserver/admission/configuration"
 
@@ -94,9 +93,6 @@ func NewGenericAdmissionWebhook() (*GenericAdmissionWebhook, error) {
 			admission.Delete,
 			admission.Update,
 		),
-		negotiatedSerializer: serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
-			Serializer: api.Codecs.LegacyCodec(admissionv1alpha1.SchemeGroupVersion),
-		}),
 		serviceResolver: defaultServiceResolver{},
 	}, nil
 }
@@ -130,6 +126,15 @@ func (a *GenericAdmissionWebhook) SetServiceResolver(sr admissioninit.ServiceRes
 	}
 }
 
+// SetScheme sets a serializer(NegotiatedSerializer) which is derived from the scheme
+func (a *GenericAdmissionWebhook) SetScheme(scheme *runtime.Scheme) {
+	if scheme != nil {
+		a.negotiatedSerializer = serializer.NegotiatedSerializerWrapper(runtime.SerializerInfo{
+			Serializer: serializer.NewCodecFactory(scheme).LegacyCodec(admissionv1alpha1.SchemeGroupVersion),
+		})
+	}
+}
+
 func (a *GenericAdmissionWebhook) SetClientCert(cert, key []byte) {
 	a.clientCert = cert
 	a.clientKey = key
@@ -145,6 +150,9 @@ func (a *GenericAdmissionWebhook) Validate() error {
 	}
 	if a.hookSource == nil {
 		return fmt.Errorf("the GenericAdmissionWebhook admission plugin requires a Kubernetes client to be provided")
+	}
+	if a.negotiatedSerializer == nil {
+		return fmt.Errorf("the GenericAdmissionWebhook admission plugin requires a runtime.Scheme to be provided to derive a serializer")
 	}
 	go a.hookSource.Run(wait.NeverStop)
 	return nil

--- a/plugin/pkg/admission/webhook/admission_test.go
+++ b/plugin/pkg/admission/webhook/admission_test.go
@@ -214,6 +214,7 @@ func TestAdmit(t *testing.T) {
 	for name, tt := range table {
 		wh.hookSource = &tt.hookSource
 		wh.serviceResolver = fakeServiceResolver{base: *serverURL, path: tt.path}
+		wh.SetScheme(api.Scheme)
 
 		err = wh.Admit(admission.NewAttributesRecord(&object, &oldObject, kind, namespace, name, resource, subResource, operation, &userInfo))
 		if tt.expectAllow != (err == nil) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/BUILD
@@ -13,6 +13,7 @@ go_library(
         "interfaces.go",
     ],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
@@ -24,6 +25,7 @@ go_test(
     name = "go_default_xtest",
     srcs = ["initializer_test.go"],
     deps = [
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package initializer
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/informers"
@@ -31,17 +32,26 @@ type pluginInitializer struct {
 	serverIdentifyingClientCert []byte
 	// serverIdentifyingClientKey private key for the client certificate used when calling out to admission plugins
 	serverIdentifyingClientKey []byte
+	scheme                     *runtime.Scheme
 }
 
 // New creates an instance of admission plugins initializer.
 // TODO(p0lyn0mial): make the parameters public, this construction seems to be redundant.
-func New(extClientset kubernetes.Interface, extInformers informers.SharedInformerFactory, authz authorizer.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey []byte) (pluginInitializer, error) {
+func New(
+	extClientset kubernetes.Interface,
+	extInformers informers.SharedInformerFactory,
+	authz authorizer.Authorizer,
+	serverIdentifyingClientCert,
+	serverIdentifyingClientKey []byte,
+	scheme *runtime.Scheme,
+) (pluginInitializer, error) {
 	return pluginInitializer{
 		externalClient:              extClientset,
 		externalInformers:           extInformers,
 		authorizer:                  authz,
 		serverIdentifyingClientCert: serverIdentifyingClientCert,
 		serverIdentifyingClientKey:  serverIdentifyingClientKey,
+		scheme: scheme,
 	}, nil
 }
 
@@ -62,6 +72,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsClientCert); ok {
 		wants.SetClientCert(i.serverIdentifyingClientCert, i.serverIdentifyingClientKey)
+	}
+
+	if wants, ok := plugin.(WantsScheme); ok {
+		wants.SetScheme(i.scheme)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package initializer
 
 import (
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/informers"
@@ -45,5 +46,11 @@ type WantsAuthorizer interface {
 // plugins that need to make calls and prove their identity.
 type WantsClientCert interface {
 	SetClientCert(cert, key []byte)
+	admission.Validator
+}
+
+// WantsScheme defines a function that accepts runtime.Scheme for admission plugins that need it.
+type WantsScheme interface {
+	SetScheme(*runtime.Scheme)
 	admission.Validator
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -48,7 +48,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil)
+	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil, nil)
 	if err != nil {
 		return handler, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/initializer"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
@@ -80,6 +81,7 @@ func (a *AdmissionOptions) ApplyTo(
 	serverIdentifyingClientCert []byte,
 	serverIdentifyingClientKey []byte,
 	clientConfig *rest.Config,
+	scheme *runtime.Scheme,
 	pluginInitializers ...admission.PluginInitializer,
 ) error {
 	pluginNames := a.PluginNames
@@ -96,7 +98,7 @@ func (a *AdmissionOptions) ApplyTo(
 	if err != nil {
 		return err
 	}
-	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey)
+	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey, scheme)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -119,7 +119,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
-	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, serverConfig.ClientConfig, admissionInitializer); err != nil {
+	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, serverConfig.ClientConfig, apiserver.Scheme, admissionInitializer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: removes `k8s.io/kubernetes/pkg/api` dependency from `webhook` plugin. The runtime.scheme can be injected to the webhook from the plugin initializer.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
