### PR TITLE
improve help information of set env command.

### DIFF
--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -54,7 +54,8 @@ var (
 		syntax.
 
 		Possible resources include (case insensitive):
-		` + envResources)
+		` + envResources + `
+		Among resources above, environment variables of pod can only be listed, not updated `)
 
 	envExample = templates.Examples(`
 		# Update deployment 'registry' with a new environment variable


### PR DESCRIPTION
modified:   pkg/kubectl/cmd/set/set_env.go

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
In current kubectl set env command, its  help information goes like:
> Update environment variables on a pod template.
> List environment variable definitions in one or more pods, pod templates.
> Add, update, or remove container environment variable definitions in one or
> more pod templates (within replication controllers or deployment configurations).
> View or modify the environment variable definitions on all containers in the
> specified pods or pod templates, or just those that match a wildcard.
> If "--env -" is passed, environment variables can be read from STDIN using the standard env
> syntax.
> Possible resources include (case insensitive):
> pod (po), replicationcontroller (rc), deployment (deploy), daemonset (ds), job, replicaset (rs)


Help information above may confused users that all the resources it lists support both list and 
update feature.However ,pod only supports list but not update.
This patch add some hint to avoid such situation.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```NONE
