### PR TITLE
Update fluentd-gcp DaemonSet

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-gcp
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -23,6 +32,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: fluentd-gcp
       dnsPolicy: Default
       hostNetwork: true
       containers:
@@ -90,9 +100,6 @@ spec:
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
           - --api-override={{ prometheus_to_sd_endpoint }}
           - --whitelisted-metrics=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
-        volumeMounts:
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/fluentd-ds-ready: "true"
@@ -118,6 +125,3 @@ spec:
       - name: config-volume
         configMap:
           name: fluentd-gcp-config-v1.2.2
-      - name: ssl-certs
-        hostPath:
-          path: /etc/ssl/certs


### PR DESCRIPTION
- Use a dedicated service account to run the fluentd-gcp DS
- Use the certificates in the prometheus-to-sd image rather than mounting the host certs

This PR lets us create a more targeted PodSecurityPolicy for fluentd. (See https://github.com/kubernetes/kubernetes/pull/52367#discussion_r145433354)

```release-note
- fluentd-gcp runs with a dedicated fluentd-gcp service account
- Stop mounting the host certificates into fluentd's prometheus-to-sd container
```
