### PR TITLE
client-gen: register standard flags

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -18,6 +18,7 @@ limitations under the License.
 package main
 
 import (
+	goflag "flag"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -153,6 +154,7 @@ func parseIncludedTypesOverrides() (map[types.GroupVersion][]string, error) {
 func main() {
 	arguments := args.Default()
 	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
+	flag.CommandLine.AddGoFlagSet(goflag.CommandLine)
 	flag.Parse()
 	var cmdArgs string
 	flag.VisitAll(func(f *flag.Flag) {


### PR DESCRIPTION
Fixes #53998.

The first `flag.Parse` refuses the glog and gengo flags because the go-flags are only added to the flagset when gengo's `execute` is called. On master this was fixed via https://github.com/kubernetes/kubernetes/pull/53202. Here we apply a minimal patch only.

```release-note
Allow standard flags in client-gen.
```