### PR TITLE
Bump cluster autoscaler to 1.0.1-beta1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.0",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.1-beta1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Contains fixes around scale from 0 and node autoprovisioning.