### PR TITLE
apiextensions: fix LastTransitionTime for NamesAccepted condition

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers.go
@@ -16,11 +16,18 @@ limitations under the License.
 
 package apiextensions
 
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
 // SetCRDCondition sets the status condition.  It either overwrites the existing one or
 // creates a new one
 func SetCRDCondition(crd *CustomResourceDefinition, newCondition CustomResourceDefinitionCondition) {
 	existingCondition := FindCRDCondition(crd, newCondition.Type)
 	if existingCondition == nil {
+		newCondition.LastTransitionTime = metav1.NewTime(time.Now())
 		crd.Status.Conditions = append(crd.Status.Conditions, newCondition)
 		return
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status/naming_controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/golang/glog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -192,22 +191,20 @@ func (c *NamingConditionController) calculateNamesAndConditions(in *apiextension
 
 	// set EstablishedCondition to true if all names are accepted. Never set it back to false.
 	establishedCondition := apiextensions.CustomResourceDefinitionCondition{
-		Type:               apiextensions.Established,
-		Status:             apiextensions.ConditionFalse,
-		Reason:             "NotAccepted",
-		Message:            "not all names are accepted",
-		LastTransitionTime: metav1.NewTime(time.Now()),
+		Type:    apiextensions.Established,
+		Status:  apiextensions.ConditionFalse,
+		Reason:  "NotAccepted",
+		Message: "not all names are accepted",
 	}
 	if old := apiextensions.FindCRDCondition(in, apiextensions.Established); old != nil {
 		establishedCondition = *old
 	}
 	if establishedCondition.Status != apiextensions.ConditionTrue && namesAcceptedCondition.Status == apiextensions.ConditionTrue {
 		establishedCondition = apiextensions.CustomResourceDefinitionCondition{
-			Type:               apiextensions.Established,
-			Status:             apiextensions.ConditionTrue,
-			Reason:             "InitialNamesAccepted",
-			Message:            "the initial names have been accepted",
-			LastTransitionTime: metav1.NewTime(time.Now()),
+			Type:    apiextensions.Established,
+			Status:  apiextensions.ConditionTrue,
+			Reason:  "InitialNamesAccepted",
+			Message: "the initial names have been accepted",
 		}
 	}
 


### PR DESCRIPTION
Fixes #54148. 

Without this change, `LastTransitionTime` for the NamesAccepted condition for CRDs always showed up as `null`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
