### PR TITLE
clarifying CLI output

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -338,8 +338,8 @@ func NewProxyCommand() *cobra.Command {
 		Use: "kube-proxy",
 		Long: `The Kubernetes network proxy runs on each node. This
 reflects services as defined in the Kubernetes API on each node and can do simple
-TCP,UDP stream forwarding or round robin TCP,UDP forwarding across a set of backends.
-Service cluster ips and ports are currently found through Docker-links-compatible
+TCP and UDP stream forwarding or round robin TCP and UDP forwarding across a set of backends.
+Service cluster IPs and ports are currently found through Docker-links-compatible
 environment variables specifying ports opened by the service proxy. There is an optional
 addon that provides cluster DNS for these cluster IPs. The user must create a service
 with the apiserver API to configure the proxy.`,


### PR DESCRIPTION
**What this PR does / why we need it**:

backporting documentation changes made to generated CLI documentation
so that the source is correct for updates to the documentation and
kubernetes website. This is part of what is needed to resolve
https://github.com/kubernetes/kubernetes.github.io/issues/5618
and is updated based on review feedback while fixing that bug at
https://github.com/kubernetes/kubernetes.github.io/pull/5824

**Which issue this PR fixes** 

needed for full resolution of https://github.com/kubernetes/kubernetes.github.io/issues/5618, but will not fix it in itself due to generated documentation being stored as a separate process

**Special notes for your reviewer**:

Feedback on these changes originated from edits in the k8s docs repository and feedback to regenerated markdown to resolve them. 

```release-note
NONE
```