### PR TITLE
Fix to prevent downward api change break on older versions

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/sysctl:go_default_library",
         "//pkg/security/apparmor:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -23,10 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
+
+var hostIPVersion = utilversion.MustParseSemantic("v1.8.0")
 
 var _ = framework.KubeDescribe("Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
@@ -63,6 +66,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 	})
 
 	It("should provide pod and host IP as an env var [Conformance]", func() {
+		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{


### PR DESCRIPTION
Signed-off-by: Timothy St. Clair <timothysc@gmail.com>

**What this PR does / why we need it**:
Prevents "should provide pod and host IP as an env var [Conformance]" from running on older versions whose api does not have that field and will break on those clusters. 

This is not a upstream tested configuration, but downstream folks do this regularly.  

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Prevent downward api-change from breaking on older version
```

/cc @kubernetes/sig-testing-bugs @jpbetz  @marun 
