### PR TITLE
Ensure network policy conversion round trips nil from fields

### DIFF
--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -318,10 +318,12 @@ func Convert_v1beta1_NetworkPolicyIngressRule_To_networking_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]networking.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]networking.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -334,10 +336,12 @@ func Convert_networking_NetworkPolicyIngressRule_To_v1beta1_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/apis/networking/v1/conversion.go
+++ b/pkg/apis/networking/v1/conversion.go
@@ -85,10 +85,12 @@ func Convert_v1_NetworkPolicyIngressRule_To_extensions_NetworkPolicyIngressRule(
 			return err
 		}
 	}
-	out.From = make([]extensions.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_v1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]extensions.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_v1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -101,10 +103,12 @@ func Convert_extensions_NetworkPolicyIngressRule_To_v1_NetworkPolicyIngressRule(
 			return err
 		}
 	}
-	out.From = make([]NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_extensions_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_extensions_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/apis/networking/validation/BUILD
+++ b/pkg/apis/networking/validation/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/api:go_default_library",
         "//pkg/api/validation:go_default_library",
         "//pkg/apis/networking:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",

--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -17,8 +17,7 @@ limitations under the License.
 package validation
 
 import (
-	"reflect"
-
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	unversionedvalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -92,7 +91,7 @@ func ValidateNetworkPolicy(np *networking.NetworkPolicy) field.ErrorList {
 func ValidateNetworkPolicyUpdate(update, old *networking.NetworkPolicy) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	if !reflect.DeepEqual(update.Spec, old.Spec) {
+	if !apiequality.Semantic.DeepEqual(update.Spec, old.Spec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to networkpolicy spec are forbidden."))
 	}
 	return allErrs

--- a/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/extensions/v1beta1/conversion.go
@@ -318,10 +318,12 @@ func Convert_v1beta1_NetworkPolicyIngressRule_To_networking_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]networking.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]networking.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -334,10 +336,12 @@ func Convert_networking_NetworkPolicyIngressRule_To_v1beta1_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/staging/src/k8s.io/client-go/pkg/apis/networking/v1/conversion.go
+++ b/staging/src/k8s.io/client-go/pkg/apis/networking/v1/conversion.go
@@ -85,10 +85,12 @@ func Convert_v1_NetworkPolicyIngressRule_To_extensions_NetworkPolicyIngressRule(
 			return err
 		}
 	}
-	out.From = make([]extensions.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_v1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]extensions.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_v1_NetworkPolicyPeer_To_extensions_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -101,10 +103,12 @@ func Convert_extensions_NetworkPolicyIngressRule_To_v1_NetworkPolicyIngressRule(
 			return err
 		}
 	}
-	out.From = make([]NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_extensions_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_extensions_NetworkPolicyPeer_To_v1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes #53906 (inability to apply network policies against v1 in 1.7)

* Changes non-mutation check to API equality (which treats nil and [] slices identically)
* Fixed bug in manual conversion that took an input of `nil` and produced an output of `[]`

```release-note
Restores the ability to apply network policy objects against the networking.k8s.io/v1 API
```