### PR TITLE
Adds support for in-server service name resolution.

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -3,6 +3,14 @@ package(default_visibility = ["//visibility:public"])
 load(
     "@io_bazel_rules_go//go:def.bzl",
     "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    importpath = "k8s.io/kubernetes/cmd/kube-apiserver/app",
+    library = ":go_default_library",
 )
 
 go_library(

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -445,7 +445,9 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 		return nil, nil, nil, nil, nil, fmt.Errorf("invalid authentication config: %v", err)
 	}
 
-	genericConfig.Authorizer, genericConfig.RuleResolver, err = BuildAuthorizer(s, sharedInformers)
+	genericConfig.Authorizer, genericConfig.RuleResolver, err =
+		BuildAuthorizer(s, sharedInformers,
+			buildWebhookDialer(serviceResolver, proxyTransport))
 	if err != nil {
 		return nil, nil, nil, nil, nil, fmt.Errorf("invalid authorization config: %v", err)
 	}
@@ -547,9 +549,55 @@ func BuildAuthenticator(s *options.ServerRunOptions, storageFactory serverstorag
 	return authenticatorConfig.New()
 }
 
+// buildWebhookDialer constructs a custom dialer function for the authorization webhook
+// that knows how to resolve references to Kubernetes services (of the form "servicename.namespace.svc")
+// to the IP address of the endpoint that currently implements it.
+func buildWebhookDialer(
+	serviceResolver aggregatorapiserver.ServiceResolver,
+	proxyTransport *http.Transport,
+) func(network, address string) (net.Conn, error) {
+	// Following sample code from issue #54163 by liggitt@redhat.com.
+	baseDialer := net.Dial
+	if proxyTransport != nil && proxyTransport.Dial != nil {
+		baseDialer = proxyTransport.Dial
+	}
+
+	return func(network, address string) (net.Conn, error) {
+		host, _, err := net.SplitHostPort(address)
+		if err != nil {
+			glog.V(6).Infof("while splitting hostport: %v", err)
+			return baseDialer(network, address)
+		}
+		// "servicename.namespace.svc"
+		if !strings.HasSuffix(host, ".svc") {
+			return baseDialer(network, address)
+		}
+		segments := strings.Split(host, ".")
+		if len(segments) != 3 {
+			glog.V(6).Infof("Dialer address is not a Kubernetes svc reference: %v", host)
+			return baseDialer(network, address)
+		}
+		namespace := segments[1]
+		service := segments[0]
+		u, err := serviceResolver.ResolveEndpoint(namespace, service)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"while resolving endpoint: namespace=%v, service=%v: %v",
+				namespace, service, err)
+		}
+		glog.V(5).Infof("Resolved: namespace=%v, service=%v to: host=%v",
+			namespace, service, u.Host)
+		return baseDialer(network, u.Host)
+	}
+}
+
 // BuildAuthorizer constructs the authorizer
