### PR TITLE
remove status option when do nova list

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -347,7 +347,6 @@ func foreachServer(client *gophercloud.ServiceClient, opts servers.ListOptsBuild
 func getServerByName(client *gophercloud.ServiceClient, name types.NodeName) (*servers.Server, error) {
 	opts := servers.ListOpts{
 		Name:   fmt.Sprintf("^%s$", regexp.QuoteMeta(mapNodeNameToServerName(name))),
-		Status: "ACTIVE",
 	}
 	pager := servers.List(client, opts)
 


### PR DESCRIPTION
We use openstack as a cloud provider.
The node maybe at `SHUTOFF` or `ERROR` status when the hypervisor down or node has issues. Then the node controller will delete this node from k8s because its status is not `ACTIVE` in the cloud.
But the volume may still attached to the node, and k8s attach_detach_controller will not detach these volumes because of the node had been deleted.

We are using k8s1.6. 

@anguslees  @dims  @gnufied @jingxu97  
