### PR TITLE
Document the etcd-quorum-read parameter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -144,7 +144,7 @@ func (s *EtcdOptions) AddFlags(fs *pflag.FlagSet) {
 		"SSL Certificate Authority file used to secure etcd communication.")
 
 	fs.BoolVar(&s.StorageConfig.Quorum, "etcd-quorum-read", s.StorageConfig.Quorum,
-		"If true, enable quorum read.")
+		"If true, enable quorum read. Required for HA configurations, otherwise you will have consistency issues.")
 
 	fs.StringVar(&s.EncryptionProviderConfigFilepath, "experimental-encryption-provider-config", s.EncryptionProviderConfigFilepath,
 		"The file containing configuration for encryption providers to be used for storing secrets in etcd")


### PR DESCRIPTION
**What this PR does / why we need it**:

Apparently the etcd-quorum-read parameter is required to make HA apiserver configurations work but that isn't documented anywhere. This documents it.

**Release note**:

```release-note
Document that etcd-quorum-read is required for HA apiserver configurations
```
