### PR TITLE
kubeadm/cmdutil.go: improve ValidateExactArgNumber()

### DIFF
--- a/cmd/kubeadm/app/cmd/util/cmdutil.go
+++ b/cmd/kubeadm/app/cmd/util/cmdutil.go
@@ -39,19 +39,21 @@ func SubCmdRunE(name string) func(*cobra.Command, []string) error {
 
 // ValidateExactArgNumber validates that the required top-level arguments are specified
 func ValidateExactArgNumber(args []string, supportedArgs []string) error {
+	lenSupported := len(supportedArgs)
 	validArgs := 0
 	// Disregard possible "" arguments; they are invalid
 	for _, arg := range args {
 		if len(arg) > 0 {
 			validArgs++
 		}
+		// break early for too many arguments
+		if validArgs > lenSupported {
+			return fmt.Errorf("too many arguments. Required arguments: %v", supportedArgs)
+		}
 	}
 
-	if validArgs < len(supportedArgs) {
+	if validArgs < lenSupported {
 		return fmt.Errorf("missing one or more required arguments. Required arguments: %v", supportedArgs)
-	}
-	if validArgs > len(supportedArgs) {
-		return fmt.Errorf("too many arguments, only %d argument(s) supported: %v", validArgs, supportedArgs)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This patch makes small changes in
ValidateExactArgNumber():

- Use a variable for the length of supported arguments
- Return an error early if the number of valid arguments
exceeds the number of supported arguments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
none

**Special notes for your reviewer**:
none

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Lubomir (VMware)