### PR TITLE
Enforce use of fixed size int types in the API

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -144,7 +144,7 @@ func AddFlags(options *Options, fs *pflag.FlagSet) {
 	fs.StringVar(&options.config.ClusterCIDR, "cluster-cidr", options.config.ClusterCIDR, "The CIDR range of pods in the cluster. When configured, traffic sent to a Service cluster IP from outside this range will be masqueraded and traffic sent from pods to an external LoadBalancer IP will be directed to the respective cluster IP instead")
 	fs.StringVar(&options.config.ClientConnection.ContentType, "kube-api-content-type", options.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
 	fs.Float32Var(&options.config.ClientConnection.QPS, "kube-api-qps", options.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&options.config.ClientConnection.Burst, "kube-api-burst", options.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
+	fs.Int32Var(&options.config.ClientConnection.Burst, "kube-api-burst", options.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
 	fs.DurationVar(&options.config.UDPIdleTimeout.Duration, "udp-timeout", options.config.UDPIdleTimeout.Duration, "How long an idle UDP connection will be kept open (e.g. '250ms', '2s').  Must be greater than 0. Only applicable for proxy-mode=userspace")
 	if options.config.Conntrack.Max == nil {
 		options.config.Conntrack.Max = utilpointer.Int32Ptr(0)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -33,7 +33,7 @@ type ClientConnectionConfiguration struct {
 	// cps controls the number of queries per second allowed for this connection.
 	QPS float32
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
-	Burst int
+	Burst int32
 }
 
 // SchedulerPolicyConfigMapKey defines the key of the element in the
@@ -87,7 +87,7 @@ type KubeSchedulerConfiguration struct {
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
-	HardPodAffinitySymmetricWeight int
+	HardPodAffinitySymmetricWeight int32
 
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection KubeSchedulerLeaderElectionConfiguration

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -33,7 +33,7 @@ type ClientConnectionConfiguration struct {
 	// cps controls the number of queries per second allowed for this connection.
 	QPS float32 `json:"qps"`
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
-	Burst int `json:"burst"`
+	Burst int32 `json:"burst"`
 }
 
 // SchedulerPolicySource configures a means to obtain a scheduler Policy. One
@@ -83,7 +83,7 @@ type KubeSchedulerConfiguration struct {
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
-	HardPodAffinitySymmetricWeight int `json:"hardPodAffinitySymmetricWeight"`
+	HardPodAffinitySymmetricWeight int32 `json:"hardPodAffinitySymmetricWeight"`
 
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection KubeSchedulerLeaderElectionConfiguration `json:"leaderElection"`

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4354,5 +4354,5 @@ const (
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// When the --hard-pod-affinity-weight scheduler flag is not specified,
 	// DefaultHardPodAffinityWeight defines the weight of the implicit PreferredDuringScheduling affinity rule.
-	DefaultHardPodAffinitySymmetricWeight int = 1
+	DefaultHardPodAffinitySymmetricWeight int32 = 1
 )

--- a/pkg/apis/extensions/types.go
+++ b/pkg/apis/extensions/types.go
@@ -879,9 +879,9 @@ type AllowedHostPath struct {
 // for pods to use.  It requires both the start and end to be defined.
 type HostPortRange struct {
 	// Min is the start of the range, inclusive.
-	Min int
+	Min int32
 	// Max is the end of the range, inclusive.
-	Max int
+	Max int32
 }
 
 // AllowAllCapabilities can be used as a value for the PodSecurityPolicy.AllowAllCapabilities

--- a/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -761,8 +761,8 @@ func Convert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_v1beta1_HostPortRange_To_extensions_HostPortRange(in *v1beta1.HostPortRange, out *extensions.HostPortRange, s conversion.Scope) error {
-	out.Min = int(in.Min)
-	out.Max = int(in.Max)
+	out.Min = in.Min
+	out.Max = in.Max
 	return nil
 }
 
@@ -772,8 +772,8 @@ func Convert_v1beta1_HostPortRange_To_extensions_HostPortRange(in *v1beta1.HostP
 }
 
 func autoConvert_extensions_HostPortRange_To_v1beta1_HostPortRange(in *extensions.HostPortRange, out *v1beta1.HostPortRange, s conversion.Scope) error {
-	out.Min = int32(in.Min)
-	out.Max = int32(in.Max)
+	out.Min = in.Min
+	out.Max = in.Max
 	return nil
 }
 
@@ -1051,17 +1051,7 @@ func autoConvert_v1beta1_PodSecurityPolicySpec_To_extensions_PodSecurityPolicySp
 	out.AllowedCapabilities = *(*[]core.Capability)(unsafe.Pointer(&in.AllowedCapabilities))
 	out.Volumes = *(*[]extensions.FSType)(unsafe.Pointer(&in.Volumes))
 	out.HostNetwork = in.HostNetwork
-	if in.HostPorts != nil {
-		in, out := &in.HostPorts, &out.HostPorts
-		*out = make([]extensions.HostPortRange, len(*in))
-		for i := range *in {
-			if err := Convert_v1beta1_HostPortRange_To_extensions_HostPortRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.HostPorts = nil
-	}
+	out.HostPorts = *(*[]extensions.HostPortRange)(unsafe.Pointer(&in.HostPorts))
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
 	if err := Convert_v1beta1_SELinuxStrategyOptions_To_extensions_SELinuxStrategyOptions(&in.SELinux, &out.SELinux, s); err != nil {
@@ -1097,17 +1087,7 @@ func autoConvert_extensions_PodSecurityPolicySpec_To_v1beta1_PodSecurityPolicySp
 	out.AllowedCapabilities = *(*[]v1.Capability)(unsafe.Pointer(&in.AllowedCapabilities))
 	out.Volumes = *(*[]v1beta1.FSType)(unsafe.Pointer(&in.Volumes))
 	out.HostNetwork = in.HostNetwork
-	if in.HostPorts != nil {
-		in, out := &in.HostPorts, &out.HostPorts
-		*out = make([]v1beta1.HostPortRange, len(*in))
-		for i := range *in {
-			if err := Convert_extensions_HostPortRange_To_v1beta1_HostPortRange(&(*in)[i], &(*out)[i], s); err != nil {
-				return err
-			}
-		}
-	} else {
-		out.HostPorts = nil
-	}
+	out.HostPorts = *(*[]v1beta1.HostPortRange)(unsafe.Pointer(&in.HostPorts))
 	out.HostPID = in.HostPID
 	out.HostIPC = in.HostIPC
 	if err := Convert_extensions_SELinuxStrategyOptions_To_v1beta1_SELinuxStrategyOptions(&in.SELinux, &out.SELinux, s); err != nil {

--- a/pkg/master/import_known_versions_test.go
+++ b/pkg/master/import_known_versions_test.go
@@ -99,7 +99,7 @@ func ensureNoTags(t *testing.T, gvk schema.GroupVersionKind, tp reflect.Type, pa
 	case reflect.Map, reflect.Slice, reflect.Ptr:
 		ensureNoTags(t, gvk, tp.Elem(), parents)
 
-	case reflect.String, reflect.Bool, reflect.Float32, reflect.Int, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uintptr, reflect.Uint32, reflect.Uint64, reflect.Interface:
+	case reflect.String, reflect.Bool, reflect.Float32, reflect.Int32, reflect.Int64, reflect.Uint8, reflect.Uintptr, reflect.Uint32, reflect.Uint64, reflect.Interface:
 		// no-op
 
 	case reflect.Struct:

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -37,7 +37,7 @@ type ClientConnectionConfiguration struct {
 	// qps controls the number of queries per second allowed for this connection.
 	QPS float32
 	// burst allows extra queries to accumulate when a client is exceeding its rate.
-	Burst int
+	Burst int32
 }
 
 // KubeProxyIPTablesConfiguration contains iptables-related configuration

--- a/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/kubeproxyconfig/v1alpha1/zz_generated.conversion.go
@@ -54,7 +54,7 @@ func autoConvert_v1alpha1_ClientConnectionConfiguration_To_kubeproxyconfig_Clien
 	out.AcceptContentTypes = in.AcceptContentTypes
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
-	out.Burst = in.Burst
+	out.Burst = int32(in.Burst)
 	return nil
 }
 
@@ -68,7 +68,7 @@ func autoConvert_kubeproxyconfig_ClientConnectionConfiguration_To_v1alpha1_Clien
 	out.AcceptContentTypes = in.AcceptContentTypes
 	out.ContentType = in.ContentType
 	out.QPS = in.QPS
-	out.Burst = in.Burst
+	out.Burst = int(in.Burst)
 	return nil
 }
 

--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -307,7 +307,7 @@ func (s *simpleProvider) ValidateContainerSecurityContext(pod *api.Pod, containe
 func (s *simpleProvider) hasInvalidHostPort(container *api.Container, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	for _, cp := range container.Ports {
-		if cp.HostPort > 0 && !s.isValidHostPort(int(cp.HostPort)) {
+		if cp.HostPort > 0 && !s.isValidHostPort(cp.HostPort) {
 			detail := fmt.Sprintf("Host port %d is not allowed to be used. Allowed ports: [%s]", cp.HostPort, hostPortRangesToString(s.psp.Spec.HostPorts))
 			allErrs = append(allErrs, field.Invalid(fldPath.Child("hostPort"), cp.HostPort, detail))
 		}
@@ -316,7 +316,7 @@ func (s *simpleProvider) hasInvalidHostPort(container *api.Container, fldPath *f
 }
 
 // isValidHostPort returns true if the port falls in any range allowed by the PSP.
-func (s *simpleProvider) isValidHostPort(port int) bool {
+func (s *simpleProvider) isValidHostPort(port int32) bool {
 	for _, hostPortRange := range s.psp.Spec.HostPorts {
 		if port >= hostPortRange.Min && port <= hostPortRange.Max {
 			return true

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -122,11 +122,11 @@ func AddFlags(options *Options, fs *pflag.FlagSet) {
 	fs.StringVar(&options.config.ClientConnection.KubeConfigFile, "kubeconfig", options.config.ClientConnection.KubeConfigFile, "Path to kubeconfig file with authorization and master location information.")
 	fs.StringVar(&options.config.ClientConnection.ContentType, "kube-api-content-type", options.config.ClientConnection.ContentType, "Content type of requests sent to apiserver.")
 	fs.Float32Var(&options.config.ClientConnection.QPS, "kube-api-qps", options.config.ClientConnection.QPS, "QPS to use while talking with kubernetes apiserver")
-	fs.IntVar(&options.config.ClientConnection.Burst, "kube-api-burst", options.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
+	fs.Int32Var(&options.config.ClientConnection.Burst, "kube-api-burst", options.config.ClientConnection.Burst, "Burst to use while talking with kubernetes apiserver")
 	fs.StringVar(&options.config.SchedulerName, "scheduler-name", options.config.SchedulerName, "Name of the scheduler, used to select which pods will be processed by this scheduler, based on pod's \"spec.SchedulerName\".")
 	fs.StringVar(&options.config.LeaderElection.LockObjectNamespace, "lock-object-namespace", options.config.LeaderElection.LockObjectNamespace, "Define the namespace of the lock object.")
 	fs.StringVar(&options.config.LeaderElection.LockObjectName, "lock-object-name", options.config.LeaderElection.LockObjectName, "Define the name of the lock object.")
-	fs.IntVar(&options.config.HardPodAffinitySymmetricWeight, "hard-pod-affinity-symmetric-weight", options.config.HardPodAffinitySymmetricWeight,
+	fs.Int32Var(&options.config.HardPodAffinitySymmetricWeight, "hard-pod-affinity-symmetric-weight", options.config.HardPodAffinitySymmetricWeight,
 		"RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule corresponding "+
 			"to every RequiredDuringScheduling affinity rule. --hard-pod-affinity-symmetric-weight represents the weight of implicit PreferredDuringScheduling affinity rule.")
 	fs.MarkDeprecated("hard-pod-affinity-symmetric-weight", "This option was moved to the policy configuration file")
@@ -358,7 +358,7 @@ type SchedulerServer struct {
 	InformerFactory                informers.SharedInformerFactory
 	PodInformer                    coreinformers.PodInformer
 	AlgorithmSource                componentconfig.SchedulerAlgorithmSource
-	HardPodAffinitySymmetricWeight int
+	HardPodAffinitySymmetricWeight int32
 	EventClient                    v1core.EventsGetter
 	Recorder                       record.EventRecorder
 	Broadcaster                    record.EventBroadcaster

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -37,14 +37,14 @@ type InterPodAffinity struct {
 	info                  predicates.NodeInfo
 	nodeLister            algorithm.NodeLister
 	podLister             algorithm.PodLister
-	hardPodAffinityWeight int
+	hardPodAffinityWeight int32
 }
 
 func NewInterPodAffinityPriority(
 	info predicates.NodeInfo,
 	nodeLister algorithm.NodeLister,
 	podLister algorithm.PodLister,
-	hardPodAffinityWeight int) algorithm.PriorityFunction {
+	hardPodAffinityWeight int32) algorithm.PriorityFunction {
 	interPodAffinity := &InterPodAffinity{
 		info:                  info,
 		nodeLister:            nodeLister,

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -561,7 +561,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 		pod                   *v1.Pod
 		pods                  []*v1.Pod
 		nodes                 []*v1.Node
-		hardPodAffinityWeight int
+		hardPodAffinityWeight int32
 		expectedList          schedulerapi.HostPriorityList
 		test                  string
 	}{

--- a/plugin/pkg/scheduler/api/types.go
+++ b/plugin/pkg/scheduler/api/types.go
@@ -46,7 +46,7 @@ type Policy struct {
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
-	HardPodAffinitySymmetricWeight int
+	HardPodAffinitySymmetricWeight int32
 }
 
 type PredicatePolicy struct {

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -113,7 +113,7 @@ type configFactory struct {
 	// RequiredDuringScheduling affinity is not symmetric, but there is an implicit PreferredDuringScheduling affinity rule
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
-	hardPodAffinitySymmetricWeight int
+	hardPodAffinitySymmetricWeight int32
 
 	// Equivalence class cache
 	equivalencePodCache *core.EquivalenceCache
@@ -136,7 +136,7 @@ func NewConfigFactory(
 	statefulSetInformer appsinformers.StatefulSetInformer,
 	serviceInformer coreinformers.ServiceInformer,
 	pdbInformer policyinformers.PodDisruptionBudgetInformer,
-	hardPodAffinitySymmetricWeight int,
+	hardPodAffinitySymmetricWeight int32,
 	enableEquivalenceClassCache bool,
 ) scheduler.Configurator {
 	stopEverything := make(chan struct{})
@@ -434,7 +434,7 @@ func (c *configFactory) GetNodeLister() corelisters.NodeLister {
 	return c.nodeLister
 }
 
-func (c *configFactory) GetHardPodAffinitySymmetricWeight() int {
+func (c *configFactory) GetHardPodAffinitySymmetricWeight() int32 {
 	return c.hardPodAffinitySymmetricWeight
 }
 

--- a/plugin/pkg/scheduler/factory/factory_test.go
+++ b/plugin/pkg/scheduler/factory/factory_test.go
@@ -408,7 +408,7 @@ func TestInvalidFactoryArgs(t *testing.T) {
 	client := clientset.NewForConfigOrDie(&restclient.Config{Host: server.URL, ContentConfig: restclient.ContentConfig{GroupVersion: &legacyscheme.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
 
 	testCases := []struct {
-		hardPodAffinitySymmetricWeight int
+		hardPodAffinitySymmetricWeight int32
 		expectErr                      string
 	}{
 		{

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -43,7 +43,7 @@ type PluginFactoryArgs struct {
 	NodeInfo                       predicates.NodeInfo
 	PVInfo                         predicates.PersistentVolumeInfo
 	PVCInfo                        predicates.PersistentVolumeClaimInfo
-	HardPodAffinitySymmetricWeight int
+	HardPodAffinitySymmetricWeight int32
 }
 
 // MetadataProducerFactory produces MetadataProducer from the given args.

--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -77,7 +77,7 @@ type Configurator interface {
 	GetPriorityMetadataProducer() (algorithm.MetadataProducer, error)
 	GetPredicateMetadataProducer() (algorithm.PredicateMetadataProducer, error)
 	GetPredicates(predicateKeys sets.String) (map[string]algorithm.FitPredicate, error)
-	GetHardPodAffinitySymmetricWeight() int
+	GetHardPodAffinitySymmetricWeight() int32
 	GetSchedulerName() string
 	MakeDefaultErrorFunc(backoff *util.PodBackoff, podQueue core.SchedulingQueue) func(pod *v1.Pod, err error)
 

--- a/plugin/pkg/scheduler/testutil.go
+++ b/plugin/pkg/scheduler/testutil.go
@@ -55,7 +55,7 @@ func (fc *FakeConfigurator) GetPredicates(predicateKeys sets.String) (map[string
 }
 
 // GetHardPodAffinitySymmetricWeight is not implemented yet.
-func (fc *FakeConfigurator) GetHardPodAffinitySymmetricWeight() int {
+func (fc *FakeConfigurator) GetHardPodAffinitySymmetricWeight() int32 {
 	panic("not implemented")
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4924,7 +4924,7 @@ const (
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// When the --hard-pod-affinity-weight scheduler flag is not specified,
 	// DefaultHardPodAffinityWeight defines the weight of the implicit PreferredDuringScheduling affinity rule.
-	DefaultHardPodAffinitySymmetricWeight int = 1
+	DefaultHardPodAffinitySymmetricWeight int32 = 1
 )
 
 // Sysctl defines a kernel parameter to be set


### PR DESCRIPTION
Changes 'int' to 'int32', enforced by import_known_versions_test

Follow up to PR #53402

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This PR changes a few fields within the API from 'int' to 'int32' and is now enforced by import_known_versions_test.  We need this so integer fields are the same size regardless of $GOARCH.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
