### PR TITLE
Add metrics.UnregisterMetricAndUntrackRateLimiterUsage function

### DIFF
--- a/pkg/util/metrics/util.go
+++ b/pkg/util/metrics/util.go
@@ -34,25 +34,34 @@ const (
 
 var (
 	metricsLock        sync.Mutex
-	rateLimiterMetrics = make(map[string]prometheus.Gauge)
+	rateLimiterMetrics = make(map[string]rateLimiterMetric)
 )
+
+type rateLimiterMetric struct {
+	metric prometheus.Gauge
+	stopCh chan struct{}
+}
 
 func registerRateLimiterMetric(ownerName string) error {
 	metricsLock.Lock()
 	defer metricsLock.Unlock()
 
 	if _, ok := rateLimiterMetrics[ownerName]; ok {
-		glog.Errorf("Metric for %v already registered", ownerName)
-		return fmt.Errorf("Metric for %v already registered", ownerName)
+		glog.Errorf("Rate Limiter Metric for %v already registered", ownerName)
+		return fmt.Errorf("Rate Limiter Metric for %v already registered", ownerName)
 	}
 	metric := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name:      "rate_limiter_use",
 		Subsystem: ownerName,
 		Help:      fmt.Sprintf("A metric measuring the saturation of the rate limiter for %v", ownerName),
 	})
-	rateLimiterMetrics[ownerName] = metric
 	if err := prometheus.Register(metric); err != nil {
 		return fmt.Errorf("error registering rate limiter usage metric: %v", err)
+	}
+	stopCh := make(chan struct{})
+	rateLimiterMetrics[ownerName] = rateLimiterMetric{
+		metric: metric,
+		stopCh: stopCh,
 	}
 	return nil
 }
@@ -60,14 +69,32 @@ func registerRateLimiterMetric(ownerName string) error {
 // RegisterMetricAndTrackRateLimiterUsage registers a metric ownerName_rate_limiter_use in prometheus to track
 // how much used rateLimiter is and starts a goroutine that updates this metric every updatePeriod
 func RegisterMetricAndTrackRateLimiterUsage(ownerName string, rateLimiter flowcontrol.RateLimiter) error {
-	err := registerRateLimiterMetric(ownerName)
-	if err != nil {
+	if err := registerRateLimiterMetric(ownerName); err != nil {
 		return err
 	}
-	go wait.Forever(func() {
+	go wait.Until(func() {
 		metricsLock.Lock()
 		defer metricsLock.Unlock()
-		rateLimiterMetrics[ownerName].Set(rateLimiter.Saturation())
-	}, updatePeriod)
+		rateLimiterMetrics[ownerName].metric.Set(rateLimiter.Saturation())
+	}, updatePeriod, rateLimiterMetrics[ownerName].stopCh)
 	return nil
+}
+
+// UnregisterMetricAndUntrackRateLimiterUsage unregisters a metric ownerName_rate_limiter_use from prometheus and
+// stops the goroutine that updates this metric
+func UnregisterMetricAndUntrackRateLimiterUsage(ownerName string) bool {
+	metricsLock.Lock()
+	defer metricsLock.Unlock()
+
+	rlm, ok := rateLimiterMetrics[ownerName]
+	if !ok {
+		glog.Warningf("Rate Limiter Metric for %v not registered", ownerName)
+		return false
+	}
+
+	close(rlm.stopCh)
+	prometheus.Unregister(rlm.metric)
+	delete(rateLimiterMetrics, ownerName)
+
+	return true
 }

--- a/pkg/util/metrics/util_test.go
+++ b/pkg/util/metrics/util_test.go
@@ -35,6 +35,11 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 			err:         "",
 		},
 		{
+			ownerName:   "owner_name",
+			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
+			err:         "already registered",
+		},
+		{
 			ownerName:   "invalid-owner-name",
 			rateLimiter: flowcontrol.NewTokenBucketRateLimiter(1, 1),
 			err:         "error registering rate limiter usage metric",
@@ -49,6 +54,30 @@ func TestRegisterMetricAndTrackRateLimiterUsage(t *testing.T) {
 			} else if !strings.Contains(e.Error(), tc.err) {
 				t.Errorf("[%d] expected an error containing %q: %v", i, tc.err, e)
 			}
+		}
+	}
+}
+
+func TestUnregisterMetricAndUntrackRateLimiterUsage(t *testing.T) {
+	RegisterMetricAndTrackRateLimiterUsage("owner_name", flowcontrol.NewTokenBucketRateLimiter(1, 1))
+	testCases := []struct {
+		ownerName string
+		ok        bool
+	}{
+		{
+			ownerName: "owner_name",
+			ok:        true,
+		},
+		{
+			ownerName: "owner_name",
+			ok:        false,
+		},
+	}
+
+	for i, tc := range testCases {
+		ok := UnregisterMetricAndUntrackRateLimiterUsage(tc.ownerName)
+		if tc.ok != ok {
+			t.Errorf("Case[%d] Expected %v, got %v", i, tc.ok, ok)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

For testing purposes, we want to unregister a previously registered rate limiter prometheus metric and stop the goroutine that updates this metric.

As part of #53571, we started updating several controllers to check `RegisterMetricAndTrackRateLimiterUsage` errors (see #53595, #53643, #53646). Some tests create multiple instances of the same controller, and as a result, they fail b/c the rate limiter metric is already registered. The `UnregisterMetricAndUntrackRateLimiterUsage` function added in this PR will help running those tests by explicitly unregistering the metric before creating a new instance of a controller.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #52872

**Special notes for your reviewer**:

/cc @liggitt

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
