### PR TITLE
Notifying vSphere Cloud Provider when Node is added or removed.

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -143,6 +143,10 @@ type Instances interface {
 	// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
 	// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 	InstanceExistsByProviderID(providerID string) (bool, error)
+	// Notification to the cloud provider when node is registered
+	NodeRegistered(nodes *v1.Node)
+	// Notification to the cloud provider when node is unregistered
+	NodeUnregistered(nodes *v1.Node)
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3602,3 +3602,11 @@ func recordAwsMetric(actionName string, timeTaken float64, err error) {
 	}
 
 }
+
+// Notification handler when node is registered.
+func (c *Cloud) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (c *Cloud) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
@@ -447,4 +448,12 @@ func initDiskControllers(az *Cloud) error {
 	az.controllerCommon = common
 
 	return nil
+}
+
+// NodeRegistered - Notification handler when node is registered.
+func (az *Cloud) NodeRegistered(node *v1.Node) {
+}
+
+// NodeUnregistered - Notification handler when node is unregistered.
+func (az *Cloud) NodeUnregistered(node *v1.Node) {
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"gopkg.in/gcfg.v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
@@ -261,4 +262,12 @@ func (cs *CSCloud) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zon
 	zone.Region = instance.Zonename
 
 	return zone, nil
+}
+
+// NodeRegistered - Notification handler when node is registered.
+func (cs *CSCloud) NodeRegistered(node *v1.Node) {
+}
+
+// NodeUnregistered - Notification handler when node is unregistered.
+func (cs *CSCloud) NodeUnregistered(node *v1.Node) {
 }

--- a/pkg/cloudprovider/providers/cloudstack/metadata.go
+++ b/pkg/cloudprovider/providers/cloudstack/metadata.go
@@ -209,3 +209,11 @@ func findDHCPServer() (string, error) {
 
 	return "", errors.New("no server found")
 }
+
+// Notification handler when node is registered.
+func (m *metadata) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (m *metadata) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -329,3 +329,11 @@ func (c *FakeCloud) GetLabelsForVolume(pv *v1.PersistentVolume) (map[string]stri
 	}
 	return nil, fmt.Errorf("label not found for volume")
 }
+
+// Notification handler when node is registered.
+func (f *FakeCloud) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (f *FakeCloud) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -770,3 +770,11 @@ func (manager *gceServiceManager) getProjectsAPIEndpointAlpha() string {
 
 	return projectsApiEndpoint
 }
+
+// Notification handler when node is registered.
+func (gce *GCECloud) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (gce *GCECloud) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -202,3 +202,11 @@ func instanceIDFromProviderID(providerID string) (instanceID string, err error) 
 	}
 	return matches[1], nil
 }
+
+// Notification handler when node is registered.
+func (i *Instances) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (i *Instances) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -322,3 +322,11 @@ func (v *OVirtCloud) CurrentNodeName(hostname string) (types.NodeName, error) {
 func (v *OVirtCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return cloudprovider.NotImplemented
 }
+
+// Notification handler when node is registered.
+func (v *OVirtCloud) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (v *OVirtCloud) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -746,3 +746,11 @@ func (pc *PCCloud) DeleteDisk(pdID string) error {
 
 	return nil
 }
+
+// Notification handler when node is registered.
+func (pc *PCCloud) NodeRegistered(node *v1.Node) {
+}
+
+// Notification handler when node is unregistered.
+func (pc *PCCloud) NodeUnregistered(node *v1.Node) {
+}

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -759,3 +759,13 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 func (vs *VSphere) HasClusterID() bool {
 	return true
 }
+
+// Notification handler when node is registered.
+func (vs *VSphere) NodeRegistered(node *v1.Node) {
+	glog.V(4).Infof("Node Registered: %+v", node)
+}
+
+// Notification handler when node is unregistered.
+func (vs *VSphere) NodeUnregistered(node *v1.Node) {
+	glog.V(4).Infof("Node Unregistered: %+v", node)
+}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -634,11 +634,26 @@ func (nc *Controller) monitorNodeStatus() error {
 		} else {
 			nc.cancelPodEviction(added[i])
 		}
+
+		if nc.cloud != nil {
+			instance, isSupported := nc.cloud.Instances()
+			if isSupported {
+				go instance.NodeRegistered(added[i])
+			}
+		}
 	}
 
 	for i := range deleted {
 		glog.V(1).Infof("Controller observed a Node deletion: %v", deleted[i].Name)
 		util.RecordNodeEvent(nc.recorder, deleted[i].Name, string(deleted[i].UID), v1.EventTypeNormal, "RemovingNode", fmt.Sprintf("Removing Node %v from Controller", deleted[i].Name))
+
+		if nc.cloud != nil {
+			instance, isSupported := nc.cloud.Instances()
+			if isSupported {
+				go instance.NodeUnregistered(deleted[i])
+			}
+		}
+
 		delete(nc.knownNodeSet, deleted[i].Name)
 	}
 

--- a/pkg/volume/cinder/attacher_test.go
+++ b/pkg/volume/cinder/attacher_test.go
@@ -665,3 +665,9 @@ func (instances *instances) AddSSHKeyToAllInstances(user string, keyData []byte)
 func (instances *instances) CurrentNodeName(hostname string) (types.NodeName, error) {
 	return "", errors.New("Not implemented")
 }
+
+func (instances *instances) NodeRegistered(node *v1.Node) {
+}
+
+func (instances *instances) NodeUnregistered(node *v1.Node) {
+}


### PR DESCRIPTION
VSphere Cloud Provider (VCP) has requests to support Kubernetes cluster spanning across multiple vSphere datacenters, vCenters. Let's call it as multi-vc support in VCP.

For multi-vc environment VCP needs to undergo large amount of changes.
First change is to get notified when any new kubernetes node VM is added or removed so that VCP can maintain the cache of VM objects correctly.
Based on the various field in the Node object, VCP can determine correct VM in the vSphere inventory.

This change allows VCP to get notified upon node registration / unregistration.
Keeping the change small enough so that it becomes easier for review.
In coming days changes will be posted for review to make use of these notifications in VCP effectively.

This fixes issue: https://github.com/vmware/kubernetes/issues/236

Testing Done:
Verified that with any Kubernetes Node addition / deletion notification functions get called.
