### PR TITLE
Fix print format of rootScoped resourced in kubectl

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -4165,6 +4165,14 @@ run_kubectl_all_namespace_tests() {
   # Post-condition: valid-pod doesn't exist
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 
+  ### Verify flag all-namespaces is ignored for rootScoped resources
+  # Pre-condition: node exists
+  kube::test::get_object_assert nodes "{{range.items}}{{$id_field}}:{{end}}" '127.0.0.1:'
+  # Command
+  output_message=$(kubectl get nodes --all-namespaces 2>&1)
+  # Post-condition: output with no NAMESPACE field
+  kube::test::if_has_not_string "${output_message}" "NAMESPACE"
+
   set +o nounset
   set +o errexit
 }
@@ -4846,7 +4854,9 @@ runTests() {
   ############################
 
   if kube::test::if_supports_resource "${pods}" ; then
-    record_command run_kubectl_all_namespace_tests
+    if kube::test::if_supports_resource "${nodes}" ; then
+      record_command run_kubectl_all_namespace_tests
+    fi
   fi
 
   ################

--- a/pkg/kubectl/cmd/get.go
+++ b/pkg/kubectl/cmd/get.go
@@ -244,7 +244,14 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 		}
 		info := infos[0]
 		mapping := info.ResourceMapping()
-		printer, err := f.PrinterForMapping(cmd, false, nil, mapping, allNamespaces)
+
+		// no need to print namespace for root-scoped resources
+		printWithNamespace := allNamespaces
+		if mapping != nil && mapping.Scope.Name() == meta.RESTScopeNameRoot {
+			printWithNamespace = false
+		}
+
+		printer, err := f.PrinterForMapping(cmd, false, nil, mapping, printWithNamespace)
 		if err != nil {
 			return err
 		}
@@ -493,6 +500,11 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				w.Flush()
 			}
 
+			printWithNamespace := allNamespaces
+			if mapping != nil && mapping.Scope.Name() == meta.RESTScopeNameRoot {
+				printWithNamespace = false
+			}
+
 			var outputOpts *printers.OutputOptions
 			// if cmd does not specify output format and useOpenAPIPrintColumnFlagLabel flag is true,
 			// then get the default output options for this mapping from OpenAPI schema.
@@ -500,7 +512,7 @@ func RunGet(f cmdutil.Factory, out, errOut io.Writer, cmd *cobra.Command, args [
 				outputOpts, _ = outputOptsForMappingFromOpenAPI(f, mapping)
 			}
 
-			printer, err = f.PrinterForMapping(cmd, false, outputOpts, mapping, allNamespaces)
+			printer, err = f.PrinterForMapping(cmd, false, outputOpts, mapping, printWithNamespace)
 			if err != nil {
 				if !errs.Has(err.Error()) {
 					errs.Insert(err.Error())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
remove _NAMESPACE_ filed when querying rootScoped resource with kubectl

**Which issue this PR fixes**

fixes #53767

**Special notes for your reviewer**:
/cc @smarterclayton 


**Release note**:
```release-note
NONE
```
