### PR TITLE
admission_test.go: remove unused functions

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -2057,23 +2057,6 @@ func permissivePSP() *extensions.PodSecurityPolicy {
 	}
 }
 
-func createNamespaceForTest() *kapi.Namespace {
-	return &kapi.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
-		},
-	}
-}
-
-func createSAForTest() *kapi.ServiceAccount {
-	return &kapi.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "default",
-			Name:      "default",
-		},
-	}
-}
-
 // goodPod is empty and should not be used directly for testing since we're providing
 // two different PSPs.  Since no values are specified it would be allowed to match any
 // psp when defaults are filled in.


### PR DESCRIPTION
**What this PR does / why we need it**:
PR removed unused `createNamespaceForTest()` and `createSAForTest()` functions from `admission_test.go`.

**Release note**:
```release-note
NONE
```

PTAL @liggitt @pweil- 
CC @simo5 