### PR TITLE
RBAC for Calico Typha Horizontal Autoscaler

### DIFF
--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: typha-cpha
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrolebinding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: typha-cpha
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: typha-cpha
+subjects:
+  - kind: ServiceAccount
+    name: typha-cpha
+    namespace: kube-system

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -31,3 +31,4 @@ spec:
               cpu: 10m
             limits:
               cpu: 10m
+      serviceAccountName: typha-cpha

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: typha-cpha
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+  - apiGroups: ["extensions"]
+    resources: ["deployments/scale"]
+    verbs: ["get", "update"]
+

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-rolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-rolebinding.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: typha-cpha
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: typha-cpha
+subjects:
+  - kind: ServiceAccount
+    name: typha-cpha
+    namespace: kube-system

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-serviceaccount.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: typha-cpha
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

On v1.8.0-gke.1 I noticed a number of RBAC failures for `default` in kube-system. Turns out the only container missing the serviceAccountName was the typha-horizontal-autoscaler.

**Special notes for your reviewer**:

cc @caseydavenport seems like this is up your alley 
