### PR TITLE
Remove DefaultExternalHost and ExternalHost

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -627,9 +627,6 @@ func defaultOptions(s *options.ServerRunOptions) error {
 	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts(s.GenericServerRunOptions.AdvertiseAddress.String(), []string{"kubernetes.default.svc", "kubernetes.default", "kubernetes"}, []net.IP{apiServerServiceIP}); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
-	if err := s.CloudProvider.DefaultExternalHost(s.GenericServerRunOptions); err != nil {
-		return fmt.Errorf("error setting the external host value: %v", err)
-	}
 
 	s.Authentication.ApplyAuthorization(s.Authorization)
 

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -102,9 +102,6 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	if err := s.SecureServing.MaybeDefaultWithSelfSignedCerts(s.GenericServerRunOptions.AdvertiseAddress.String(), nil, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
-	if err := s.CloudProvider.DefaultExternalHost(s.GenericServerRunOptions); err != nil {
-		return fmt.Errorf("error setting the external host value: %v", err)
-	}
 
 	s.Authentication.ApplyAuthorization(s.Authorization)
 

--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
-        "//pkg/cloudprovider:go_default_library",
         "//pkg/kubeapiserver/authenticator:go_default_library",
         "//pkg/kubeapiserver/authorizer:go_default_library",
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
@@ -29,7 +28,6 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -17,15 +17,7 @@ limitations under the License.
 package options
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/golang/glog"
 	"github.com/spf13/pflag"
-
-	"k8s.io/api/core/v1"
-	genericoptions "k8s.io/apiserver/pkg/server/options"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 type CloudProviderOptions struct {
@@ -48,43 +40,4 @@ func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile,
 		"The path to the cloud provider configuration file. Empty string for no configuration file.")
-}
-
-func (s *CloudProviderOptions) DefaultExternalHost(genericoptions *genericoptions.ServerRunOptions) error {
-	if len(genericoptions.ExternalHost) != 0 {
-		return nil
-	}
-
-	if cloudprovider.IsCloudProvider(s.CloudProvider) {
-		glog.Info("--external-hostname was not specified. Trying to get it from the cloud provider.")
-
-		cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-		if err != nil {
-			return fmt.Errorf("%q cloud provider could not be initialized: %v", s.CloudProvider, err)
-		}
-		instances, supported := cloud.Instances()
-		if !supported {
-			return fmt.Errorf("%q cloud provider has no instances", s.CloudProvider)
-		}
-		hostname, err := os.Hostname()
-		if err != nil {
-			return fmt.Errorf("failed to get hostname: %v", err)
-		}
-		nodeName, err := instances.CurrentNodeName(hostname)
-		if err != nil {
-			return fmt.Errorf("failed to get NodeName from %q cloud provider: %v", s.CloudProvider, err)
-		}
-		addrs, err := instances.NodeAddresses(nodeName)
-		if err != nil {
-			return fmt.Errorf("failed to get external host address from %q cloud provider: %v", s.CloudProvider, err)
-		} else {
-			for _, addr := range addrs {
-				if addr.Type == v1.NodeExternalIP {
-					genericoptions.ExternalHost = addr.Address
-				}
-			}
-		}
-	}
-
-	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -36,7 +36,9 @@ import (
 type ServerRunOptions struct {
 	AdvertiseAddress net.IP
 
-	CorsAllowedOriginList       []string
+	CorsAllowedOriginList []string
+	// TODO: "--external-hostname" command line param has been deprecated, we should remove
+	// the field below when we clean up the flag.
 	ExternalHost                string
 	MaxRequestsInFlight         int
 	MaxMutatingRequestsInFlight int
@@ -58,7 +60,6 @@ func NewServerRunOptions() *ServerRunOptions {
 // ApplyOptions applies the run options to the method receiver and returns self
 func (s *ServerRunOptions) ApplyTo(c *server.Config) error {
 	c.CorsAllowedOriginList = s.CorsAllowedOriginList
-	c.ExternalAddress = s.ExternalHost
 	c.MaxRequestsInFlight = s.MaxRequestsInFlight
 	c.MaxMutatingRequestsInFlight = s.MaxMutatingRequestsInFlight
 	c.RequestTimeout = s.RequestTimeout
@@ -124,8 +125,10 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&s.TargetRAMMB, "target-ram-mb", s.TargetRAMMB,
 		"Memory limit for apiserver in MB (used to configure sizes of caches, etc.)")
 
+	// TODO: When we remove this command line option, we should remove the ExternalHost field as well
 	fs.StringVar(&s.ExternalHost, "external-hostname", s.ExternalHost,
 		"The hostname to use when generating externalized URLs for this master (e.g. Swagger API Docs).")
+	fs.MarkDeprecated("external-hostname", "will be removed in a future release")
 
 	deprecatedMasterServiceNamespace := metav1.NamespaceDefault
 	fs.StringVar(&deprecatedMasterServiceNamespace, "master-service-namespace", deprecatedMasterServiceNamespace, ""+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Firstly ExternalHost in ServerRunOptions is not used anywhere and
secondly DefaultExternalHost depends on cloud provider API to look up
an IP address. This assumes that the kube api server is running inside
a VM that has access to the cloud provider API and makes kube api
server unnecessarily depend on cloud provider interface. Note that
since there is a plan in the community to move to an external cloud
provider, we should just drop DefaultExternalHost, but not the
actual command line parameter. The command line parameter should
be marked as deprecated. Added a couple of TODO(s) for later.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, 
...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #54077

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
--external-host parameter is not being currently used anywhere. action required - If you currently use this command line option, please remove it as this parameter will be removed in a future release.
```
