### PR TITLE
Split downward API e2e test case for pod/host IP into two

### DIFF
--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -65,8 +65,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 		testDownwardAPI(f, podName, env, expectations)
 	})
 
-	It("should provide pod and host IP as an env var [Conformance]", func() {
-		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
+	It("should provide pod IP as an env var [Conformance]", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
@@ -78,6 +77,19 @@ var _ = framework.KubeDescribe("Downward API", func() {
 					},
 				},
 			},
+		}
+
+		expectations := []string{
+			"POD_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
+		}
+
+		testDownwardAPI(f, podName, env, expectations)
+	})
+
+	It("should provide host IP as an env var [Conformance]", func() {
+		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
+		podName := "downward-api-" + string(uuid.NewUUID())
+		env := []v1.EnvVar{
 			{
 				Name: "HOST_IP",
 				ValueFrom: &v1.EnvVarSource{
@@ -90,7 +102,6 @@ var _ = framework.KubeDescribe("Downward API", func() {
 		}
 
 		expectations := []string{
-			"POD_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
 			"HOST_IP=(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)\\.(?:\\d+)",
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Split the test case in order to avoid version block pod IP e2e test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
ref: https://github.com/kubernetes/kubernetes/pull/42717#discussion_r144026427

**Special notes for your reviewer**:
/cc @timothysc @andrewsykim 