### PR TITLE
Automated cherry pick of #53551 #53673

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//pkg/kubectl/util/logs:go_default_library",
         "//pkg/kubelet/apis:go_default_library",
         "//pkg/quota/evaluator/core:go_default_library",
+        "//pkg/version:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",

--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//pkg/kubelet:go_default_library",
         "//pkg/kubelet/sysctl:go_default_library",
         "//pkg/security/apparmor:go_default_library",
+        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -23,10 +23,13 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
+
+var hostIPVersion = utilversion.MustParseSemantic("v1.8.0")
 
 var _ = framework.KubeDescribe("Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
@@ -63,6 +66,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 	})
 
 	It("should provide pod and host IP as an env var [Conformance]", func() {
+		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/kubectl/util/logs"
+	"k8s.io/kubernetes/pkg/version"
 	commontest "k8s.io/kubernetes/test/e2e/common"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
@@ -225,6 +226,19 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 			framework.Logf("Dumping network health container logs from all nodes...")
 		}
 		framework.LogContainersInPodsWithLabels(c, metav1.NamespaceSystem, framework.ImagePullerLabels, "nethealth", logFunc)
+	}
+
+	// Log the version of the server and this client.
+	framework.Logf("Client version: %s", version.Get().GitVersion)
+
+	dc := c.DiscoveryClient
+
+	serverVersion, serverErr := dc.ServerVersion()
+	if serverErr != nil {
+		framework.Logf("Unexpected server error retrieving version: %v", serverErr)
+	}
+	if serverVersion != nil {
+		framework.Logf("Server version: %s", serverVersion.GitVersion)
 	}
 
 	// Reference common test to make the import valid.


### PR DESCRIPTION
Cherry pick of #53551 #53673 on release-1.8.

#53551: Add client and server versions to the e2e.test output.
#53673: Fix to prevent downward api change break on older versions

**Release note**:
```
Prevent downward api-change from breaking on older version
```