### PR TITLE
Allow e2e ServiceLoadBalancer test to run without cloud provider

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4059,27 +4059,57 @@ func WaitForMasters(masterPrefix string, c clientset.Interface, size int, timeou
 	return fmt.Errorf("timeout waiting %v for the number of masters to be %d", timeout, size)
 }
 
-// GetHostExternalAddress gets the node for a pod and returns the first External
-// address. Returns an error if the node the pod is on doesn't have an External
-// address.
-func GetHostExternalAddress(client clientset.Interface, p *v1.Pod) (externalAddress string, err error) {
+// getHostAddressByType gets the node for a pod and returns the first address
+// of a given type (external or internal). Returns an error if that node
+// doesn't have an address of that type.
+func getHostAddressByType(client clientset.Interface, p *v1.Pod, addressType v1.NodeAddressType) (foundAddress string, err error) {
 	node, err := client.CoreV1().Nodes().Get(p.Spec.NodeName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
 	for _, address := range node.Status.Addresses {
-		if address.Type == v1.NodeExternalIP {
-			if address.Address != "" {
-				externalAddress = address.Address
-				break
-			}
+		if address.Type == addressType && address.Address != "" {
+			foundAddress = address.Address
+			break
 		}
 	}
-	if externalAddress == "" {
-		err = fmt.Errorf("No external address for pod %v on node %v",
-			p.Name, p.Spec.NodeName)
+	if foundAddress == "" {
+		var typeStr string
+		if addressType == v1.NodeExternalIP {
+			typeStr = "external"
+		} else {
+			typeStr = "internal"
+		}
+		err = fmt.Errorf("No %s address for pod %v on node %v",
+			typeStr, p.Name, p.Spec.NodeName)
 	}
 	return
+}
+
+// GetHostExternalAddress gets the node for a pod and returns the first External
+// address. Returns an error if the node the pod is on doesn't have an External
+// address.
+func GetHostExternalAddress(client clientset.Interface, p *v1.Pod) (externalAddress string, err error) {
+	return getHostAddressByType(client, p, v1.NodeExternalIP)
+}
+
+// getHostInternalAddress gets the node for a pod and returns the first Internal
+// address. Returns an error if the node the pod is on doesn't have an Internal
+// address.
+func getHostInternalAddress(client clientset.Interface, p *v1.Pod) (internalAddress string, err error) {
+	return getHostAddressByType(client, p, v1.NodeInternalIP)
+}
+
+// GetHostAddress gets the node for a pod and returns the first External
+// address if one is available, otherwise it returns the first Internal
+// address. If neither external nor internal addresses are available,
+// it returns an error.
+func GetHostAddress(client clientset.Interface, p *v1.Pod) (foundAddress string, err error) {
+	foundAddress, err = GetHostExternalAddress(client, p)
+	if err != nil {
+		foundAddress, err = getHostInternalAddress(client, p)
+	}
+	return foundAddress, err
 }
 
 type extractRT struct {

--- a/test/e2e/network/serviceloadbalancers.go
+++ b/test/e2e/network/serviceloadbalancers.go
@@ -120,10 +120,11 @@ func (h *haproxyControllerTester) start(namespace string) (err error) {
 		return err
 	}
 
-	// Find the external addresses of the nodes the pods are running on.
+	// Find an address for each node the pods are running on, with external
+	// addresses taking precedence.
 	for _, p := range pods.Items {
 		wait.Poll(1*time.Second, framework.ServiceRespondingTimeout, func() (bool, error) {
-			address, err := framework.GetHostExternalAddress(h.client, &p)
+			address, err := framework.GetHostAddress(h.client, &p)
 			if err != nil {
 				framework.Logf("%v", err)
 				return false, nil
@@ -133,7 +134,7 @@ func (h *haproxyControllerTester) start(namespace string) (err error) {
 		})
 	}
 	if len(h.address) == 0 {
-		return fmt.Errorf("No external ips found for loadbalancer %v", h.getName())
+		return fmt.Errorf("No host ips found for loadbalancer %v", h.getName())
 	}
 	return nil
 }


### PR DESCRIPTION
This change allows users to run the e2e ServiceLoadBalancer test
even when there is no (non-local or non-skeleton) cloud provider
configured, or no explicit external IP configured by a cloud
provider. It does this by having the e2e test case fallback to
using an internal node address when no explicit external IPs
are available for the node on which the test is to be run.

fixes #53674

/area ipv6
/sig network

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This change allows users to run the e2e ServiceLoadBalancer test
even when there is no (non-local or non-skeleton) cloud provider
configured, or no explicit external IP configured by a cloud
provider. It does this by having the e2e test case fallback to
using an internal node address when no explicit external IPs
are available for the node on which the test is to be run.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53674

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
