### PR TITLE
fix generate-groups.sh

### DIFF
--- a/staging/src/k8s.io/code-generator/generate-groups.sh
+++ b/staging/src/k8s.io/code-generator/generate-groups.sh
@@ -21,7 +21,7 @@ set -o pipefail
 # generate-groups generates everything for a project with external types only, e.g. a project based
 # on CustomResourceDefinitions.
 
-if [ "$#" -le 4 ] || [ "${1}" == "--help" ]; then
+if [ "$#" -lt 4 ] || [ "${1}" == "--help" ]; then
   cat <<EOF
 Usage: $(basename $0) <generators> <output-package> <apis-package> <groups-versions> ...
 


### PR DESCRIPTION
This script should run when user pass arguements like this:
```
generate-groups.sh  deepcopy "k8s.io/coredump-detector/" "k8s.io/coredump-detector/apis/" "coredump:v1alpha1"
```
/assign @sttts 

**Release note**:
```
NONE
```
