### PR TITLE
Add sample-apiserver namespace manifest

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/ns.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/ns.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wardle
+spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a manifest to also create the required namespace for the api server example.

It was previously proposed here kubernetes/sample-apiserver#11

```release-note
```