### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting replicaset controller

### DIFF
--- a/cmd/kube-controller-manager/app/extensions.go
+++ b/cmd/kube-controller-manager/app/extensions.go
@@ -21,6 +21,7 @@ limitations under the License.
 package app
 
 import (
+	"fmt"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	"k8s.io/kubernetes/pkg/controller/deployment"
@@ -58,11 +59,15 @@ func startReplicaSetController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}] {
 		return false, nil
 	}
-	go replicaset.NewReplicaSetController(
+	rsc, err := replicaset.NewReplicaSetController(
 		ctx.InformerFactory.Extensions().V1beta1().ReplicaSets(),
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.ClientBuilder.ClientOrDie("replicaset-controller"),
 		replicaset.BurstReplicas,
-	).Run(int(ctx.Options.ConcurrentRSSyncs), ctx.Stop)
+	)
+	if err != nil {
+		return false, fmt.Errorf("Failed to start replicaset controller: %v", err)
+	}
+	go rsc.Run(int(ctx.Options.ConcurrentRSSyncs), ctx.Stop)
 	return true, nil
 }

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -94,9 +94,12 @@ type ReplicaSetController struct {
 }
 
 // NewReplicaSetController configures a replica set controller with the specified event recorder
-func NewReplicaSetController(rsInformer extensionsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int) *ReplicaSetController {
+func NewReplicaSetController(rsInformer extensionsinformers.ReplicaSetInformer, podInformer coreinformers.PodInformer, kubeClient clientset.Interface, burstReplicas int) (*ReplicaSetController, error) {
 	if kubeClient != nil && kubeClient.Core().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("replicaset_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("replicaset_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 	eventBroadcaster := record.NewBroadcaster()
 	eventBroadcaster.StartLogging(glog.Infof)
@@ -137,7 +140,7 @@ func NewReplicaSetController(rsInformer extensionsinformers.ReplicaSetInformer, 
 
 	rsc.syncHandler = rsc.syncReplicaSet
 
-	return rsc
+	return rsc, nil
 }
 
 // SetEventRecorder replaces the event recorder used by the ReplicaSetController

--- a/test/integration/deployment/deployment_test.go
+++ b/test/integration/deployment/deployment_test.go
@@ -30,7 +30,11 @@ import (
 )
 
 func TestNewDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, error := dcSetup(t)
+	if error != nil {
+		t.Errorf("Deployment setup error : %v", error)
+		return
+	}
 	defer closeFn()
 	name := "test-new-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
@@ -141,7 +145,11 @@ func TestDeploymentSelectorImmutability(t *testing.T) {
 
 // Paused deployment should not start new rollout
 func TestPausedDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, error := dcSetup(t)
+	if error != nil {
+		t.Errorf("Deployment setup error : %v", error)
+		return
+	}
 	defer closeFn()
 	name := "test-paused-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
@@ -242,7 +250,11 @@ func TestPausedDeployment(t *testing.T) {
 
 // Paused deployment can be scaled
 func TestScalePausedDeployment(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, error := dcSetup(t)
+	if error != nil {
+		t.Errorf("Deployment setup error : %v", error)
+		return
+	}
 	defer closeFn()
 	name := "test-scale-paused-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)
@@ -323,7 +335,11 @@ func TestScalePausedDeployment(t *testing.T) {
 
 // Deployment rollout shouldn't be blocked on hash collisions
 func TestDeploymentHashCollision(t *testing.T) {
-	s, closeFn, rm, dc, informers, c := dcSetup(t)
+	s, closeFn, rm, dc, informers, c, error := dcSetup(t)
+	if error != nil {
+		t.Errorf("Deployment setup error : %v", error)
+		return
+	}
 	defer closeFn()
 	name := "test-hash-collision-deployment"
 	ns := framework.CreateTestingNamespace(name, s, t)

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -148,7 +148,7 @@ func rmSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *replicaset.R
 	resyncPeriod := 12 * time.Hour
 	informers := informers.NewSharedInformerFactory(clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "rs-informers")), resyncPeriod)
 
-	rm := replicaset.NewReplicaSetController(
+	rm, err := replicaset.NewReplicaSetController(
 		informers.Extensions().V1beta1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "replicaset-controller")),


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Prevent  `replicaset`  controller to start if  `metrics.RegisterMetricAndTrackRateLimiterUsage`  returns an error

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:  complements #53571

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
