### PR TITLE
Support completion for kubectl cp

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -164,6 +164,92 @@ __kubectl_require_pod_and_container()
     return 0
 }
 
+# Complete remote files with kubectl exec for kubectl cp
+__kubectl_cp_remote_files()
+{
+    # remove backslash escape from the first colon
+    cur=${cur/\\:/:}
+
+    local namespacepod="${cur%%?(\\):*}"
+    local pathname=${cur#*:}
+
+    local pathname_esc='[][(){}<>",:;^&!$=?` + "`" + `|\\'"'"'[:space:]]'
+
+    # unescape
+    pathname=$(sed -e 's/\\\\\\\('$pathname_esc'\)/\\\1/g' <<<"$pathname")
+
+    local namespace pod
+    if [[ "$namespacepod" == */* ]]; then
+        namespace="${namespacepod%%/*}"
+        pod="${namespacepod#*/}"
+    else
+        pod="${namespacepod}"
+    fi
+
+    local kubectl_flags
+    if [[ -n "$namespace" ]]; then
+        kubectl_flags="--namespace=$namespace"
+    fi
+
+    local kubectl_out
+    if kubectl_out=$(kubectl $(__kubectl_override_flags) $kubectl_flags exec $pod -- sh -c "ls -aF1dL ${pathname}*" 2>/dev/null | sed -e 's/'$pathname_esc'/\\\\&/g' -e 's/[*@|=]$//g'); then
+        local IFS=$'\n'
+        COMPREPLY=( $(compgen -W "${kubectl_out[*]}" -- ${cur#*:}) )
+
+        if [ -n "${ZSH_VERSION}" ]; then
+            # zsh completion needs [<namespace>/]<pod-name>: prefix
+            COMPREPLY=( "${COMPREPLY[@]/#/${namespacepod}:}" )
+        fi
+    fi
+}
+
+# Complete <namespace>/<pod-name> for kubectl cp
+__kubectl_cp_namespacepods()
+{
+    local namespace="${cur%%/*}"
+    local pod="${cur#*/}"
+
+    local template="{{ range .items }}{{.metadata.namespace}}/{{.metadata.name}}: {{ end }}"
+    local kubectl_out
+    if kubectl_out=$(kubectl $(__kubectl_override_flags) --namespace="${namespace}" get pods -o template --template "${template}" 2>/dev/null); then
+        COMPREPLY=( $(compgen -W "${kubectl_out[*]}" -- $cur) )
+    fi
+}
+
+# Complete namespaces and pods for kubectl cp
+__kubectl_cp_namespaces_and_pods()
+{
+    local template kubectl_out
+
+    template="{{ range .items }}{{.metadata.name}}/ {{ end }}"
+    if kubectl_out=$(kubectl $(__kubectl_override_flags) get namespaces -o template --template "${template}" 2>/dev/null); then
+        COMPREPLY+=( $(compgen -W "${kubectl_out[*]}" -- $cur) )
+    fi
+
+    template="{{ range .items }}{{.metadata.name}}: {{ end }}"
+    if kubectl_out=$(kubectl $(__kubectl_override_flags) get pods -o template --template "${template}" 2>/dev/null); then
+        COMPREPLY+=( $(compgen -W "${kubectl_out[*]}" -- $cur) )
+    fi
+}
+
+__kubectl_cp()
+{
+    local cur
+    _get_comp_words_by_ref -n : cur
+
+    if [[ $(type -t compopt) = "builtin" ]]; then
+        compopt -o nospace
+    fi
+
+    case $cur in
+        /*|[.~]*) _filedir ;; # looks like a path
+        *:*) __kubectl_cp_remote_files ;;
+        */*) __kubectl_cp_namespacepods; _filedir ;;
+        *) __kubectl_cp_namespaces_and_pods; _filedir ;;
+    esac
+}
+
+
 __custom_func() {
     case ${last_command} in
         kubectl_get | kubectl_describe | kubectl_delete | kubectl_label | kubectl_edit | kubectl_patch |\
@@ -193,6 +279,10 @@ __custom_func() {
             ;;
         kubectl_config_delete-cluster)
             __kubectl_config_get_clusters
+            return
+            ;;
+        kubectl_cp)
+            __kubectl_cp
             return
             ;;
         *)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: With this PR, `kubectl cp` supports completion. I tested this PR in both bash and zsh.

```
$ bash --version
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2013 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
$ . /home/ksuda/.linuxbrew/etc/bash_completion
$ source <(./kubectl completion bash)

# Complete <namespaces>/, <pod-name>: and files
$ kubectl cp <tab><tab>
api/                      CHANGELOG-1.4.md          CHANGELOG.md              docs/                     .github/                  kube-public/              Makefile.generated_files  plugin/                   translations/
.bazelrc                  CHANGELOG-1.5.md          cluster/                  examples/                 .gitignore                kube-system/              nginx-4217019353-mw1pk:   README.md                 Vagrantfile
build/                    CHANGELOG-1.6.md          cmd/                      federation/               Godeps/                   labels.yaml               nginx-4217019353-rzw2c:   staging/                  vendor/
BUILD.bazel               CHANGELOG-1.7.md          code-of-conduct.md        .generated_files          hack/                     LICENSE                   OWNERS                    SUPPORT.md                WORKSPACE
CHANGELOG-1.2.md          CHANGELOG-1.8.md          CONTRIBUTING.md           .git/                     .kazelcfg.json            logo/                     OWNERS_ALIASES            test/                     
CHANGELOG-1.3.md          CHANGELOG-1.9.md          default/                  .gitattributes            kubectl                   Makefile                  pkg/                      third_party/              
$ kubectl cp nginx-4217019353-<tab><tab>
nginx-4217019353-mw1pk:  nginx-4217019353-rzw2c:  
# Complete remote files of pod/nginx-4217019353-rzw2c
$ kubectl cp nginx-4217019353-rzw2c:<tab><tab>
bin/    boot/   dev/    etc/    home/   lib/    lib64/  media/  mnt/    opt/    proc/   root/   run/    sbin/   srv/    sys/    tmp/    usr/    var/    
$ kubectl cp nginx-4217019353-rzw2c:etc/<tab><tab>
etc/adduser.conf               etc/environment                etc/init.d/                    etc/machine-id                 etc/passwd-                    etc/resolv.conf                etc/subuid
etc/alternatives/              etc/fonts/                     etc/issue                      etc/mke2fs.conf                etc/profile                    etc/rmt                        etc/systemd/
etc/apt/                       etc/fstab                      etc/issue.net                  etc/motd                       etc/profile.d/                 etc/securetty                  etc/terminfo/
etc/bash.bashrc                etc/gai.conf                   etc/kernel/                    etc/mtab                       etc/rc0.d/                     etc/security/                  etc/timezone
etc/bindresvport.blacklist     etc/group                      etc/ld.so.cache                etc/nginx/                     etc/rc1.d/                     etc/selinux/                   etc/ucf.conf
etc/cron.daily/                etc/group-                     etc/ld.so.conf                 etc/nsswitch.conf              etc/rc2.d/                     etc/shadow                     etc/update-motd.d/
etc/debconf.conf               etc/gshadow                    etc/ld.so.conf.d/              etc/opt/                       etc/rc3.d/                     etc/shadow-                    
etc/debian_version             etc/gshadow-                   etc/libaudit.conf              etc/os-release                 etc/rc4.d/                     etc/shells                     
etc/default/                   etc/host.conf                  etc/localtime                  etc/pam.conf                   etc/rc5.d/                     etc/skel/                      
etc/deluser.conf               etc/hostname                   etc/login.defs                 etc/pam.d/                     etc/rc6.d/                     etc/staff-group-for-usr-local  
etc/dpkg/                      etc/hosts                      etc/logrotate.d/               etc/passwd                     etc/rcS.d/                     etc/subgid                     
$ kubectl cp nginx-4217019353-rzw2c:etc/nginx/nginx.conf ./nginx.conf

$ kubectl cp ./CHANGELOG<tab><tab>
CHANGELOG-1.2.md  CHANGELOG-1.3.md  CHANGELOG-1.4.md  CHANGELOG-1.5.md  CHANGELOG-1.6.md  CHANGELOG-1.7.md  CHANGELOG-1.8.md  CHANGELOG-1.9.md  CHANGELOG.md      
$ kubectl cp ./CHANGELOG-1.8.md kube<tab><tab>
kubectl       kube-public/  kube-system/  
$ kubectl cp ./CHANGELOG-1.8.md kube-system/kube<tab><tab>
kube-system/kube-addon-manager-minikube:  kube-system/kube-dns-910330662-l9pwt:     kube-system/kubernetes-dashboard-9fbhm:   
$ kubectl cp ./CHANGELOG-1.8.md kube-system/kube-dns-910330662-l9pwt:<tab><tab>
bin/              etc/              kube-dns          lib/              mnt/              root/             sbin/             sys/              usr/              
dev/              home/             kube-dns-config/  media/            proc/             run/              srv/              tmp/              var/              
$ kubectl cp ./CHANGELOG-1.8.md kube-system/kube-dns-910330662-l9pwt:home/
Defaulting container name to kubedns.
$ kubectl exec --namespace kube-system kube-dns-910330662-l9pwt ls home/
Defaulting container name to kubedns.
Use 'kubectl describe pod/kube-dns-910330662-l9pwt' to see all of the containers in this pod.
CHANGELOG-1.8.md
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes kubernetes/kubectl#5

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
`kubectl cp` supports completion.
```
