### PR TITLE
NewProxierWithNoProxyCIDR: fix handling IPv6 URLs

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http.go
@@ -276,17 +276,7 @@ func NewProxierWithNoProxyCIDR(delegate func(req *http.Request) (*url.URL, error
 	}
 
 	return func(req *http.Request) (*url.URL, error) {
-		host := req.URL.Host
-		// for some urls, the Host is already the host, not the host:port
-		if net.ParseIP(host) == nil {
-			var err error
-			host, _, err = net.SplitHostPort(req.URL.Host)
-			if err != nil {
-				return delegate(req)
-			}
-		}
-
-		ip := net.ParseIP(host)
+		ip := net.ParseIP(req.URL.Hostname())
 		if ip == nil {
 			return delegate(req)
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -172,6 +172,30 @@ func TestProxierWithNoProxyCIDR(t *testing.T) {
 			url:               "https://192.168.143.1:8443/api",
 			expectedDelegated: false,
 		},
+		{
+			name:              "IPv6 cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8::1]/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "IPv6+port cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8::1]:8443/api",
+			expectedDelegated: false,
+		},
+		{
+			name:              "IPv6, not matching cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8:1::1]/api",
+			expectedDelegated: true,
+		},
+		{
+			name:              "IPv6+port, not matching cidr",
+			noProxy:           "2001:db8::/48",
+			url:               "https://[2001:db8:1::1]:8443/api",
+			expectedDelegated: true,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
Current logic of splitting hostname from URL does not work if URL
is for IPv6 address and does not explicitly specify port number.
Example: "https://[2001:db8::1]/".

Use standard library function to get hostname out of URL string.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
**Special notes for your reviewer**:

**Release note**:
```release-note
- Fix handling of IPv6 URLs in NO_PROXY.
```

/area ipv6
/sig api-machinery