### PR TITLE
Improve generated proxy URLs for cluster-info

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -125,6 +125,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/jsonmergepatch:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/mergepatch:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",


### PR DESCRIPTION
Fixes #53927

improves the output of `kubectl cluster-info` to print more qualified URLs, including changing the proxied scheme to `https` if the service port name is `https` or port number is 443

```release-note
NONE
```