### PR TITLE
[GCE] Bump GLBC to 0.9.7

### DIFF
--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -1,19 +1,19 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: l7-lb-controller-v0.9.6
+  name: l7-lb-controller-v0.9.7
   namespace: kube-system
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: gcp-lb-controller
-    version: v0.9.6
+    version: v0.9.7
     kubernetes.io/name: "GLBC"
 spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.6
+  - image: gcr.io/google_containers/glbc:0.9.7
     livenessProbe:
       httpGet:
         path: /healthz


### PR DESCRIPTION
Updating GLBC to the latest version

```release-note
GCE: Bump GLBC version to [0.9.7](https://github.com/kubernetes/ingress/releases/tag/0.9.7).
```