### PR TITLE
 default admission hook failure safely

### DIFF
--- a/plugin/pkg/admission/webhook/admission.go
+++ b/plugin/pkg/admission/webhook/admission.go
@@ -191,7 +191,7 @@ func (a *GenericAdmissionWebhook) Admit(attr admission.Attributes) error {
 				return
 			}
 
-			ignoreClientCallFailures := hook.FailurePolicy == nil || *hook.FailurePolicy == v1alpha1.Ignore
+			ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == v1alpha1.Ignore
 			if callErr, ok := err.(*ErrCallingWebhook); ok {
 				if ignoreClientCallFailures {
 					glog.Warningf("Failed calling webhook, failing open %v: %v", hook.Name, callErr)

--- a/plugin/pkg/admission/webhook/admission_test.go
+++ b/plugin/pkg/admission/webhook/admission_test.go
@@ -216,7 +216,7 @@ func TestAdmit(t *testing.T) {
 			},
 			expectAllow: true,
 		},
-		"match & fail (but allow because fail open on nil)": {
+		"match & fail (but disallow because fail closed on nil)": {
 			hookSource: fakeHookSource{
 				hooks: []registrationv1alpha1.ExternalAdmissionHook{{
 					Name:         "internalErr A",
@@ -232,7 +232,7 @@ func TestAdmit(t *testing.T) {
 					Rules:        matchEverythingRules,
 				}},
 			},
-			expectAllow: true,
+			expectAllow: false,
 		},
 		"match & fail (but fail because fail closed)": {
 			hookSource: fakeHookSource{


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/kubernetes/pull/53823

 This sets the default for admission webhook to fail safely closed.  You can still set it to fail open, but it isn't the default.

/assign liggitt
/assign caesarxuchao

```release-note
admission webhook registrations without a specific failure policy default to failing closed.
```