### PR TITLE
Increases test coverage for kubelet/kuberuntime

### DIFF
--- a/pkg/kubelet/kuberuntime/instrumented_services_test.go
+++ b/pkg/kubelet/kuberuntime/instrumented_services_test.go
@@ -59,3 +59,11 @@ func TestRecordOperation(t *testing.T) {
 		mux.ServeHTTP(w, r)
 	}), "GET", prometheusUrl, nil, runtimeOperationsLatencyExpected)
 }
+
+func TestInstrumentedVersion(t *testing.T) {
+	fakeRuntime, _, _, _ := createTestRuntimeManager()
+	irs := newInstrumentedRuntimeService(fakeRuntime)
+	vr, err := irs.Version("1")
+	assert.NoError(t, err)
+	assert.Equal(t, kubeRuntimeAPIVersion, vr.Version)
+}


### PR DESCRIPTION
What this PR does / why we need it:
Increases test coverage for kubelet/kuberuntime
#46123

Which issue this PR fixes:
#46123

/assign @feiskyer 