### PR TITLE
Automated cherry pick of #54109

### DIFF
--- a/pkg/apis/extensions/v1beta1/conversion.go
+++ b/pkg/apis/extensions/v1beta1/conversion.go
@@ -338,10 +338,12 @@ func Convert_v1beta1_NetworkPolicyIngressRule_To_networking_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]networking.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]networking.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_v1beta1_NetworkPolicyPeer_To_networking_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -354,10 +356,12 @@ func Convert_networking_NetworkPolicyIngressRule_To_v1beta1_NetworkPolicyIngress
 			return err
 		}
 	}
-	out.From = make([]extensionsv1beta1.NetworkPolicyPeer, len(in.From))
-	for i := range in.From {
-		if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
-			return err
+	if in.From != nil {
+		out.From = make([]extensionsv1beta1.NetworkPolicyPeer, len(in.From))
+		for i := range in.From {
+			if err := Convert_networking_NetworkPolicyPeer_To_v1beta1_NetworkPolicyPeer(&in.From[i], &out.From[i], s); err != nil {
+				return err
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
Cherry pick of #54109 on release-1.8.

#54109:  Ensure network policy conversion round trips nil from field

```release-note
Fixes conversion of networkpolicy objects in the networking.k8s.io/v1 API group
```