### PR TITLE
Optimize Repeated registration of AlgorithmProvider when ApplyFeatureGates

### DIFF
--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -195,20 +195,24 @@ func defaultPredicates() sets.String {
 
 // ApplyFeatureGates applies algorithm by feature gates.
 func ApplyFeatureGates() {
-	predSet := defaultPredicates()
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
 		// Remove "CheckNodeCondition" predicate
 		factory.RemoveFitPredicate("CheckNodeCondition")
-		predSet.Delete("CheckNodeCondition")
+		// Remove Key "CheckNodeCondition" From All Algorithm Provider
+		// The key will be removed from all providers which in algorithmProviderMap[]
+		// if you just want remove specific provider, call func RemovePredicateKeyFromAlgoProvider()
+		factory.RemovePredicateKeyFromAlgorithmProviderMap("CheckNodeCondition")
 
 		// Fit is determined based on whether a pod can tolerate all of the node's taints
-		predSet.Insert(factory.RegisterMandatoryFitPredicate("PodToleratesNodeTaints", predicates.PodToleratesNodeTaints))
+		factory.RegisterMandatoryFitPredicate("PodToleratesNodeTaints", predicates.PodToleratesNodeTaints)
+		// Insert Key "PodToleratesNodeTaints" To All Algorithm Provider
+		// The key will insert to all providers which in algorithmProviderMap[]
+		// if you just want insert to specific provider, call func InsertPredicateKeyToAlgoProvider()
+		factory.InsertPredicateKeyToAlgorithmProviderMap("PodToleratesNodeTaints")
 
 		glog.Warningf("TaintNodesByCondition is enabled, PodToleratesNodeTaints predicate is mandatory")
 	}
-
-	registerAlgorithmProvider(predSet, defaultPriorities())
 }
 
 func registerAlgorithmProvider(predSet, priSet sets.String) {

--- a/plugin/pkg/scheduler/factory/plugins.go
+++ b/plugin/pkg/scheduler/factory/plugins.go
@@ -115,6 +115,56 @@ func RemoveFitPredicate(name string) {
 	mandatoryFitPredicates.Delete(name)
 }
 
+// RemovePredicateKeyFromAlgoProvider removes a fit predicate key from algorithmProvider.
+func RemovePredicateKeyFromAlgoProvider(providerName, key string) error {
+	schedulerFactoryMutex.Lock()
+	defer schedulerFactoryMutex.Unlock()
+
+	validateAlgorithmNameOrDie(providerName)
+	provider, ok := algorithmProviderMap[providerName]
+	if !ok {
+		return fmt.Errorf("plugin %v has not been registered", providerName)
+	}
+	provider.FitPredicateKeys.Delete(key)
+	return nil
+}
+
+// RemovePredicateKeyFromAlgoProvider removes a fit predicate key from all algorithmProviders which in algorithmProviderMap.
+func RemovePredicateKeyFromAlgorithmProviderMap(key string) {
+	schedulerFactoryMutex.Lock()
+	defer schedulerFactoryMutex.Unlock()
+
+	for _, provider := range algorithmProviderMap {
+		provider.FitPredicateKeys.Delete(key)
+	}
+	return
+}
+
+// InsertPredicateKeyToAlgoProvider insert a fit predicate key to algorithmProvider.
+func InsertPredicateKeyToAlgoProvider(providerName, key string) error {
+	schedulerFactoryMutex.Lock()
+	defer schedulerFactoryMutex.Unlock()
+
+	validateAlgorithmNameOrDie(providerName)
+	provider, ok := algorithmProviderMap[providerName]
+	if !ok {
+		return fmt.Errorf("plugin %v has not been registered", providerName)
+	}
+	provider.FitPredicateKeys.Insert(key)
+	return nil
+}
+
+// InsertPredicateKeyToAlgorithmProviderMap insert a fit predicate key to all algorithmProviders which in algorithmProviderMap.
+func InsertPredicateKeyToAlgorithmProviderMap(key string) {
+	schedulerFactoryMutex.Lock()
+	defer schedulerFactoryMutex.Unlock()
+
+	for _, provider := range algorithmProviderMap {
+		provider.FitPredicateKeys.Insert(key)
+	}
+	return
+}
+
 // RegisterMandatoryFitPredicate registers a fit predicate with the algorithm registry, the predicate is used by
 // kubelet, DaemonSet; it is always included in configuration. Returns the name with which the predicate was
 // registered.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
modified ApplyFeatureGates() just add/del features, cancel the register of all AlgorithmProvider.

 there is Repeated registration of all AlgorithmProvider when ApplyFeatureGates() runs;
AlgorithmProvider have already registered when  package defaults loaded;
I think ApplyFeatureGates() is just add/del features, it needn't  register all AlgorithmProvider again
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```/release-note-none
``` 
