### PR TITLE
Optionally launch build containers inside a specific parent cgroup

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -589,7 +589,7 @@ function kube::build::run_build_command_ex() {
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
   )
 
-  if [ ! -z "${DOCKER_CGROUP_PARENT:-}" ]; then
+  if [[ -n "${DOCKER_CGROUP_PARENT:-}" ]]; then
     kube::log::status "Using ${DOCKER_CGROUP_PARENT} as container cgroup parent"
     docker_run_opts+=(--cgroup-parent "${DOCKER_CGROUP_PARENT}")
   fi

--- a/build/common.sh
+++ b/build/common.sh
@@ -589,6 +589,11 @@ function kube::build::run_build_command_ex() {
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
   )
 
+  if [ ! -z "${DOCKER_CGROUP_PARENT:-}" ]; then
+    kube::log::status "Using ${DOCKER_CGROUP_PARENT} as container cgroup parent"
+    docker_run_opts+=(--cgroup-parent "${DOCKER_CGROUP_PARENT}")
+  fi
+
   # If we have stdin we can run interactive.  This allows things like 'shell.sh'
   # to work.  However, if we run this way and don't have stdin, then it ends up
   # running in a daemon-ish mode.  So if we don't have a stdin, we explicitly


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Adds support to the build process for launching containers inside a specific parent cgroup via the `--cgroup-parent` docker arg. We needed this to enforce resource usage when building Kubernetes in our CI environment.

**Special notes for your reviewer**: None

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
