### PR TITLE
Create new unit tests for version and kind validation

### DIFF
--- a/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
@@ -335,4 +335,63 @@ items:
 
 		Expect(err).To(BeNil())
 	})
+
+	It("fails because apiVersion is not provided", func() {
+		err := validator.ValidateBytes([]byte(`
+kind: Pod
+metadata:
+  name: name
+spec:
+  containers:
+  - name: name
+    image: image
+`))
+		Expect(err.Error()).To(Equal("apiVersion not set"))
+	})
+
+	It("fails because apiVersion type is not string and kind is not provided", func() {
+		err := validator.ValidateBytes([]byte(`
+apiVersion: 1
+metadata:
+  name: name
+spec:
+  containers:
+  - name: name
+    image: image
+`))
+		Expect(err.Error()).To(Equal("[apiVersion isn't string type, kind not set]"))
+	})
+
+	It("fails because List first item is missing kind and second item is missing apiVersion", func() {
+		err := validator.ValidateBytes([]byte(`
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  metadata:
+    name: name
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          name: name
+      spec:
+        containers:
+        - name: name
+          image: image
+- kind: Service
+  metadata:
+    name: name
+  spec:
+    type: NodePort
+    ports:
+    - port: 123
+      targetPort: 1234
+      name: name
+    selector:
+      name: name
+`))
+		Expect(err.Error()).To(Equal("[kind not set, apiVersion not set]"))
+	})
 })


### PR DESCRIPTION
This is a follow up PR per discussion in the
https://github.com/kubernetes/kubernetes/pull/53587
Creating new unit tests here for basic and aggregated validation of version
and kind group.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
