### PR TITLE
Add feature gate for allocatable disk eviction

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager_test.go
+++ b/pkg/kubelet/eviction/eviction_manager_test.go
@@ -1431,6 +1431,7 @@ func TestAllocatableMemoryPressure(t *testing.T) {
 
 // TestAllocatableNodeFsPressure
 func TestAllocatableNodeFsPressure(t *testing.T) {
+	utilfeature.DefaultFeatureGate.Set("LocalStorageCapacityIsolation=True")
 	podMaker := makePodWithDiskStats
 	summaryStatsMaker := makeDiskStats
 
@@ -1583,6 +1584,7 @@ func TestAllocatableNodeFsPressure(t *testing.T) {
 }
 
 func TestNodeReclaimForAllocatableFuncs(t *testing.T) {
+	utilfeature.DefaultFeatureGate.Set("LocalStorageCapacityIsolation=True")
 	podMaker := makePodWithDiskStats
 	summaryStatsMaker := makeDiskStats
 	podsToMake := []podToMake{

--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -27,7 +27,9 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	v1qos "k8s.io/kubernetes/pkg/api/v1/helper/qos"
+	"k8s.io/kubernetes/pkg/features"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
@@ -790,31 +792,33 @@ func makeSignalObservations(summaryProvider stats.SummaryProvider, capacityProvi
 		}
 	}
 
-	ephemeralStorageCapacity, ephemeralStorageAllocatable, exist := getResourceAllocatable(nodeCapacity, allocatableReservation, v1.ResourceEphemeralStorage)
-	if exist {
-		for _, pod := range pods {
-			podStat, ok := statsFunc(pod)
-			if !ok {
-				continue
-			}
+	if utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+		ephemeralStorageCapacity, ephemeralStorageAllocatable, exist := getResourceAllocatable(nodeCapacity, allocatableReservation, v1.ResourceEphemeralStorage)
+		if exist {
+			for _, pod := range pods {
+				podStat, ok := statsFunc(pod)
+				if !ok {
+					continue
+				}
 
-			fsStatsSet := []fsStatsType{}
-			if withImageFs {
-				fsStatsSet = []fsStatsType{fsStatsLogs, fsStatsLocalVolumeSource}
-			} else {
-				fsStatsSet = []fsStatsType{fsStatsRoot, fsStatsLogs, fsStatsLocalVolumeSource}
-			}
+				fsStatsSet := []fsStatsType{}
+				if withImageFs {
+					fsStatsSet = []fsStatsType{fsStatsLogs, fsStatsLocalVolumeSource}
+				} else {
+					fsStatsSet = []fsStatsType{fsStatsRoot, fsStatsLogs, fsStatsLocalVolumeSource}
+				}
 
-			usage, err := podDiskUsage(podStat, pod, fsStatsSet)
-			if err != nil {
-				glog.Warningf("eviction manager: error getting pod disk usage %v", err)
-				continue
+				usage, err := podDiskUsage(podStat, pod, fsStatsSet)
+				if err != nil {
+					glog.Warningf("eviction manager: error getting pod disk usage %v", err)
+					continue
+				}
+				ephemeralStorageAllocatable.Sub(usage[resourceDisk])
 			}
-			ephemeralStorageAllocatable.Sub(usage[resourceDisk])
-		}
-		result[evictionapi.SignalAllocatableNodeFsAvailable] = signalObservation{
-			available: ephemeralStorageAllocatable,
-			capacity:  ephemeralStorageCapacity,
+			result[evictionapi.SignalAllocatableNodeFsAvailable] = signalObservation{
+				available: ephemeralStorageAllocatable,
+				capacity:  ephemeralStorageCapacity,
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue: #52336 
This PR adds the local storage feature gate to local storage allocatable eviction.

cc @kubernetes/sig-node-bugs 
/assign @jingxu97 @dchen1107 

we should target this for 1.7 if possible.

```release-note
fix a bug where disk pressure could trigger prematurely when using overlay2
```