### PR TITLE
allow fail close webhook admission

### DIFF
--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -179,12 +179,16 @@ func validateExternalAdmissionHook(hook *admissionregistration.ExternalAdmission
 	for i, rule := range hook.Rules {
 		allErrors = append(allErrors, validateRuleWithOperations(&rule, fldPath.Child("rules").Index(i))...)
 	}
-	// TODO: relax the validation rule when admissionregistration is beta.
-	if hook.FailurePolicy != nil && *hook.FailurePolicy != admissionregistration.Ignore {
-		allErrors = append(allErrors, field.NotSupported(fldPath.Child("failurePolicy"), *hook.FailurePolicy, []string{string(admissionregistration.Ignore)}))
+	if hook.FailurePolicy != nil && !supportedFailurePolicies.Has(string(*hook.FailurePolicy)) {
+		allErrors = append(allErrors, field.NotSupported(fldPath.Child("failurePolicy"), *hook.FailurePolicy, supportedFailurePolicies.List()))
 	}
 	return allErrors
 }
+
+var supportedFailurePolicies = sets.NewString(
+	string(admissionregistration.Ignore),
+	string(admissionregistration.Fail),
+)
 
 var supportedOperations = sets.NewString(
 	string(admissionregistration.OperationAll),

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -469,18 +469,18 @@ func TestValidateExternalAdmissionHookConfiguration(t *testing.T) {
 			expectedError: `externalAdmissionHooks[0].rules[0].resources: Invalid value: []string{"*/*", "a"}: if '*/*' is present, must not specify other resources`,
 		},
 		{
-			name: "FailurePolicy can only be \"Ignore\"",
+			name: "FailurePolicy can only be \"Ignore\" or \"Fail\"",
 			config: getExternalAdmissionHookConfiguration(
 				[]admissionregistration.ExternalAdmissionHook{
 					{
 						Name: "webhook.k8s.io",
 						FailurePolicy: func() *admissionregistration.FailurePolicyType {
-							r := admissionregistration.Fail
+							r := admissionregistration.FailurePolicyType("other")
 							return &r
 						}(),
 					},
 				}),
-			expectedError: `failurePolicy: Unsupported value: "Fail": supported values: "Ignore"`,
+			expectedError: `externalAdmissionHooks[0].failurePolicy: Unsupported value: "other": supported values: "Fail", "Ignore"`,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Webhook admission needs to allow failing closed.  Even in an alpha state, I don't want to be one DDOS away from having an exposed cluster.

/assign caesarxuchao
/assign sttts