### PR TITLE
ScaleIO - Secret to be stored in/loaded from a static namespace

### DIFF
--- a/pkg/volume/scaleio/sio_util.go
+++ b/pkg/volume/scaleio/sio_util.go
@@ -206,7 +206,7 @@ func attachSecret(plug *sioPlugin, namespace string, configData map[string]strin
 	kubeClient := plug.host.GetKubeClient()
 	secretMap, err := volutil.GetSecretForPV(namespace, secretRefName, sioPluginName, kubeClient)
 	if err != nil {
-		glog.Error(log("failed to get secret: %v", err))
+		glog.Error(log("failed to get secret from namespace %s: %v", namespace, err))
 		return secretNotFoundErr
 	}
 	// merge secret data

--- a/pkg/volume/scaleio/sio_util_test.go
+++ b/pkg/volume/scaleio/sio_util_test.go
@@ -194,7 +194,7 @@ func TestUtilAttachSecret(t *testing.T) {
 	for k, v := range config {
 		data[k] = v
 	}
-	if err := attachSecret(sioPlug, "default", data); err != nil {
+	if err := attachSecret(sioPlug, "scaleio", data); err != nil {
 		t.Errorf("failed to setupConfigData %v", err)
 	}
 	if data[confKey.username] == "" {

--- a/pkg/volume/scaleio/sio_volume_test.go
+++ b/pkg/volume/scaleio/sio_volume_test.go
@@ -38,7 +38,7 @@ var (
 	testSioSystem  = "sio"
 	testSioPD      = "default"
 	testSioVol     = "vol-0001"
-	testns         = "default"
+	testns         = "scaleio"
 	testSioVolName = fmt.Sprintf("%s%s%s", testns, "-", testSioVol)
 	podUID         = types.UID("sio-pod")
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to decouple the ScaleIO secret from the same namespace as that of the PV/PVC/Storageclass that uses it (#53619). Currently, authorized non-admin k8s user, who creates volumes, may end up having unauthorized access to ScaleIO secret information.  This PR assumes all ScaleIO secrets are assigned to a namespace called `scaleio` that is protected from non-admin users.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53619 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
