### PR TITLE
Fix bug of unit test in printers

### DIFF
--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1475,14 +1475,19 @@ func TestPrintHumanReadableWithNamespace(t *testing.T) {
 				t.Errorf("%d: Expect printing object to contain namespace: %#v", i, test.obj)
 			}
 		} else {
-			// Expect error when trying to get all namespaces for un-namespaced object.
+			// Expect output not to include namespace when requested.
 			printer := printers.NewHumanReadablePrinter(nil, nil, printers.PrintOptions{
-				WithNamespace: true,
+				WithNamespace: false,
 			})
+			AddHandlers(printer)
 			buffer := &bytes.Buffer{}
 			err := printer.PrintObj(test.obj, buffer)
-			if err == nil {
-				t.Errorf("Expected error when printing un-namespaced type")
+			if err != nil {
+				t.Fatalf("An error occurred printing object: %#v", err)
+			}
+			matched := contains(strings.Fields(buffer.String()), fmt.Sprintf("%s", namespaceName))
+			if matched {
+				t.Errorf("%d: Unexpect printing object to contain namespace: %#v", i, test.obj)
 			}
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Test case _TestPrintHumanReadableWithNamespace_ of printers meant to test the rejection of nonnamespacesd resources from printer with param _WithNamespace_, i.e logic as below:
```
func printNamespace(obj *api.Namespace, options printers.PrintOptions) ([]metav1alpha1.TableRow, error) {
	if options.WithNamespace {
		return nil, fmt.Errorf("namespace is not namespaced")
	}
	row := metav1alpha1.TableRow{
		Object: runtime.RawExtension{Object: obj},
	}
	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, translateTimestamp(obj.CreationTimestamp))
	return []metav1alpha1.TableRow{row}, nil
```

but due to a lack of statement `AddHandlers(printer)`  in test case, it would always succeed, even though corresponding logic has been removed

Besides, as the rejection logic no longer exists, the test case should be changed to test the relationship between param _WithNamespace_ in printers and output format


**Special notes for your reviewer**:
/cc @zjj2wry 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
