### PR TITLE
Parse cluster-cidr only if it is specified

### DIFF
--- a/cmd/kube-proxy/app/validation.go
+++ b/cmd/kube-proxy/app/validation.go
@@ -58,8 +58,10 @@ func Validate(config *componentconfig.KubeProxyConfiguration) field.ErrorList {
 	allErrs = append(allErrs, validateHostPort(config.HealthzBindAddress, newPath.Child("HealthzBindAddress"))...)
 	allErrs = append(allErrs, validateHostPort(config.MetricsBindAddress, newPath.Child("MetricsBindAddress"))...)
 
-	if _, _, err := net.ParseCIDR(config.ClusterCIDR); err != nil {
-		allErrs = append(allErrs, field.Invalid(newPath.Child("ClusterCIDR"), config.ClusterCIDR, "must be a valid CIDR block (e.g. 10.100.0.0/16)"))
+	if config.ClusterCIDR != "" {
+		if _, _, err := net.ParseCIDR(config.ClusterCIDR); err != nil {
+			allErrs = append(allErrs, field.Invalid(newPath.Child("ClusterCIDR"), config.ClusterCIDR, "must be a valid CIDR block (e.g. 10.100.0.0/16)"))
+		}
 	}
 
 	if _, err := utilnet.ParsePortRange(config.PortRange); err != nil {


### PR DESCRIPTION
xref https://github.com/kubernetes/kubernetes/issues/53570#issuecomment-335943956

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

In iptables/proxier.go, there is code to check the length of the
CIDR and setup nat/iptables only if the length of the string is
greater than zero. However in PR #49087, strong validation was
added so kube proxy currently bails out and basically mandates
a valid cidr has to be specified. Let us go back to the earlier
behavior.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
