### PR TITLE
kubeadm: add new options to kubeadm init for specifying custom images

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -185,6 +185,14 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfigur
 	)
 	flagSet.StringVar(featureGatesString, "feature-gates", *featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))
+	flagSet.StringVar(
+		&cfg.UnifiedControlPlaneImage, "unified-control-plane-image", cfg.UnifiedControlPlaneImage,
+		"Specify the unfied control plane image.",
+	)
+	flagSet.StringVar(
+		&cfg.Etcd.Image, "etcd-image", cfg.Etcd.Image,
+		"Specify the etcd image.",
+	)
 }
 
 // AddInitOtherFlags adds init flags that are not bound to a configuration file to the given flagset


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that `kubeadm init` doesn't provide an option for specifying
custom images of control planes and etcd. This commit adds a new
option, `--unified-control-plane-image` and `--etcd-image` to the
subcommand for the purposes.

Although they can be specified with a config file, I found passing the parameters with a config file is an experimental. Also, it would be a little bit convenient for testing purposes if we can specify custom images with just command line options.

**Special notes for your reviewer**:

None

**Release note**:
```release-note
Add --unified-control-plane-image and --etcd-image to kubeadm for specifying images of the components.
```
