### PR TITLE
Deprecate cloud-provider options in kube-apiserver

### DIFF
--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -45,9 +45,11 @@ func (s *CloudProviderOptions) Validate() []error {
 func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.CloudProvider, "cloud-provider", s.CloudProvider,
 		"The provider for cloud services. Empty string for no provider.")
+	fs.MarkDeprecated("cloud-provider", "will be removed in a future version")
 
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile,
 		"The path to the cloud provider configuration file. Empty string for no configuration file.")
+	fs.MarkDeprecated("cloud-config", "will be removed in a future version")
 }
 
 func (s *CloudProviderOptions) DefaultExternalHost(genericoptions *genericoptions.ServerRunOptions) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

The API Server should not need to know about cloud providers. This
is even more important since we are moving to external cloud providers.

Note that we use these options are used in CreateNodeDialer and for
DefaultExternalHost methods, so we will need to figure out how to
handle those situations before we can rip the code out.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53734 

Related to #49402 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
--cloud-provider related option in Kubernetes API Server is now deprecated
```
