### PR TITLE
update .dockercfg content to config.json

### DIFF
--- a/pkg/kubectl/cmd/create_secret.go
+++ b/pkg/kubectl/cmd/create_secret.go
@@ -169,6 +169,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, cmdOut io.Writer) *cobr
 	cmd.Flags().String("docker-email", "", i18n.T("Email for Docker registry"))
 	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", i18n.T("Server location for Docker registry"))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+
 	cmdutil.AddInclude3rdPartyFlags(cmd)
 	return cmd
 }

--- a/pkg/kubectl/secret_for_docker_registry.go
+++ b/pkg/kubectl/secret_for_docker_registry.go
@@ -141,7 +141,9 @@ func handleDockercfgContent(username, password, email, server string) ([]byte, e
 		Email:    email,
 	}
 
-	dockerCfg := map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth}
+	dockerCfg := credentialprovider.DockerConfigJson{
+		Auths: map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth},
+	}
 
 	return json.Marshal(dockerCfg)
 }

--- a/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/pkg/kubectl/secret_for_docker_registry_test.go
@@ -70,7 +70,7 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expected: &api.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-gb4kftc655",
+					Name: "foo-94759gc65b",
 				},
 				Data: map[string][]byte{
 					api.DockerConfigKey: secretData,


### PR DESCRIPTION
update the data format of .dockercfg to match the new docker config.json
format, which encapsulates all registry auth objects in an overall
"auths" object when an option `--config-format` is specified with the value
`--config-format=config.json`:

```
{
    "auths": {
        "reg.url": {
            "auth": "...=="
        }
    }
}
```

**Release note**:
```release-note
secret data containing Docker registry auth objects is now generated using the config.json format
```

cc @bparees @fabianofranz 
