### PR TITLE
kubeadm: Utilize transport defaults from API machinery for http calls inside kubeadm

### DIFF
--- a/cmd/kubeadm/app/discovery/https/BUILD
+++ b/cmd/kubeadm/app/discovery/https/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/discovery/https",
     deps = [
         "//cmd/kubeadm/app/discovery/file:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/tools/clientcmd/api:go_default_library",
     ],

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/kubernetes/cmd/kubeadm/app/discovery/file"
@@ -29,7 +30,8 @@ import (
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
 func RetrieveValidatedClusterInfo(httpsURL string) (*clientcmdapi.Cluster, error) {
-	response, err := http.Get(httpsURL)
+	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+	response, err := client.Get(httpsURL)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -332,7 +332,7 @@ func (hst HTTPProxyCheck) Check() (warnings, errors []error) {
 		return nil, []error{err}
 	}
 
-	proxy, err := http.DefaultTransport.(*http.Transport).Proxy(req)
+	proxy, err := netutil.SetOldTransportDefaults(&http.Transport{}).Proxy(req)
 	if err != nil {
 		return nil, []error{err}
 	}
@@ -670,15 +670,15 @@ func (evc ExternalEtcdVersionCheck) configCertAndKey(config *tls.Config) (*tls.C
 
 func (evc ExternalEtcdVersionCheck) getHTTPClient(config *tls.Config) *http.Client {
 	if config != nil {
-		transport := &http.Transport{
+		transport := netutil.SetOldTransportDefaults(&http.Transport{
 			TLSClientConfig: config,
-		}
+		})
 		return &http.Client{
 			Transport: transport,
 			Timeout:   externalEtcdRequestTimeout,
 		}
 	}
-	return &http.Client{Timeout: externalEtcdRequestTimeout}
+	return &http.Client{Timeout: externalEtcdRequestTimeout, Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 }
 
 func getEtcdVersionResponse(client *http.Client, url string, target interface{}) error {

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/apiclient/BUILD
+++ b/cmd/kubeadm/app/util/apiclient/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -130,7 +131,8 @@ func (w *KubeWaiter) WaitForPodToDisappear(podName string) error {
 func (w *KubeWaiter) WaitForHealthyKubelet(initalTimeout time.Duration, healthzEndpoint string) error {
 	time.Sleep(initalTimeout)
 	return TryRunCommand(func() error {
-		resp, err := http.Get(healthzEndpoint)
+		client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+		resp, err := client.Get(healthzEndpoint)
 		if err != nil {
 			fmt.Printf("[kubelet-check] It seems like the kubelet isn't running or healthy.\n")
 			fmt.Printf("[kubelet-check] The HTTP call equal to 'curl -sSL %s' failed with error: %v.\n", healthzEndpoint, err)

--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+
+	netutil "k8s.io/apimachinery/pkg/util/net"
 )
 
 var (
@@ -131,7 +133,8 @@ func splitVersion(version string) (string, string, error) {
 
 // Internal helper: return content of URL
 func fetchFromURL(url string) (string, error) {
-	resp, err := http.Get(url)
+	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
+	resp, err := client.Get(url)
 	if err != nil {
 		return "", fmt.Errorf("unable to get URL %q: %s", url, err.Error())
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Default Go HTTP transport does not allow to use CIDR notations in
NO_PROXY variables, thus for certain HTTP calls that is done inside
kubeadm user needs to put explicitly multiple IP addresses. For most of
calls done via API machinery it is get solved by setting different Proxy
resolver. This patch allows to use CIDR notations in NO_PROXY variables
for currently all other HTTP calls that is made inside kubeadm.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/kubeadm#324

**Special notes for your reviewer**:
Based on discussion in #52788, replacing this patch replacing all calls inside kubeadm that are done via DefaultTransport to explicitly defined and initialized with API machinery defaults Transport and http client.

**Release note**:
```release-note
- kubeadm now supports CIDR notations in NO_PROXY environment variable
```
