### PR TITLE
staging README: update code-generator to published

### DIFF
--- a/staging/README.md
+++ b/staging/README.md
@@ -12,7 +12,7 @@ Repositories currently staged here:
 - [`k8s.io/apiserver`](https://github.com/kubernetes/apiserver)
 - [`k8s.io/client-go`](https://github.com/kubernetes/client-go)
 - [`k8s.io/kube-aggregator`](https://github.com/kubernetes/kube-aggregator)
-- [`k8s.io/code-generator`](https://github.com/kubernetes/code-generator) (about to be published)
+- [`k8s.io/code-generator`](https://github.com/kubernetes/code-generator)
 - [`k8s.io/metrics`](https://github.com/kubernetes/metrics)
 - [`k8s.io/sample-apiserver`](https://github.com/kubernetes/sample-apiserver)
 


### PR DESCRIPTION
The code-generator repository has been published long back.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
