### PR TITLE
Add pod related conformance annotations

### DIFF
--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -128,6 +128,11 @@ var _ = framework.KubeDescribe("Pods", func() {
 		podClient = f.PodClient()
 	})
 
+	/*
+		    Testname: pods-created-pod-assigned-hostip
+		    Description: Make sure when a pod is created that it is assigned a host IP
+			Address.
+	*/
 	It("should get a host IP [Conformance]", func() {
 		name := "pod-hostip-" + string(uuid.NewUUID())
 		testHostIP(podClient, &v1.Pod{
@@ -145,6 +150,11 @@ var _ = framework.KubeDescribe("Pods", func() {
 		})
 	})
 
+	/*
+		    Testname: pods-submitted-removed
+		    Description: Makes sure a pod is created, a watch can be setup for the pod,
+			pod creation was observed, pod is deleted, and pod deletion is observed.
+	*/
 	It("should be submitted and removed [Conformance]", func() {
 		By("creating the pod")
 		name := "pod-submit-remove-" + string(uuid.NewUUID())
@@ -266,6 +276,10 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Expect(len(pods.Items)).To(Equal(0))
 	})
 
+	/*
+	   Testname: pods-updated-successfully
+	   Description: Make sure it is possible to successfully update a pod's labels.
+	*/
 	It("should be updated [Conformance]", func() {
 		By("creating the pod")
 		name := "pod-update-" + string(uuid.NewUUID())
@@ -315,6 +329,12 @@ var _ = framework.KubeDescribe("Pods", func() {
 		framework.Logf("Pod update OK")
 	})
 
+	/*
+		    Testname: pods-update-active-deadline-seconds
+		    Description: Make sure it is possible to create a pod, update its
+			activeDeadlineSecondsValue, and then waits for the deadline to pass
+			and verifies the pod is terminated.
+	*/
 	It("should allow activeDeadlineSeconds to be updated [Conformance]", func() {
 		By("creating the pod")
 		name := "pod-update-activedeadlineseconds-" + string(uuid.NewUUID())
@@ -356,6 +376,11 @@ var _ = framework.KubeDescribe("Pods", func() {
 		framework.ExpectNoError(f.WaitForPodTerminated(pod.Name, "DeadlineExceeded"))
 	})
 
+	/*
+		    Testname: pods-contain-services-environment-variables
+		    Description: Make sure that when a pod is created it contains environment
+			variables for each active service.
+	*/
 	It("should contain environment variables for services [Conformance]", func() {
 		// Make a pod that will be a service.
 		// This pod serves its hostname via HTTP.


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->
/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds pod related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822.  It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests. 
**Special notes for your reviewer**:
Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
