### PR TITLE
Extends gpu_device_plugin e2e_node test to excercise non-device extended resource scheduling

### DIFF
--- a/test/e2e_node/gpu_device_plugin.go
+++ b/test/e2e_node/gpu_device_plugin.go
@@ -36,6 +36,7 @@ import (
 const (
 	devicePluginFeatureGate = "DevicePlugins=true"
 	testPodNamePrefix       = "nvidia-gpu-"
+	nonDeviceResource       = "example.com/exampleResource"
 )
 
 // Serial because the test restarts Kubelet
@@ -65,19 +66,37 @@ var _ = framework.KubeDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugi
 			if framework.NumberOfNVIDIAGPUs(getLocalNode(f)) < 2 {
 				Skip("Not enough GPUs to execute this test (at least two needed)")
 			}
+
+			By("Adding extended resource not managed by device plugin")
+			node := getLocalNode(f)
+			node.Status.Capacity[nonDeviceResource] = resource.MustParse("5")
+			_, err := f.ClientSet.CoreV1().Nodes().UpdateStatus(node)
+			framework.ExpectNoError(err)
+			Eventually(func() bool {
+				alloc, ok := getLocalNode(f).Status.Allocatable[nonDeviceResource]
+				return ok && alloc.Value() == 5
+			}, 5*time.Minute, framework.Poll).Should(BeTrue())
 		})
 
 		AfterEach(func() {
 			l, err := f.PodClient().List(metav1.ListOptions{})
 			framework.ExpectNoError(err)
-
 			for _, p := range l.Items {
 				if p.Namespace != f.Namespace.Name {
 					continue
 				}
-
 				f.PodClient().Delete(p.Name, &metav1.DeleteOptions{})
 			}
+
+			By("Removing extended resource not managed by device plugin")
+			node := getLocalNode(f)
+			delete(node.Status.Capacity, nonDeviceResource)
+			_, err = f.ClientSet.CoreV1().Nodes().UpdateStatus(node)
+			framework.ExpectNoError(err)
+			Eventually(func() bool {
+				_, ok := getLocalNode(f).Status.Allocatable[nonDeviceResource]
+				return !ok
+			}, 5*time.Minute, framework.Poll).Should(BeTrue())
 		})
 
 		It("checks that when Kubelet restarts exclusive GPU assignation to pods is kept.", func() {
@@ -125,16 +144,18 @@ func makeCudaPauseImage() *v1.Pod {
 				Command: []string{"sh", "-c", "devs=$(ls /dev/ | egrep '^nvidia[0-9]+$') && echo gpu devices: $devs"},
 
 				Resources: v1.ResourceRequirements{
-					Limits:   newDecimalResourceList(framework.NVIDIAGPUResourceName, 1),
-					Requests: newDecimalResourceList(framework.NVIDIAGPUResourceName, 1),
+					Limits: v1.ResourceList{
+						framework.NVIDIAGPUResourceName: *resource.NewQuantity(1, resource.DecimalSI),
+						nonDeviceResource:               *resource.NewQuantity(1, resource.DecimalSI),
+					},
+					Requests: v1.ResourceList{
+						framework.NVIDIAGPUResourceName: *resource.NewQuantity(1, resource.DecimalSI),
+						nonDeviceResource:               *resource.NewQuantity(1, resource.DecimalSI),
+					},
 				},
 			}},
 		},
 	}
-}
-
-func newDecimalResourceList(name v1.ResourceName, quantity int64) v1.ResourceList {
-	return v1.ResourceList{name: *resource.NewQuantity(quantity, resource.DecimalSI)}
 }
 
 // TODO: Find a uniform way to deal with systemctl/initctl/service operations. #34494


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
