### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting podgc controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -229,11 +229,15 @@ func startReplicationController(ctx ControllerContext) (bool, error) {
 }
 
 func startPodGCController(ctx ControllerContext) (bool, error) {
-	go podgc.NewPodGC(
+	gcc, err := podgc.NewPodGC(
 		ctx.ClientBuilder.ClientOrDie("pod-garbage-collector"),
 		ctx.InformerFactory.Core().V1().Pods(),
 		int(ctx.Options.TerminatedPodGCThreshold),
-	).Run(ctx.Stop)
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to start pod GC controller: %v", err)
+	}
+	go gcc.Run(ctx.Stop)
 	return true, nil
 }
 

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -51,9 +51,12 @@ type PodGCController struct {
 	terminatedPodThreshold int
 }
 
-func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInformer, terminatedPodThreshold int) *PodGCController {
+func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInformer, terminatedPodThreshold int) (*PodGCController, error) {
 	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
@@ -67,7 +70,7 @@ func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInfor
 	gcc.podLister = podInformer.Lister()
 	gcc.podListerSynced = podInformer.Informer().HasSynced
 
-	return gcc
+	return gcc, nil
 }
 
 func (gcc *PodGCController) Run(stop <-chan struct{}) {

--- a/pkg/controller/podgc/gc_controller_test.go
+++ b/pkg/controller/podgc/gc_controller_test.go
@@ -47,12 +47,15 @@ func (*FakeController) LastSyncResourceVersion() string {
 
 func alwaysReady() bool { return true }
 
-func NewFromClient(kubeClient clientset.Interface, terminatedPodThreshold int) (*PodGCController, coreinformers.PodInformer) {
+func NewFromClient(kubeClient clientset.Interface, terminatedPodThreshold int) (*PodGCController, coreinformers.PodInformer, error) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	podInformer := informerFactory.Core().V1().Pods()
-	controller := NewPodGC(kubeClient, podInformer, terminatedPodThreshold)
+	controller, err := NewPodGC(kubeClient, podInformer, terminatedPodThreshold)
+	if err != nil {
+		return nil, nil, err
+	}
 	controller.podListerSynced = alwaysReady
-	return controller, podInformer
+	return controller, podInformer, nil
 }
 
 func TestGCTerminated(t *testing.T) {
@@ -113,7 +116,10 @@ func TestGCTerminated(t *testing.T) {
 
 	for i, test := range testCases {
 		client := fake.NewSimpleClientset(&v1.NodeList{Items: []v1.Node{*testutil.NewNode("node")}})
-		gcc, podInformer := NewFromClient(client, test.threshold)
+		gcc, podInformer, err := NewFromClient(client, test.threshold)
+		if err != nil {
+			t.Errorf("Failed to create pod GC controller: %v", err)
+		}
 		deletedPodNames := make([]string, 0)
 		var lock sync.Mutex
 		gcc.deletePod = func(_, name string) error {
@@ -180,7 +186,10 @@ func TestGCOrphaned(t *testing.T) {
 
 	for i, test := range testCases {
 		client := fake.NewSimpleClientset()
-		gcc, podInformer := NewFromClient(client, test.threshold)
+		gcc, podInformer, err := NewFromClient(client, test.threshold)
+		if err != nil {
+			t.Errorf("Failed to create pod GC controller: %v", err)
+		}
 		deletedPodNames := make([]string, 0)
 		var lock sync.Mutex
 		gcc.deletePod = func(_, name string) error {
@@ -257,7 +266,10 @@ func TestGCUnscheduledTerminating(t *testing.T) {
 
 	for i, test := range testCases {
 		client := fake.NewSimpleClientset()
-		gcc, podInformer := NewFromClient(client, -1)
+		gcc, podInformer, err := NewFromClient(client, -1)
+		if err != nil {
+			t.Errorf("Failed to create pod GC controller: %v", err)
+		}
 		deletedPodNames := make([]string, 0)
 		var lock sync.Mutex
 		gcc.deletePod = func(_, name string) error {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Prevent `podgc` controller to start if `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
