### PR TITLE
ScaleIO - Secret to be loaded from kube-system namespace.

### DIFF
--- a/pkg/volume/scaleio/sio_plugin.go
+++ b/pkg/volume/scaleio/sio_plugin.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	sioName           = "scaleio"
-	sioPluginName     = "kubernetes.io/scaleio"
-	sioConfigFileName = "sioconf.dat"
+	sioName            = "scaleio"
+	sioPluginName      = "kubernetes.io/scaleio"
+	sioConfigFileName  = "sioconf.dat"
+	sioSecretNamespace = "kube-system"
 )
 
 type sioPlugin struct {
@@ -77,6 +78,8 @@ func (p *sioPlugin) RequiresRemount() bool {
 	return false
 }
 
+// NewMounter creates a scaleio mounter.
+// It assumes scaleio secret to be in kube-system ns.
 func (p *sioPlugin) NewMounter(
 	spec *volume.Spec,
 	pod *api.Pod,
@@ -91,7 +94,7 @@ func (p *sioPlugin) NewMounter(
 		pod:         pod,
 		spec:        spec,
 		source:      sioSource,
-		namespace:   pod.Namespace,
+		namespace:   sioSecretNamespace,
 		volSpecName: spec.Name(),
 		volName:     sioSource.VolumeName,
 		podUID:      pod.UID,
@@ -102,8 +105,6 @@ func (p *sioPlugin) NewMounter(
 }
 
 // NewUnmounter creates a representation of the volume to unmount
-// The specName param can be used to carry the namespace value (if needed) using format:
-// specName = [<namespace>nsSep]<somevalue> where the specname is pre-pended with the namespace
 func (p *sioPlugin) NewUnmounter(specName string, podUID types.UID) (volume.Unmounter, error) {
 	glog.V(4).Info(log("Unmounter for %s", specName))
 
@@ -155,6 +156,8 @@ func (p *sioPlugin) GetAccessModes() []api.PersistentVolumeAccessMode {
 //****************************
 var _ volume.DeletableVolumePlugin = &sioPlugin{}
 
+// NewDeleter returns a new scaleio deleter.
+// It assumes scaleio secret to be in kube-system ns.
 func (p *sioPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
 	sioSource, err := getVolumeSourceFromSpec(spec)
 	if err != nil {
@@ -162,12 +165,10 @@ func (p *sioPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
 		return nil, err
 	}
 
-	namespace := spec.PersistentVolume.Spec.ClaimRef.Namespace
-
 	return &sioVolume{
 		spec:        spec,
 		source:      sioSource,
-		namespace:   namespace,
+		namespace:   sioSecretNamespace,
 		volSpecName: spec.Name(),
 		volName:     sioSource.VolumeName,
 		plugin:      p,
@@ -180,6 +181,8 @@ func (p *sioPlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
 // *********************************
 var _ volume.ProvisionableVolumePlugin = &sioPlugin{}
 
+// NewProvisioner returns a new scaleio provisioner.
+// It assumes scaleio secret to be in kube-system ns.
 func (p *sioPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
 	glog.V(4).Info(log("creating Provisioner"))
 
@@ -189,13 +192,11 @@ func (p *sioPlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisi
 		return nil, errors.New("option parameters missing")
 	}
 
-	namespace := options.PVC.Namespace
-
 	return &sioVolume{
 		configData:  configData,
 		plugin:      p,
 		options:     options,
-		namespace:   namespace,
+		namespace:   sioSecretNamespace,
 		volSpecName: options.PVName,
 	}, nil
 }

--- a/pkg/volume/scaleio/sio_util.go
+++ b/pkg/volume/scaleio/sio_util.go
@@ -206,7 +206,7 @@ func attachSecret(plug *sioPlugin, namespace string, configData map[string]strin
 	kubeClient := plug.host.GetKubeClient()
 	secretMap, err := volutil.GetSecretForPV(namespace, secretRefName, sioPluginName, kubeClient)
 	if err != nil {
-		glog.Error(log("failed to get secret: %v", err))
+		glog.Error(log("failed to get secret from namespace %s: %v", namespace, err))
 		return secretNotFoundErr
 	}
 	// merge secret data

--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -194,7 +194,7 @@ func TestUtilAttachSecret(t *testing.T) {
 	for k, v := range config {
 		data[k] = v
 	}
-	if err := attachSecret(sioPlug, "default", data); err != nil {
+	if err := attachSecret(sioPlug, "kube-system", data); err != nil {
 		t.Errorf("failed to setupConfigData %v", err)
 	}
 	if data[confKey.username] == "" {

--- a/pkg/volume/scaleio/sio_volume_test.go
+++ b/pkg/volume/scaleio/sio_volume_test.go
@@ -38,7 +38,7 @@ var (
 	testSioSystem  = "sio"
 	testSioPD      = "default"
 	testSioVol     = "vol-0001"
-	testns         = "default"
+	testns         = "kube-system"
 	testSioVolName = fmt.Sprintf("%s%s%s", testns, "-", testSioVol)
 	podUID         = types.UID("sio-pod")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to decouple the ScaleIO secret from the same namespace as that of the PV/PVC/Storageclass that uses it.  Currently, `authorized non-admin k8s user`, who to creates volumes may also have unauthorized access to ScaleIO secret information.  This PR assumes the ScaleIO secret is assigned to `kube-system` namespace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes  #53619 

**Release note**:
```release-note
NONE
```
