### PR TITLE
perform nil check before iterating over keys

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -539,6 +539,10 @@ func (f *DeltaFIFO) Resync() error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
+	if f.knownObjects == nil {
+		return nil
+	}
+
 	keys := f.knownObjects.ListKeys()
 	for _, k := range keys {
 		if err := f.syncKeyLocked(k); err != nil {


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Fixes panic due to nil pointer dereference 

Related downstream bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1377940
cc @smarterclayton 