### PR TITLE
Fix `kubeadm upgrade plan` for offline operation

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/compute.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute.go
@@ -62,7 +62,7 @@ type ClusterState struct {
 // GetAvailableUpgrades fetches all versions from the specified VersionGetter and computes which
 // kinds of upgrades can be performed
 func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesAllowed, rcUpgradesAllowed bool) ([]Upgrade, error) {
-	fmt.Println("[upgrade] Fetching available versions to upgrade to:")
+	fmt.Println("[upgrade] Fetching available versions to upgrade to")
 
 	// Collect the upgrades kubeadm can do in this list
 	upgrades := []Upgrade{}
@@ -82,7 +82,9 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 	// Get and output the current latest stable version
 	stableVersionStr, stableVersion, err := versionGetterImpl.VersionFromCILabel("stable", "stable version")
 	if err != nil {
-		return nil, err
+		fmt.Printf("[upgrade/versions] WARNING: %v\n", err)
+		fmt.Println("[upgrade/versions] WARNING: Falling back to current kubeadm version as latest stable version")
+		stableVersionStr, stableVersion = kubeadmVersionStr, kubeadmVersion
 	}
 
 	// Get the kubelet versions in the cluster
@@ -115,34 +117,34 @@ func GetAvailableUpgrades(versionGetterImpl VersionGetter, experimentalUpgradesA
 		// Get and output the latest patch version for the cluster branch
 		patchVersionStr, patchVersion, err := versionGetterImpl.VersionFromCILabel(versionLabel, description)
 		if err != nil {
-			return nil, err
-		}
+			fmt.Printf("[upgrade/versions] WARNING: %v\n", err)
+		} else {
+			// Check if a minor version upgrade is possible when a patch release exists
+			// It's only possible if the latest patch version is higher than the current patch version
+			// If that's the case, they must be on different branches => a newer minor version can be upgraded to
+			canDoMinorUpgrade = minorUpgradePossibleWithPatchRelease(stableVersion, patchVersion)
 
-		// Check if a minor version upgrade is possible when a patch release exists
-		// It's only possible if the latest patch version is higher than the current patch version
-		// If that's the case, they must be on different branches => a newer minor version can be upgraded to
-		canDoMinorUpgrade = minorUpgradePossibleWithPatchRelease(stableVersion, patchVersion)
+			// If the cluster version is lower than the newest patch version, we should inform about the possible upgrade
+			if patchUpgradePossible(clusterVersion, patchVersion) {
 
-		// If the cluster version is lower than the newest patch version, we should inform about the possible upgrade
-		if patchUpgradePossible(clusterVersion, patchVersion) {
+				// The kubeadm version has to be upgraded to the latest patch version
+				newKubeadmVer := patchVersionStr
+				if kubeadmVersion.AtLeast(patchVersion) {
+					// In this case, the kubeadm CLI version is new enough. Don't display an update suggestion for kubeadm by making .NewKubeadmVersion equal .CurrentKubeadmVersion
+					newKubeadmVer = kubeadmVersionStr
+				}
 
-			// The kubeadm version has to be upgraded to the latest patch version
-			newKubeadmVer := patchVersionStr
-			if kubeadmVersion.AtLeast(patchVersion) {
-				// In this case, the kubeadm CLI version is new enough. Don't display an update suggestion for kubeadm by making .NewKubeadmVersion equal .CurrentKubeadmVersion
-				newKubeadmVer = kubeadmVersionStr
+				upgrades = append(upgrades, Upgrade{
+					Description: description,
+					Before:      beforeState,
+					After: ClusterState{
+						KubeVersion:    patchVersionStr,
+						DNSVersion:     dns.GetKubeDNSVersion(patchVersion),
+						KubeadmVersion: newKubeadmVer,
+						// KubeletVersions is unset here as it is not used anywhere in .After
+					},
+				})
 			}
-
-			upgrades = append(upgrades, Upgrade{
-				Description: description,
-				Before:      beforeState,
-				After: ClusterState{
-					KubeVersion:    patchVersionStr,
-					DNSVersion:     dns.GetKubeDNSVersion(patchVersion),
-					KubeadmVersion: newKubeadmVer,
-					// KubeletVersions is unset here as it is not used anywhere in .After
-				},
-			})
 		}
 	}
 

--- a/cmd/kubeadm/app/phases/upgrade/versiongetter.go
+++ b/cmd/kubeadm/app/phases/upgrade/versiongetter.go
@@ -86,7 +86,7 @@ func (g *KubeVersionGetter) KubeadmVersion() (string, *versionutil.Version, erro
 func (g *KubeVersionGetter) VersionFromCILabel(ciVersionLabel, description string) (string, *versionutil.Version, error) {
 	versionStr, err := kubeadmutil.KubernetesReleaseVersion(ciVersionLabel)
 	if err != nil {
-		return "", nil, fmt.Errorf("Couldn't fetch latest %s version from the internet: %v", description, err)
+		return "", nil, fmt.Errorf("Couldn't fetch latest %s from the internet: %v", description, err)
 	}
 
 	if description != "" {
@@ -95,7 +95,7 @@ func (g *KubeVersionGetter) VersionFromCILabel(ciVersionLabel, description strin
 
 	ver, err := versionutil.ParseSemantic(versionStr)
 	if err != nil {
-		return "", nil, fmt.Errorf("Couldn't parse latest %s version: %v", description, err)
+		return "", nil, fmt.Errorf("Couldn't parse latest %s: %v", description, err)
 	}
 	return versionStr, ver, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows `kubeadm upgrade plan` to work in firewalled/offline/otherwise restricted environments by ignoring errors when trying to reach dl.k8s.io. Instead, we fall back to the current kubeadm version as the latest stable version. This is a reasonable as a user is [expected to install a recent version of kubeadm before upgrading](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm-upgrade-1-8/#upgrading-your-control-plane).

**Which issue this PR fixes**: Fixes kubernetes/kubeadm#498

**Special notes for your reviewer**: Should preferably be cherrypicked to 1.8.

```release-note
Fix `kubeadm upgrade plan` for offline operation: ignore errors when trying to fetch latest versions from dl.k8s.io
```