### PR TITLE
Automated cherry pick of #52131 #52575 upstream release 1.8

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/virtualdisk.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/virtualdisk.go
@@ -39,7 +39,7 @@ const (
 
 // VirtualDiskProvider defines interfaces for creating disk
 type VirtualDiskProvider interface {
-	Create(ctx context.Context, datastore *vclib.Datastore) error
+	Create(ctx context.Context, datastore *vclib.Datastore) (string, error)
 	Delete(ctx context.Context, datastore *vclib.Datastore) error
 }
 
@@ -60,16 +60,16 @@ func getDiskManager(disk *VirtualDisk, diskOperation string) VirtualDiskProvider
 }
 
 // Create gets appropriate disk manager and calls respective create method
-func (virtualDisk *VirtualDisk) Create(ctx context.Context, datastore *vclib.Datastore) error {
+func (virtualDisk *VirtualDisk) Create(ctx context.Context, datastore *vclib.Datastore) (string, error) {
 	if virtualDisk.VolumeOptions.DiskFormat == "" {
 		virtualDisk.VolumeOptions.DiskFormat = vclib.ThinDiskType
 	}
 	if !virtualDisk.VolumeOptions.VerifyVolumeOptions() {
 		glog.Error("VolumeOptions verification failed. volumeOptions: ", virtualDisk.VolumeOptions)
-		return vclib.ErrInvalidVolumeOptions
+		return "", vclib.ErrInvalidVolumeOptions
 	}
 	if virtualDisk.VolumeOptions.StoragePolicyID != "" && virtualDisk.VolumeOptions.StoragePolicyName != "" {
-		return fmt.Errorf("Storage Policy ID and Storage Policy Name both set, Please set only one parameter")
+		return "", fmt.Errorf("Storage Policy ID and Storage Policy Name both set, Please set only one parameter")
 	}
 	return getDiskManager(virtualDisk, VirtualDiskCreateOperation).Create(ctx, datastore)
 }

--- a/pkg/cloudprovider/providers/vsphere/vclib/utils.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/utils.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/types"
@@ -129,4 +130,45 @@ func RemoveClusterFromVDiskPath(vDiskPath string) string {
 		vDiskPath = strings.Replace(vDiskPath, datastore, filepath.Base(datastore), 1)
 	}
 	return vDiskPath
+}
+
+// GetPathFromVMDiskPath retrieves the path from VM Disk Path.
+// Example: For vmDiskPath - [vsanDatastore] kubevols/volume.vmdk, the path is kubevols/volume.vmdk
+func GetPathFromVMDiskPath(vmDiskPath string) string {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		return ""
+	}
+	return datastorePathObj.Path
+}
+
+// GetDatastoreFromVMDiskPath retrieves the path from VM Disk Path.
+// Example: For vmDiskPath - [vsanDatastore] kubevols/volume.vmdk, the path is vsanDatastore
+func GetDatastoreFromVMDiskPath(vmDiskPath string) string {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse vmDiskPath: %s", vmDiskPath)
+		return ""
+	}
+	return datastorePathObj.Datastore
+}
+
+//GetDatastorePathObjFromVMDiskPath gets the datastorePathObj from VM disk path.
+func GetDatastorePathObjFromVMDiskPath(vmDiskPath string) (*object.DatastorePath, error) {
+	datastorePathObj := new(object.DatastorePath)
+	isSuccess := datastorePathObj.FromString(vmDiskPath)
+	if !isSuccess {
+		glog.Errorf("Failed to parse volPath: %s", vmDiskPath)
+		return nil, fmt.Errorf("Failed to parse volPath: %s", vmDiskPath)
+	}
+	return datastorePathObj, nil
+}
+
+//IsValidUUID checks if the string is a valid UUID.
+func IsValidUUID(uuid string) bool {
+	r := regexp.MustCompile("^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+	return r.MatchString(uuid)
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -412,8 +412,8 @@ func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 	if isActive {
 		return "/" + vm.InventoryPath, nil
 	}
-
-	return "", fmt.Errorf("The node %q is not active", nodeNameToVMName(nodeName))
+	glog.Warningf("The VM: %s is not in %s state", nodeNameToVMName(nodeName), vclib.ActivePowerState)
+	return "", cloudprovider.InstanceNotFound
 }
 
 // InstanceTypeByProviderID returns the cloudprovider instance type of the node with the specified unique providerID

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -86,34 +86,57 @@ func (attacher *vsphereVMDKAttacher) Attach(spec *volume.Spec, nodeName types.No
 }
 
 func (attacher *vsphereVMDKAttacher) VolumesAreAttached(specs []*volume.Spec, nodeName types.NodeName) (map[*volume.Spec]bool, error) {
-	volumesAttachedCheck := make(map[*volume.Spec]bool)
-	volumeSpecMap := make(map[string]*volume.Spec)
-	volumePathList := []string{}
-	for _, spec := range specs {
-		volumeSource, _, err := getVolumeSource(spec)
-		if err != nil {
-			glog.Errorf("Error getting volume (%q) source : %v", spec.Name(), err)
-			continue
-		}
-		volumePathList = append(volumePathList, volumeSource.VolumePath)
-		volumeSpecMap[volumeSource.VolumePath] = spec
+	glog.Warningf("Attacher.VolumesAreAttached called for node %q - Please use BulkVerifyVolumes for vSphere", nodeName)
+	volumeNodeMap := map[types.NodeName][]*volume.Spec{
+		nodeName: specs,
 	}
-	attachedResult, err := attacher.vsphereVolumes.DisksAreAttached(volumePathList, nodeName)
+	nodeVolumesResult := make(map[*volume.Spec]bool)
+	nodesVerificationMap, err := attacher.BulkVerifyVolumes(volumeNodeMap)
 	if err != nil {
-		glog.Errorf(
-			"Error checking if volumes (%v) are attached to current node (%q). err=%v",
-			volumePathList, nodeName, err)
-		return nil, err
+		glog.Errorf("Attacher.VolumesAreAttached - error checking volumes for node %q with %v", nodeName, err)
+		return nodeVolumesResult, err
+	}
+	if result, ok := nodesVerificationMap[nodeName]; ok {
+		return result, nil
+	}
+	return nodeVolumesResult, nil
+}
+
+func (attacher *vsphereVMDKAttacher) BulkVerifyVolumes(volumesByNode map[types.NodeName][]*volume.Spec) (map[types.NodeName]map[*volume.Spec]bool, error) {
+	volumesAttachedCheck := make(map[types.NodeName]map[*volume.Spec]bool)
+	volumePathsByNode := make(map[types.NodeName][]string)
+	volumeSpecMap := make(map[string]*volume.Spec)
+
+	for nodeName, volumeSpecs := range volumesByNode {
+		for _, volumeSpec := range volumeSpecs {
+			volumeSource, _, err := getVolumeSource(volumeSpec)
+			if err != nil {
+				glog.Errorf("Error getting volume (%q) source : %v", volumeSpec.Name(), err)
+				continue
+			}
+			volPath := volumeSource.VolumePath
+			volumePathsByNode[nodeName] = append(volumePathsByNode[nodeName], volPath)
+			nodeVolume, nodeVolumeExists := volumesAttachedCheck[nodeName]
+			if !nodeVolumeExists {
+				nodeVolume = make(map[*volume.Spec]bool)
+			}
+			nodeVolume[volumeSpec] = true
+			volumeSpecMap[volPath] = volumeSpec
+			volumesAttachedCheck[nodeName] = nodeVolume
+		}
+	}
+	attachedResult, err := attacher.vsphereVolumes.DisksAreAttached(volumePathsByNode)
+	if err != nil {
+		glog.Errorf("Error checking if volumes are attached to nodes: %+v. err: %v", volumePathsByNode, err)
+		return volumesAttachedCheck, err
 	}
 
-	for volumePath, attached := range attachedResult {
-		spec := volumeSpecMap[volumePath]
-		if !attached {
-			volumesAttachedCheck[spec] = false
-			glog.V(2).Infof("VolumesAreAttached: volume %q (specName: %q) is no longer attached", volumePath, spec.Name())
-		} else {
-			volumesAttachedCheck[spec] = true
-			glog.V(2).Infof("VolumesAreAttached: volume %q (specName: %q) is attached", volumePath, spec.Name())
+	for nodeName, nodeVolumes := range attachedResult {
+		for volumePath, attached := range nodeVolumes {
+			if !attached {
+				spec := volumeSpecMap[volumePath]
+				setNodeVolume(volumesAttachedCheck, spec, nodeName, false)
+			}
 		}
 	}
 	return volumesAttachedCheck, nil
@@ -256,4 +279,18 @@ func (detacher *vsphereVMDKDetacher) Detach(deviceMountPath string, nodeName typ
 
 func (detacher *vsphereVMDKDetacher) UnmountDevice(deviceMountPath string) error {
 	return volumeutil.UnmountPath(deviceMountPath, detacher.mounter)
+}
+
+func setNodeVolume(
+	nodeVolumeMap map[types.NodeName]map[*volume.Spec]bool,
+	volumeSpec *volume.Spec,
+	nodeName types.NodeName,
+	check bool) {
+
+	volumeMap := nodeVolumeMap[nodeName]
+	if volumeMap == nil {
+		volumeMap = make(map[*volume.Spec]bool)
+		nodeVolumeMap[nodeName] = volumeMap
+	}
+	volumeMap[volumeSpec] = check
 }

--- a/pkg/volume/vsphere_volume/attacher_test.go
+++ b/pkg/volume/vsphere_volume/attacher_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -308,7 +309,7 @@ func (testcase *testcase) DiskIsAttached(diskName string, nodeName types.NodeNam
 	return expected.isAttached, expected.ret
 }
 
-func (testcase *testcase) DisksAreAttached(diskNames []string, nodeName types.NodeName) (map[string]bool, error) {
+func (testcase *testcase) DisksAreAttached(nodeVolumes map[k8stypes.NodeName][]string) (map[k8stypes.NodeName]map[string]bool, error) {
 	return nil, errors.New("Not implemented")
 }
 

--- a/pkg/volume/vsphere_volume/vsphere_volume.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume.go
@@ -85,7 +85,7 @@ func (plugin *vsphereVolumePlugin) SupportsMountOption() bool {
 }
 
 func (plugin *vsphereVolumePlugin) SupportsBulkVolumeVerification() bool {
-	return false
+	return true
 }
 
 func (plugin *vsphereVolumePlugin) NewMounter(spec *volume.Spec, pod *v1.Pod, _ volume.VolumeOptions) (volume.Mounter, error) {


### PR DESCRIPTION
Cherry pick of #52131, #52575 on release-1.8

#52131: Implement bulk polling of volumes for vSphere
#52575: Unable to detach the vSphere volume from Powered off node

@BaluDontu 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
BulkVerifyVolumes() implementation for vSphere Cloud Provider
Fixed volume detachment from powered off node
```