### PR TITLE
kubelet/cm: remove unneeded fork of 'cat'

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -19,13 +19,13 @@ limitations under the License.
 package cm
 
 import (
-	"bufio"
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -197,31 +197,17 @@ func NewContainerManager(mountUtil mount.Interface, cadvisorInterface cadvisor.I
 	}
 
 	// Check whether swap is enabled. The Kubelet does not support running with swap enabled.
-	cmd := exec.Command("cat", "/proc/swaps")
-	stdout, err := cmd.StdoutPipe()
+	swapData, err := ioutil.ReadFile("/proc/swaps")
 	if err != nil {
 		return nil, err
 	}
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-	var buf []string
-	scanner := bufio.NewScanner(stdout)
-	for scanner.Scan() { // Splits on newlines by default
-		buf = append(buf, scanner.Text())
-	}
-	if err := cmd.Wait(); err != nil { // Clean up
-		return nil, err
-	}
+	swapData = bytes.TrimSpace(swapData) // extra trailing \n
+	swapLines := strings.Split(string(swapData), "\n")
 
-	// Running with swap enabled should be considered an error, but in order to maintain legacy
-	// behavior we have to require an opt-in to this error for a period of time.
 	// If there is more than one line (table headers) in /proc/swaps, swap is enabled and we should
 	// error out unless --fail-swap-on is set to false.
-	if len(buf) > 1 {
-		if failSwapOn {
-			return nil, fmt.Errorf("Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: %v", buf)
-		}
+	if failSwapOn && len(swapLines) > 1 {
+		return nil, fmt.Errorf("Running with swap on is not supported, please disable swap! or set --fail-swap-on flag to false. /proc/swaps contained: %v", swapLines)
 	}
 	var capacity = v1.ResourceList{}
 	// It is safe to invoke `MachineInfo` on cAdvisor before logically initializing cAdvisor here because


### PR DESCRIPTION
Reading a file in Go is perfectly possible without invoking cat.

I also removed an outdated comment.

This is meant to be a trivial/minor code cleanup, nothing more.

```release-note
NONE
```
