### PR TITLE
Move --enable-cusom-metrics to KubeletFlags and mark it deprecated

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -156,6 +156,8 @@ type KubeletFlags struct {
 	// This flag, if set, instructs the kubelet to keep volumes from terminated pods mounted to the node.
 	// This can be useful for debugging volume related issues.
 	KeepTerminatedPodVolumes bool
+	// enable gathering custom metrics.
+	EnableCustomMetrics bool
 }
 
 // NewKubeletFlags will create a new KubeletFlags with default values
@@ -184,6 +186,8 @@ func NewKubeletFlags() *KubeletFlags {
 		ExperimentalQOSReserved:             make(map[string]string),
 		RemoteRuntimeEndpoint:               remoteRuntimeEndpoint,
 		RotateCertificates:                  false,
+		// TODO(#54161:v1.11.0): Remove --enable-custom-metrics flag, it is deprecated.
+		EnableCustomMetrics: false,
 	}
 }
 
@@ -316,6 +320,9 @@ func (f *KubeletFlags) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("non-masquerade-cidr", "will be removed in a future version")
 	fs.BoolVar(&f.KeepTerminatedPodVolumes, "keep-terminated-pod-volumes", f.KeepTerminatedPodVolumes, "Keep terminated pod volumes mounted to the node after the pod terminates.  Can be useful for debugging volume related issues.")
 	fs.MarkDeprecated("keep-terminated-pod-volumes", "will be removed in a future version")
+	// TODO(#54161:v1.11.0): Remove --enable-custom-metrics flag, it is deprecated.
+	fs.BoolVar(&f.EnableCustomMetrics, "enable-custom-metrics", f.EnableCustomMetrics, "Support for gathering custom metrics.")
+	fs.MarkDeprecated("enable-custom-metrics", "will be removed in a future version")
 
 }
 
@@ -428,7 +435,6 @@ func AddKubeletConfigFlags(fs *pflag.FlagSet, c *kubeletconfig.KubeletConfigurat
 	fs.Int32Var(&c.KubeAPIBurst, "kube-api-burst", c.KubeAPIBurst, "Burst to use while talking with kubernetes apiserver")
 	fs.BoolVar(&c.SerializeImagePulls, "serialize-image-pulls", c.SerializeImagePulls, "Pull images one at a time. We recommend *not* changing the default value on nodes that run docker daemon with version < 1.9 or an Aufs storage backend. Issue #10959 has more details.")
 
-	fs.BoolVar(&c.EnableCustomMetrics, "enable-custom-metrics", c.EnableCustomMetrics, "Support for gathering custom metrics.")
 	fs.StringVar(&c.RuntimeCgroups, "runtime-cgroups", c.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
 	fs.StringVar(&c.EvictionHard, "eviction-hard", c.EvictionHard, "A set of eviction thresholds (e.g. memory.available<1Gi) that if met would trigger a pod eviction.")
 	fs.StringVar(&c.EvictionSoft, "eviction-soft", c.EvictionSoft, "A set of eviction thresholds (e.g. memory.available<1.5Gi) that if met over a corresponding grace period would trigger a pod eviction.")

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -252,8 +252,6 @@ type KubeletConfiguration struct {
 	SerializeImagePulls bool
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string
-	// enable gathering custom metrics.
-	EnableCustomMetrics bool
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
 	// +optional
 	EvictionHard string

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
@@ -244,8 +244,6 @@ type KubeletConfiguration struct {
 	SerializeImagePulls *bool `json:"serializeImagePulls"`
 	// nodeLabels to add when registering the node in the cluster.
 	NodeLabels map[string]string `json:"nodeLabels"`
-	// enable gathering custom metrics.
-	EnableCustomMetrics bool `json:"enableCustomMetrics"`
 	// Comma-delimited list of hard eviction expressions.  For example, 'memory.available<300Mi'.
 	EvictionHard *string `json:"evictionHard"`
 	// Comma-delimited list of soft eviction expressions.  For example, 'memory.available<300Mi'.

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -244,7 +244,6 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfigura
 		return err
 	}
 	out.NodeLabels = *(*map[string]string)(unsafe.Pointer(&in.NodeLabels))
-	out.EnableCustomMetrics = in.EnableCustomMetrics
 	if err := v1.Convert_Pointer_string_To_string(&in.EvictionHard, &out.EvictionHard, s); err != nil {
 		return err
 	}
@@ -385,7 +384,6 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 		return err
 	}
 	out.NodeLabels = *(*map[string]string)(unsafe.Pointer(&in.NodeLabels))
-	out.EnableCustomMetrics = in.EnableCustomMetrics
 	if err := v1.Convert_string_To_Pointer_string(&in.EvictionHard, &out.EvictionHard, s); err != nil {
 		return err
 	}

--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -144,7 +144,6 @@ func GetHollowKubeletConfig(
 	c.CPUCFSQuota = true
 	c.RuntimeCgroups = ""
 	c.EnableControllerAttachDetach = false
-	c.EnableCustomMetrics = false
 	c.EnableDebuggingHandlers = true
 	c.EnableServer = true
 	c.CgroupsPerQOS = false


### PR DESCRIPTION
With respect to https://github.com/kubernetes/kubernetes/pull/53833#issuecomment-336890235, EnableCustomMetrics should be marked deprecated and should not remain in the KubeletConfiguration struct. 

Broader issue: https://github.com/kubernetes/features/issues/281

```release-note
The Kubelet's --enable-custom-metrics flag is now marked deprecated.
```