### PR TITLE
Remove duplicated Hairpin constant definition

### DIFF
--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -213,24 +213,6 @@ type KubeSchedulerConfiguration struct {
 	UseLegacyPolicyConfig bool `json:"useLegacyPolicyConfig"`
 }
 
-// HairpinMode denotes how the kubelet should configure networking to handle
-// hairpin packets.
-type HairpinMode string
-
-// Enum settings for different ways to handle hairpin packets.
-const (
-	// Set the hairpin flag on the veth of containers in the respective
-	// container runtime.
-	HairpinVeth = "hairpin-veth"
-	// Make the container bridge promiscuous. This will force it to accept
-	// hairpin packets, even if the flag isn't set on ports of the bridge.
-	PromiscuousBridge = "promiscuous-bridge"
-	// Neither of the above. If the kubelet is started in this hairpin mode
-	// and kube-proxy is running in iptables mode, hairpin packets will be
-	// dropped by the container bridge.
-	HairpinNone = "none"
-)
-
 // LeaderElectionConfiguration defines the configuration of leader election
 // clients for components that can run with leader election enabled.
 type LeaderElectionConfiguration struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Clean up the hairpin definition in conponent config since it has been remove to [kubelet config](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/apis/kubeletconfig/types.go#L36)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
no issue, just clean up the code

**Special notes for your reviewer**:
none

**Release note**:
none
