### PR TITLE
add NamespaceSelector to select namespaces for Initializers

### DIFF
--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -70,6 +70,12 @@ type Initializer struct {
 	// The initializer cares about an operation if it matches _any_ Rule.
 	// Rule.Resources must not include subresources.
 	Rules []Rule
+
+	// NamespaceSelector describes what namespace the initializer cares about.
+	// This field follows standard selector semantics.
+	// If present but empty, this selector selects all namespaces.
+	// +optional
+	NamespaceSelector *metav1.LabelSelector
 }
 
 // Rule is a tuple of APIGroups, APIVersion, and Resources.It is recommended

--- a/pkg/apis/admissionregistration/validation/BUILD
+++ b/pkg/apis/admissionregistration/validation/BUILD
@@ -24,6 +24,7 @@ go_library(
     deps = [
         "//pkg/apis/admissionregistration:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",

--- a/pkg/apis/admissionregistration/validation/validation.go
+++ b/pkg/apis/admissionregistration/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	genericvalidation "k8s.io/apimachinery/pkg/api/validation"
+	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -39,6 +40,10 @@ func validateInitializer(initializer *admissionregistration.Initializer, fldPath
 	var allErrors field.ErrorList
 	// initlializer.Name must be fully qualified
 	allErrors = append(allErrors, validation.IsFullyQualifiedName(fldPath.Child("name"), initializer.Name)...)
+
+	if initializer.NamespaceSelector != nil {
+		allErrors = append(allErrors, unversionedvalidation.ValidateLabelSelector(initializer.NamespaceSelector, fldPath.Child("namespaceSelector"))...)
+	}
 
 	for i, rule := range initializer.Rules {
 		notAllowSubresources := false

--- a/pkg/apis/admissionregistration/validation/validation_test.go
+++ b/pkg/apis/admissionregistration/validation/validation_test.go
@@ -214,6 +214,31 @@ func TestValidateInitializerConfiguration(t *testing.T) {
 				}),
 			expectedError: ` "a/b": must not specify subresources`,
 		},
+		{
+			name: "valid namespaceSelector",
+			config: getInitializerConfiguration(
+				[]admissionregistration.Initializer{
+					{
+						Name: "initializer.k8s.io",
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"namespace": "d"},
+						},
+					},
+				}),
+		},
+		{
+			name: "invalid namespaceSelector",
+			config: getInitializerConfiguration(
+				[]admissionregistration.Initializer{
+					{
+						Name: "initializer.k8s.io",
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"namespace=Equals": "b"},
+						},
+					},
+				}),
+			expectedError: `initializers[0].namespaceSelector.matchLabels: Invalid value: "namespace=Equals": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`,
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1alpha1/types.go
@@ -72,6 +72,12 @@ type Initializer struct {
 	// The initializer cares about an operation if it matches _any_ Rule.
 	// Rule.Resources must not include subresources.
 	Rules []Rule `json:"rules,omitempty" protobuf:"bytes,2,rep,name=rules"`
+
+	// NamespaceSelector describes what namespace the initializer cares about.
+	// This field follows standard selector semantics.
+	// If present but empty, this selector selects all namespaces.
+	// +optional
+	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty" protobuf:"bytes,3,opt,name=namespaceSelector"`
 }
 
 // Rule is a tuple of APIGroups, APIVersion, and Resources.It is recommended

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/initialization/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/initialization/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
add `NamespaceSelector` to enforce [initializers](https://kubernetes.io/docs/admin/extensible-admission-controllers/#initializers) to specific namespaces.

* Apply initializer to ALL namespaces (by default with NamespaceSelector not setting);
* Apply initializer to selected namespaces in particular;

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #51290, fixes #53859

**Special notes for your reviewer**:
/assign @ahmetb @caesarxuchao 
/cc @gyliu513 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add NamespaceSelector to select namespaces for Initializers
```
