### PR TITLE
Change --etcd-quorum-read default to true

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/config.go
@@ -74,5 +74,6 @@ func NewDefaultConfig(prefix string, copier runtime.ObjectCopier, codec runtime.
 		Copier:             copier,
 		Codec:              codec,
 		CompactionInterval: DefaultCompactInterval,
+		Quorum:             true,
 	}
 }


### PR DESCRIPTION
The tested configurations for HA etcd use quorum reads. Defaulting this off causes potential correctness issues in controllers that do live lookups when processing their work queue. Given that, we should default this on.

Quorum reads are far more performant on etcd3 than they were on etcd2

xref
https://github.com/kubernetes/kubernetes/pull/53662#discussion_r143806500
https://github.com/kubernetes/kubernetes/issues/19902
https://github.com/kubernetes/kubernetes/issues/48865

```release-note
apiserver: --etcd-quorum-read now defaults to true, to ensure correct operation with HA etcd clusters
```