### PR TITLE
Remove duplicated container-runtime and container-runtime-endpoint.

### DIFF
--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -135,8 +135,9 @@ if [ $remote = true ] ; then
     --hosts="$hosts" --images="$images" --cleanup="$cleanup" \
     --results-dir="$artifacts" --ginkgo-flags="$ginkgoflags" \
     --image-project="$image_project" --instance-name-prefix="$instance_prefix" \
-    --delete-instances="$delete_instances" --test_args="$test_args" --instance-metadata="$metadata" \
-    --image-config-file="$image_config_file" --system-spec-name="$system_spec_name" \
+    --delete-instances="$delete_instances" \
+    --test_args="$test_args --container-runtime=${runtime} --container-runtime-endpoint=${container_runtime_endpoint} --image-service-endpoint=${image_service_endpoint}" \
+    --instance-metadata="$metadata" --image-config-file="$image_config_file" --system-spec-name="$system_spec_name" \
     2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 
@@ -150,17 +151,6 @@ else
   # Do not use any network plugin by default. User could override the flags with
   # test_args.
   test_args='--kubelet-flags="--network-plugin= --cni-bin-dir=" '$test_args
-
-  # Runtime flags
-  test_args='--kubelet-flags="--container-runtime='$runtime'" '$test_args
-  if [[ $runtime == "remote" ]] ; then
-      if [[ ! -z $container_runtime_endpoint ]] ; then
-	      test_args='--kubelet-flags="--container-runtime-endpoint='$container_runtime_endpoint'" '$test_args
-      fi
-      if [[ ! -z $image_service_endpoint ]] ; then
-	      test_args='--kubelet-flags="--image-service-endpoint='$image_service_endpoint'" '$test_args
-      fi
-  fi
 
   # Test using the host the script was run on
   # Provided for backwards compatibility

--- a/test/e2e_node/services/kubelet.go
+++ b/test/e2e_node/services/kubelet.go
@@ -203,6 +203,18 @@ func (e *E2EServices) startKubelet() (*server, error) {
 		cmdArgs = append(cmdArgs, "--hostname-override", framework.TestContext.NodeName)
 	}
 
+	if framework.TestContext.ContainerRuntime != "" {
+		cmdArgs = append(cmdArgs, "--container-runtime", framework.TestContext.ContainerRuntime)
+	}
+
+	if framework.TestContext.ContainerRuntimeEndpoint != "" {
+		cmdArgs = append(cmdArgs, "--container-runtime-endpoint", framework.TestContext.ContainerRuntimeEndpoint)
+	}
+
+	if framework.TestContext.ImageServiceEndpoint != "" {
+		cmdArgs = append(cmdArgs, "--image-service-endpoint", framework.TestContext.ImageServiceEndpoint)
+	}
+
 	// Override the default kubelet flags.
 	cmdArgs = append(cmdArgs, kubeletArgs...)
 


### PR DESCRIPTION
Specify kubelet flags, If `container-runtime` and `container-runtime-endpoint` in test is specified.

With this, we don't need to specify the flag twice.

```release-note
NONE
```
