### PR TITLE
Cosmetical cleanup after pkg/api/legacyscheme move

### DIFF
--- a/pkg/apis/abac/v0/conversion_test.go
+++ b/pkg/apis/abac/v0/conversion_test.go
@@ -21,64 +21,64 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/user"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 	"k8s.io/kubernetes/pkg/apis/abac/v0"
 )
 
 func TestV0Conversion(t *testing.T) {
 	testcases := map[string]struct {
 		old      *v0.Policy
-		expected *api.Policy
+		expected *abac.Policy
 	}{
 		// a completely empty policy rule allows everything to all users
 		"empty": {
 			old:      &v0.Policy{},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
 		},
 
 		// specifying a user is preserved
 		"user": {
 			old:      &v0.Policy{User: "bob"},
-			expected: &api.Policy{Spec: api.PolicySpec{User: "bob", Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{User: "bob", Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
 		},
 
 		// specifying a group is preserved (and no longer matches all users)
 		"group": {
 			old:      &v0.Policy{Group: "mygroup"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: "mygroup", Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: "mygroup", Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
 		},
 
 		// specifying * for user or group maps to all authenticated subjects
 		"* user": {
 			old:      &v0.Policy{User: "*"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
 		},
 		"* group": {
 			old:      &v0.Policy{Group: "*"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "*", Namespace: "*", Resource: "*", APIGroup: "*"}},
 		},
 
 		// specifying a namespace removes the * match on non-resource path
 		"namespace": {
 			old:      &v0.Policy{Namespace: "myns"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "myns", Resource: "*", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "myns", Resource: "*", APIGroup: "*"}},
 		},
 
 		// specifying a resource removes the * match on non-resource path
 		"resource": {
 			old:      &v0.Policy{Resource: "myresource"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "*", Resource: "myresource", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "*", Resource: "myresource", APIGroup: "*"}},
 		},
 
 		// specifying a namespace+resource removes the * match on non-resource path
 		"namespace+resource": {
 			old:      &v0.Policy{Namespace: "myns", Resource: "myresource"},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "myns", Resource: "myresource", APIGroup: "*"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated, Readonly: false, NonResourcePath: "", Namespace: "myns", Resource: "myresource", APIGroup: "*"}},
 		},
 	}
 	for k, tc := range testcases {
-		internal := &api.Policy{}
-		if err := api.Scheme.Convert(tc.old, internal, nil); err != nil {
+		internal := &abac.Policy{}
+		if err := abac.Scheme.Convert(tc.old, internal, nil); err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 		}
 		if !reflect.DeepEqual(internal, tc.expected) {

--- a/pkg/apis/abac/v0/register.go
+++ b/pkg/apis/abac/v0/register.go
@@ -19,7 +19,7 @@ package v0
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 )
 
 const GroupName = "abac.authorization.kubernetes.io"
@@ -29,11 +29,11 @@ var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v0"}
 
 func init() {
 	// TODO: Delete this init function, abac should not have its own scheme.
-	if err := addKnownTypes(api.Scheme); err != nil {
+	if err := addKnownTypes(abac.Scheme); err != nil {
 		// Programmer error.
 		panic(err)
 	}
-	if err := addConversionFuncs(api.Scheme); err != nil {
+	if err := addConversionFuncs(abac.Scheme); err != nil {
 		// Programmer error.
 		panic(err)
 	}

--- a/pkg/apis/abac/v1beta1/conversion_test.go
+++ b/pkg/apis/abac/v1beta1/conversion_test.go
@@ -21,40 +21,40 @@ import (
 	"testing"
 
 	"k8s.io/apiserver/pkg/authentication/user"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 	"k8s.io/kubernetes/pkg/apis/abac/v1beta1"
 )
 
 func TestV1Beta1Conversion(t *testing.T) {
 	testcases := map[string]struct {
 		old      *v1beta1.Policy
-		expected *api.Policy
+		expected *abac.Policy
 	}{
 		// specifying a user is preserved
 		"user": {
 			old:      &v1beta1.Policy{Spec: v1beta1.PolicySpec{User: "bob"}},
-			expected: &api.Policy{Spec: api.PolicySpec{User: "bob"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{User: "bob"}},
 		},
 
 		// specifying a group is preserved
 		"group": {
 			old:      &v1beta1.Policy{Spec: v1beta1.PolicySpec{Group: "mygroup"}},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: "mygroup"}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: "mygroup"}},
 		},
 
 		// specifying * for user or group maps to all authenticated subjects
 		"* user": {
 			old:      &v1beta1.Policy{Spec: v1beta1.PolicySpec{User: "*"}},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated}},
 		},
 		"* group": {
 			old:      &v1beta1.Policy{Spec: v1beta1.PolicySpec{Group: "*"}},
-			expected: &api.Policy{Spec: api.PolicySpec{Group: user.AllAuthenticated}},
+			expected: &abac.Policy{Spec: abac.PolicySpec{Group: user.AllAuthenticated}},
 		},
 	}
 	for k, tc := range testcases {
-		internal := &api.Policy{}
-		if err := api.Scheme.Convert(tc.old, internal, nil); err != nil {
+		internal := &abac.Policy{}
+		if err := abac.Scheme.Convert(tc.old, internal, nil); err != nil {
 			t.Errorf("%s: unexpected error: %v", k, err)
 		}
 		if !reflect.DeepEqual(internal, tc.expected) {

--- a/pkg/apis/abac/v1beta1/register.go
+++ b/pkg/apis/abac/v1beta1/register.go
@@ -19,7 +19,7 @@ package v1beta1
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 )
 
 const GroupName = "abac.authorization.kubernetes.io"
@@ -29,11 +29,11 @@ var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1
 
 func init() {
 	// TODO: delete this, abac should not have its own scheme.
-	if err := addKnownTypes(api.Scheme); err != nil {
+	if err := addKnownTypes(abac.Scheme); err != nil {
 		// Programmer error.
 		panic(err)
 	}
-	if err := addConversionFuncs(api.Scheme); err != nil {
+	if err := addConversionFuncs(abac.Scheme); err != nil {
 		// Programmer error.
 		panic(err)
 	}

--- a/pkg/apis/apps/register.go
+++ b/pkg/apis/apps/register.go
@@ -43,7 +43,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	// TODO this will get cleaned up with the scheme types are fixed
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/pkg/apis/autoscaling/register.go
+++ b/pkg/apis/autoscaling/register.go
@@ -42,7 +42,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Scale{},

--- a/pkg/apis/batch/register.go
+++ b/pkg/apis/batch/register.go
@@ -42,7 +42,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Job{},

--- a/pkg/apis/certificates/register.go
+++ b/pkg/apis/certificates/register.go
@@ -42,7 +42,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&CertificateSigningRequest{},

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -43,7 +43,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	// TODO this gets cleaned up when the types are fixed
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/pkg/apis/policy/register.go
+++ b/pkg/apis/policy/register.go
@@ -42,7 +42,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	// TODO this gets cleaned up when the types are fixed
 	scheme.AddKnownTypes(SchemeGroupVersion,

--- a/pkg/apis/policy/v1alpha1/register.go
+++ b/pkg/apis/policy/v1alpha1/register.go
@@ -48,7 +48,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes, RegisterDefaults)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&PodDisruptionBudget{},

--- a/pkg/apis/rbac/register.go
+++ b/pkg/apis/rbac/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Role{},

--- a/pkg/apis/settings/register.go
+++ b/pkg/apis/settings/register.go
@@ -42,7 +42,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&PodPreset{},

--- a/pkg/auth/authorizer/abac/abac.go
+++ b/pkg/auth/authorizer/abac/abac.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 	_ "k8s.io/kubernetes/pkg/apis/abac/latest"
 	"k8s.io/kubernetes/pkg/apis/abac/v0"
 )
@@ -49,7 +49,7 @@ func (p policyLoadError) Error() string {
 	return fmt.Sprintf("error reading policy file %s: %v", p.path, p.err)
 }
 
-type policyList []*api.Policy
+type policyList []*abac.Policy
 
 // TODO: Have policies be created via an API call and stored in REST storage.
 func NewFromFile(path string) (policyList, error) {
@@ -64,13 +64,13 @@ func NewFromFile(path string) (policyList, error) {
 	scanner := bufio.NewScanner(file)
 	pl := make(policyList, 0)
 
-	decoder := api.Codecs.UniversalDecoder()
+	decoder := abac.Codecs.UniversalDecoder()
 
 	i := 0
 	unversionedLines := 0
 	for scanner.Scan() {
 		i++
-		p := &api.Policy{}
+		p := &abac.Policy{}
 		b := scanner.Bytes()
 
 		// skip comment lines and blank lines
@@ -90,14 +90,14 @@ func NewFromFile(path string) (policyList, error) {
 			if err := runtime.DecodeInto(decoder, b, oldPolicy); err != nil {
 				return nil, policyLoadError{path, i, b, err}
 			}
-			if err := api.Scheme.Convert(oldPolicy, p, nil); err != nil {
+			if err := abac.Scheme.Convert(oldPolicy, p, nil); err != nil {
 				return nil, policyLoadError{path, i, b, err}
 			}
 			pl = append(pl, p)
 			continue
 		}
 
-		decodedPolicy, ok := decodedObj.(*api.Policy)
+		decodedPolicy, ok := decodedObj.(*abac.Policy)
 		if !ok {
 			return nil, policyLoadError{path, i, b, fmt.Errorf("unrecognized object: %#v", decodedObj)}
 		}
@@ -114,7 +114,7 @@ func NewFromFile(path string) (policyList, error) {
 	return pl, nil
 }
 
-func matches(p api.Policy, a authorizer.Attributes) bool {
+func matches(p abac.Policy, a authorizer.Attributes) bool {
 	if subjectMatches(p, a.GetUser()) {
 		if verbMatches(p, a) {
 			// Resource and non-resource requests are mutually exclusive, at most one will match a policy
@@ -130,7 +130,7 @@ func matches(p api.Policy, a authorizer.Attributes) bool {
 }
 
 // subjectMatches returns true if specified user and group properties in the policy match the attributes
-func subjectMatches(p api.Policy, user user.Info) bool {
+func subjectMatches(p abac.Policy, user user.Info) bool {
 	matched := false
 
 	if user == nil {
@@ -171,7 +171,7 @@ func subjectMatches(p api.Policy, user user.Info) bool {
 	return matched
 }
 
-func verbMatches(p api.Policy, a authorizer.Attributes) bool {
+func verbMatches(p abac.Policy, a authorizer.Attributes) bool {
 	// TODO: match on verb
 
 	// All policies allow read only requests
@@ -187,7 +187,7 @@ func verbMatches(p api.Policy, a authorizer.Attributes) bool {
 	return false
 }
 
-func nonResourceMatches(p api.Policy, a authorizer.Attributes) bool {
+func nonResourceMatches(p abac.Policy, a authorizer.Attributes) bool {
 	// A non-resource policy cannot match a resource request
 	if !a.IsResourceRequest() {
 		// Allow wildcard match
@@ -206,7 +206,7 @@ func nonResourceMatches(p api.Policy, a authorizer.Attributes) bool {
 	return false
 }
 
-func resourceMatches(p api.Policy, a authorizer.Attributes) bool {
+func resourceMatches(p abac.Policy, a authorizer.Attributes) bool {
 	// A resource policy cannot match a non-resource request
 	if a.IsResourceRequest() {
 		if p.Spec.Namespace == "*" || p.Spec.Namespace == a.GetNamespace() {

--- a/pkg/auth/authorizer/abac/abac_test.go
+++ b/pkg/auth/authorizer/abac/abac_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
-	api "k8s.io/kubernetes/pkg/apis/abac"
+	"k8s.io/kubernetes/pkg/apis/abac"
 	"k8s.io/kubernetes/pkg/apis/abac/v0"
 	"k8s.io/kubernetes/pkg/apis/abac/v1beta1"
 )
@@ -799,8 +799,8 @@ func TestSubjectMatches(t *testing.T) {
 	}
 
 	for k, tc := range testCases {
-		policy := &api.Policy{}
-		if err := api.Scheme.Convert(tc.Policy, policy, nil); err != nil {
+		policy := &abac.Policy{}
+		if err := abac.Scheme.Convert(tc.Policy, policy, nil); err != nil {
 			t.Errorf("%s: error converting: %v", k, err)
 			continue
 		}
@@ -1254,8 +1254,8 @@ func TestPolicy(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		policy := &api.Policy{}
-		if err := api.Scheme.Convert(test.policy, policy, nil); err != nil {
+		policy := &abac.Policy{}
+		if err := abac.Scheme.Convert(test.policy, policy, nil); err != nil {
 			t.Errorf("%s: error converting: %v", test.name, err)
 			continue
 		}

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -623,7 +623,7 @@ func (a *HorizontalController) updateStatus(hpa *autoscalingv2.HorizontalPodAuto
 	return nil
 }
 
-// unsafeConvertToVersionVia is like api.Scheme.UnsafeConvertToVersion, but it does so via an internal version first.
+// unsafeConvertToVersionVia is like Scheme.UnsafeConvertToVersion, but it does so via an internal version first.
 // We use it since working with v2alpha1 is convenient here, but we want to use the v1 client (and
 // can't just use the internal version).  Note that conversion mutates the object, so you need to deepcopy
 // *before* you call this if the input object came out of a shared cache.

--- a/plugin/pkg/scheduler/api/latest/latest.go
+++ b/plugin/pkg/scheduler/api/latest/latest.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/api"
+	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 	_ "k8s.io/kubernetes/plugin/pkg/scheduler/api/v1"
 )
 
@@ -42,9 +42,9 @@ var Versions = []string{"v1"}
 var Codec runtime.Codec
 
 func init() {
-	jsonSerializer := json.NewSerializer(json.DefaultMetaFactory, api.Scheme, api.Scheme, true)
+	jsonSerializer := json.NewSerializer(json.DefaultMetaFactory, schedulerapi.Scheme, schedulerapi.Scheme, true)
 	Codec = versioning.NewDefaultingCodecForScheme(
-		api.Scheme,
+		schedulerapi.Scheme,
 		jsonSerializer,
 		jsonSerializer,
 		schema.GroupVersion{Version: Version},

--- a/plugin/pkg/scheduler/api/v1/register.go
+++ b/plugin/pkg/scheduler/api/v1/register.go
@@ -19,7 +19,7 @@ package v1
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubernetes/plugin/pkg/scheduler/api"
+	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
 
 // SchemeGroupVersion is group version used to register these objects
@@ -27,7 +27,7 @@ import (
 var SchemeGroupVersion = schema.GroupVersion{Group: "", Version: "v1"}
 
 func init() {
-	if err := addKnownTypes(api.Scheme); err != nil {
+	if err := addKnownTypes(schedulerapi.Scheme); err != nil {
 		// Programmer error.
 		panic(err)
 	}

--- a/staging/src/k8s.io/api/admission/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/admission/v1alpha1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AdmissionReview{},

--- a/staging/src/k8s.io/api/apps/v1/register.go
+++ b/staging/src/k8s.io/api/apps/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&DaemonSet{},

--- a/staging/src/k8s.io/api/apps/v1beta1/register.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Deployment{},

--- a/staging/src/k8s.io/api/apps/v1beta2/register.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Deployment{},

--- a/staging/src/k8s.io/api/authentication/v1/register.go
+++ b/staging/src/k8s.io/api/authentication/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TokenReview{},

--- a/staging/src/k8s.io/api/authentication/v1beta1/register.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TokenReview{},

--- a/staging/src/k8s.io/api/authorization/v1/register.go
+++ b/staging/src/k8s.io/api/authorization/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&SelfSubjectRulesReview{},

--- a/staging/src/k8s.io/api/authorization/v1beta1/register.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&SelfSubjectRulesReview{},

--- a/staging/src/k8s.io/api/autoscaling/v1/register.go
+++ b/staging/src/k8s.io/api/autoscaling/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/api/autoscaling/v2beta1/register.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&HorizontalPodAutoscaler{},

--- a/staging/src/k8s.io/api/batch/v1/register.go
+++ b/staging/src/k8s.io/api/batch/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Job{},

--- a/staging/src/k8s.io/api/batch/v1beta1/register.go
+++ b/staging/src/k8s.io/api/batch/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&JobTemplate{},

--- a/staging/src/k8s.io/api/batch/v2alpha1/register.go
+++ b/staging/src/k8s.io/api/batch/v2alpha1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&JobTemplate{},

--- a/staging/src/k8s.io/api/certificates/v1beta1/register.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/register.go
@@ -46,7 +46,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&CertificateSigningRequest{},

--- a/staging/src/k8s.io/api/core/v1/register.go
+++ b/staging/src/k8s.io/api/core/v1/register.go
@@ -43,7 +43,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},

--- a/staging/src/k8s.io/api/extensions/v1beta1/register.go
+++ b/staging/src/k8s.io/api/extensions/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Deployment{},

--- a/staging/src/k8s.io/api/imagepolicy/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/imagepolicy/v1alpha1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&ImageReview{},

--- a/staging/src/k8s.io/api/networking/v1/register.go
+++ b/staging/src/k8s.io/api/networking/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&NetworkPolicy{},

--- a/staging/src/k8s.io/api/policy/v1beta1/register.go
+++ b/staging/src/k8s.io/api/policy/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&PodDisruptionBudget{},

--- a/staging/src/k8s.io/api/rbac/v1/register.go
+++ b/staging/src/k8s.io/api/rbac/v1/register.go
@@ -40,7 +40,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Role{},

--- a/staging/src/k8s.io/api/rbac/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/rbac/v1alpha1/register.go
@@ -40,7 +40,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Role{},

--- a/staging/src/k8s.io/api/rbac/v1beta1/register.go
+++ b/staging/src/k8s.io/api/rbac/v1beta1/register.go
@@ -40,7 +40,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Role{},

--- a/staging/src/k8s.io/api/scheduling/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/scheduling/v1alpha1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&PriorityClass{},

--- a/staging/src/k8s.io/api/settings/v1alpha1/register.go
+++ b/staging/src/k8s.io/api/settings/v1alpha1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&PodPreset{},

--- a/staging/src/k8s.io/api/storage/v1/register.go
+++ b/staging/src/k8s.io/api/storage/v1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&StorageClass{},

--- a/staging/src/k8s.io/api/storage/v1beta1/register.go
+++ b/staging/src/k8s.io/api/storage/v1beta1/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&StorageClass{},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&CustomResourceDefinition{},

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/register.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/register.go
@@ -43,7 +43,7 @@ var (
 	AddToScheme        = localSchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&CustomResourceDefinition{},

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/registered/registered.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package to keep track of API Versions that can be registered and are enabled in api.Scheme.
+// Package to keep track of API Versions that can be registered and are enabled in a Scheme.
 package registered
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/apimachinery/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apimachinery/types.go
@@ -38,7 +38,7 @@ type GroupMeta struct {
 	// to go through the InterfacesFor method below.
 	SelfLinker runtime.SelfLinker
 
-	// RESTMapper provides the default mapping between REST paths and the objects declared in api.Scheme and all known
+	// RESTMapper provides the default mapping between REST paths and the objects declared in a Scheme and all known
 	// versions.
 	RESTMapper meta.RESTMapper
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/register.go
@@ -42,7 +42,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Carp{},

--- a/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/register.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1/register.go
@@ -53,7 +53,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes, addConversionFuncs, addDefaultingFuncs)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Carp{},

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AdmissionConfiguration{},

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/register.go
@@ -42,7 +42,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&AdmissionConfiguration{},

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/register.go
@@ -42,7 +42,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},

--- a/staging/src/k8s.io/apiserver/pkg/apis/example/v1/register.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/example/v1/register.go
@@ -53,7 +53,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes, addConversionFuncs, addDefaultingFuncs)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Pod{},

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/register.go
@@ -33,7 +33,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TestType{},

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/v1/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/apis/example/v1/register.go
@@ -44,7 +44,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TestType{},

--- a/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/register.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/register.go
@@ -44,7 +44,7 @@ func Resource(resource string) schema.GroupResource {
 	return SchemeGroupVersion.WithResource(resource).GroupResource()
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&TestType{},

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&APIService{},

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/register.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1/register.go
@@ -47,7 +47,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&APIService{},

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/register.go
@@ -41,7 +41,7 @@ var (
 	AddToScheme   = SchemeBuilder.AddToScheme
 )
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Flunder{},

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/register.go
@@ -42,7 +42,7 @@ func init() {
 	localSchemeBuilder.Register(addKnownTypes)
 }
 
-// Adds the list of known types to api.Scheme.
+// Adds the list of known types to the given scheme.
 func addKnownTypes(scheme *runtime.Scheme) error {
 	scheme.AddKnownTypes(SchemeGroupVersion,
 		&Flunder{},


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/53984

- Fix and update comment with api.Scheme
- Remove all api.Scheme references by using explicit package aliases