### PR TITLE
GCE: Handle BadRquest response when reserving external address

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_external.go
@@ -941,10 +941,11 @@ func (gce *GCECloud) ensureStaticIP(name, serviceName, region, existingIP string
 	}
 
 	if err = gce.ReserveRegionAddress(addressObj, region); err != nil {
-		if !isHTTPErrorCode(err, http.StatusConflict) {
+		if !isHTTPErrorCode(err, http.StatusConflict) && !isHTTPErrorCode(err, http.StatusBadRequest) {
 			return "", false, fmt.Errorf("error creating gce static IP address: %v", err)
 		}
-		// StatusConflict == the IP exists already.
+		// StatusConflict = Address name is already used
+		// StatusBadRequest = IP is already used (Only for External addresses - not Internal addresses)
 		existed = true
 	}
 


### PR DESCRIPTION
**Which issue this PR fixes**
Fixes #53475

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
GCE: Stops re-sync loop when a service's LB IP is promoted to static.
```
