### PR TITLE
Automated cherry pick of #52679 #53209 #53599

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -11,3 +11,9 @@ build --sandbox_tmpfs_path=/tmp
 # Ensure that Bazel never runs as root, which can cause unit tests to fail.
 # This flag requires Bazel 0.5.0+
 build --sandbox_fake_username
+
+# rules_go@82483596ec203eb9c1849937636f4cbed83733eb has a typo that
+# inadvertently relies on comprehension variables leaking.
+# TODO(ixdy): Remove this default once rules_go is bumped.
+# Ref kubernetes/kubernetes#52677
+build --incompatible_comprehension_variables_do_not_leak=false

--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -17,3 +17,6 @@ build --sandbox_fake_username
 # TODO(ixdy): Remove this default once rules_go is bumped.
 # Ref kubernetes/kubernetes#52677
 build --incompatible_comprehension_variables_do_not_leak=false
+
+# TODO(ixdy): remove the following once repo-infra is bumped.
+build --incompatible_disallow_set_constructor=false

--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -14,9 +14,11 @@ build --sandbox_fake_username
 
 # rules_go@82483596ec203eb9c1849937636f4cbed83733eb has a typo that
 # inadvertently relies on comprehension variables leaking.
-# TODO(ixdy): Remove this default once rules_go is bumped.
+# TODO(ixdy): Remove these defaults once rules_go is bumped.
 # Ref kubernetes/kubernetes#52677
 build --incompatible_comprehension_variables_do_not_leak=false
+query --incompatible_comprehension_variables_do_not_leak=false
 
 # TODO(ixdy): remove the following once repo-infra is bumped.
 build --incompatible_disallow_set_constructor=false
+query --incompatible_disallow_set_constructor=false


### PR DESCRIPTION
Cherry pick of #52679 #53209 #53599 on release-1.7.

#52679: bazel: set --incompatible_comprehension_variables_do_not_leak=false
#53209: bazel: bazel: set --incompatible_disallow_set_constructor=false to fix breakage
#53599: query --incompatible_comprehension_variables_do_not_leak=false

x-ref #52677