### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting job controller

### DIFF
--- a/pkg/controller/job/job_controller_test.go
+++ b/pkg/controller/job/job_controller_test.go
@@ -94,12 +94,15 @@ func getKey(job *batch.Job, t *testing.T) string {
 	}
 }
 
-func newJobControllerFromClient(kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc) (*JobController, informers.SharedInformerFactory) {
+func newJobControllerFromClient(kubeClient clientset.Interface, resyncPeriod controller.ResyncPeriodFunc) (*JobController, informers.SharedInformerFactory, error) {
 	sharedInformers := informers.NewSharedInformerFactory(kubeClient, resyncPeriod())
-	jm := NewJobController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient)
+	jm, err := NewJobController(sharedInformers.Core().V1().Pods(), sharedInformers.Batch().V1().Jobs(), kubeClient)
+	if err != nil {
+		return nil, nil, err
+	}
 	jm.podControl = &controller.FakePodControl{}
 
-	return jm, sharedInformers
+	return jm, sharedInformers, nil
 }
 
 // create count pods with the given phase for the given job
@@ -254,7 +257,10 @@ func TestControllerSyncJob(t *testing.T) {
 	for name, tc := range testCases {
 		// job manager setup
 		clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-		manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+		manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+		if err != nil {
+			t.Errorf("Failed to create job controller: %v", err)
+		}
 		fakePodControl := controller.FakePodControl{Err: tc.podControllerError, CreateLimit: tc.podLimit}
 		manager.podControl = &fakePodControl
 		manager.podStoreSynced = alwaysReady
@@ -406,7 +412,10 @@ func TestSyncJobPastDeadline(t *testing.T) {
 	for name, tc := range testCases {
 		// job manager setup
 		clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-		manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+		manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+		if err != nil {
+			t.Errorf("Failed to create job controller: %v", err)
+		}
 		fakePodControl := controller.FakePodControl{}
 		manager.podControl = &fakePodControl
 		manager.podStoreSynced = alwaysReady
@@ -480,7 +489,10 @@ func getCondition(job *batch.Job, condition batch.JobConditionType, reason strin
 
 func TestSyncPastDeadlineJobFinished(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.podStoreSynced = alwaysReady
@@ -518,7 +530,10 @@ func TestSyncPastDeadlineJobFinished(t *testing.T) {
 
 func TestSyncJobComplete(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.podStoreSynced = alwaysReady
@@ -546,7 +561,10 @@ func TestSyncJobComplete(t *testing.T) {
 
 func TestSyncJobDeleted(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	manager, _ := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, _, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.podStoreSynced = alwaysReady
@@ -571,7 +589,10 @@ func TestSyncJobDeleted(t *testing.T) {
 func TestSyncJobUpdateRequeue(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
 	DefaultJobBackOff = time.Duration(0) // overwrite the default value for testing
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.podStoreSynced = alwaysReady
@@ -600,7 +621,10 @@ func TestSyncJobUpdateRequeue(t *testing.T) {
 
 func TestJobPodLookup(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	manager.podStoreSynced = alwaysReady
 	manager.jobStoreSynced = alwaysReady
 	testCases := []struct {
@@ -693,7 +717,10 @@ func newPod(name string, job *batch.Job) *v1.Pod {
 
 func TestGetPodsForJob(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -741,7 +768,10 @@ func TestGetPodsForJobAdopt(t *testing.T) {
 	job1 := newJob(1, 1, 6)
 	job1.Name = "job1"
 	clientset := fake.NewSimpleClientset(job1)
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -768,7 +798,10 @@ func TestGetPodsForJobNoAdoptIfBeingDeleted(t *testing.T) {
 	job1.Name = "job1"
 	job1.DeletionTimestamp = &metav1.Time{}
 	clientset := fake.NewSimpleClientset(job1)
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -799,7 +832,10 @@ func TestGetPodsForJobNoAdoptIfBeingDeletedRace(t *testing.T) {
 	// The up-to-date object says it's being deleted.
 	job1.DeletionTimestamp = &metav1.Time{}
 	clientset := fake.NewSimpleClientset(job1)
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -829,7 +865,10 @@ func TestGetPodsForJobNoAdoptIfBeingDeletedRace(t *testing.T) {
 
 func TestGetPodsForJobRelease(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -858,7 +897,10 @@ func TestGetPodsForJobRelease(t *testing.T) {
 
 func TestAddPod(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -903,7 +945,10 @@ func TestAddPod(t *testing.T) {
 
 func TestAddPodOrphan(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -931,7 +976,10 @@ func TestAddPodOrphan(t *testing.T) {
 
 func TestUpdatePod(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -980,7 +1028,10 @@ func TestUpdatePod(t *testing.T) {
 
 func TestUpdatePodOrphanWithNewLabels(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -1007,7 +1058,10 @@ func TestUpdatePodOrphanWithNewLabels(t *testing.T) {
 
 func TestUpdatePodChangeControllerRef(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -1033,7 +1087,10 @@ func TestUpdatePodChangeControllerRef(t *testing.T) {
 
 func TestUpdatePodRelease(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -1059,7 +1116,10 @@ func TestUpdatePodRelease(t *testing.T) {
 
 func TestDeletePod(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -1104,7 +1164,10 @@ func TestDeletePod(t *testing.T) {
 
 func TestDeletePodOrphan(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	jm, informer := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	jm, informer, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	jm.podStoreSynced = alwaysReady
 	jm.jobStoreSynced = alwaysReady
 
@@ -1144,7 +1207,10 @@ func (fe FakeJobExpectations) SatisfiedExpectations(controllerKey string) bool {
 // and checking expectations.
 func TestSyncJobExpectations(t *testing.T) {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: "", ContentConfig: restclient.ContentConfig{GroupVersion: &api.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	fakePodControl := controller.FakePodControl{}
 	manager.podControl = &fakePodControl
 	manager.podStoreSynced = alwaysReady
@@ -1178,7 +1244,10 @@ func TestWatchJobs(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
 	fakeWatch := watch.NewFake()
 	clientset.PrependWatchReactor("jobs", core.DefaultWatchReactor(fakeWatch, nil))
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	manager.podStoreSynced = alwaysReady
 	manager.jobStoreSynced = alwaysReady
 
@@ -1223,7 +1292,10 @@ func TestWatchPods(t *testing.T) {
 	clientset := fake.NewSimpleClientset(testJob)
 	fakeWatch := watch.NewFake()
 	clientset.PrependWatchReactor("pods", core.DefaultWatchReactor(fakeWatch, nil))
-	manager, sharedInformerFactory := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	manager, sharedInformerFactory, err := newJobControllerFromClient(clientset, controller.NoResyncPeriodFunc)
+	if err != nil {
+		t.Errorf("Failed to create job controller: %v", err)
+	}
 	manager.podStoreSynced = alwaysReady
 	manager.jobStoreSynced = alwaysReady
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Prevent `job` controller to start if  `metrics.RegisterMetricAndTrackRateLimiterUsage` returns an error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
