### PR TITLE
Update GPU e2es to use a release 1.8 dedicated branch for device plugins

### DIFF
--- a/test/e2e/framework/gpu_util.go
+++ b/test/e2e/framework/gpu_util.go
@@ -32,7 +32,7 @@ const (
 	// TODO: Parametrize it by making it a feature in TestFramework.
 	// so we can override the daemonset in other setups (non COS).
 	// GPUDevicePluginDSYAML is the official Google Device Plugin Daemonset NVIDIA GPU manifest for GKE
-	GPUDevicePluginDSYAML = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/device-plugin-daemonset.yaml"
+	GPUDevicePluginDSYAML = "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/k8s-1.8/device-plugin-daemonset.yaml"
 )
 
 // TODO make this generic and not linked to COS only


### PR DESCRIPTION
k8s release 1.8 GPU support requires GPU Device plugins. Device plugin APIs are evolving in k8s HEAD. To continually test release 1.8 GPU support, a release 1.8 branch has been created for GPU device plugins and e2e GPU tests in k8s release 1.8 branch are being updated to the use the dedicated device plugin branch.

For #53497