### PR TITLE
use --ports to replace --tcp and --node-port for nodeport service

### DIFF
--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -124,7 +124,7 @@ var (
 // NewCmdCreateServiceNodePort is a macro command for creating a NodePort service
 func NewCmdCreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "nodeport NAME [--tcp=port:targetPort] [--dry-run]",
+		Use:     "nodeport NAME [--ports=port:targetPort[:nodePort]] [--dry-run]",
 		Short:   i18n.T("Create a NodePort service."),
 		Long:    serviceNodePortLong,
 		Example: serviceNodePortExample,
@@ -138,8 +138,10 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer) *cobra.Com
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ServiceNodePortGeneratorV1Name)
 	cmd.Flags().Int("node-port", 0, "Port used to expose the service on each node in a cluster.")
-	cmd.Flags().MarkDeprecated("node-port", "This flag will be removed in a later release")
-	addPortFlags(cmd)
+	cmd.Flags().MarkDeprecated("node-port", "This flag will be removed in a later release, please use --ports instead")
+	cmd.Flags().StringSlice("tcp", []string{}, "Port pairs can be specified as '<port>:<targetPort>'.")
+	cmd.Flags().MarkDeprecated("node-port", "This flag will be removed in a later release, please use --ports instead")
+	cmd.Flags().StringSlice("ports", []string{}, "Port pairs can be specified as '<port>:<targetPort>[:nodePort]'.")
 
 	return cmd
 }
@@ -155,7 +157,7 @@ func CreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comma
 	case cmdutil.ServiceNodePortGeneratorV1Name:
 		generator = &kubectl.ServiceCommonGeneratorV1{
 			Name:      name,
-			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
+			TCP:       cmdutil.GetFlagStringSlice(cmd, "ports"),
 			Type:      v1.ServiceTypeNodePort,
 			ClusterIP: "",
 		}

--- a/pkg/kubectl/cmd/create_service.go
+++ b/pkg/kubectl/cmd/create_service.go
@@ -138,7 +138,9 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer) *cobra.Com
 	cmdutil.AddPrinterFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, cmdutil.ServiceNodePortGeneratorV1Name)
 	cmd.Flags().Int("node-port", 0, "Port used to expose the service on each node in a cluster.")
+	cmd.Flags().MarkDeprecated("node-port", "This flag will be removed in a later release")
 	addPortFlags(cmd)
+
 	return cmd
 }
 
@@ -156,7 +158,6 @@ func CreateServiceNodePort(f cmdutil.Factory, cmdOut io.Writer, cmd *cobra.Comma
 			TCP:       cmdutil.GetFlagStringSlice(cmd, "tcp"),
 			Type:      v1.ServiceTypeNodePort,
 			ClusterIP: "",
-			NodePort:  cmdutil.GetFlagInt(cmd, "node-port"),
 		}
 	default:
 		return errUnsupportedGenerator(cmd, generatorName)

--- a/pkg/kubectl/service_basic.go
+++ b/pkg/kubectl/service_basic.go
@@ -33,7 +33,6 @@ type ServiceCommonGeneratorV1 struct {
 	TCP          []string
 	Type         v1.ServiceType
 	ClusterIP    string
-	NodePort     int
 	ExternalName string
 }
 
@@ -65,7 +64,6 @@ func (ServiceNodePortGeneratorV1) ParamNames() []GeneratorParam {
 	return []GeneratorParam{
 		{"name", true},
 		{"tcp", true},
-		{"nodeport", true},
 	}
 }
 func (ServiceLoadBalancerGeneratorV1) ParamNames() []GeneratorParam {
@@ -219,7 +217,7 @@ func (s ServiceCommonGeneratorV1) StructuredGenerate() (runtime.Object, error) {
 			Port:       port,
 			TargetPort: targetPort,
 			Protocol:   v1.Protocol("TCP"),
-			NodePort:   int32(s.NodePort),
+			NodePort:   0,
 		})
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
--tcp can accept multiple port:targetport pairs. But currently, we set one nodeport value for all port pairs.
This is not correct.
Different port:targetport should have different nodeport, may be 0 for automatically assignment or specified value.
I think we should let user can set them. 


**Release note**:
```release-note
NONE
```
