### PR TITLE
Remove hard code of session affinity timeout in winows kernel proxy

### DIFF
--- a/pkg/proxy/winkernel/proxier_test.go
+++ b/pkg/proxy/winkernel/proxier_test.go
@@ -42,8 +42,8 @@ import (
 
 func newFakeServiceInfo(service proxy.ServicePortName, ip net.IP, port int, protocol api.Protocol, onlyNodeLocalEndpoints bool) *serviceInfo {
 	return &serviceInfo{
-		sessionAffinityType:    api.ServiceAffinityNone, // default
-		stickyMaxAgeMinutes:    180,
+		sessionAffinityType:    api.ServiceAffinityNone,                        // default
+		stickyMaxAgeSeconds:    int(api.DefaultClientIPServiceAffinitySeconds), // default
 		clusterIP:              ip,
 		port:                   port,
 		protocol:               protocol,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Remove hard code of session affinity timeout in winows kernel proxy - we have already done this in userspace, iptables and ipvs proxy.

**Which issue this PR fixes**: 

fixes #53636 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/sig network
/area kube-proxy
