### PR TITLE
Make scheduler integration test faster

### DIFF
--- a/plugin/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates.go
@@ -49,7 +49,7 @@ const (
 
 // IMPORTANT NOTE for predicate developers:
 // We are using cached predicate result for pods belonging to the same equivalence class.
-// So when updating a existing predicate, you should consider whether your change will introduce new
+// So when updating an existing predicate, you should consider whether your change will introduce new
 // dependency to attributes of any API object like Pod, Node, Service etc.
 // If yes, you are expected to invalidate the cached predicate result for related API object change.
 // For example:

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -384,7 +384,7 @@ func TestUnschedulableNodes(t *testing.T) {
 		}
 
 		// There are no schedulable nodes - the pod shouldn't be scheduled.
-		err = waitForPodToSchedule(context.clientSet, myPod)
+		err = waitForPodToScheduleWithTimeout(context.clientSet, myPod, 2*time.Second)
 		if err == nil {
 			t.Errorf("Pod scheduled successfully on unschedulable nodes")
 		}

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -332,13 +332,13 @@ func podScheduled(c clientset.Interface, podNamespace, podName string) wait.Cond
 // waitForPodToScheduleWithTimeout waits for a pod to get scheduled and returns
 // an error if it does not scheduled within the given timeout.
 func waitForPodToScheduleWithTimeout(cs clientset.Interface, pod *v1.Pod, timeout time.Duration) error {
-	return wait.Poll(time.Second, timeout, podScheduled(cs, pod.Namespace, pod.Name))
+	return wait.Poll(100*time.Millisecond, timeout, podScheduled(cs, pod.Namespace, pod.Name))
 }
 
 // waitForPodToSchedule waits for a pod to get scheduled and returns an error if
-// it does not scheduled within the timeout duration (30 seconds).
+// it does not get scheduled within the timeout duration (30 seconds).
 func waitForPodToSchedule(cs clientset.Interface, pod *v1.Pod) error {
-	return waitForPodToScheduleWithTimeout(cs, pod, wait.ForeverTestTimeout)
+	return waitForPodToScheduleWithTimeout(cs, pod, 30*time.Second)
 }
 
 // deletePod deletes the given pod in the given namespace.


### PR DESCRIPTION
Not to wait for 30 seconds for every negative test case. This commit
also organizes the test code to make it more readable.

It cuts the test time from 450s to 125s.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53302

**Special notes for your reviewer**:

**Release note**: 
```release-note
NONE
```
