### PR TITLE
fix azure file mount limit issue on windows due to using drive letter

### DIFF
--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -84,12 +84,8 @@ func (mounter *Mounter) Mount(source string, target string, fstype string, optio
 			`$Credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $User, $PWord`,
 			options[0], options[1])
 
-		driverLetter, err := getAvailableDriveLetter()
-		if err != nil {
-			return err
-		}
-		bindSource = driverLetter + ":"
-		cmdLine += fmt.Sprintf(";New-SmbGlobalMapping -LocalPath %s -RemotePath %s -Credential $Credential", bindSource, source)
+		bindSource = source
+		cmdLine += fmt.Sprintf(";New-SmbGlobalMapping -RemotePath %s -Credential $Credential", source)
 
 		if output, err := exec.Command("powershell", "/c", cmdLine).CombinedOutput(); err != nil {
 			// we don't return error here, even though New-SmbGlobalMapping failed, we still make it successful,

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -256,20 +256,6 @@ func normalizeWindowsPath(path string) string {
 	return normalizedPath
 }
 
-func getAvailableDriveLetter() (string, error) {
-	cmd := "$used = Get-PSDrive | Select-Object -Expand Name | Where-Object { $_.Length -eq 1 }"
-	cmd += ";$drive = 67..90 | ForEach-Object { [string][char]$_ } | Where-Object { $used -notcontains $_ } | Select-Object -First 1;$drive"
-	output, err := exec.Command("powershell", "/c", cmd).CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("getAvailableDriveLetter failed: %v, output: %q", err, string(output))
-	}
-
-	if len(output) == 0 {
-		return "", fmt.Errorf("azureMount: there is no available drive letter now")
-	}
-	return string(output)[:1], nil
-}
-
 // ValidateDiskNumber : disk number should be a number in [0, 99]
 func ValidateDiskNumber(disk string) error {
 	diskNum, err := strconv.Atoi(disk)

--- a/pkg/util/mount/mount_windows_test.go
+++ b/pkg/util/mount/mount_windows_test.go
@@ -22,12 +22,6 @@ import (
 	"testing"
 )
 
-func TestGetAvailableDriveLetter(t *testing.T) {
-	if _, err := getAvailableDriveLetter(); err != nil {
-		t.Errorf("getAvailableDriveLetter test failed : %v", err)
-	}
-}
-
 func TestNormalizeWindowsPath(t *testing.T) {
 	path := `/var/lib/kubelet/pods/146f8428-83e7-11e7-8dd4-000d3a31dac4/volumes/kubernetes.io~azure-disk`
 	normalizedPath := normalizeWindowsPath(path)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
It's not necessary to use drive letter in azure file mount, correct usage for New-SmbGlobalMapping is like following:
```
New-SmbGlobalMapping -RemotePath $AzureFilePath -Credential $Credential
mklink /D $mountPath $AzureFilePath 
```
I removed the `LocalPath` parameter in New-SmbGlobalMapping

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54668
Without this PR, there is a limit(25) for azure file mount number on each node because only 25 drive letters could be used on each windows node, With this PR, there would be no such limit.

**Special notes for your reviewer**:
@PatrickLang 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix azure file mount limit issue on windows due to using drive letter
```
/sig azure
/sig windows