### PR TITLE
A sample PR showing how the conformance comments might look

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -123,6 +123,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}, 1, defaultObservationTimeout)
 	})
 
+	/*
+	  Testname: pods-exec-liveness-probe-not-restarted
+	  Description: Make sure when exec liveness probe succeeds, the pod should
+	         not be restarted.
+	*/
 	It("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Using the data in:
https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400

this PR shows how the human readable descriptions of the conformance tests
will appear as comments in the code.

While suggested edits on the text itself are welcome, the biggest issue
for this PR is whether people are ok with this as the template for
subsequent PR to add text like this to all 143 conformance tests.

For those who want to know more... see this PR: https://github.com/kubernetes/kubernetes/pull/52863  for the code that will generate a doc based on these comments.

Signed-off-by: Doug Davis <dug@us.ibm.com>