### PR TITLE
Automated cherry pick of #53359

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -152,7 +152,16 @@ func ClusterRoles() []rbac.ClusterRole {
 			// a role which provides just enough power to determine if the server is ready and discover API versions for negotiation
 			ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbac.PolicyRule{
-				rbac.NewRule("get").URLs("/healthz", "/version", "/swaggerapi", "/swaggerapi/*", "/api", "/api/*", "/apis", "/apis/*").RuleOrDie(),
+				rbac.NewRule("get").URLs(
+					"/healthz", "/version",
+					// remove once swagger 1.2 support is removed
+					"/swaggerapi", "/swaggerapi/*",
+					// do not expand this pattern for openapi discovery docs
+					// move to a single openapi endpoint that takes accept/accept-encoding headers
+					"/swagger.json", "/swagger-2.0.0.pb-v1",
+					"/api", "/api/*",
+					"/apis", "/apis/*",
+				).RuleOrDie(),
 			},
 		},
 		{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -408,6 +408,8 @@ items:
     - /apis
     - /apis/*
     - /healthz
+    - /swagger-2.0.0.pb-v1
+    - /swagger.json
     - /swaggerapi
     - /swaggerapi/*
     - /version


### PR DESCRIPTION
Cherry pick of #53359 on release-1.8.

#53359: Add /swagger.json and /swagger-2.0.0.pb-v1 to discovery role

```release-note
Fixes forbidden errors accessing openapi discovery documents
```