-func BuildAuthorizer(s *options.ServerRunOptions, sharedInformers informers.SharedInformerFactory) (authorizer.Authorizer, authorizer.RuleResolver, error) {
-	authorizationConfig := s.Authorization.ToAuthorizationConfig(sharedInformers)
+func BuildAuthorizer(
+	s *options.ServerRunOptions,
+	sharedInformers informers.SharedInformerFactory,
+	dialer func(network, address string) (net.Conn, error),
+) (authorizer.Authorizer, authorizer.RuleResolver, error) {
+	authorizationConfig := s.Authorization.ToAuthorizationConfig(sharedInformers, dialer)
 	return authorizationConfig.New()
 }
 

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type fakeServiceResolver struct {
+	// The hostport to resolve a fake address to.
+	resolveHostport string
+	// The last used namespace and name.
+	lastNamespace, lastName string
+}
+
+func (r *fakeServiceResolver) ResolveEndpoint(namespace, name string) (*url.URL, error) {
+	r.lastNamespace = namespace
+	r.lastName = name
+	return url.Parse(r.resolveHostport)
+}
+
+type fakeDialer struct {
+	network, host string
+}
+
+func TestAuthorizationWebhookDialer(t *testing.T) {
+	tt := []struct {
+		expectedNamespace, expectedName string
+		serverAddress                   string
+		expectedError                   error
+		// If set, passes a nil http.Transport to the function under test.
+		useNilTransport bool
+	}{
+		{
+			expectedNamespace: "servicenamespace",
+			expectedName:      "servicename",
+			serverAddress:     "http://servicename.servicenamespace.svc",
+		},
+		{
+			expectedNamespace: "servicenamespace",
+			expectedName:      "servicename",
+			serverAddress:     "http://servicename.servicenamespace.svc",
+			useNilTransport:   true,
+		},
+		{
+			serverAddress: "http://somename.svc",
+			expectedError: fmt.Errorf("no such host"),
+		},
+		{
+			serverAddress: "http://servicename.servicenamespace.svc.com",
+			expectedError: fmt.Errorf("no such host"),
+		},
+		{
+			expectedNamespace: "servicenamespace",
+			expectedName:      "servicename",
+			serverAddress:     "http://someunlikelyhostname.someunlikelydomain.someunlikelytld",
+			expectedError:     fmt.Errorf("no such host"),
+		},
+	}
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintf(w, "hello")
+	}))
+	defer testServer.Close()
+	resolver := fakeServiceResolver{
+		resolveHostport: testServer.URL,
+	}
+
+	for i, ttt := range tt {
+		var transport *http.Transport
+		defaultTransport := &http.Transport{}
+		if ttt.useNilTransport {
+			defaultTransport = nil
+		}
+		transport = &http.Transport{
+			Dial: buildWebhookDialer(&resolver, defaultTransport)}
+		client := &http.Client{Transport: transport}
+		response, err := client.Get(ttt.serverAddress)
+		if err != nil {
+			if ttt.expectedError == nil {
+				t.Errorf("[%v] unexpected error: %v", i, err)
+			} else if strings.Index(err.Error(), ttt.expectedError.Error()) == -1 {
+				t.Errorf("[%v] error mismatch: expected: %v, actual: %v",
+					i, ttt.expectedError, err)
+			}
+			continue
+		}
+		defer response.Body.Close()
+		responseBytes, err := ioutil.ReadAll(response.Body)
+		if err != nil {
+			t.Fatalf("[%v] unexpected error: %v", i, err)
+		}
+		responseStr := string(responseBytes)
+		if responseStr != "hello" {
+			t.Errorf("[%v] unexpected response: '%v'", i, responseStr)
+		}
+		if ttt.expectedNamespace != resolver.lastNamespace ||
+			ttt.expectedName != resolver.lastName {
+			t.Errorf("[%v] unexpected name and namespace: expected: name=%v, namespace=%v; actual: name=%v, namespace=%v",
+				i, ttt.expectedName, ttt.expectedNamespace, resolver.lastName, resolver.lastNamespace)
+		}
+	}
+}

