### PR TITLE
GCE kube-down: Delete all remaining firewall rules when DELETE_NETWORK is set

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -912,6 +912,15 @@ function detect-subnetworks() {
   echo "${color_red}Could not find subnetwork with region ${REGION}, network ${NETWORK}, and project ${NETWORK_PROJECT}"
 }
 
+function delete-all-firewall-rules() {
+  if fws=$(gcloud compute firewall-rules list --project "${NETWORK_PROJECT}" --filter="network=${NETWORK}" --format="value(name)"); then
+    echo "Deleting firewall rules remaining in network ${NETWORK}: ${fws}"
+    delete-firewall-rules "$fws"
+  else
+    echo "Failed to list firewall rules from the network ${NETWORK}"
+  fi
+}
+
 function delete-firewall-rules() {
   for fw in $@; do
     if [[ -n $(gcloud compute firewall-rules --project "${NETWORK_PROJECT}" describe "${fw}" --format='value(name)' 2>/dev/null || true) ]]; then
@@ -1728,8 +1737,10 @@ function kube-down() {
       "${NETWORK}-default-internal"  # Pre-1.5 clusters
 
     if [[ "${KUBE_DELETE_NETWORK}" == "true" ]]; then
+      # Delete all remaining firewall rules in the network.
+      delete-all-firewall-rules || true
       delete-subnetworks || true
-      delete-network || true  # might fail if there are leaked firewall rules
+      delete-network || true  # might fail if there are leaked resources that reference the network
     fi
 
     # If there are no more remaining master replicas, we should update kubeconfig.


### PR DESCRIPTION
**What this PR does / why we need it**: From https://github.com/kubernetes/kubernetes/issues/52347#issuecomment-335245693, we think it'd be reasonable to cleanup firewall resources as well during GCE kube-down.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE

**Special notes for your reviewer**:
/assign @shyamjvs @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```