### PR TITLE
update admission webhook to accept client config

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -70,6 +70,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/storage/etcd3/preflight:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",

--- a/federation/cmd/federation-apiserver/app/BUILD
+++ b/federation/cmd/federation-apiserver/app/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
     ],
 )

--- a/federation/cmd/federation-apiserver/app/server.go
+++ b/federation/cmd/federation-apiserver/app/server.go
@@ -42,6 +42,7 @@ import (
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
 	clientgoinformers "k8s.io/client-go/informers"
 	clientgoclientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
 	federationv1beta1 "k8s.io/kubernetes/federation/apis/federation/v1beta1"
 	"k8s.io/kubernetes/federation/cmd/federation-apiserver/app/options"
@@ -215,9 +216,8 @@ func NonBlockingRun(s *options.ServerRunOptions, stopCh <-chan struct{}) error {
 	err = s.Admission.ApplyTo(
 		genericConfig,
 		versionedInformers,
-		nil,
-		nil,
 		kubeClientConfig,
+		rest.AnonymousClientConfig(kubeClientConfig),
 		legacyscheme.Scheme,
 		pluginInitializer,
 	)

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -86,7 +86,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 		whiteList: whiteList,
 	}
 
-	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil, nil)
+	genericPluginInitializer, err := initializer.New(nil, nil, fakeAuthorizer{}, nil, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/admission/webhook/BUILD
+++ b/plugin/pkg/admission/webhook/BUILD
@@ -53,6 +53,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/plugin/pkg/admission/webhook/admission_test.go
+++ b/plugin/pkg/admission/webhook/admission_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/client-go/rest"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 
@@ -89,8 +90,10 @@ func TestAdmit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	wh.clientCert = clientCert
-	wh.clientKey = clientKey
+	wh.restClientConfig = &rest.Config{}
+	wh.restClientConfig.TLSClientConfig.CAData = caCert
+	wh.restClientConfig.TLSClientConfig.CertData = clientCert
+	wh.restClientConfig.TLSClientConfig.KeyData = clientKey
 
 	// Set up a test object for the call
 	kind := api.Kind("Pod").WithVersion("v1")

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/initializer_test.go
@@ -33,7 +33,7 @@ import (
 // the WantsScheme interface is implemented by a plugin.
 func TestWantsScheme(t *testing.T) {
 	scheme := runtime.NewScheme()
-	target, err := initializer.New(nil, nil, nil, nil, nil, scheme)
+	target, err := initializer.New(nil, nil, nil, nil, scheme)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -47,7 +47,7 @@ func TestWantsScheme(t *testing.T) {
 // TestWantsAuthorizer ensures that the authorizer is injected
 // when the WantsAuthorizer interface is implemented by a plugin.
 func TestWantsAuthorizer(t *testing.T) {
-	target, err := initializer.New(nil, nil, &TestAuthorizer{}, nil, nil, nil)
+	target, err := initializer.New(nil, nil, &TestAuthorizer{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +62,7 @@ func TestWantsAuthorizer(t *testing.T) {
 // when the WantsExternalKubeClientSet interface is implemented by a plugin.
 func TestWantsExternalKubeClientSet(t *testing.T) {
 	cs := &fake.Clientset{}
-	target, err := initializer.New(cs, nil, &TestAuthorizer{}, nil, nil, nil)
+	target, err := initializer.New(cs, nil, &TestAuthorizer{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,7 +78,7 @@ func TestWantsExternalKubeClientSet(t *testing.T) {
 func TestWantsExternalKubeInformerFactory(t *testing.T) {
 	cs := &fake.Clientset{}
 	sf := informers.NewSharedInformerFactory(cs, time.Duration(1)*time.Second)
-	target, err := initializer.New(cs, sf, &TestAuthorizer{}, nil, nil, nil)
+	target, err := initializer.New(cs, sf, &TestAuthorizer{}, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,20 +86,6 @@ func TestWantsExternalKubeInformerFactory(t *testing.T) {
 	target.Initialize(wantExternalKubeInformerFactory)
 	if wantExternalKubeInformerFactory.sf != sf {
 		t.Errorf("expected informer factory to be initialized")
-	}
-}
-
-// TestWantsClientCert ensures that the client certificate and key are injected
-// when the WantsClientCert interface is implemented by a plugin.
-func TestWantsClientCert(t *testing.T) {
-	target, err := initializer.New(nil, nil, nil, []byte("cert"), []byte("key"), nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wantClientCert := &clientCertWanter{}
-	target.Initialize(wantClientCert)
-	if string(wantClientCert.gotCert) != "cert" || string(wantClientCert.gotKey) != "key" {
-		t.Errorf("expected client cert to be initialized, clientCert = %v, clientKey = %v", wantClientCert.gotCert, wantClientCert.gotKey)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/initializer/interfaces.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // WantsExternalKubeClientSet defines a function which sets external ClientSet for admission plugins that need it
@@ -42,10 +43,10 @@ type WantsAuthorizer interface {
 	admission.Validator
 }
 
-// WantsClientCert defines a fuction that accepts a cert & key for admission
+// WantsWebhookRESTClientConfig defines a function that accepts client config for admission
 // plugins that need to make calls and prove their identity.
-type WantsClientCert interface {
-	SetClientCert(cert, key []byte)
+type WantsWebhookRESTClientConfig interface {
+	SetWebhookRESTClientConfig(*rest.Config)
 	admission.Validator
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission_test.go
@@ -48,7 +48,7 @@ func newHandlerForTestWithClock(c clientset.Interface, cacheClock clock.Clock) (
 	if err != nil {
 		return nil, f, err
 	}
-	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil, nil)
+	pluginInitializer, err := kubeadmission.New(c, f, nil, nil, nil)
 	if err != nil {
 		return handler, f, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -80,9 +80,8 @@ func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
 func (a *AdmissionOptions) ApplyTo(
 	c *server.Config,
 	informers informers.SharedInformerFactory,
-	serverIdentifyingClientCert []byte,
-	serverIdentifyingClientKey []byte,
-	clientConfig *rest.Config,
+	kubeAPIServerClientConfig *rest.Config,
+	webhookClientConfig *rest.Config,
 	scheme *runtime.Scheme,
 	pluginInitializers ...admission.PluginInitializer,
 ) error {
@@ -96,11 +95,11 @@ func (a *AdmissionOptions) ApplyTo(
 		return fmt.Errorf("failed to read plugin config: %v", err)
 	}
 
-	clientset, err := kubernetes.NewForConfig(clientConfig)
+	clientset, err := kubernetes.NewForConfig(kubeAPIServerClientConfig)
 	if err != nil {
 		return err
 	}
-	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, serverIdentifyingClientCert, serverIdentifyingClientKey, scheme)
+	genericInitializer, err := initializer.New(clientset, informers, c.Authorizer, webhookClientConfig, scheme)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -420,5 +420,45 @@ func AnonymousClientConfig(config *Config) *Config {
 		QPS:           config.QPS,
 		Burst:         config.Burst,
 		Timeout:       config.Timeout,
+		Dial:          config.Dial,
+	}
+}
+
+// CopyConfig returns a copy of the given config
+func CopyConfig(config *Config) *Config {
+	return &Config{
+		Host:          config.Host,
+		APIPath:       config.APIPath,
+		Prefix:        config.Prefix,
+		ContentConfig: config.ContentConfig,
+		Username:      config.Username,
+		Password:      config.Password,
+		BearerToken:   config.BearerToken,
+		CacheDir:      config.CacheDir,
+		Impersonate: ImpersonationConfig{
+			Groups:   config.Impersonate.Groups,
+			Extra:    config.Impersonate.Extra,
+			UserName: config.Impersonate.UserName,
+		},
+		AuthProvider:        config.AuthProvider,
+		AuthConfigPersister: config.AuthConfigPersister,
+		TLSClientConfig: TLSClientConfig{
+			Insecure:   config.TLSClientConfig.Insecure,
+			ServerName: config.TLSClientConfig.ServerName,
+			CertFile:   config.TLSClientConfig.CertFile,
+			KeyFile:    config.TLSClientConfig.KeyFile,
+			CAFile:     config.TLSClientConfig.CAFile,
+			CertData:   config.TLSClientConfig.CertData,
+			KeyData:    config.TLSClientConfig.KeyData,
+			CAData:     config.TLSClientConfig.CAData,
+		},
+		UserAgent:     config.UserAgent,
+		Transport:     config.Transport,
+		WrapTransport: config.WrapTransport,
+		QPS:           config.QPS,
+		Burst:         config.Burst,
+		RateLimiter:   config.RateLimiter,
+		Timeout:       config.Timeout,
+		Dial:          config.Dial,
 	}
 }

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -35,6 +35,8 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/util/flowcontrol"
 
+	"errors"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -206,6 +208,19 @@ func (n *fakeNegotiatedSerializer) DecoderToVersion(serializer runtime.Decoder, 
 	return &fakeCodec{}
 }
 
+var fakeDialFunc = func(network, addr string) (net.Conn, error) {
+	return nil, fakeDialerError
+}
+var fakeDialerError = errors.New("fakedialer")
+
+type fakeAuthProviderConfigPersister struct{}
+
+func (fakeAuthProviderConfigPersister) Persist(map[string]string) error {
+	return fakeAuthProviderConfigPersisterError
+}
+
+var fakeAuthProviderConfigPersisterError = errors.New("fakeAuthProviderConfigPersisterError")
+
 func TestAnonymousConfig(t *testing.T) {
 	f := fuzz.New().NilChance(0.0).NumElements(1, 1)
 	f.Funcs(
@@ -268,9 +283,94 @@ func TestAnonymousConfig(t *testing.T) {
 			actual.WrapTransport = nil
 			expected.WrapTransport = nil
 		}
+		if actual.Dial != nil {
+			_, actualError := actual.Dial("", "")
+			_, expectedError := actual.Dial("", "")
+			if !reflect.DeepEqual(expectedError, actualError) {
+				t.Fatalf("CopyConfig  dropped the Dial field")
+			}
+		} else {
+			actual.Dial = nil
+			expected.Dial = nil
+		}
 
 		if !reflect.DeepEqual(*actual, expected) {
 			t.Fatalf("AnonymousClientConfig dropped unexpected fields, identify whether they are security related or not: %s", diff.ObjectGoPrintDiff(expected, actual))
+		}
+	}
+}
+
+func TestCopyConfig(t *testing.T) {
+	f := fuzz.New().NilChance(0.0).NumElements(1, 1)
+	f.Funcs(
+		func(r *runtime.Codec, f fuzz.Continue) {
+			codec := &fakeCodec{}
+			f.Fuzz(codec)
+			*r = codec
+		},
+		func(r *http.RoundTripper, f fuzz.Continue) {
+			roundTripper := &fakeRoundTripper{}
+			f.Fuzz(roundTripper)
+			*r = roundTripper
+		},
+		func(fn *func(http.RoundTripper) http.RoundTripper, f fuzz.Continue) {
+			*fn = fakeWrapperFunc
+		},
+		func(r *runtime.NegotiatedSerializer, f fuzz.Continue) {
+			serializer := &fakeNegotiatedSerializer{}
+			f.Fuzz(serializer)
+			*r = serializer
+		},
+		func(r *flowcontrol.RateLimiter, f fuzz.Continue) {
+			limiter := &fakeLimiter{}
+			f.Fuzz(limiter)
+			*r = limiter
+		},
+		func(r *AuthProviderConfigPersister, f fuzz.Continue) {
+			*r = fakeAuthProviderConfigPersister{}
+		},
+		func(r *func(network, addr string) (net.Conn, error), f fuzz.Continue) {
+			*r = fakeDialFunc
+		},
+	)
+	for i := 0; i < 20; i++ {
+		original := &Config{}
+		f.Fuzz(original)
+		actual := CopyConfig(original)
+		expected := *original
+
+		// this is the list of known risky fields, add to this list if a new field
+		// is added to Config, update CopyConfig to preserve the field otherwise.
+
+		// The DeepEqual cannot handle the func comparison, so we just verify if the
+		// function return the expected object.
+		if actual.WrapTransport == nil || !reflect.DeepEqual(expected.WrapTransport(nil), &fakeRoundTripper{}) {
+			t.Fatalf("CopyConfig dropped the WrapTransport field")
+		} else {
+			actual.WrapTransport = nil
+			expected.WrapTransport = nil
+		}
+		if actual.Dial != nil {
+			_, actualError := actual.Dial("", "")
+			_, expectedError := actual.Dial("", "")
+			if !reflect.DeepEqual(expectedError, actualError) {
+				t.Fatalf("CopyConfig  dropped the Dial field")
+			}
+		}
+		actual.Dial = nil
+		expected.Dial = nil
+		if actual.AuthConfigPersister != nil {
+			actualError := actual.AuthConfigPersister.Persist(nil)
+			expectedError := actual.AuthConfigPersister.Persist(nil)
+			if !reflect.DeepEqual(expectedError, actualError) {
+				t.Fatalf("CopyConfig  dropped the Dial field")
+			}
+		}
+		actual.AuthConfigPersister = nil
+		expected.AuthConfigPersister = nil
+
+		if !reflect.DeepEqual(*actual, expected) {
+			t.Fatalf("CopyConfig  dropped unexpected fields, identify whether they are security related or not: %s", diff.ObjectReflectDiff(expected, *actual))
 		}
 	}
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -119,7 +119,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 		return nil, err
 	}
 
-	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, nil, nil, serverConfig.ClientConfig, apiserver.Scheme, admissionInitializer); err != nil {
+	if err := o.Admission.ApplyTo(&serverConfig.Config, serverConfig.SharedInformerFactory, serverConfig.ClientConfig, serverConfig.ClientConfig, apiserver.Scheme, admissionInitializer); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/53827

This plumbs a complete client through the plugin initializer for admission webhooks.  It achieves parity with our existing webhooks and provides flexibility if people want to do something special or different.  Easy things are easy, hard things are possible.  This does not change behavior for kube-apiserver.

@kubernetes/sig-auth-api-reviews @kubernetes/sig-api-machinery-bugs 