### PR TITLE
Automated cherry pick of #54073

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -176,6 +176,10 @@ func (kl *Kubelet) updateDefaultLabels(initialNode, existingNode *v1.Node) bool 
 	var needsUpdate bool = false
 	//Set default labels but make sure to not set labels with empty values
 	for _, label := range defaultLabels {
+		if _, hasInitialValue := initialNode.Labels[label]; !hasInitialValue {
+			continue
+		}
+
 		if existingNode.Labels[label] != initialNode.Labels[label] {
 			existingNode.Labels[label] = initialNode.Labels[label]
 			needsUpdate = true

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1234,6 +1234,37 @@ func TestUpdateDefaultLabels(t *testing.T) {
 			},
 		},
 		{
+			name: "make sure existing labels do not get deleted when initial node has no opinion",
+			initialNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			existingNode: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						kubeletapis.LabelHostname:          "new-hostname",
+						kubeletapis.LabelZoneFailureDomain: "new-zone-failure-domain",
+						kubeletapis.LabelZoneRegion:        "new-zone-region",
+						kubeletapis.LabelInstanceType:      "new-instance-type",
+						kubeletapis.LabelOS:                "new-os",
+						kubeletapis.LabelArch:              "new-arch",
+						"please-persist":                   "foo",
+					},
+				},
+			},
+			needsUpdate: false,
+			finalLabels: map[string]string{
+				kubeletapis.LabelHostname:          "new-hostname",
+				kubeletapis.LabelZoneFailureDomain: "new-zone-failure-domain",
+				kubeletapis.LabelZoneRegion:        "new-zone-region",
+				kubeletapis.LabelInstanceType:      "new-instance-type",
+				kubeletapis.LabelOS:                "new-os",
+				kubeletapis.LabelArch:              "new-arch",
+				"please-persist":                   "foo",
+			},
+		},
+		{
 			name: "no update needed",
 			initialNode: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Cherry pick of #54073 on release-1.8.

#54073: Do not remove kubelet labels during startup