### PR TITLE
Printing performance numbers for volume lifecycle operations

### DIFF
--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -27,6 +27,7 @@ go_library(
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",
         "vsphere_volume_ops_storm.go",
+        "vsphere_volume_perf.go",
         "vsphere_volume_placement.go",
         "vsphere_volume_vsan_policy.go",
     ],

--- a/test/e2e/storage/vsphere_volume_perf.go
+++ b/test/e2e/storage/vsphere_volume_perf.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	k8stype "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = SIGDescribe("vcp-performance", func() {
+	f := framework.NewDefaultFramework("vcp-performance")
+
+	var (
+		client    clientset.Interface
+		namespace string
+		//iterations int
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		Expect(os.Getenv("VSPHERE_SPBM_GOLD_POLICY")).NotTo(BeEmpty(), "ENV VSPHERE_SPBM_GOLD_POLICY is not set")
+		Expect(os.Getenv("VSPHERE_DATASTORE")).NotTo(BeEmpty(), "ENV VSPHERE_DATASTORE is not set")
+		Expect(os.Getenv("VCP_PERF_VOLUME_PER_POD")).NotTo(BeEmpty(), "ENV VCP_PERF_VOLUME_PER_POD is not set")
+
+		nodes := framework.GetReadySchedulableNodesOrDie(client)
+		if len(nodes.Items) < 2 {
+			framework.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+		}
+	})
+
+	It("vcp performance tests", func() {
+		// Volumes will be provisioned with each different types of Storage Class
+		scArrays := make([]*storageV1.StorageClass, 4)
+		// Create default vSphere Storage Class
+		By("Creating Storage Class : sc-default")
+		scDefaultSpec := getVSphereStorageClassSpec("sc-default", nil)
+		scDefault, err := client.StorageV1().StorageClasses().Create(scDefaultSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scDefault.Name, nil)
+		scArrays[0] = scDefault
+
+		// Create Storage Class with vsan storage capabilities
+		By("Creating Storage Class : sc-vsan")
+		var scvsanParameters map[string]string
+		scvsanParameters = make(map[string]string)
+		scvsanParameters[Policy_HostFailuresToTolerate] = "1"
+		scvsanSpec := getVSphereStorageClassSpec("sc-vsan", scvsanParameters)
+		scvsan, err := client.StorageV1().StorageClasses().Create(scvsanSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scvsan.Name, nil)
+		scArrays[1] = scvsan
+
+		// Create Storage Class with SPBM Policy
+		By("Creating Storage Class : sc-spbm")
+		var scSpbmPolicyParameters map[string]string
+		scSpbmPolicyParameters = make(map[string]string)
+		goldPolicy := os.Getenv("VSPHERE_SPBM_GOLD_POLICY")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scSpbmPolicyParameters[SpbmStoragePolicy] = goldPolicy
+		scSpbmPolicySpec := getVSphereStorageClassSpec("sc-spbm", scSpbmPolicyParameters)
+		scSpbmPolicy, err := client.StorageV1().StorageClasses().Create(scSpbmPolicySpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scSpbmPolicy.Name, nil)
+		scArrays[2] = scSpbmPolicy
+
+		// Create Storage Class with User Specified Datastore.
+		By("Creating Storage Class : sc-user-specified-datastore")
+		var scWithDatastoreParameters map[string]string
+		scWithDatastoreParameters = make(map[string]string)
+		datastore := os.Getenv("VSPHERE_DATASTORE")
+		Expect(goldPolicy).NotTo(BeEmpty())
+		scWithDatastoreParameters[Datastore] = datastore
+		scWithDatastoreSpec := getVSphereStorageClassSpec("sc-user-specified-ds", scWithDatastoreParameters)
+		scWithDatastore, err := client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(scWithDatastore.Name, nil)
+		scArrays[3] = scWithDatastore
+
+		volumesPerPod, err := strconv.Atoi(os.Getenv("VCP_PERF_VOLUME_PER_POD"))
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_PERF_VOLUME_PER_POD")
+
+		for i := 0; i < 3; i++ {
+			latency := PerformVolumeLifeCycleAtScale(f, client, namespace, scArrays, volumesPerPod)
+			framework.Logf("Performance numbers for iteration %d", i)
+			framework.Logf("Creating PVCs and waiting for bound phase: %v microseconds", latency[0])
+			framework.Logf("Creating Pod and verifying attached status: %v microseconds", latency[1])
+			framework.Logf("Deleting Pod and waiting for disk to be detached: %v microseconds", latency[2])
+			framework.Logf("Deleting the PVCs: %v microseconds", latency[3])
+		}
+	})
+})
+
+// PerformVolumeLifeCycleAtScale peforms full volume life cycle management at scale
+func PerformVolumeLifeCycleAtScale(f *framework.Framework, client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumesPerPod int) []int64 {
+	var latency []int64
+
+	By(fmt.Sprintf("Creating %v PVCs per pod ", volumesPerPod))
+	var pvclaims []*v1.PersistentVolumeClaim
+	start := time.Now()
+	for i := 0; i < volumesPerPod; i++ {
+		pvclaim, err := framework.CreatePVC(client, namespace, getVSphereClaimSpecWithStorageClassAnnotation(namespace, sc[i%len(sc)]))
+		Expect(err).NotTo(HaveOccurred())
+		pvclaims = append(pvclaims, pvclaim)
+	}
+
+	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+	Expect(err).NotTo(HaveOccurred())
+	elapsed := time.Since(start)
+	latency = append(latency, elapsed.Nanoseconds()/1000)
+
+	By("Creating pod to attach PVs to the node and verifying access")
+	start = time.Now()
+	pod, err := framework.CreatePod(client, namespace, pvclaims, false, "")
+	Expect(err).NotTo(HaveOccurred())
+
+	vsp, err := vsphere.GetVSphere()
+	Expect(err).NotTo(HaveOccurred())
+
+	verifyVSphereVolumesAccessible(pod, persistentvolumes, vsp)
+	elapsed = time.Since(start)
+	latency = append(latency, elapsed.Nanoseconds()/1000)
+
+	By("Deleting pod and waiting for volumes to be detached from the node")
+	start = time.Now()
+	err = framework.DeletePodWithWait(f, client, pod)
+	Expect(err).NotTo(HaveOccurred())
+
+	for _, pv := range persistentvolumes {
+		err = waitForVSphereDiskToDetach(vsp, pv.Spec.VsphereVolume.VolumePath, k8stype.NodeName(pod.Spec.NodeName))
+		Expect(err).NotTo(HaveOccurred())
+	}
+	elapsed = time.Since(start)
+	latency = append(latency, elapsed.Nanoseconds()/1000)
+
+	By("Deleting the PVCs")
+	start = time.Now()
+	for _, pvc := range pvclaims {
+		err = framework.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	elapsed = time.Since(start)
+	latency = append(latency, elapsed.Nanoseconds()/1000)
+
+	return latency
+}


### PR DESCRIPTION


**What this PR does / why we need it**:
This PR introduces test that prints latency numbers for volume lifecycle operations. The tests doesn't take into account minor latency number overhead of test assertions and verifications.

**Which issue this PR fixes** : fixes #292

**Special notes for your reviewer**:

The numbers are printed in microseconds after each iterations.
As of now the iterations are 3.

Test logs:
```
root@k8s-dev-vm-01:~/shahzeb/k8s/kubernetes# go run hack/e2e.go --check-version-skew=false -v -test --test_args='--ginkgo.focus=vcp-performance'
flag provided but not defined: -check-version-skew
Usage of /tmp/go-build593004825/command-line-arguments/_obj/exe/e2e:
  -get
    	go get -u kubetest if old or not installed (default true)
  -old duration
    	Consider kubetest old if it exceeds this (default 24h0m0s)
2017/10/12 16:48:20 e2e.go:55: NOTICE: go run hack/e2e.go is now a shim for test-infra/kubetest
2017/10/12 16:48:20 e2e.go:56:   Usage: go run hack/e2e.go [--get=true] [--old=24h0m0s] -- [KUBETEST_ARGS]
2017/10/12 16:48:20 e2e.go:57:   The separator is required to use --get or --old flags
2017/10/12 16:48:20 e2e.go:58:   The -- flag separator also suppresses this message
2017/10/12 16:48:20 e2e.go:77: Calling kubetest --check-version-skew=false -v -test --test_args=--ginkgo.focus=vcp-performance...
2017/10/12 16:48:20 util.go:154: Running: ./cluster/kubectl.sh --match-server-version=false version
2017/10/12 16:48:21 util.go:156: Step './cluster/kubectl.sh --match-server-version=false version' finished in 467.099685ms
2017/10/12 16:48:21 util.go:154: Running: ./hack/e2e-internal/e2e-status.sh
Skeleton Provider: prepare-e2e not implemented
Client Version: version.Info{Major:"1", Minor:"6+", GitVersion:"v1.6.0-alpha.0.17390+60c9e59ad2b417", GitCommit:"60c9e59ad2b4179a4b6e89343cfeb9eb73a9d6b7", GitTreeState:"clean", BuildDate:"2017-10-12T23:38:22Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"9+", GitVersion:"v1.9.0-alpha.1.1030+4ff6ef4a378748", GitCommit:"4ff6ef4a378748d4c1667f352fb5d300170e4429", GitTreeState:"clean", BuildDate:"2017-10-12T07:15:39Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
2017/10/12 16:48:21 util.go:156: Step './hack/e2e-internal/e2e-status.sh' finished in 290.420892ms
2017/10/12 16:48:21 util.go:154: Running: ./hack/ginkgo-e2e.sh --ginkgo.focus=vcp-performance
Conformance test: not doing test setup.
Oct 12 16:48:23.149: INFO: Overriding default scale value of zero to 1
Oct 12 16:48:23.149: INFO: Overriding default milliseconds value of zero to 5000
I1012 16:48:23.395591   12633 e2e.go:383] Starting e2e run "d52f8cfd-afa7-11e7-a479-0050569c27f6" on Ginkgo node 1
Running Suite: Kubernetes e2e suite
===================================
Random Seed: 1507852102 - Will randomize all specs
Will run 1 of 706 specs

Oct 12 16:48:23.431: INFO: >>> kubeConfig: /tmp/kube204.json
Oct 12 16:48:23.439: INFO: Waiting up to 4h0m0s for all (but 0) nodes to be schedulable
Oct 12 16:48:23.473: INFO: Waiting up to 10m0s for all pods (need at least 0) in namespace 'kube-system' to be running and ready
Oct 12 16:48:23.599: INFO: 4 / 4 pods in namespace 'kube-system' are running and ready (0 seconds elapsed)
Oct 12 16:48:23.599: INFO: expected 0 pod replicas in namespace 'kube-system', 0 are Running and Ready.
Oct 12 16:48:23.605: INFO: Waiting for pods to enter Success, but no pods in "kube-system" match label map[name:e2e-image-puller]
Oct 12 16:48:23.605: INFO: Dumping network health container logs from all nodes...
Oct 12 16:48:23.612: INFO: Client version: v1.6.0-alpha.0.17390+60c9e59ad2b417
Oct 12 16:48:23.615: INFO: Server version: v1.9.0-alpha.1.1030+4ff6ef4a378748
SSSSSSSSSS
------------------------------
[sig-storage] vcp-performance
  vcp performance tests
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_perf.go:118
[BeforeEach] [sig-storage] vcp-performance
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:133
STEP: Creating a kubernetes client
Oct 12 16:48:23.615: INFO: >>> kubeConfig: /tmp/kube204.json
STEP: Building a namespace api object
STEP: Waiting for a default service account to be provisioned in namespace
[BeforeEach] [sig-storage] vcp-performance
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_perf.go:57
[It] vcp performance tests
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_perf.go:118
STEP: Creating Storage Class : sc-default
STEP: Creating Storage Class : sc-vsan
STEP: Creating Storage Class : sc-spbm
STEP: Creating Storage Class : sc-user-specified-datastore
STEP: Creating 1 PVCs per pod
Oct 12 16:48:23.828: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-9knbm to have phase Bound
Oct 12 16:48:23.838: INFO: PersistentVolumeClaim pvc-9knbm found but phase is Pending instead of Bound.
Oct 12 16:48:25.843: INFO: PersistentVolumeClaim pvc-9knbm found and phase=Bound (2.015459164s)
STEP: Creating pod to attach PVs to the node and verifying access
Oct 12 16:48:50.138: INFO: Running '/root/shahzeb/k8s/kubernetes/_output/bin/kubectl --server=https://10.192.101.43 --kubeconfig=/tmp/kube204.json exec pvc-tester-74fhw --namespace=e2e-tests-vcp-performance-n69h5 -- /bin/touch /mnt/volume1/emptyFile.txt'
Oct 12 16:48:50.644: INFO: stderr: ""
Oct 12 16:48:50.644: INFO: stdout: ""
STEP: Deleting pod and waiting for volumes to be detached from the node
Oct 12 16:48:50.644: INFO: Deleting pod "pvc-tester-74fhw" in namespace "e2e-tests-vcp-performance-n69h5"
Oct 12 16:48:50.678: INFO: Wait up to 5m0s for pod "pvc-tester-74fhw" to be fully deleted
Oct 12 16:49:32.808: INFO: Volume "[vsanDatastore] 8c95d659-46fa-b9a6-5e19-02002f28e688/kubernetes-dynamic-pvc-d5b7ba0a-afa7-11e7-9d69-005056ad5ee7.vmdk" appears to have successfully detached from "kubernetes-node4".
STEP: Deleting the PVCs
Oct 12 16:49:32.808: INFO: Deleting PersistentVolumeClaim "pvc-9knbm"
Oct 12 16:49:32.831: INFO: Performance numbers for iteration 0
Oct 12 16:49:32.831: INFO: Creating PVCs and waiting for bound phase: 2060995 microseconds
Oct 12 16:49:32.831: INFO: Creating Pod and verifying attached status: 24780199 microseconds
Oct 12 16:49:32.831: INFO: Deleting Pod and waiting for disk to be detached: 42163845 microseconds
Oct 12 16:49:32.831: INFO: Deleting the PVCs: 23074 microseconds
STEP: Creating 1 PVCs per pod
Oct 12 16:49:32.866: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-bmczh to have phase Bound
Oct 12 16:49:32.874: INFO: PersistentVolumeClaim pvc-bmczh found but phase is Pending instead of Bound.
Oct 12 16:49:34.880: INFO: PersistentVolumeClaim pvc-bmczh found and phase=Bound (2.014204015s)
STEP: Creating pod to attach PVs to the node and verifying access
Oct 12 16:49:51.133: INFO: Running '/root/shahzeb/k8s/kubernetes/_output/bin/kubectl --server=https://10.192.101.43 --kubeconfig=/tmp/kube204.json exec pvc-tester-bddc7 --namespace=e2e-tests-vcp-performance-n69h5 -- /bin/touch /mnt/volume1/emptyFile.txt'
Oct 12 16:49:51.624: INFO: stderr: ""
Oct 12 16:49:51.624: INFO: stdout: ""
STEP: Deleting pod and waiting for volumes to be detached from the node
Oct 12 16:49:51.624: INFO: Deleting pod "pvc-tester-bddc7" in namespace "e2e-tests-vcp-performance-n69h5"
Oct 12 16:49:51.655: INFO: Wait up to 5m0s for pod "pvc-tester-bddc7" to be fully deleted
Oct 12 16:50:33.774: INFO: Volume "[vsanDatastore] 8c95d659-46fa-b9a6-5e19-02002f28e688/kubernetes-dynamic-pvc-fede3696-afa7-11e7-9d69-005056ad5ee7.vmdk" appears to have successfully detached from "kubernetes-node3".
STEP: Deleting the PVCs
Oct 12 16:50:33.774: INFO: Deleting PersistentVolumeClaim "pvc-bmczh"
Oct 12 16:50:33.798: INFO: Performance numbers for iteration 1
Oct 12 16:50:33.798: INFO: Creating PVCs and waiting for bound phase: 2072174 microseconds
Oct 12 16:50:33.798: INFO: Creating Pod and verifying attached status: 16720792 microseconds
Oct 12 16:50:33.798: INFO: Deleting Pod and waiting for disk to be detached: 42149319 microseconds
Oct 12 16:50:33.798: INFO: Deleting the PVCs: 24493 microseconds
STEP: Creating 1 PVCs per pod
Oct 12 16:50:33.843: INFO: Waiting up to 5m0s for PersistentVolumeClaim pvc-msf85 to have phase Bound
Oct 12 16:50:33.852: INFO: PersistentVolumeClaim pvc-msf85 found but phase is Pending instead of Bound.
Oct 12 16:50:35.857: INFO: PersistentVolumeClaim pvc-msf85 found and phase=Bound (2.013909379s)
STEP: Creating pod to attach PVs to the node and verifying access
Oct 12 16:50:48.072: INFO: Running '/root/shahzeb/k8s/kubernetes/_output/bin/kubectl --server=https://10.192.101.43 --kubeconfig=/tmp/kube204.json exec pvc-tester-lzk5s --namespace=e2e-tests-vcp-performance-n69h5 -- /bin/touch /mnt/volume1/emptyFile.txt'
Oct 12 16:50:48.470: INFO: stderr: ""
Oct 12 16:50:48.470: INFO: stdout: ""
STEP: Deleting pod and waiting for volumes to be detached from the node
Oct 12 16:50:48.470: INFO: Deleting pod "pvc-tester-lzk5s" in namespace "e2e-tests-vcp-performance-n69h5"
Oct 12 16:50:48.503: INFO: Wait up to 5m0s for pod "pvc-tester-lzk5s" to be fully deleted
Oct 12 16:51:40.610: INFO: Volume "[vsanDatastore] 8c95d659-46fa-b9a6-5e19-02002f28e688/kubernetes-dynamic-pvc-2336b76f-afa8-11e7-9d69-005056ad5ee7.vmdk" appears to have successfully detached from "kubernetes-node2".
STEP: Deleting the PVCs
Oct 12 16:51:40.613: INFO: Deleting PersistentVolumeClaim "pvc-msf85"
Oct 12 16:51:40.641: INFO: Performance numbers for iteration 2
Oct 12 16:51:40.641: INFO: Creating PVCs and waiting for bound phase: 2079622 microseconds
Oct 12 16:51:40.641: INFO: Creating Pod and verifying attached status: 12591784 microseconds
Oct 12 16:51:40.641: INFO: Deleting Pod and waiting for disk to be detached: 52142761 microseconds
Oct 12 16:51:40.642: INFO: Deleting the PVCs: 28793 microseconds
[AfterEach] [sig-storage] vcp-performance
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:134
Oct 12 16:51:40.792: INFO: Waiting up to 3m0s for all (but 0) nodes to be ready
STEP: Destroying namespace "e2e-tests-vcp-performance-n69h5" for this suite.
Oct 12 16:51:49.131: INFO: namespace: e2e-tests-vcp-performance-n69h5, resource: bindings, ignored listing per whitelist
Oct 12 16:51:49.231: INFO: namespace e2e-tests-vcp-performance-n69h5 deletion completed in 8.429454096s

• [SLOW TEST:205.616 seconds]
[sig-storage] vcp-performance
/root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/framework.go:22
  vcp performance tests
  /root/shahzeb/k8s/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/storage/vsphere_volume_perf.go:118
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSOct 12 16:51:49.263: INFO: Running AfterSuite actions on all node
Oct 12 16:51:49.263: INFO: Running AfterSuite actions on node 1

Ran 1 of 706 Specs in 205.833 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 705 Skipped PASS

Ginkgo ran 1 suite in 3m26.629212734s
```
**Release note**:
```
None
```
