### PR TITLE
use multi-arch busybox for e2e

### DIFF
--- a/federation/test/e2e/BUILD
+++ b/federation/test/e2e/BUILD
@@ -34,7 +34,6 @@ go_library(
         "//test/e2e/chaosmonkey:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",

--- a/federation/test/e2e/job.go
+++ b/federation/test/e2e/job.go
@@ -29,7 +29,6 @@ import (
 	fedutil "k8s.io/kubernetes/federation/pkg/federation-controller/util"
 	fedframework "k8s.io/kubernetes/federation/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -279,7 +278,7 @@ func newJobForFed(namespace string, name string, completions int32, parallelism 
 					Containers: []v1.Container{
 						{
 							Name:    "sleep",
-							Image:   imageutils.GetBusyBoxImage(),
+							Image:   "busybox",
 							Command: []string{"sleep", "1"},
 						},
 					},

--- a/federation/test/e2e/util.go
+++ b/federation/test/e2e/util.go
@@ -36,7 +36,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var (
@@ -403,7 +402,7 @@ func discoverService(f *fedframework.Framework, name string, exists bool, podNam
 			Containers: []v1.Container{
 				{
 					Name:    "federated-service-discovery-container",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: command,
 				},
 			},

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -288,7 +288,7 @@ func newCronJob(name, schedule string) *batchv1beta1.CronJob {
 							Containers: []v1.Container{
 								{
 									Name:    "c",
-									Image:   imageutils.GetBusyBoxImage(),
+									Image:   "busybox",
 									Command: []string{"sleep", "300"},
 								},
 							},

--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -243,7 +243,7 @@ func newTestingCronJob(name string, value string) *batchv1beta1.CronJob {
 							Containers: []v1.Container{
 								{
 									Name:  "c",
-									Image: imageutils.GetBusyBoxImage(),
+									Image: "busybox",
 									VolumeMounts: []v1.VolumeMount{
 										{
 											MountPath: "/data",

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/job"
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -304,7 +303,7 @@ func newTestCronJob(name, schedule string, concurrencyPolicy batchv1beta1.Concur
 							Containers: []v1.Container{
 								{
 									Name:  "c",
-									Image: imageutils.GetBusyBoxImage(),
+									Image: "busybox",
 									VolumeMounts: []v1.VolumeMount{
 										{
 											MountPath: "/data",

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -42,7 +42,7 @@ const (
 
 var (
 	mountImage   = imageutils.GetE2EImage(imageutils.Mounttest)
-	busyboxImage = imageutils.GetBusyBoxImage()
+	busyboxImage = "busybox"
 )
 
 var CurrentSuite Suite
@@ -52,7 +52,7 @@ var CurrentSuite Suite
 // only used by node e2e test.
 // TODO(random-liu): Change the image puller pod to use similar mechanism.
 var CommonImageWhiteList = sets.NewString(
-	imageutils.GetBusyBoxImage(),
+	"busybox",
 	imageutils.GetE2EImage(imageutils.EntrypointTester),
 	imageutils.GetE2EImage(imageutils.Liveness),
 	imageutils.GetE2EImage(imageutils.Mounttest),

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func EtcdUpgrade(target_storage, target_version string) error {
@@ -327,7 +326,7 @@ func gceUpgradeScript() string {
 func waitForSSHTunnels() {
 	Logf("Waiting for SSH tunnels to establish")
 	RunKubectl("run", "ssh-tunnel-test",
-		"--image="+imageutils.GetBusyBoxImage(),
+		"--image=busybox",
 		"--restart=Never",
 		"--command", "--",
 		"echo", "Hello")

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -192,7 +192,7 @@ const (
 )
 
 var (
-	BusyBoxImage = imageutils.GetBusyBoxImage()
+	BusyBoxImage = "busybox"
 	// Label allocated to the image puller static pod that runs on each node
 	// before e2es.
 	ImagePullerLabels = map[string]string{"name": "e2e-image-puller"}

--- a/test/e2e/instrumentation/logging/BUILD
+++ b/test/e2e/instrumentation/logging/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//test/e2e/instrumentation/common:go_default_library",
         "//test/e2e/instrumentation/logging/elasticsearch:go_default_library",
         "//test/e2e/instrumentation/logging/stackdrvier:go_default_library",
-        "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	instrumentation "k8s.io/kubernetes/test/e2e/instrumentation/common"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disruptive]", func() {
@@ -101,7 +100,7 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 			return v1.PodSpec{
 				Containers: []v1.Container{{
 					Name:  "logging-soak",
-					Image: imageutils.GetBusyBoxImage(),
+					Image: "busybox",
 					Args: []string{
 						"/bin/sh",
 						"-c",

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -95,7 +95,7 @@ var (
 	kittenImage   = imageutils.GetE2EImage(imageutils.Kitten)
 	redisImage    = imageutils.GetE2EImage(imageutils.Redis)
 	nginxImage    = imageutils.GetE2EImage(imageutils.NginxSlim)
-	busyboxImage  = imageutils.GetBusyBoxImage()
+	busyboxImage  = "busybox"
 )
 
 var testImages = struct {

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -514,7 +514,7 @@ func createNetworkClientPod(f *framework.Framework, namespace *v1.Namespace, pod
 			Containers: []v1.Container{
 				{
 					Name:  fmt.Sprintf("%s-container", podName),
-					Image: imageutils.GetBusyBoxImage(),
+					Image: "busybox",
 					Args: []string{
 						"/bin/sh",
 						"-c",

--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/utils:go_default_library",
-        "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -34,7 +34,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -170,7 +169,7 @@ func createPodUsingNfs(f *framework.Framework, c clientset.Interface, ns, nfsIP,
 			Containers: []v1.Container{
 				{
 					Name:    "pod-nfs-vol",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"/bin/sh"},
 					Args:    cmdLine,
 					VolumeMounts: []v1.VolumeMount{

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -32,7 +32,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func scTestPod(hostIPC bool, hostPID bool) *v1.Pod {
@@ -50,7 +49,7 @@ func scTestPod(hostIPC bool, hostPID bool) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "test-container",
-					Image: imageutils.GetBusyBoxImage(),
+					Image: "busybox",
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever,

--- a/test/e2e/pod_gc.go
+++ b/test/e2e/pod_gc.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // This test requires that --terminated-pod-gc-threshold=100 be set on the controller manager
@@ -90,7 +89,7 @@ func createTerminatingPod(f *framework.Framework) (*v1.Pod, error) {
 			Containers: []v1.Container{
 				{
 					Name:  string(uuid),
-					Image: imageutils.GetBusyBoxImage(),
+					Image: "busybox",
 				},
 			},
 			SchedulerName: "please don't schedule my pods",

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -80,7 +80,7 @@ func testPreStop(c clientset.Interface, ns string) {
 			Containers: []v1.Container{
 				{
 					Name:    "tester",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"sleep", "600"},
 					Lifecycle: &v1.Lifecycle{
 						PreStop: &v1.Handler{

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -351,7 +351,7 @@ func testNoWrappedVolumeRace(f *framework.Framework, volumes []v1.Volume, volume
 					Containers: []v1.Container{
 						{
 							Name:    "test-container",
-							Image:   imageutils.GetBusyBoxImage(),
+							Image:   "busybox",
 							Command: []string{"sleep", "10000"},
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -38,7 +38,6 @@ import (
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -486,7 +485,7 @@ func testPDPod(diskNames []string, targetNode types.NodeName, readOnly bool, num
 		if numContainers > 1 {
 			containers[i].Name = fmt.Sprintf("mycontainer%v", i+1)
 		}
-		containers[i].Image = imageutils.GetBusyBoxImage()
+		containers[i].Image = "busybox"
 		containers[i].Command = []string{"sleep", "6000"}
 		containers[i].VolumeMounts = make([]v1.VolumeMount, len(diskNames))
 		for k := range diskNames {

--- a/test/e2e/storage/volume_provisioning.go
+++ b/test/e2e/storage/volume_provisioning.go
@@ -45,7 +45,6 @@ import (
 	storageutil "k8s.io/kubernetes/pkg/apis/storage/v1/util"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 type storageClassTest struct {
@@ -796,7 +795,7 @@ func runInPodWithVolume(c clientset.Interface, ns, claimName, command string) {
 			Containers: []v1.Container{
 				{
 					Name:    "volume-tester",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", command},
 					VolumeMounts: []v1.VolumeMount{

--- a/test/e2e/storage/vsphere_utils.go
+++ b/test/e2e/storage/vsphere_utils.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // Sanity check for vSphere testing.  Verify the persistent disk attached to the node.
@@ -245,7 +244,7 @@ func getVSpherePodSpecWithClaim(claimName string, nodeSelectorKV map[string]stri
 			Containers: []v1.Container{
 				{
 					Name:    "volume-tester",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", command},
 					VolumeMounts: []v1.VolumeMount{
@@ -310,7 +309,7 @@ func getVSpherePodSpecWithVolumePaths(volumePaths []string, keyValuelabel map[st
 			Containers: []v1.Container{
 				{
 					Name:         "vsphere-e2e-container-" + string(uuid.NewUUID()),
-					Image:        imageutils.GetBusyBoxImage(),
+					Image:        "busybox",
 					Command:      commands,
 					VolumeMounts: volumeMounts,
 				},

--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -118,7 +118,7 @@ func (t *ConfigMapUpgradeTest) testPod(f *framework.Framework) {
 				},
 				{
 					Name:    "configmap-env-test",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"sh", "-c", "env"},
 					Env: []v1.EnvVar{
 						{

--- a/test/e2e/upgrades/secrets.go
+++ b/test/e2e/upgrades/secrets.go
@@ -114,7 +114,7 @@ func (t *SecretUpgradeTest) testPod(f *framework.Framework) {
 				},
 				{
 					Name:    "secret-env-test",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: []string{"sh", "-c", "env"},
 					Env: []v1.EnvVar{
 						{

--- a/test/e2e/upgrades/sysctl.go
+++ b/test/e2e/upgrades/sysctl.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
 
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // SecretUpgradeTest tests that a pod with sysctls runs before and after an upgrade. During
@@ -132,7 +131,7 @@ func sysctlTestPod(name string, sysctls map[string]string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:    "test-container",
-					Image:   imageutils.GetBusyBoxImage(),
+					Image:   "busybox",
 					Command: append([]string{"/bin/sysctl"}, keys...),
 				},
 			},

--- a/test/e2e_node/docker_test.go
+++ b/test/e2e_node/docker_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -55,12 +54,12 @@ var _ = framework.KubeDescribe("Docker features [Feature:Docker]", func() {
 					Containers: []v1.Container{
 						{
 							Name:    "test-container-1",
-							Image:   imageutils.GetBusyBoxImage(),
+							Image:   "busybox",
 							Command: []string{"/bin/top"},
 						},
 						{
 							Name:    "test-container-2",
-							Image:   imageutils.GetBusyBoxImage(),
+							Image:   "busybox",
 							Command: []string{"/bin/sleep"},
 							Args:    []string{"10000"},
 						},

--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -341,7 +341,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 		createAndWaitUserPod := func(readOnlyRootFilesystem bool) string {
 			podName := fmt.Sprintf("busybox-readonly-%v-%s", readOnlyRootFilesystem, uuid.NewUUID())
 			podClient.Create(makeUserPod(podName,
-				imageutils.GetBusyBoxImage(),
+				"busybox",
 				[]string{"sh", "-c", "touch checkfile"},
 				readOnlyRootFilesystem,
 			))

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -45,7 +45,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // TODO(random-liu): Get this automatically from kubelet flag.
@@ -53,7 +52,7 @@ var kubeletAddress = flag.String("kubelet-address", "http://127.0.0.1:10255", "H
 
 var startServices = flag.Bool("start-services", true, "If true, start local node services")
 var stopServices = flag.Bool("stop-services", true, "If true, stop local node services after running tests")
-var busyboxImage = imageutils.GetBusyBoxImage()
+var busyboxImage = "busybox"
 
 func getNodeSummary() (*stats.Summary, error) {
 	req, err := http.NewRequest("GET", *kubeletAddress+"/stats/summary", nil)

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -86,21 +86,3 @@ var (
 func GetE2EImage(image ImageConfig) string {
 	return fmt.Sprintf("%s/%s-%s:%s", image.registry, image.name, runtime.GOARCH, image.version)
 }
-
-// GetBusyboxImage returns multi-arch busybox docker image
-func GetBusyBoxImage() string {
-	switch arch := runtime.GOARCH; arch {
-	case "amd64":
-		return "busybox"
-	case "arm":
-		return "arm32v6/busybox"
-	case "arm64":
-		return "arm64v8/busybox"
-	case "ppc64le":
-		return "ppc64le/busybox"
-	case "s390x":
-		return "s390x/busybox"
-	default:
-		return ""
-	}
-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Since [multi-arch is supported already for Official images on Dockerhub](https://blog.docker.com/2017/09/docker-official-images-now-multi-platform/), we can use `busybox` directly instead of having our own `GetBusyBoxImage` for multi-arch. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
xref #53958

**Special notes for your reviewer**:
/assign @mkumatag @ixdy 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use multi-arch busybox image for e2e
```
