### PR TITLE
Automated cherry pick of #53417

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1657,6 +1657,10 @@
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/util/flowcontrol",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		}
 	]
 }

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/webhook:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Cherry pick of #53417 on release-1.8.

#53417: Adjust defaults of audit webhook backends

```release-note
Adjust batching audit webhook default parameters: increase queue size, batch size, and initial backoff.
Add throttling to the batching audit webhook. Default rate limit is 10 QPS.
```