### PR TITLE
Automated cherry pick of #53559

### DIFF
--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig.go
@@ -40,6 +40,9 @@ func UploadConfiguration(cfg *kubeadmapi.MasterConfiguration, client clientset.I
 	externalcfg := &kubeadmapiext.MasterConfiguration{}
 	api.Scheme.Convert(cfg, externalcfg, nil)
 
+	// Removes sensitive info from the data that will be stored in the config map
+	externalcfg.Token = ""
+
 	cfgYaml, err := yaml.Marshal(*externalcfg)
 	if err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
+++ b/cmd/kubeadm/app/phases/uploadconfig/uploadconfig_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package uploadconfig
 
 import (
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,6 +36,7 @@ func TestUploadConfiguration(t *testing.T) {
 			"basic validation with correct key",
 			&kubeadmapi.MasterConfiguration{
 				KubernetesVersion: "1.7.3",
+				Token:             "1234567",
 			},
 			false,
 		},
@@ -50,6 +52,11 @@ func TestUploadConfiguration(t *testing.T) {
 				t.Errorf("Fail to query ConfigMap error = %v", err)
 			} else if masterCfg.Data[kubeadmconstants.MasterConfigurationConfigMapKey] == "" {
 				t.Errorf("Fail to find ConfigMap key = %v", err)
+			}
+
+			configStr := masterCfg.Data[kubeadmconstants.MasterConfigurationConfigMapKey]
+			if strings.Contains(configStr, tt.cfg.Token) {
+				t.Errorf("Decoded value contains token (sensitive info): %#v, expected not to contain %q", configStr, tt.cfg.Token)
 			}
 		})
 	}


### PR DESCRIPTION
Cherry pick of #53559 on release-1.8.

#53559: Strip tokens from `kubeadm-config` config map