### PR TITLE
Automated cherry pick of #53642

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -24,6 +24,7 @@ RUN echo CACHEBUST>/dev/null && clean-install \
     e2fsprogs \
     ebtables \
     ethtool \
+    kmod \
     ca-certificates \
     conntrack \
     util-linux \

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=gcr.io/google-containers
 IMAGE?=debian-hyperkube-base
-TAG=0.3
+TAG=0.4
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -63,14 +63,6 @@ docker_pull(
 )
 
 docker_pull(
-    name = "debian-hyperkube-base-amd64",
-    digest = "sha256:f3a37c4d8700a5ff454d94a2bef7d165d287759cea737a621c20e4aa3891dbbb",
-    registry = "gcr.io",
-    repository = "google-containers/debian-hyperkube-base-amd64",
-    tag = "0.4",  # ignored, but kept here for documentation
-)
-
-docker_pull(
     name = "official_busybox",
     digest = "sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642",
     registry = "index.docker.io",

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -63,6 +63,14 @@ docker_pull(
 )
 
 docker_pull(
+    name = "debian-hyperkube-base-amd64",
+    digest = "sha256:f3a37c4d8700a5ff454d94a2bef7d165d287759cea737a621c20e4aa3891dbbb",
+    registry = "gcr.io",
+    repository = "google-containers/debian-hyperkube-base-amd64",
+    tag = "0.4",  # ignored, but kept here for documentation
+)
+
+docker_pull(
     name = "official_busybox",
     digest = "sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642",
     registry = "index.docker.io",

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.3
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.4
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
Cherry pick of #53642 on release-1.8.

#53642: Ensure base image includes the modprobe binary

```release-note
Adds modprobe back into the hyperkube image. 
```