### PR TITLE
Switch cloud-controller-manager image to debian-hyperkube

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -86,12 +86,13 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   debian_iptables_version=v8
+  debian_hyperkube_version=0.3
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD.
   case $1 in
     "amd64")
         local targets=(
-          cloud-controller-manager,busybox
+          cloud-controller-manager,gcr.io/google-containers/debian-hyperkube-base-amd64:${debian_hyperkube_version}
           kube-apiserver,busybox
           kube-controller-manager,busybox
           kube-scheduler,busybox
@@ -100,7 +101,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "arm")
         local targets=(
-          cloud-controller-manager,arm32v7/busybox
+          cloud-controller-manager,gcr.io/google-containers/debian-hyperkube-base-arm:${debian_hyperkube_version}
           kube-apiserver,arm32v7/busybox
           kube-controller-manager,arm32v7/busybox
           kube-scheduler,arm32v7/busybox
@@ -109,7 +110,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "arm64")
         local targets=(
-          cloud-controller-manager,arm64v8/busybox
+          cloud-controller-manager,gcr.io/google-containers/debian-hyperkube-base-arm64:${debian_hyperkube_version}
           kube-apiserver,arm64v8/busybox
           kube-controller-manager,arm64v8/busybox
           kube-scheduler,arm64v8/busybox
@@ -118,7 +119,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "ppc64le")
         local targets=(
-          cloud-controller-manager,ppc64le/busybox
+          cloud-controller-manager,gcr.io/google-containers/debian-hyperkube-base-ppc64le:${debian_hyperkube_version}
           kube-apiserver,ppc64le/busybox
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
@@ -127,7 +128,7 @@ kube::build::get_docker_wrapped_binaries() {
         );;
     "s390x")
         local targets=(
-          cloud-controller-manager,s390x/busybox
+          cloud-controller-manager,gcr.io/google-containers/debian-hyperkube-base-s390x:${debian_hyperkube_version}
           kube-apiserver,s390x/busybox
           kube-controller-manager,s390x/busybox
           kube-scheduler,s390x/busybox


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

The regular hyperkube image is based on debian. The cloud-controller
one was based on busybox. In this PR, we switch over from busybox
to hyperkube-debian to allow some common functionality that was possible
from hyperkube. The example in the bug report was about having default
/etc/ssl directory with reloaded system roots.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #53635 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cloud-controller-manager now uses the hyperkube/debian image instead of busybox
```
