### PR TITLE
kubelet: use crio socket from cadvisor

### DIFF
--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -20,6 +20,7 @@ package cadvisor
 
 import (
 	"fmt"
+	"strings"
 
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
@@ -43,7 +44,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 		// This is a temporary workaround to get stats for cri-o from cadvisor
 		// and should be removed.
 		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == "/var/run/crio.sock" {
+		if strings.HasSuffix(i.runtimeEndpoint, "crio.sock") {
 			return cadvisorfs.LabelCrioImages, nil
 		}
 	}

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -18,6 +18,7 @@ package cadvisor
 
 import (
 	goruntime "runtime"
+	"strings"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapi2 "github.com/google/cadvisor/info/v2"
@@ -71,5 +72,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
 	return runtime == kubetypes.RktContainerRuntime ||
 		(runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == "/var/run/crio.sock"
+		strings.HasSuffix(runtimeEndpoint, "crio.sock")
 }


### PR DESCRIPTION
Parametrize the crio socket using the one in cadvisor directly

ref https://github.com/kubernetes-incubator/cri-o/pull/1030
depends on https://github.com/google/cadvisor/pull/1773

@derekwaynecarr @smarterclayton @mrunalp PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
