### PR TITLE
fed: Move cluster generator & constants from kubectl to kubefed pkg

### DIFF
--- a/federation/pkg/kubefed/BUILD
+++ b/federation/pkg/kubefed/BUILD
@@ -9,6 +9,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "cluster.go",
         "join.go",
         "kubefed.go",
         "unjoin.go",
@@ -31,6 +32,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -46,6 +48,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cluster_test.go",
         "join_test.go",
         "unjoin_test.go",
     ],
@@ -58,7 +61,6 @@ go_test(
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/apis/rbac/v1:go_default_library",
-        "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/federation/pkg/kubefed/cluster.go
+++ b/federation/pkg/kubefed/cluster.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package kubefed
 
 import (
 	"fmt"
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	federationapi "k8s.io/kubernetes/federation/apis/federation/v1beta1"
+	"k8s.io/kubernetes/pkg/kubectl"
 )
 
 const (
@@ -57,15 +58,15 @@ type ClusterGeneratorV1Beta1 struct {
 
 // Ensure it supports the generator pattern that uses parameter
 // injection.
-var _ Generator = &ClusterGeneratorV1Beta1{}
+var _ kubectl.Generator = &ClusterGeneratorV1Beta1{}
 
 // Ensure it supports the generator pattern that uses parameters
 // specified during construction.
-var _ StructuredGenerator = &ClusterGeneratorV1Beta1{}
+var _ kubectl.StructuredGenerator = &ClusterGeneratorV1Beta1{}
 
 // Generate returns a cluster resource using the specified parameters.
 func (s ClusterGeneratorV1Beta1) Generate(genericParams map[string]interface{}) (runtime.Object, error) {
-	err := ValidateParams(s.ParamNames(), genericParams)
+	err := kubectl.ValidateParams(s.ParamNames(), genericParams)
 	if err != nil {
 		return nil, err
 	}
@@ -89,14 +90,32 @@ func (s ClusterGeneratorV1Beta1) Generate(genericParams map[string]interface{}) 
 
 // ParamNames returns the set of supported input parameters when using
 // the parameter injection generator pattern.
-func (s ClusterGeneratorV1Beta1) ParamNames() []GeneratorParam {
-	return []GeneratorParam{
-		{"name", true},
-		{"client-cidr", false},
-		{"server-address", true},
-		{"secret", false},
-		{"service-account-name", false},
-		{"cluster-role-name", false},
+func (s ClusterGeneratorV1Beta1) ParamNames() []kubectl.GeneratorParam {
+	return []kubectl.GeneratorParam{
+		{
+			Name:     "name",
+			Required: true,
+		},
+		{
+			Name:     "client-cidr",
+			Required: false,
+		},
+		{
+			Name:     "server-address",
+			Required: true,
+		},
+		{
+			Name:     "secret",
+			Required: false,
+		},
+		{
+			Name:     "service-account-name",
+			Required: false,
+		},
+		{
+			Name:     "cluster-role-name",
+			Required: false,
+		},
 	}
 }
 

--- a/federation/pkg/kubefed/cluster_test.go
+++ b/federation/pkg/kubefed/cluster_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package kubectl
+package kubefed
 
 import (
 	"reflect"

--- a/federation/pkg/kubefed/join.go
+++ b/federation/pkg/kubefed/join.go
@@ -427,7 +427,7 @@ func clusterGenerator(clientConfig *clientcmdapi.Config, name, contextName, secr
 		serverAddress = strings.Join([]string{scheme, serverAddress}, "://")
 	}
 
-	generator := &kubectl.ClusterGeneratorV1Beta1{
+	generator := &ClusterGeneratorV1Beta1{
 		Name:               name,
 		ClientCIDR:         defaultClientCIDR,
 		ServerAddress:      serverAddress,

--- a/federation/pkg/kubefed/join_test.go
+++ b/federation/pkg/kubefed/join_test.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	k8srbacv1 "k8s.io/kubernetes/pkg/apis/rbac/v1"
-	"k8s.io/kubernetes/pkg/kubectl"
 	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
@@ -595,8 +594,8 @@ func fakeCluster(clusterName, secretName, server string, isRBACAPIAvailable bool
 	if isRBACAPIAvailable {
 		saName := serviceAccountName(clusterName)
 		annotations := map[string]string{
-			kubectl.ServiceAccountNameAnnotation: saName,
-			kubectl.ClusterRoleNameAnnotation:    util.ClusterRoleName(testFederationName, saName),
+			ServiceAccountNameAnnotation: saName,
+			ClusterRoleNameAnnotation:    util.ClusterRoleName(testFederationName, saName),
 		}
 		cluster.ObjectMeta.SetAnnotations(annotations)
 	}

--- a/federation/pkg/kubefed/unjoin.go
+++ b/federation/pkg/kubefed/unjoin.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/kubernetes/federation/pkg/kubefed/util"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
-	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
@@ -304,7 +303,7 @@ func removeConfigMapString(str string, toRemove string) string {
 // deleteServiceAccountFromCluster removes the service account that the federation control plane uses
 // to access the cluster from the cluster that is leaving the federation.
 func deleteServiceAccountFromCluster(unjoiningClusterClientset internalclientset.Interface, cluster *federationapi.Cluster, fedSystemNamespace string) error {
-	serviceAccountName, ok := cluster.ObjectMeta.Annotations[kubectl.ServiceAccountNameAnnotation]
+	serviceAccountName, ok := cluster.ObjectMeta.Annotations[ServiceAccountNameAnnotation]
 	if !ok {
 		// If there is no service account name annotation, assume that this cluster does not have a federation control plane service account.
 		return nil
@@ -315,7 +314,7 @@ func deleteServiceAccountFromCluster(unjoiningClusterClientset internalclientset
 // deleteClusterRoleBindingFromCluster deletes the ClusterRole and ClusterRoleBinding from the
 // cluster that is leaving the federation.
 func deleteClusterRoleBindingFromCluster(unjoiningClusterClientset internalclientset.Interface, cluster *federationapi.Cluster) error {
-	clusterRoleName, ok := cluster.ObjectMeta.Annotations[kubectl.ClusterRoleNameAnnotation]
+	clusterRoleName, ok := cluster.ObjectMeta.Annotations[ClusterRoleNameAnnotation]
 	if !ok {
 		// If there is no cluster role name annotation, assume that this cluster does not have cluster role bindings.
 		return nil

--- a/pkg/kubectl/BUILD
+++ b/pkg/kubectl/BUILD
@@ -10,7 +10,6 @@ go_test(
     name = "go_default_test",
     srcs = [
         "autoscale_test.go",
-        "cluster_test.go",
         "clusterrolebinding_test.go",
         "configmap_test.go",
         "delete_test.go",
@@ -35,7 +34,6 @@ go_test(
     ],
     library = ":go_default_library",
     deps = [
-        "//federation/apis/federation/v1beta1:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/api/testing:go_default_library",
@@ -83,7 +81,6 @@ go_library(
         "apply.go",
         "autoscale.go",
         "bash_comp_utils.go",
-        "cluster.go",
         "clusterrolebinding.go",
         "configmap.go",
         "delete.go",
@@ -114,7 +111,6 @@ go_library(
         "versioned_client.go",
     ],
     deps = [
-        "//federation/apis/federation/v1beta1:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/api/v1:go_default_library",
         "//pkg/api/v1/pod:go_default_library",


### PR DESCRIPTION
This will ensure the history of the federation-only files can be cheaply retained during the branch filtering that will occur for #52992.

cc: @kubernetes/sig-multicluster-pr-reviews

/sig multicluster
/area federation
/assign irfanurrehman shashidharatd
/release-note-none