### PR TITLE
Add e2e test case for downward API exposing pod UID

### DIFF
--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -187,6 +187,29 @@ var _ = framework.KubeDescribe("Downward API", func() {
 
 		testDownwardAPIUsingPod(f, pod, env, expectations)
 	})
+
+	It("should provide pod UID as env vars [Conformance]", func() {
+		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
+		podUID := uuid.NewUUID()
+		podName := "downward-api-" + string(podUID)
+		env := []v1.EnvVar{
+			{
+				Name: "POD_UID",
+				ValueFrom: &v1.EnvVarSource{
+					FieldRef: &v1.ObjectFieldSelector{
+						APIVersion: "v1",
+						FieldPath:  "metadata.uid",
+					},
+				},
+			},
+		}
+
+		expectations := []string{
+			fmt.Sprintf("POD_UID=%v", podUID),
+		}
+
+		testDownwardAPI(f, podName, env, expectations)
+	})
 })
 
 func testDownwardAPI(f *framework.Framework, podName string, env []v1.EnvVar, expectations []string) {

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -29,7 +29,10 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-var hostIPVersion = utilversion.MustParseSemantic("v1.8.0")
+var (
+	hostIPVersion = utilversion.MustParseSemantic("v1.8.0")
+	podUIDVersion = utilversion.MustParseSemantic("v1.8.0")
+)
 
 var _ = framework.KubeDescribe("Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
@@ -189,7 +192,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 	})
 
 	It("should provide pod UID as env vars [Conformance]", func() {
-		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
+		framework.SkipUnlessServerVersionGTE(podUIDVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -190,8 +190,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 
 	It("should provide pod UID as env vars [Conformance]", func() {
 		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
-		podUID := uuid.NewUUID()
-		podName := "downward-api-" + string(podUID)
+		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
 			{
 				Name: "POD_UID",
@@ -205,7 +204,7 @@ var _ = framework.KubeDescribe("Downward API", func() {
 		}
 
 		expectations := []string{
-			fmt.Sprintf("POD_UID=%v", podUID),
+			fmt.Sprintf("POD_UID=[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}"),
 		}
 
 		testDownwardAPI(f, podName, env, expectations)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Pod UID is added to downward API env var in #48125 for 1.8. This PR adds a e2e test case for it.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
ref: #48125

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
