### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting namespace controller

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -282,7 +282,7 @@ func startNamespaceController(ctx ControllerContext) (bool, error) {
 
 	discoverResourcesFn := namespaceKubeClient.Discovery().ServerPreferredNamespacedResources
 
-	namespaceController := namespacecontroller.NewNamespaceController(
+	namespaceController, err := namespacecontroller.NewNamespaceController(
 		namespaceKubeClient,
 		namespaceClientPool,
 		discoverResourcesFn,
@@ -290,6 +290,9 @@ func startNamespaceController(ctx ControllerContext) (bool, error) {
 		ctx.Options.NamespaceSyncPeriod.Duration,
 		v1.FinalizerKubernetes,
 	)
+	if err != nil {
+		return false, fmt.Errorf("failed to start namespace controller : %v", err)
+	}
 	go namespaceController.Run(int(ctx.Options.ConcurrentNamespaceSyncs), ctx.Stop)
 
 	return true, nil

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -67,7 +67,7 @@ func NewNamespaceController(
 	discoverResourcesFn func() ([]*metav1.APIResourceList, error),
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
-	finalizerToken v1.FinalizerName) *NamespaceController {
+	finalizerToken v1.FinalizerName) (*NamespaceController, error) {
 
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
@@ -76,7 +76,10 @@ func NewNamespaceController(
 	}
 
 	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// configure the namespace informer event handlers
@@ -96,7 +99,7 @@ func NewNamespaceController(
 	namespaceController.lister = namespaceInformer.Lister()
 	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced
 
-	return namespaceController
+	return namespaceController, nil
 }
 
 // enqueueNamespace adds an object to the controller work queue


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Prevent `namespace ` controller to start if  `metrics.RegisterMetricAndTrackRateLimiterUsage`  returns an error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
