### PR TITLE
Fix dockershim panic when listing images

### DIFF
--- a/pkg/kubelet/dockershim/docker_image.go
+++ b/pkg/kubelet/dockershim/docker_image.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	dockertypes "github.com/docker/docker/api/types"
+	dockerfilters "github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/pkg/jsonmessage"
 
 	runtimeapi "k8s.io/kubernetes/pkg/kubelet/apis/cri/v1alpha1/runtime"
@@ -33,8 +34,9 @@ import (
 func (ds *dockerService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	opts := dockertypes.ImageListOptions{}
 	if filter != nil {
-		if imgSpec := filter.GetImage(); imgSpec != nil {
-			opts.Filters.Add("reference", imgSpec.Image)
+		if filter.GetImage().GetImage() != "" {
+			opts.Filters = dockerfilters.NewArgs()
+			opts.Filters.Add("reference", filter.GetImage().GetImage())
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

dockershim panic when listing containers because of `opts.Filters` not initialized:

https://github.com/kubernetes/kubernetes/blob/505ccb88da14d8dda25cb9ea4db8578666b9cc0e/pkg/kubelet/dockershim/docker_image.go#L35-L39

Also when imgSpec.Image is empty string, dockershim returns an empty image list which is not expected. (We should not set opts.Filters in this case).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54122

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
