### PR TITLE
Add `CONCURRENT_SERVICE_SYNCS` to kube-env

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -894,6 +894,11 @@ EOF
 CLUSTER_SIGNING_DURATION: $(yaml-quote ${CLUSTER_SIGNING_DURATION})
 EOF
     fi
+    if [ -n "${CONCURRENT_SERVICE_SYNCS:-}" ]; then
+      cat >>$file <<EOF
+CONCURRENT_SERVICE_SYNCS: $(yaml-quote ${CONCURRENT_SERVICE_SYNCS})
+EOF
+    fi
 
   else
     # Node-only env vars.


### PR DESCRIPTION
**What this PR does / why we need it**: Follow up of https://github.com/kubernetes/kubernetes/pull/52684, this PR properly pipes `CONCURRENT_SERVICE_SYNCS` onto master.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: ref https://github.com/kubernetes/kubernetes/issues/52495

**Special notes for your reviewer**:
/assign @shyamjvs @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
