### PR TITLE
Reduce log spam in qos container manager

### DIFF
--- a/pkg/kubelet/cm/qos_container_manager_linux.go
+++ b/pkg/kubelet/cm/qos_container_manager_linux.go
@@ -317,7 +317,7 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
 		}
 	}
 	if updateSuccess {
-		glog.V(2).Infof("[ContainerManager]: Updated QoS cgroup configuration")
+		glog.V(4).Infof("[ContainerManager]: Updated QoS cgroup configuration")
 		return nil
 	}
 
@@ -334,12 +334,12 @@ func (m *qosContainerManagerImpl) UpdateCgroups() error {
 	for _, config := range qosConfigs {
 		err := m.cgroupManager.Update(config)
 		if err != nil {
-			glog.V(2).Infof("[ContainerManager]: Failed to update QoS cgroup configuration")
+			glog.Errorf("[ContainerManager]: Failed to update QoS cgroup configuration")
 			return err
 		}
 	}
 
-	glog.V(2).Infof("[ContainerManager]: Updated QoS cgroup configuration on retry")
+	glog.V(4).Infof("[ContainerManager]: Updated QoS cgroup configuration on retry")
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
excessive log stmts make it hard to debug actual problems.

**Release note**:
```release-note
NONE
```
