### PR TITLE
Make sure we use rwlocks not just RLock

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/desired_state_of_world.go
@@ -336,8 +336,8 @@ func (dsw *desiredStateOfWorld) VolumeExists(
 func (dsw *desiredStateOfWorld) SetMultiAttachError(
 	volumeName v1.UniqueVolumeName,
 	nodeName k8stypes.NodeName) {
-	dsw.RLock()
-	defer dsw.RUnlock()
+	dsw.Lock()
+	defer dsw.Unlock()
 
 	nodeObj, nodeExists := dsw.nodesManaged[nodeName]
 	if nodeExists {


### PR DESCRIPTION
We need to use of rwlock for updating the desired state of world. I think `-race` flag doesn't detects this consistently.

Fixes #53590