### PR TITLE
self-signed certs: warn on low entropy

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -77,6 +77,7 @@ go_test(
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/util/cert:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -47,6 +47,7 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/util/cert"
 )
 
 func setUp(t *testing.T) Config {
@@ -212,6 +213,11 @@ func TestGetNamedCertificateMap(t *testing.T) {
 
 NextTest:
 	for i, test := range tests {
+		// this test needs tons of entropy. So better warn if it is low, making debugging of timeout much easier.
+		if s, _ := cert.EntropyWarning(); len(s) != 0 {
+			t.Log(s)
+		}
+
 		var namedTLSCerts []NamedTLSCert
 		bySignature := map[string]int{} // index in test.certs by cert signature
 		for j, c := range test.certs {
@@ -401,6 +407,11 @@ func TestServerRunWithSNI(t *testing.T) {
 
 NextTest:
 	for title, test := range tests {
+		// this test needs tons of entropy. So better warn if it is low, making debugging of timeout much easier.
+		if s, _ := cert.EntropyWarning(); len(s) != 0 {
+			t.Log(s)
+		}
+
 		// create server cert
 		certDir := "testdata/" + specToName(test.Cert)
 		serverCertBundleFile := filepath.Join(certDir, "cert")

--- a/staging/src/k8s.io/client-go/util/cert/BUILD
+++ b/staging/src/k8s.io/client-go/util/cert/BUILD
@@ -21,12 +21,20 @@ go_library(
     srcs = [
         "cert.go",
         "csr.go",
+        "entropy.go",
+        "entropy_other.go",
         "io.go",
         "pem.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:linux_amd64": [
+            "entropy_linux.go",
+        ],
+        "//conditions:default": [],
+    }),
     data = [
         "testdata/dontUseThisKey.pem",
     ],
+    deps = ["//vendor/github.com/golang/glog:go_default_library"],
 )
 
 filegroup(

--- a/staging/src/k8s.io/client-go/util/cert/cert.go
+++ b/staging/src/k8s.io/client-go/util/cert/cert.go
@@ -138,6 +138,8 @@ func MakeEllipticPrivateKeyPEM() ([]byte, error) {
 // Host may be an IP or a DNS name
 // You may also specify additional subject alt names (either ip or dns names) for the certificate
 func GenerateSelfSignedCertKey(host string, alternateIPs []net.IP, alternateDNS []string) ([]byte, []byte, error) {
+	CheckEntropy() // sanity check entropy, ignore errors
+
 	priv, err := rsa.GenerateKey(cryptorand.Reader, 2048)
 	if err != nil {
 		return nil, nil, err

--- a/staging/src/k8s.io/client-go/util/cert/entropy.go
+++ b/staging/src/k8s.io/client-go/util/cert/entropy.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"github.com/golang/glog"
+)
+
+// CheckEntropy checks for enough entropy on the machine for SSL operations and warns if low.
+func CheckEntropy() error {
+	s, err := EntropyWarning()
+	if err != nil {
+		return err
+	}
+
+	if len(s) != 0 {
+		glog.Warningf(s)
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/client-go/util/cert/entropy_linux.go
+++ b/staging/src/k8s.io/client-go/util/cert/entropy_linux.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+import (
+	"io/ioutil"
+	"strconv"
+	"strings"
+
+	"fmt"
+)
+
+const EntropyGoodLevel = 100
+
+// EntropyWarning checks for enough entropy on the machine for SSL operations and returns a warning string if yes.
+func EntropyWarning() (string, error) {
+	bs, err := ioutil.ReadFile("/proc/sys/kernel/random/entropy_avail")
+	if err != nil {
+		return "", err
+	}
+
+	s := strings.SplitN(string(bs), "\n", 2)[0]
+	entropy, err := strconv.Atoi(s)
+	if err != nil {
+		return "", err
+	}
+
+	if entropy < EntropyGoodLevel {
+		return fmt.Sprintf("Entropy of the system is below %d which is considered low: %d. SSL operations might take long.", EntropyGoodLevel, entropy), nil
+	}
+
+	return "", nil
+}

--- a/staging/src/k8s.io/client-go/util/cert/entropy_other.go
+++ b/staging/src/k8s.io/client-go/util/cert/entropy_other.go
@@ -1,0 +1,24 @@
+// +build !linux
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cert
+
+// EntropyWarning checks for enough entropy on the machine for SSL operations and returns a warning string if yes.
+func EntropyWarning() (string, error) {
+	return "", nil
+}


### PR DESCRIPTION
We have seen SNI test flakes which might be caused by low entropy: https://github.com/openshift/origin/issues/16702