### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting endpoint controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -209,12 +209,16 @@ func startVolumeExpandController(ctx ControllerContext) (bool, error) {
 }
 
 func startEndpointController(ctx ControllerContext) (bool, error) {
-	go endpointcontroller.NewEndpointController(
+	epc, err := endpointcontroller.NewEndpointController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Core().V1().Services(),
 		ctx.InformerFactory.Core().V1().Endpoints(),
 		ctx.ClientBuilder.ClientOrDie("endpoint-controller"),
-	).Run(int(ctx.Options.ConcurrentEndpointSyncs), ctx.Stop)
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to start endpoint controller: %v", err)
+	}
+	go epc.Run(int(ctx.Options.ConcurrentEndpointSyncs), ctx.Stop)
 	return true, nil
 }
 

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -74,9 +74,12 @@ var (
 
 // NewEndpointController returns a new *EndpointController.
 func NewEndpointController(podInformer coreinformers.PodInformer, serviceInformer coreinformers.ServiceInformer,
-	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface) *EndpointController {
+	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface) (*EndpointController, error) {
 	if client != nil && client.Core().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.Core().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 	e := &EndpointController{
 		client:           client,
@@ -105,7 +108,7 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 	e.endpointsLister = endpointsInformer.Lister()
 	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	return e
+	return e, nil
 }
 
 // EndpointController manages selector-based service endpoints.

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -160,7 +160,10 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Errorf("Failed to create endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -160,10 +160,7 @@ func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -187,10 +184,7 @@ func TestSyncEndpointsExistingNilSubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -214,10 +208,7 @@ func TestSyncEndpointsExistingEmptySubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -241,10 +232,7 @@ func TestSyncEndpointsNewNoSubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
@@ -260,10 +248,7 @@ func TestCheckLeftoverEndpoints(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, _ := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -289,10 +274,7 @@ func TestSyncEndpointsProtocolTCP(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -333,10 +315,7 @@ func TestSyncEndpointsProtocolUDP(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -377,10 +356,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAll(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -417,10 +393,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllNotReady(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -457,10 +430,7 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllMixed(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -498,10 +468,7 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 	ns := "bar"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -541,10 +508,7 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "1",
@@ -572,10 +536,7 @@ func TestSyncEndpointsItems(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	addPods(endpoints.podStore, ns, 3, 2, 0)
 	addPods(endpoints.podStore, "blah", 5, 2, 0) // make sure these aren't found!
 	endpoints.serviceStore.Add(&v1.Service{
@@ -616,10 +577,7 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	addPods(endpoints.podStore, ns, 3, 2, 0)
 	serviceLabels := map[string]string{"foo": "bar"}
 	endpoints.serviceStore.Add(&v1.Service{
@@ -665,10 +623,7 @@ func TestSyncEndpointsItemsPreexistingLabelsChange(t *testing.T) {
 	ns := "bar"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -731,10 +686,7 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			ns := "other"
 			testServer, endpointsHandler := makeTestServer(t, ns)
 			defer testServer.Close()
-			endpoints, err := newController(testServer.URL)
-			if err != nil {
-				t.Errorf("Failed to create endpoint controller: %v", err)
-			}
+			endpoints, _ := newController(testServer.URL)
 			addPods(endpoints.podStore, ns, 1, 1, 0)
 			service := &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
@@ -774,10 +726,7 @@ func TestSyncEndpointsHeadlessService(t *testing.T) {
 	ns := "headless"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -818,10 +767,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseFail
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -857,10 +803,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseSucc
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -896,10 +839,7 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyOnFailureAndPhase
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints, err := newController(testServer.URL)
-	if err != nil {
-		t.Errorf("Failed to create endpoint controller: %v", err)
-	}
+	endpoints, _ := newController(testServer.URL)
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Prevent `Endpoint` controller to start if `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
