### PR TITLE
Automated cherry pick of #52477 #53262 #53346

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -110,7 +110,7 @@ func masterUpgradeKubernetesAnywhere(v string) error {
 	// modify config with specified k8s version
 	if _, _, err := RunCmd("sed",
 		"-i.bak", // writes original to .config.bak
-		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%q/`, v),
 		originalConfigPath); err != nil {
 		return err
 	}

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -107,23 +107,20 @@ func masterUpgradeKubernetesAnywhere(v string) error {
 	backupConfigPath := filepath.Join(kaPath, ".config.bak")
 	updatedConfigPath := filepath.Join(kaPath, fmt.Sprintf(".config-%s", v))
 
-	// backup .config to .config.bak
-	if err := os.Rename(originalConfigPath, backupConfigPath); err != nil {
+	// modify config with specified k8s version
+	if _, _, err := RunCmd("sed",
+		"-i.bak", // writes original to .config.bak
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		originalConfigPath); err != nil {
 		return err
 	}
+
 	defer func() {
 		// revert .config.bak to .config
 		if err := os.Rename(backupConfigPath, originalConfigPath); err != nil {
 			Logf("Could not rename %s back to %s", backupConfigPath, originalConfigPath)
 		}
 	}()
-
-	// modify config with specified k8s version
-	if _, _, err := RunCmd("sed",
-		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
-		backupConfigPath, ">", originalConfigPath); err != nil {
-		return err
-	}
 
 	// invoke ka upgrade
 	if _, _, err := RunCmd("make", "-C", TestContext.KubernetesAnywherePath,

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -45,6 +46,8 @@ func MasterUpgrade(v string) error {
 		return masterUpgradeGCE(v)
 	case "gke":
 		return masterUpgradeGKE(v)
+	case "kubernetes-anywhere":
+		return masterUpgradeKubernetesAnywhere(v)
 	default:
 		return fmt.Errorf("MasterUpgrade() is not implemented for provider %s", TestContext.Provider)
 	}
@@ -92,6 +95,46 @@ func masterUpgradeGKE(v string) error {
 	}
 
 	waitForSSHTunnels()
+
+	return nil
+}
+
+func masterUpgradeKubernetesAnywhere(v string) error {
+	Logf("Upgrading master to %q", v)
+
+	kaPath := TestContext.KubernetesAnywherePath
+	originalConfigPath := filepath.Join(kaPath, ".config")
+	backupConfigPath := filepath.Join(kaPath, ".config.bak")
+	updatedConfigPath := filepath.Join(kaPath, fmt.Sprintf(".config-%s", v))
+
+	// backup .config to .config.bak
+	if err := os.Rename(originalConfigPath, backupConfigPath); err != nil {
+		return err
+	}
+	defer func() {
+		// revert .config.bak to .config
+		if err := os.Rename(backupConfigPath, originalConfigPath); err != nil {
+			Logf("Could not rename %s back to %s", backupConfigPath, originalConfigPath)
+		}
+	}()
+
+	// modify config with specified k8s version
+	if _, _, err := RunCmd("sed",
+		fmt.Sprintf(`s/kubernetes_version=.*$/kubernetes_version=%s/`, v),
+		backupConfigPath, ">", originalConfigPath); err != nil {
+		return err
+	}
+
+	// invoke ka upgrade
+	if _, _, err := RunCmd("make", "-C", TestContext.KubernetesAnywherePath,
+		"WAIT_FOR_KUBECONFIG=y", "upgrade-master"); err != nil {
+		return err
+	}
+
+	// move .config to .config.<version>
+	if err := os.Rename(originalConfigPath, updatedConfigPath); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -99,6 +99,9 @@ type TestContextType struct {
 	// Whether configuration for accessing federation member clusters should be sourced from the host cluster
 	FederationConfigFromCluster bool
 
+	// Indicates what path the kubernetes-anywhere is installed on
+	KubernetesAnywherePath string
+
 	// Viper-only parameters.  These will in time replace all flags.
 
 	// Example: Create a file 'e2e.json' with the following:
@@ -183,6 +186,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ContainerRuntime, "container-runtime", "docker", "The container runtime of cluster VM instances (docker/rkt/remote).")
 	flag.StringVar(&TestContext.ContainerRuntimeEndpoint, "container-runtime-endpoint", "", "The container runtime endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
+	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
 }
 
 // Register flags specific to the cluster e2e test suite.


### PR DESCRIPTION
Cherry pick of #52477 #53262 #53346 on release-1.7.

#52477: Support kubernetes-anywhere provider
#53262: Fix sed command to not try shell redirection
#53346: Version should be quoted so jq doesn't interpret it as

For context, this supports testing master upgrades with kubernetes anywhere for 1.6 -> 1.7 upgrades.