### PR TITLE
Increase l7-lb-controller's memory check threshold in density test

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -152,7 +152,7 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 	}
 	constraints["l7-lb-controller"] = framework.ResourceConstraint{
 		CPUConstraint:    0.2 + 0.0001*float64(numNodes),
-		MemoryConstraint: (75 + uint64(math.Ceil(0.6*float64(numNodes)))) * (1024 * 1024),
+		MemoryConstraint: (75 + uint64(math.Ceil(0.8*float64(numNodes)))) * (1024 * 1024),
 	}
 	constraints["influxdb"] = framework.ResourceConstraint{
 		CPUConstraint:    2,


### PR DESCRIPTION
Reason for density test failing in our [latest 5k-node run](https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-performance/49):

```
I1016 23:17:15.673]       Container l7-lb-controller-v0.9.7-gce-scale-cluster-master/l7-lb-controller is using 3428.52734375/3075 MB of memory
I1016 23:17:15.673]   not to have occurred[0m
```

cc @kubernetes/sig-scalability-misc 