--- a/pkg/kubeapiserver/authorizer/BUILD
+++ b/pkg/kubeapiserver/authorizer/BUILD
@@ -8,18 +8,30 @@ load(
 
 go_test(
     name = "go_default_test",
-    srcs = ["config_test.go"],
+    srcs = [
+        "config_test.go",
+        "webhook_test.go",
+    ],
     data = [
         "//pkg/auth/authorizer/abac:example_policy",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubeapiserver/authorizer",
     library = ":go_default_library",
-    deps = ["//pkg/kubeapiserver/authorizer/modes:go_default_library"],
+    deps = [
+        "//pkg/kubeapiserver/authorizer/modes:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+        "//vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook:go_default_library",
+    ],
 )
 
 go_library(
     name = "go_default_library",
-    srcs = ["config.go"],
+    srcs = [
+        "config.go",
+        "webhook.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/kubeapiserver/authorizer",
     deps = [
         "//pkg/auth/authorizer/abac:go_default_library",
@@ -29,10 +41,19 @@ go_library(
         "//plugin/pkg/auth/authorizer/node:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac:go_default_library",
         "//plugin/pkg/auth/authorizer/rbac/bootstrappolicy:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizerfactory:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/union:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/pkg/kubeapiserver/authorizer/webhook.go
+++ b/pkg/kubeapiserver/authorizer/webhook.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+
+	authorization "k8s.io/api/authorization/v1beta1"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilwebhook "k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
+	"k8s.io/client-go/kubernetes/scheme"
+	authorizationclient "k8s.io/client-go/kubernetes/typed/authorization/v1beta1"
+	"k8s.io/client-go/rest"
+)
+
+// defaultRequestTimeout is the default timeout for the kube apiserver webhook
+// requests.
+const defaultRequestTimeout = 30 * time.Second
+
+// This code is copied from the generic version at
+// k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+var (
+	registry      = registered.NewOrDie("")
+	groupVersions = []schema.GroupVersion{authorization.SchemeGroupVersion}
+)
+
+func init() {
+	registry.RegisterVersions(groupVersions)
+	if err := registry.EnableVersions(groupVersions...); err != nil {
+		panic(fmt.Sprintf("failed to enable version %v", groupVersions))
+	}
+}
+
+// NewWebhookAuthorizer creates a new kubeapiserver specific webhook
+// authorizer.  configFilePath is the filesystem path to a kubeconfig file that
+// holds the webhook configuration.  cacheAuthorizedTTL is the time for which
+// the positive responses from the authorizer are cached.
+// cacheUnauthorizedTTL is the time for which the negative responses from the
+// authorizer are cached.  dialer is the custom dialer function for establishing
+// the webhook server connections.
+func NewWebhookAuthorizer(
+	configFilePath string,
+	cacheAuthorizedTTL time.Duration,
+	cacheUnauthorizedTTL time.Duration,
+	dialer func(network, address string) (net.Conn, error),
+) (*webhook.WebhookAuthorizer, error) {
+	// Load the configuration from a kubeconfig file.
+	clientConfig, err := utilwebhook.NewRestConfig(
+		registry, scheme.Codecs, configFilePath, groupVersions, defaultRequestTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("invalid webhook config: %v", err)
+	}
+	clientConfig.Dial = dialer
+	restClient, err := rest.UnversionedRESTClientFor(clientConfig)
+	if err != nil {
+		return nil, errors.Wrapf(err, "while creating REST client for webhook config: %v", configFilePath)
+	}
+	return webhook.NewFromInterface(&subjectAccessReviewClient{restClient},
+		cacheAuthorizedTTL, cacheUnauthorizedTTL)
+}
+
+var _ authorizationclient.SubjectAccessReviewInterface = (*subjectAccessReviewClient)(nil)
+
+// subjectAccessReview client is a kubeapiserver specific authorizer client.
+type subjectAccessReviewClient struct {
+	// The REST client used to issue authorization requests.
+	restClient *rest.RESTClient
+}
+
+// Create calls out to the webhook authorizer with 'subjectAccessReview' to
+// review.  Returns the authorization decision, or error in case of failure.
+func (t *subjectAccessReviewClient) Create(
+	subjectAccessReview *authorization.SubjectAccessReview,
+) (*authorization.SubjectAccessReview, error) {
+	glog.V(2).Infof("Create request: %+v", subjectAccessReview)
+	result := &authorization.SubjectAccessReview{}
+	err := t.restClient.Post().Body(subjectAccessReview).Do().Into(result)
+	glog.V(4).Infof("Create response:\n\tresult=%+v\n\terr=%v", result, err)
+	return result, err
+}

--- a/pkg/kubeapiserver/authorizer/webhook_test.go
+++ b/pkg/kubeapiserver/authorizer/webhook_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authorizer
+
+import (
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	authorization "k8s.io/api/authorization/v1beta1"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/plugin/pkg/authorizer/webhook"
+)
+
+// kubeConfigData is formatted into kubeConfigTmpl below.
+type kubeConfigData struct {
+	Server                    string
+	CAFilePath                string
+	ClientCertificateFilePath string
+	ClientKeyFilePath         string
+}
+
+// kubeConfigTmpl is a template kubeconfig file content, as used by the webhook
+// authorizer subsystem.
+const kubeConfigTmpl = `clusters:
+- name: name-of-remote-authz-service
+  cluster:
+    certificate-authority: {{ .CAFilePath }}
+    server: {{ .Server }}
+users:
+- name: name-of-api-server
+  user:
+    # In our test, it is OK that these two remain unfilled.
+    client-certificate:
+    client-key:
+current-context: webhook
+contexts:
+- context:
+    cluster: name-of-remote-authz-service
+    user: name-of-api-server
+  name: webhook
+`
+
+// must panics if it is passed a non-nil error.  Useful for short-circuiting
+// error handling where we don't expect actual errors to occur.
+func must(i interface{}, err error) interface{} {
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %v", err))
+	}
+	return i
+}
+
+// noerror is a one-argument must (see above).
+func noerror(err error) {
+	if err != nil {
+		panic(fmt.Sprintf("unexpected error: %v", err))
+	}
+}
+
+func TestNewWebhookAuthorizer(t *testing.T) {
+	tt := []struct {
+		// This is appended to the TLS server base URL to form final URL.  We
+		// can't set a full URL here since the address of the TLS server will
+		// vary per run.
+		UrlPath string
+
+		// The authz request to send to the authorizer.
+		Request authorizer.AttributesRecord
+
+		// The full content of the fake authorizer's response.
+		VerdictResponse authorization.SubjectAccessReview
+
+		// The URL that the fake server responded for must have this suffix.
+		// For example, if the URL is "https://somewhere:port/someurl", then
+		// we expect ExpectedPath == "/someurl".
+		ExpectedPath string
+
+		// Whether the request was authorized or not.
+		Verdict bool
+
+		// What was the reason given for the verdict by the authz server.
+		Reason string
+
+		// If set, this is the error we expect.  Its error text must appear in
+		// the error text of the actual error.
+		Error error
+	}{
+		{
+			// Test that the authz verdict is correctly propagated back to the
+			// authorizer.
+			UrlPath:      "/authorize",
+			ExpectedPath: "/authorize",
+			Request: authorizer.AttributesRecord{
+				User: &user.DefaultInfo{
+					Name: "jane",
+				},
+				Verb:            "GET",
+				Resource:        "somepod",
+				Namespace:       "somenamespace",
+				APIGroup:        "someapigroup",
+				Path:            "somepath",
+				ResourceRequest: true,
+			},
+			VerdictResponse: authorization.SubjectAccessReview{
+				Status: authorization.SubjectAccessReviewStatus{
+					Allowed: false,
+					Reason:  "No authz for you!",
+				},
+			},
+			Verdict: false,
+			Reason:  "No authz for you!",
+		},
+		{
+			// Test that changing the URL path in the configuration file
+			// results in an actual change in the URL that the webhook
+			// authorizer calls out to.
+			UrlPath:      "/authorize/again",
+			ExpectedPath: "/authorize/again",
+			Request: authorizer.AttributesRecord{
+				User: &user.DefaultInfo{
+					Name: "jane",
+				},
+				Verb:            "GET",
+				Resource:        "somepod",
+				Namespace:       "somenamespace",
+				APIGroup:        "someapigroup",
+				Path:            "somepath",
+				ResourceRequest: true,
+			},
+			VerdictResponse: authorization.SubjectAccessReview{},
+			Verdict:         false,
+		},
+		{
+			// Test a positive verdict.
+			UrlPath:      "/authorize",
+			ExpectedPath: "/authorize",
+			Request: authorizer.AttributesRecord{
+				User: &user.DefaultInfo{
+					Name: "jane",
+				},
+				Verb:            "GET",
+				Resource:        "somepod",
+				Namespace:       "somenamespace",
+				APIGroup:        "someapigroup",
+				Path:            "somepath",
+				ResourceRequest: true,
+			},
+			VerdictResponse: authorization.SubjectAccessReview{
+				Status: authorization.SubjectAccessReviewStatus{
+					Allowed: true,
+				},
+			},
+			Verdict: true,
+		},
+	}
+
+	for i, ttt := range tt {
+		// Ensures that defer is called after each loop iteration.
+		func() {
+			// Create a test harness.
+			var url *url.URL
+			ts := httptest.NewTLSServer(
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					resp := must(json.Marshal(ttt.VerdictResponse)).([]byte)
+					w.Write(resp)
+					url = r.URL
+				}))
+			defer ts.Close()
+
+			// Save the certificate authority from the fake TLS server into a
+			// cert file.  The client must have access to this data to validate
+			// the request.  We make the CA file available on the filesystem,
+			// and later point the kubeconfig file to this file path.
+			certfile := must(ioutil.TempFile("", "ca-")).(*os.File)
+			pem.Encode(certfile, &pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: ts.TLS.Certificates[0].Certificate[0]})
+			certfile.Close()
+			defer os.Remove(certfile.Name())
+
+			// Create a kubeconfig file with configuration bits pointing to
+			// correct files.
+			kubeConfig := must(ioutil.TempFile("", "kubeconfig-")).(*os.File)
+			defer os.Remove(kubeConfig.Name())
+
+			// Format the kubeconfig data into the kubeconfig file.  Normally
+			// all of this fixture setup will complete without error.
+			tmpl := must(template.New("kubecofig").
+				Parse(kubeConfigTmpl)).(*template.Template)
+			data := kubeConfigData{
+				Server:     fmt.Sprintf("%v%v", ts.URL, ttt.UrlPath),
+				CAFilePath: certfile.Name(),
+			}
+			noerror(tmpl.Execute(kubeConfig, data))
+			noerror(kubeConfig.Close())
+
+			// And now, for the actual test case...
+			transport := &http.Transport{}
+			authz := must(NewWebhookAuthorizer(
+				kubeConfig.Name(), 1*time.Second,
+				2*time.Second, transport.Dial)).(*webhook.WebhookAuthorizer)
+
+			verdict, reason, err := authz.Authorize(ttt.Request)
+			if err != nil {
+				if ttt.Error == nil {
+					t.Fatalf("[%v] unexpected error: %v", i, err)
+				} else if strings.Index(err.Error(), ttt.Error.Error()) == -1 {
+					t.Errorf("[%v] unexpected error: actual: %v, expected: %v",
+						i, err, ttt.Error)
+				}
+				return
+			}
+			if verdict != ttt.Verdict {
+				t.Errorf("[%v] verdict mismatch: actual: %v, expected: %v",
+					i, verdict, ttt.Verdict)
+			}
+			if reason != ttt.Reason {
+				t.Errorf("[%v] reason mismatch: actual: %v, expected: %v",
+					i, reason, ttt.Reason)
+			}
+			if !strings.HasSuffix(url.String(), ttt.ExpectedPath) {
+				t.Errorf("[%v] url suffix mismatch: actual: %v, expected: %v",
+					i, url, ttt.ExpectedPath)
+			}
+		}()
+
+	}
+}


