### PR TITLE
Ensure base image includes the modprobe binary

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -24,6 +24,7 @@ RUN echo CACHEBUST>/dev/null && clean-install \
     e2fsprogs \
     ebtables \
     ethtool \
+    kmod \
     ca-certificates \
     conntrack \
     util-linux \

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=gcr.io/google-containers
 IMAGE?=debian-hyperkube-base
-TAG=0.3
+TAG=0.4
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -64,10 +64,10 @@ docker_pull(
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:e45d35f9f967ef7d49496d1d2e6f9ad378a29012b0c90f78b5d59a254f3135e6",
+    digest = "sha256:f3a37c4d8700a5ff454d94a2bef7d165d287759cea737a621c20e4aa3891dbbb",
     registry = "gcr.io",
     repository = "google-containers/debian-hyperkube-base-amd64",
-    tag = "0.3",  # ignored, but kept here for documentation
+    tag = "0.4",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.3
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.4
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes the kmod package so that "modprobe" is available for kubelet and kube-proxy.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53396


