### PR TITLE
Increase default service-controller parallelism

### DIFF
--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -62,7 +62,7 @@ func NewCMServer() *CMServer {
 			Port:                                            ports.ControllerManagerPort,
 			Address:                                         "0.0.0.0",
 			ConcurrentEndpointSyncs:                         5,
-			ConcurrentServiceSyncs:                          1,
+			ConcurrentServiceSyncs:                          5,
 			ConcurrentRCSyncs:                               5,
 			ConcurrentRSSyncs:                               5,
 			ConcurrentDaemonSetSyncs:                        2,


### PR DESCRIPTION
Based off of @MrHohn 's suggestion. Ref: https://github.com/kubernetes/kubernetes/issues/52495#issuecomment-337106218

I think we should make this the cluster default. As current situation is not very desirable, i.e multiple updates (potentially small) could be waiting for a long time because of a single big update (possibly due to external LB creation).

cc @kubernetes/sig-network-misc @nicksardo 