### PR TITLE
bazel cleanup: remove --incompatible workaround flags

### DIFF
--- a/build/root/.bazelrc
+++ b/build/root/.bazelrc
@@ -12,16 +12,5 @@ build --sandbox_tmpfs_path=/tmp
 # This flag requires Bazel 0.5.0+
 build --sandbox_fake_username
 
-# rules_go@82483596ec203eb9c1849937636f4cbed83733eb has a typo that
-# inadvertently relies on comprehension variables leaking.
-# TODO(ixdy): Remove these defaults once rules_go is bumped.
-# Ref kubernetes/kubernetes#52677
-build --incompatible_comprehension_variables_do_not_leak=false
-query --incompatible_comprehension_variables_do_not_leak=false
-
-# TODO(ixdy): remove the following once repo-infra is bumped.
-build --incompatible_disallow_set_constructor=false
-query --incompatible_disallow_set_constructor=false
-
 # Enable go race detection.
 test --features=race


### PR DESCRIPTION
**What this PR does / why we need it**: since #53839 bumped all of our dependencies, we no longer need to use these workaround flags to support building with bazel 0.6.0+.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @BenTheElder @spxtr @mikedanese 
