### PR TITLE
moves WantsServiceResolver interface to apiserver

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -454,7 +454,6 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 		s,
 		client,
 		sharedInformers,
-		serviceResolver,
 		proxyTransport,
 	)
 	if err != nil {
@@ -485,6 +484,7 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 		keyBytes,
 		kubeClientConfig,
 		api.Scheme,
+		serviceResolver,
 		pluginInitializer)
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("failed to initialize admission: %v", err)
@@ -493,7 +493,7 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 }
 
 // BuildAdmissionPluginInitializer constructs the admission plugin initializer
-func BuildAdmissionPluginInitializer(s *options.ServerRunOptions, client internalclientset.Interface, sharedInformers informers.SharedInformerFactory, serviceResolver aggregatorapiserver.ServiceResolver, proxyTransport *http.Transport) (admission.PluginInitializer, error) {
+func BuildAdmissionPluginInitializer(s *options.ServerRunOptions, client internalclientset.Interface, sharedInformers informers.SharedInformerFactory, proxyTransport *http.Transport) (admission.PluginInitializer, error) {
 	var cloudConfig []byte
 
 	if s.CloudProvider.CloudConfigFile != "" {
@@ -512,8 +512,6 @@ func BuildAdmissionPluginInitializer(s *options.ServerRunOptions, client interna
 	quotaRegistry := quotainstall.NewRegistry(nil, nil)
 
 	pluginInitializer := kubeapiserveradmission.NewPluginInitializer(client, sharedInformers, cloudConfig, restMapper, quotaRegistry)
-
-	pluginInitializer = pluginInitializer.SetServiceResolver(serviceResolver)
 	pluginInitializer = pluginInitializer.SetProxyTransport(proxyTransport)
 
 	return pluginInitializer, nil

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -219,6 +219,7 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 		nil,
 		kubeClientConfig,
 		api.Scheme,
+		nil,
 		pluginInitializer,
 	)
 	if err != nil {

--- a/pkg/kubeapiserver/admission/init_test.go
+++ b/pkg/kubeapiserver/admission/init_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package admission
 
 import (
-	"net/url"
 	"testing"
 
 	"k8s.io/apiserver/pkg/admission"
@@ -46,28 +45,5 @@ func TestCloudConfigAdmissionPlugin(t *testing.T) {
 
 	if wantsCloudConfigAdmission.cloudConfig == nil {
 		t.Errorf("Expected cloud config to be initialized but found nil")
-	}
-}
-
-type fakeServiceResolver struct{}
-
-func (f *fakeServiceResolver) ResolveEndpoint(namespace, name string) (*url.URL, error) {
-	return nil, nil
-}
-
-type serviceWanter struct {
-	doNothingAdmission
-	got ServiceResolver
-}
-
-func (s *serviceWanter) SetServiceResolver(sr ServiceResolver) { s.got = sr }
-
-func TestWantsServiceResolver(t *testing.T) {
-	sw := &serviceWanter{}
-	fsr := &fakeServiceResolver{}
-	i := &PluginInitializer{}
-	i.SetServiceResolver(fsr).Initialize(sw)
-	if got, ok := sw.got.(*fakeServiceResolver); !ok || got != fsr {
-		t.Errorf("plumbing fail - %v %v#", ok, got)
 	}
 }

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -85,7 +85,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 		whiteList: whiteList,
 	}
 
-	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil, nil)
+	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/webhook/BUILD
+++ b/plugin/pkg/admission/webhook/BUILD
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/admission/install:go_default_library",
-        "//pkg/kubeapiserver/admission:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/admission/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",

--- a/plugin/pkg/admission/webhook/admission.go
+++ b/plugin/pkg/admission/webhook/admission.go
@@ -42,7 +42,6 @@ import (
 	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	admissioninit "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 
 	// install the clientgo admission API for use with api registry
 	_ "k8s.io/kubernetes/pkg/apis/admission/install"
@@ -101,7 +100,7 @@ func NewGenericAdmissionWebhook() (*GenericAdmissionWebhook, error) {
 type GenericAdmissionWebhook struct {
 	*admission.Handler
 	hookSource           WebhookSource
-	serviceResolver      admissioninit.ServiceResolver
+	serviceResolver      genericadmissioninit.ServiceResolver
 	negotiatedSerializer runtime.NegotiatedSerializer
 	clientCert           []byte
 	clientKey            []byte
@@ -109,7 +108,7 @@ type GenericAdmissionWebhook struct {
 }
 
 var (
-	_ = admissioninit.WantsServiceResolver(&GenericAdmissionWebhook{})
+	_ = genericadmissioninit.WantsServiceResolver(&GenericAdmissionWebhook{})
 	_ = genericadmissioninit.WantsClientCert(&GenericAdmissionWebhook{})
 	_ = genericadmissioninit.WantsExternalKubeClientSet(&GenericAdmissionWebhook{})
 )
@@ -120,7 +119,7 @@ func (a *GenericAdmissionWebhook) SetProxyTransport(pt *http.Transport) {
 
 // SetServiceResolver sets a service resolver for the webhook admission plugin.
 // Passing a nil resolver does not have an effect, instead a default one will be used.
-func (a *GenericAdmissionWebhook) SetServiceResolver(sr admissioninit.ServiceResolver) {
+func (a *GenericAdmissionWebhook) SetServiceResolver(sr genericadmissioninit.ServiceResolver) {
 	if sr != nil {
 		a.serviceResolver = sr
 	}

--- a/plugin/pkg/admission/webhook/serviceresolver.go
+++ b/plugin/pkg/admission/webhook/serviceresolver.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"net/url"
 
-	admissioninit "k8s.io/kubernetes/pkg/kubeapiserver/admission"
+	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
 )
 
 type defaultServiceResolver struct{}
 
-var _ admissioninit.ServiceResolver = defaultServiceResolver{}
+var _ genericadmissioninit.ServiceResolver = defaultServiceResolver{}
 
 // ResolveEndpoint constructs a service URL from a given namespace and name
 // note that the name and namespace are required and by default all created addresses use HTTPS scheme.

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer.go
@@ -33,6 +33,7 @@ type pluginInitializer struct {
 	// serverIdentifyingClientKey private key for the client certificate used when calling out to admission plugins
 	serverIdentifyingClientKey []byte
 	scheme                     *runtime.Scheme
+	serviceResolver            ServiceResolver
 }
 
 // New creates an instance of admission plugins initializer.
@@ -44,6 +45,7 @@ func New(
 	serverIdentifyingClientCert,
 	serverIdentifyingClientKey []byte,
 	scheme *runtime.Scheme,
+	serviceResolver ServiceResolver,
 ) (pluginInitializer, error) {
 	return pluginInitializer{
 		externalClient:              extClientset,
@@ -51,7 +53,8 @@ func New(
 		authorizer:                  authz,
 		serverIdentifyingClientCert: serverIdentifyingClientCert,
 		serverIdentifyingClientKey:  serverIdentifyingClientKey,
-		scheme: scheme,
+		scheme:          scheme,
+		serviceResolver: serviceResolver,
 	}, nil
 }
 
@@ -76,6 +79,10 @@ func (i pluginInitializer) Initialize(plugin admission.Interface) {
 
 	if wants, ok := plugin.(WantsScheme); ok {
 		wants.SetScheme(i.scheme)
+	}
+
+	if wants, ok := plugin.(WantsServiceResolver); ok {
+		wants.SetServiceResolver(i.serviceResolver)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package initializer
 
 import (
+	"net/url"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -53,4 +55,16 @@ type WantsClientCert interface {
 type WantsScheme interface {
 	SetScheme(*runtime.Scheme)
 	admission.Validator
+}
+
+// WantsServiceResolver defines a fuction that accepts a ServiceResolver for
+// admission plugins that need to make calls to services.
+type WantsServiceResolver interface {
+	SetServiceResolver(ServiceResolver)
+}
+
+// ServiceResolver knows how to convert a service reference into an actual
+// location.
+type ServiceResolver interface {
+	ResolveEndpoint(namespace, name string) (*url.URL, error)
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
-	kubeadmission "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/apiserver/pkg/admission/initializer"
 	informers "k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -48,7 +48,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil, nil)
+	pluginInitializer, err := initializer.New(c, f, nil, nil, nil, nil, nil)
 	if err != nil {
 		return handler, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -84,6 +84,7 @@ func (a *AdmissionOptions) ApplyTo(
 	serverIdentifyingClientKey []byte,
 	clientConfig *rest.Config,
 	scheme *runtime.Scheme,
+	serviceResolver initializer.ServiceResolver,
 	pluginInitializers ...admission.PluginInitializer,
 ) error {
 	pluginNames := a.PluginNames
@@ -100,7 +101,15 @@ func (a *AdmissionOptions) ApplyTo(
 	if err != nil {
 		return err
 	}
-	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey, scheme)
+	genericInitializer, err := initializer.New(
+		clientset,
+		informers,
+		c.Authorizer,
+		serverIdentifyingClientCert,
+		serverIdentifyingClientKey,
+		scheme,
+		serviceResolver,
+	)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -119,7 +119,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
-	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, serverConfig.ClientConfig, apiserver.Scheme, admissionInitializer); err != nil {
+	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, serverConfig.ClientConfig, apiserver.Scheme, nil, admissionInitializer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
removes k8s.io/kubernetes/pkg/kubeapiserver/admission dependency from webhook plugin  by moving WantsServiceResolver interface to apiserver

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
