### PR TITLE
Don't fail if Rate Limiter metric is already registered

### DIFF
--- a/pkg/util/metrics/util_test.go
+++ b/pkg/util/metrics/util_test.go
@@ -35,6 +35,12 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 			err:         "",
 		},
 		{
+			// Registering the same owner should not fail
+			ownerName:   "owner_name",
+			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			err:         "",
+		},
+		{
 			ownerName:   "invalid-owner-name",
 			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
 			err:         "error registering rate limiter usage metric",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

If a Rate Limiter metric is already registered don't return an error (and don't start a new goroutine to report the saturation, as it is already tracked by the existing goroutine).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52872

**Special notes for your reviewer**:

As part of #52872 we're starting to update the controllers to catch `RegisterMetricAndTrackRateLimiterUsage` errors. When running the integration tests, multiple instances of controllers will be created, and each controller instance will try to register the same metric, and as a result, tests will fail. This PR will help writing integrarion tests for those controllers.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