### PR DESCRIPTION
Note: the full design proposal is available at: https://goo.gl/APfsCE

This change allows webhook authorizer that call out to an endpoint of
the form:

    https://servicename.namespace.svc/someurl

to resolve "servicename.namespace.svc" to the service's current
endpoint, without contacting kube-dns.

This allows deployments without kube-dns access (e.g. GKE, or the
default k8s-on-GCP) to host the webhook authorizer as a pod.  It is
somewhat similar to the resolution already used for say admission
control plugins, but has a few important differences:

- The configuration files for admission control and webhook authz are
different.

- There is no dynamic registration support for authz webhooks.

The feature depends on a recent change that requires server certificate
to have CN subject field in the certificate be set to the Kubernetes
service name (for example: "/CN=servicename.namespace.svc").

Also, since the authz webhook is already released and being used, we
must uphold a few constraints:

- Deployments that don't need or use this feature should not have to pay
the cost of having it around.

- Since kube-apiserver is the only server that would need this feature,
the changes are confined to kube-apiserver specific code, and not pushed
deeper into generic webhook.

Changes inside:

- Introduced a flag --authorization-webhook-use-service-resolution
(default: false) that gates the service resolution.  This is because
there may be deployments that can do service resolution from the master
node through kube-dns, which do not need this additional functionality.
Those users can simply keep the flag set to its default value and
pretend that this functionality does not exist.

- Wired through a service resolver and the proxy transport dialer from
the apiserver setup code into authorizer.  This is a very similar
approach to how this is done today with the admission control code.

- In the authz webhook proper, added a whole optional section that
periodically recreates the webhook client based off of the freshest
available endpoint IP address for the service in question.  The optional
section only makes a difference when the resolution is used.  Otherwise,
the code paths are not extended.  I did introduce a lock for the client
refresh; but I expect that the contention would be significant in
regular use, since write locks are rare, and regular requests use the
read locks.

- Some refactoring and reformatting of the existing code.  Namely the
webhook client construction was broken up into two smaller pieces:
reading the kubeconfig file, and creating the client proper from the
kubeconfig file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: This pull request handles item (2) from https://github.com/kubernetes/kubernetes/issues/52511  It mirrors the approach that is already in use
for webhook admission control for example, but is adjusted to fit neatly in the current kubeconfig-based
webhook authz configuration.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds support for in-server service name resolution.

This change allows webhook authorizer that call out to an endpoint of
the form:

    https://servicename.namespace.svc/someurl

to resolve "servicename.namespace.svc" to the service's current
endpoint, without contacting kube-dns.

Design proposal is available at: https://goo.gl/APfsCE
```
