### PR TITLE
Properly detect ip command in build/common.sh script

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -330,7 +330,7 @@ function kube::build::has_docker() {
 }
 
 function kube::build::has_ip() {
-  ip -Version | grep 'iproute2' &> /dev/null
+  command -v ip &>/dev/null
 }
 
 # Detect if a specific image exists


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes `build/common.sh` script when testing the availability of command `ip` on the local machine.  If the machine does not have the command on its `PATH`, function `kube::build::has_ip()` will fail because of it actually invokes the command directly as shown below:
```
function kube::build::has_ip() {
  ip -Version | grep 'iproute2' &> /dev/null
}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53952

**Release note**:
```release-note
NONE
```
