### PR TITLE
Automated cherry pick of #53793 upstream release 1.7 

### DIFF
--- a/plugin/cmd/kube-scheduler/app/configurator.go
+++ b/plugin/cmd/kube-scheduler/app/configurator.go
@@ -54,22 +54,22 @@ func createRecorder(kubecli *clientset.Clientset, s *options.SchedulerServer) re
 	return eventBroadcaster.NewRecorder(api.Scheme, clientv1.EventSource{Component: s.SchedulerName})
 }
 
-func createClient(s *options.SchedulerServer) (*clientset.Clientset, error) {
+func createClients(s *options.SchedulerServer) (*clientset.Clientset, *clientset.Clientset, error) {
 	kubeconfig, err := clientcmd.BuildConfigFromFlags(s.Master, s.Kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("unable to build config from flags: %v", err)
+		return nil, nil, fmt.Errorf("unable to build config from flags: %v", err)
 	}
 
 	kubeconfig.ContentType = s.ContentType
 	// Override kubeconfig qps/burst settings from flags
 	kubeconfig.QPS = s.KubeAPIQPS
 	kubeconfig.Burst = int(s.KubeAPIBurst)
-
-	cli, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "leader-election"))
+	kubeClient, err := clientset.NewForConfig(restclient.AddUserAgent(kubeconfig, "scheduler"))
 	if err != nil {
-		return nil, fmt.Errorf("invalid API configuration: %v", err)
+		glog.Fatalf("Invalid API configuration: %v", err)
 	}
-	return cli, nil
+	leaderElectionClient := clientset.NewForConfigOrDie(restclient.AddUserAgent(kubeconfig, "leader-election"))
+	return kubeClient, leaderElectionClient, nil
 }
 
 // CreateScheduler encapsulates the entire creation of a runnable scheduler.

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -65,20 +65,20 @@ through the API as necessary.`,
 
 // Run runs the specified SchedulerServer.  This should never exit.
 func Run(s *options.SchedulerServer) error {
-	kubecli, err := createClient(s)
+	kubeClient, leaderElectionClient, err := createClients(s)
 	if err != nil {
 		return fmt.Errorf("unable to create kube client: %v", err)
 	}
 
-	recorder := createRecorder(kubecli, s)
+	recorder := createRecorder(kubeClient, s)
 
-	informerFactory := informers.NewSharedInformerFactory(kubecli, 0)
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, 0)
 	// cache only non-terminal pods
-	podInformer := factory.NewPodInformer(kubecli, 0)
+	podInformer := factory.NewPodInformer(kubeClient, 0)
 
 	sched, err := CreateScheduler(
 		s,
-		kubecli,
+		kubeClient,
 		informerFactory.Core().V1().Nodes(),
 		podInformer,
 		informerFactory.Core().V1().PersistentVolumes(),
@@ -121,7 +121,7 @@ func Run(s *options.SchedulerServer) error {
 	rl, err := resourcelock.New(s.LeaderElection.ResourceLock,
 		s.LockObjectNamespace,
 		s.LockObjectName,
-		kubecli,
+		leaderElectionClient,
 		resourcelock.ResourceLockConfig{
 			Identity:      id,
 			EventRecorder: recorder,


### PR DESCRIPTION
Cherry pick of #53793 on release-1.7.

#53793: Use separate client for leader election in scheduler