### PR TITLE
Updated DeleteVolume implementation to use the cache and workspace

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -140,16 +140,13 @@ type Instances interface {
 	// CurrentNodeName returns the name of the node we are currently running on
 	// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 	CurrentNodeName(hostname string) (types.NodeName, error)
-<<<<<<< HEAD
 	// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
 	// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 	InstanceExistsByProviderID(providerID string) (bool, error)
-=======
 	// Notification to the cloud provider when node is registered
 	NodeRegistered(nodes *v1.Node)
 	// Notification to the cloud provider when node is unregistered
 	NodeUnregistered(nodes *v1.Node)
->>>>>>>   Below changes are made
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -140,9 +140,16 @@ type Instances interface {
 	// CurrentNodeName returns the name of the node we are currently running on
 	// On most clouds (e.g. GCE) this is the hostname, so we provide the hostname
 	CurrentNodeName(hostname string) (types.NodeName, error)
+<<<<<<< HEAD
 	// InstanceExistsByProviderID returns true if the instance for the given provider id still is running.
 	// If false is returned with no error, the instance will be immediately deleted by the cloud controller manager.
 	InstanceExistsByProviderID(providerID string) (bool, error)
+=======
+	// Notification to the cloud provider when node is registered
+	NodeRegistered(nodes *v1.Node)
+	// Notification to the cloud provider when node is unregistered
+	NodeUnregistered(nodes *v1.Node)
+>>>>>>>   Below changes are made
 }
 
 // Route is a representation of an advanced routing rule.

--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -999,6 +999,16 @@ func (c *Cloud) HasClusterID() bool {
 	return len(c.tagging.clusterID()) > 0
 }
 
+// Notification handler when node is registered.
+func (c *Cloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (c *Cloud) NodeUnregistered(node *v1.Node) {
+
+}
+
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (c *Cloud) NodeAddresses(name types.NodeName) ([]v1.NodeAddress, error) {
 	if c.selfAWSInstance.nodeName == name || len(name) == 0 {

--- a/pkg/cloudprovider/providers/azure/azure.go
+++ b/pkg/cloudprovider/providers/azure/azure.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"time"
 
+	"k8s.io/api/core/v1"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
@@ -447,4 +448,14 @@ func initDiskControllers(az *Cloud) error {
 	az.controllerCommon = common
 
 	return nil
+}
+
+// Notification handler when node is registered.
+func (az *Cloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (az *Cloud) NodeUnregistered(node *v1.Node) {
+
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -27,7 +27,11 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"gopkg.in/gcfg.v1"
+<<<<<<< HEAD
 	"k8s.io/apimachinery/pkg/types"
+=======
+	"k8s.io/api/core/v1"
+>>>>>>>   Below changes are made
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 )
@@ -261,4 +265,14 @@ func (cs *CSCloud) GetZoneByNodeName(nodeName types.NodeName) (cloudprovider.Zon
 	zone.Region = instance.Zonename
 
 	return zone, nil
+}
+
+// Notification handler when node is registered.
+func (cs *CSCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (cs *CSCloud) NodeUnregistered(node *v1.Node) {
+
 }

--- a/pkg/cloudprovider/providers/cloudstack/cloudstack.go
+++ b/pkg/cloudprovider/providers/cloudstack/cloudstack.go
@@ -27,11 +27,8 @@ import (
 	"github.com/kardianos/osext"
 	"github.com/xanzy/go-cloudstack/cloudstack"
 	"gopkg.in/gcfg.v1"
-<<<<<<< HEAD
 	"k8s.io/apimachinery/pkg/types"
-=======
 	"k8s.io/api/core/v1"
->>>>>>>   Below changes are made
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
 )

--- a/pkg/cloudprovider/providers/cloudstack/metadata.go
+++ b/pkg/cloudprovider/providers/cloudstack/metadata.go
@@ -209,3 +209,13 @@ func findDHCPServer() (string, error) {
 
 	return "", errors.New("no server found")
 }
+
+// Notification handler when node is registered.
+func (m *metadata) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (m *metadata) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -330,3 +330,13 @@ func (c *FakeCloud) GetLabelsForVolume(pv *v1.PersistentVolume) (map[string]stri
 	}
 	return nil, fmt.Errorf("label not found for volume")
 }
+
+// Notification handler when node is registered.
+func (f *FakeCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (f *FakeCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -1147,3 +1147,13 @@ func (manager *GCEServiceManager) getRegionFromZone(zoneInfo zoneType) (string, 
 
 	return region, nil
 }
+
+// Notification handler when node is registered.
+func (gce *GCECloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (gce *GCECloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/openstack/openstack_instances.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_instances.go
@@ -199,3 +199,13 @@ func instanceIDFromProviderID(providerID string) (instanceID string, err error) 
 	}
 	return matches[1], nil
 }
+
+// Notification handler when node is registered.
+func (i *Instances) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (i *Instances) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/ovirt/ovirt.go
+++ b/pkg/cloudprovider/providers/ovirt/ovirt.go
@@ -323,3 +323,13 @@ func (v *OVirtCloud) CurrentNodeName(hostname string) (types.NodeName, error) {
 func (v *OVirtCloud) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 	return errors.New("unimplemented")
 }
+
+// Notification handler when node is registered.
+func (v *OVirtCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (v *OVirtCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/photon/photon.go
+++ b/pkg/cloudprovider/providers/photon/photon.go
@@ -737,3 +737,13 @@ func (pc *PCCloud) DeleteDisk(pdID string) error {
 
 	return nil
 }
+
+// Notification handler when node is registered.
+func (pc *PCCloud) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (pc *PCCloud) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/rackspace/rackspace.go
+++ b/pkg/cloudprovider/providers/rackspace/rackspace.go
@@ -784,3 +784,13 @@ func (rs *Rackspace) DisksAreAttached(instanceID string, volumeIDs []string) (ma
 func (rs *Rackspace) ShouldTrustDevicePath() bool {
 	return true
 }
+
+// Notification handler when node is registered.
+func (i *Instances) NodeRegistered(node *v1.Node) {
+
+}
+
+// Notification handler when node is unregistered.
+func (i *Instances) NodeUnregistered(node *v1.Node) {
+
+}

--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"k8s.io/api/core/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
+)
+
+// Stores info about the kubernetes node
+type NodeInfo struct {
+	vm       *vclib.VirtualMachine
+	vcServer string
+}
+
+type NodeManager struct {
+	// Maps the VC server to VSphereInstance
+	vsphereInstanceMap map[string]*VSphereInstance
+	// Maps node name to node info.
+	nodeInfoMap map[string]*NodeInfo
+}
+
+func (nm *NodeManager) registerNode(node *v1.Node) error {
+	return nil
+}
+
+func (nm *NodeManager) unregisterNode(node *v1.Node) error {
+	return nil
+}
+
+func (nm *NodeManager) getNodeInfo(nodeName k8stypes.NodeName) (*NodeInfo, error) {
+	return nil, nil
+}
+
+func (nm *NodeManager) getVSphereInstance(nodeName k8stypes.NodeName) (*VSphereInstance, error) {
+	return nil, nil
+}

--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -20,33 +20,230 @@ import (
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
+	"github.com/golang/glog"
+	"golang.org/x/net/context"
+	"strings"
+	"sync"
+	"fmt"
 )
 
 // Stores info about the kubernetes node
 type NodeInfo struct {
+	dataCenter *vclib.Datacenter
 	vm       *vclib.VirtualMachine
 	vcServer string
 }
 
 type NodeManager struct {
+	// TODO: replace map with concurrent map when k8s supports go v1.9
+
 	// Maps the VC server to VSphereInstance
 	vsphereInstanceMap map[string]*VSphereInstance
 	// Maps node name to node info.
 	nodeInfoMap map[string]*NodeInfo
+	// Maps node name to node structure
+	registeredNodes map[string]*v1.Node
+
+
+	// Mutexes
+	registeredNodesLock sync.RWMutex
+	nodeInfoLock sync.RWMutex
 }
 
-func (nm *NodeManager) registerNode(node *v1.Node) error {
+// TODO: Make it configurable in vsphere.conf
+const (
+	POOL_SIZE = 8
+	QUEUE_SIZE = POOL_SIZE * 10
+)
+
+
+func (nm *NodeManager) DiscoverNode(node *v1.Node) error {
+
+	type VmSearch struct {
+		vc string
+		datacenter *vclib.Datacenter
+	}
+
+
+	var mutex = &sync.Mutex{}
+
+	var queueChannel chan *VmSearch
+	var wg sync.WaitGroup
+	queueChannel = make(chan *VmSearch, QUEUE_SIZE)
+	nodeUUID := node.Status.NodeInfo.SystemUUID
+	vmFound := false
+
+
+	go func() {
+		var datacenterObjs []*vclib.Datacenter
+		for vc, vsi := range nm.vsphereInstanceMap {
+
+			mutex.Lock()
+			found := vmFound
+			mutex.Unlock()
+			if found == true {
+				break
+			}
+
+			// Create context
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			err := vsi.conn.Connect(ctx)
+			if err != nil {
+				glog.V(4).Info("Discovering node error vc:", err)
+			}
+
+			if vsi.cfg.Datacenters == "" {
+				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
+				if err != nil {
+					glog.V(4).Info("Discovering node error dc:", err)
+				}
+			} else {
+				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
+				for _, dc := range datacenters {
+					dc = strings.TrimSpace(dc)
+					if dc == "" {
+						continue
+					}
+					datacenterObj, err := vclib.GetDatacenter(ctx, vsi.conn, dc)
+					if err != nil {
+						glog.V(4).Info("Discovering node error dc:", err)
+					}
+					datacenterObjs = append(datacenterObjs, datacenterObj)
+				}
+			}
+
+			for _, datacenterObj := range datacenterObjs {
+				mutex.Lock()
+				found := vmFound
+				mutex.Unlock()
+				if found == true {
+					break
+				}
+
+				glog.V(4).Infof("Finding node %s in vc=%s and datacenter=%s", node.Name, vc, datacenterObj.Name())
+				queueChannel <- &VmSearch{
+					vc:         vc,
+					datacenter: datacenterObj,
+				}
+			}
+		}
+		close(queueChannel)
+	}()
+
+	for i := 0; i < POOL_SIZE; i++ {
+		go func() {
+			for res:= range queueChannel {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				vm, err := res.datacenter.GetVMByUUID(ctx, nodeUUID)
+				if err != nil {
+					glog.V(4).Infof("Error %q while looking for vm=%+v in vc=%s and datacenter=%s",
+						err, node.Name, vm, res.vc, res.datacenter.Name())
+						continue
+				}
+				if vm != nil {
+					glog.V(4).Infof("Found node %s as vm=%+v in vc=%s and datacenter=%s",
+						node.Name, vm, res.vc, res.datacenter.Name())
+
+					nodeInfo := &NodeInfo{dataCenter: res.datacenter, vm: vm, vcServer: res.vc}
+					nm.addNodeInfo(node.ObjectMeta.Name, nodeInfo)
+					for range queueChannel {}
+					mutex.Lock()
+					vmFound = true
+					mutex.Unlock()
+					break
+
+				} else {
+					glog.V(4).Infof("Did not find node %s in vc=%s and datacenter=%s",
+						node.Name, res.vc, res.datacenter.Name(), err)
+				}
+			}
+			wg.Done()
+		}()
+		wg.Add(1)
+	}
+	wg.Wait()
+	if !vmFound {
+		return fmt.Errorf("discovery failed for node %q", node.ObjectMeta.Name)
+	}
 	return nil
 }
 
-func (nm *NodeManager) unregisterNode(node *v1.Node) error {
+
+
+func (nm *NodeManager) RegisterNode(node *v1.Node) error {
+	nm.addNode(node)
+	return nm.DiscoverNode(node)
+}
+
+func (nm *NodeManager) UnRegisterNode(node *v1.Node) error {
+	nm.removeNode(node)
 	return nil
 }
 
-func (nm *NodeManager) getNodeInfo(nodeName k8stypes.NodeName) (*NodeInfo, error) {
-	return nil, nil
+func (nm *NodeManager) RediscoverNode(nodeName k8stypes.NodeName) error {
+	node, err := nm.GetNode(nodeName)
+
+	if err != nil {
+		return err
+	}
+	return nm.DiscoverNode(&node)
 }
 
-func (nm *NodeManager) getVSphereInstance(nodeName k8stypes.NodeName) (*VSphereInstance, error) {
-	return nil, nil
+func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
+	nm.nodeInfoLock.RLock()
+	node := nm.registeredNodes[convertToString(nodeName)]
+	nm.registeredNodesLock.RUnlock()
+	if node == nil {
+		return v1.Node{}, fmt.Errorf("node %q not found", convertToString(nodeName))
+	}
+	return *node, nil
 }
+
+func (nm *NodeManager) addNode(node *v1.Node) {
+	nm.registeredNodesLock.Lock()
+	nm.registeredNodes[node.ObjectMeta.Name] = node
+	nm.registeredNodesLock.Unlock()
+}
+
+func (nm *NodeManager) removeNode(node *v1.Node) {
+	nm.registeredNodesLock.Lock()
+	delete(nm.registeredNodes, node.ObjectMeta.Name)
+	nm.registeredNodesLock.Unlock()
+}
+
+func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error) {
+	nm.nodeInfoLock.RLock()
+	nodeInfo := nm.nodeInfoMap[convertToString(nodeName)]
+	nm.registeredNodesLock.RUnlock()
+	if nodeInfo == nil {
+		err := nm.RediscoverNode(nodeName)
+		if err != nil {
+			return NodeInfo{}, fmt.Errorf("error %q node info for node %q not found", err, convertToString(nodeName))
+		}
+	}
+	return *nodeInfo, nil
+}
+
+func (nm *NodeManager) addNodeInfo(nodeName string, nodeInfo *NodeInfo) {
+	nm.nodeInfoLock.Lock()
+	nm.nodeInfoMap[nodeName] = nodeInfo
+	nm.nodeInfoLock.Unlock()
+}
+
+func (nm *NodeManager) GetVSphereInstance(nodeName k8stypes.NodeName) (VSphereInstance, error) {
+	nodeInfo, err := nm.GetNodeInfo(nodeName)
+	if err != nil {
+		return VSphereInstance{}, fmt.Errorf("node info for node %q not found", convertToString(nodeName))
+	}
+	vsphereInstance := nm.vsphereInstanceMap[nodeInfo.vcServer]
+	if vsphereInstance == nil {
+		return VSphereInstance{}, fmt.Errorf("vSphereInstance for vc server %q not found while looking for node %q", nodeInfo.vcServer, convertToString(nodeName))
+	}
+	return *nm.vsphereInstanceMap[convertToString(nodeName)], nil
+}
+
+
+

--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -92,12 +92,14 @@ func (nm *NodeManager) DiscoverNode(node *v1.Node) error {
 			err := vsi.conn.Connect(ctx)
 			if err != nil {
 				glog.V(4).Info("Discovering node error vc:", err)
+				continue
 			}
 
 			if vsi.cfg.Datacenters == "" {
 				datacenterObjs, err = vclib.GetAllDatacenter(ctx, vsi.conn)
 				if err != nil {
 					glog.V(4).Info("Discovering node error dc:", err)
+					continue
 				}
 			} else {
 				datacenters := strings.Split(vsi.cfg.Datacenters, ",")
@@ -193,7 +195,7 @@ func (nm *NodeManager) RediscoverNode(nodeName k8stypes.NodeName) error {
 }
 
 func (nm *NodeManager) GetNode(nodeName k8stypes.NodeName) (v1.Node, error) {
-	nm.nodeInfoLock.RLock()
+	nm.registeredNodesLock.RLock()
 	node := nm.registeredNodes[convertToString(nodeName)]
 	nm.registeredNodesLock.RUnlock()
 	if node == nil {
@@ -217,7 +219,7 @@ func (nm *NodeManager) removeNode(node *v1.Node) {
 func (nm *NodeManager) GetNodeInfo(nodeName k8stypes.NodeName) (NodeInfo, error) {
 	nm.nodeInfoLock.RLock()
 	nodeInfo := nm.nodeInfoMap[convertToString(nodeName)]
-	nm.registeredNodesLock.RUnlock()
+	nm.nodeInfoLock.RUnlock()
 	if nodeInfo == nil {
 		err := nm.RediscoverNode(nodeName)
 		if err != nil {
@@ -242,7 +244,7 @@ func (nm *NodeManager) GetVSphereInstance(nodeName k8stypes.NodeName) (VSphereIn
 	if vsphereInstance == nil {
 		return VSphereInstance{}, fmt.Errorf("vSphereInstance for vc server %q not found while looking for node %q", nodeInfo.vcServer, convertToString(nodeName))
 	}
-	return *nm.vsphereInstanceMap[convertToString(nodeName)], nil
+	return *vsphereInstance, nil
 }
 
 

--- a/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/datacenter.go
@@ -48,6 +48,22 @@ func GetDatacenter(ctx context.Context, connection *VSphereConnection, datacente
 	return &dc, nil
 }
 
+// GetDatacenter returns all the DataCenter Objects
+func GetAllDatacenter(ctx context.Context, connection *VSphereConnection) ([]*Datacenter, error) {
+	var dc []*Datacenter
+	finder := find.NewFinder(connection.GoVmomiClient.Client, true)
+	datacenters, err := finder.DatacenterList(ctx, "*")
+	if err != nil {
+		glog.Errorf("Failed to find the datacenter. err: %+v", err)
+		return nil, err
+	}
+	for _, datacenter := range datacenters {
+		dc = append(dc, &(Datacenter{datacenter}))
+	}
+
+	return dc, nil
+}
+
 // GetVMByUUID gets the VM object from the given vmUUID
 func (dc *Datacenter) GetVMByUUID(ctx context.Context, vmUUID string) (*VirtualMachine, error) {
 	s := object.NewSearchIndex(dc.Client())

--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vdm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vdm.go
@@ -69,13 +69,13 @@ func (diskManager virtualDiskManager) Create(ctx context.Context, datastore *vcl
 }
 
 // Delete implements Disk's Delete interface
-func (diskManager virtualDiskManager) Delete(ctx context.Context, datastore *vclib.Datastore) error {
+func (diskManager virtualDiskManager) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
 	// Create a virtual disk manager
-	virtualDiskManager := object.NewVirtualDiskManager(datastore.Client())
+	virtualDiskManager := object.NewVirtualDiskManager(datacenter.Client())
 	diskPath := vclib.RemoveClusterFromVDiskPath(diskManager.diskPath)
 	requestTime := time.Now()
 	// Delete virtual disk
-	task, err := virtualDiskManager.DeleteVirtualDisk(ctx, diskPath, datastore.Datacenter.Datacenter)
+	task, err := virtualDiskManager.DeleteVirtualDisk(ctx, diskPath, datacenter.Datacenter)
 	if err != nil {
 		glog.Errorf("Failed to delete virtual disk. err: %v", err)
 		vclib.RecordvSphereMetric(vclib.APIDeleteVolume, requestTime, err)

--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/virtualdisk.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/virtualdisk.go
@@ -40,7 +40,7 @@ const (
 // VirtualDiskProvider defines interfaces for creating disk
 type VirtualDiskProvider interface {
 	Create(ctx context.Context, datastore *vclib.Datastore) error
-	Delete(ctx context.Context, datastore *vclib.Datastore) error
+	Delete(ctx context.Context, datacenter *vclib.Datacenter) error
 }
 
 // getDiskManager returns vmDiskManager or vdmDiskManager based on given volumeoptions
@@ -75,6 +75,6 @@ func (virtualDisk *VirtualDisk) Create(ctx context.Context, datastore *vclib.Dat
 }
 
 // Delete gets appropriate disk manager and calls respective delete method
-func (virtualDisk *VirtualDisk) Delete(ctx context.Context, datastore *vclib.Datastore) error {
-	return getDiskManager(virtualDisk, VirtualDiskDeleteOperation).Delete(ctx, datastore)
+func (virtualDisk *VirtualDisk) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
+	return getDiskManager(virtualDisk, VirtualDiskDeleteOperation).Delete(ctx, datacenter)
 }

--- a/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
+++ b/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers/vmdm.go
@@ -157,7 +157,7 @@ func (vmdisk vmDiskManager) Create(ctx context.Context, datastore *vclib.Datasto
 	return nil
 }
 
-func (vmdisk vmDiskManager) Delete(ctx context.Context, datastore *vclib.Datastore) error {
+func (vmdisk vmDiskManager) Delete(ctx context.Context, datacenter *vclib.Datacenter) error {
 	return fmt.Errorf("vmDiskManager.Delete is not supported")
 }
 

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -63,10 +64,9 @@ var cleanUpDummyVMLock sync.RWMutex
 
 // VSphere is an implementation of cloud provider Interface for VSphere.
 type VSphere struct {
-	conn *vclib.VSphereConnection
-	cfg  *VSphereConfig
-	// InstanceID of the server where this VSphere object is instantiated.
-	localInstanceID string
+	conn     *vclib.VSphereConnection
+	cfg      *VSphereConfig
+	hostName string
 }
 
 // VSphereConfig information that is used by vSphere Cloud Provider to connect to VC
@@ -83,9 +83,9 @@ type VSphereConfig struct {
 		// True if vCenter uses self-signed cert.
 		InsecureFlag bool `gcfg:"insecure-flag"`
 		// Datacenter in which VMs are located.
-		Datacenter string `gcfg:"datacenter"`
+		Datacenters string `gcfg:"datacenters"`
 		// Datastore in which vmdks are stored.
-		Datastore string `gcfg:"datastore"`
+		DeafultDatastore string `gcfg:"default-datastore"`
 		// WorkingDir is path where VMs can be found.
 		WorkingDir string `gcfg:"working-dir"`
 		// Soap round tripper count (retries = RoundTripper - 1)
@@ -98,6 +98,23 @@ type VSphereConfig struct {
 		// Combining the WorkingDir and VMName can form a unique InstanceID.
 		// When vm-name is set, no username/password is required on worker nodes.
 		VMName string `gcfg:"vm-name"`
+	}
+
+	VirtualCenter map[string]*struct {
+		// vCenter username.
+		User string `gcfg:"user"`
+		// vCenter password in clear text.
+		Password string `gcfg:"password"`
+		// vCenter port.
+		VCenterPort string `gcfg:"port"`
+		// True if vCenter uses self-signed cert.
+		InsecureFlag bool `gcfg:"insecure-flag"`
+		// Datacenter in which VMs are located.
+		Datacenters string `gcfg:"datacenters"`
+		// WorkingDir is path where VMs can be found.
+		WorkingDir string `gcfg:"working-dir"`
+		// Soap round tripper count (retries = RoundTripper - 1)
+		RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
 	}
 
 	Network struct {
@@ -151,19 +168,40 @@ func readConfig(config io.Reader) (VSphereConfig, error) {
 func init() {
 	vclib.RegisterMetrics()
 	cloudprovider.RegisterCloudProvider(ProviderName, func(config io.Reader) (cloudprovider.Interface, error) {
+		// If vSphere.conf file is not present then it is worker node.
+		if config == nil {
+			return newWorkerNode()
+		}
 		cfg, err := readConfig(config)
 		if err != nil {
 			return nil, err
 		}
-		return newVSphere(cfg)
+		return newControllerNode(cfg)
 	})
 }
 
 // Initialize passes a Kubernetes clientBuilder interface to the cloud provider
 func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) {}
 
-func newVSphere(cfg VSphereConfig) (*VSphere, error) {
+// Creates new worker node interface and returns
+func newWorkerNode() (*VSphere, error) {
 	var err error
+	vs := VSphere{}
+	vs.hostName, err = os.Hostname()
+	if err != nil {
+		glog.Errorf("Failed to get hostname. err: %+v", err)
+		return nil, err
+	}
+
+	return &vs, nil
+}
+
+// Creates new Contreoller node interface and returns
+func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
+	var err error
+
+	// TODO: Remove this log as it will print VC credentials in log.
+	glog.V(4).Infof("cfg is %+v", cfg)
 	if cfg.Disk.SCSIControllerType == "" {
 		cfg.Disk.SCSIControllerType = vclib.PVSCSIControllerType
 	} else if !vclib.CheckControllerSupported(cfg.Disk.SCSIControllerType) {
@@ -195,40 +233,18 @@ func newVSphere(cfg VSphereConfig) (*VSphere, error) {
 		RoundTripperCount: cfg.Global.RoundTripperCount,
 		Port:              cfg.Global.VCenterPort,
 	}
-	var instanceID string
 
-	if cfg.Global.VMName == "" {
-		// if VMName is not set in the cloud config file, each nodes (including worker nodes) need credentials to obtain VMName from vCenter
-		glog.V(4).Infof("Cannot find VMName from cloud config file, start obtaining it from vCenter")
-		// Create context
-		ctx, cancel := context.WithCancel(context.TODO())
-		defer cancel()
-		err = vSphereConn.Connect(ctx)
-		if err != nil {
-			glog.Errorf("Failed to connect to vSphere")
-			return nil, err
-		}
-		dc, err := vclib.GetDatacenter(ctx, &vSphereConn, cfg.Global.Datacenter)
-		if err != nil {
-			return nil, err
-		}
-		vm, err := dc.GetVMByUUID(ctx, cfg.Global.VMUUID)
-		if err != nil {
-			return nil, err
-		}
-		vmName, err := vm.ObjectName(ctx)
-		if err != nil {
-			return nil, err
-		}
-		instanceID = vmName
-	} else {
-		instanceID = cfg.Global.VMName
-	}
 	vs := VSphere{
-		conn:            &vSphereConn,
-		cfg:             &cfg,
-		localInstanceID: instanceID,
+		conn: &vSphereConn,
+		cfg:  &cfg,
 	}
+
+	vs.hostName, err = os.Hostname()
+	if err != nil {
+		glog.Errorf("Failed to get hostname. err: %+v", err)
+		return nil, err
+	}
+
 	runtime.SetFinalizer(&vs, logout)
 	return &vs, nil
 }
@@ -300,47 +316,12 @@ func (vs *VSphere) getVMByName(ctx context.Context, nodeName k8stypes.NodeName) 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, error) {
 	// Get local IP addresses if node is local node
-	if vs.localInstanceID == nodeNameToVMName(nodeName) {
+	if vs.hostName == nodeNameToVMName(nodeName) {
 		return getLocalIP()
 	}
-	addrs := []v1.NodeAddress{}
-	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	// Ensure client is logged in and session is valid
-	err := vs.conn.Connect(ctx)
-	if err != nil {
-		return nil, err
-	}
-	vm, err := vs.getVMByName(ctx, nodeName)
-	if err != nil {
-		glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
-		return nil, err
-	}
-	vmMoList, err := vm.Datacenter.GetVMMoList(ctx, []*vclib.VirtualMachine{vm}, []string{"guest.net"})
-	if err != nil {
-		glog.Errorf("Failed to get VM Managed object with property guest.net for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
-		return nil, err
-	}
-	// retrieve VM's ip(s)
-	for _, v := range vmMoList[0].Guest.Net {
-		if vs.cfg.Network.PublicNetwork == v.Network {
-			for _, ip := range v.IpAddress {
-				if net.ParseIP(ip).To4() != nil {
-					v1helper.AddToNodeAddresses(&addrs,
-						v1.NodeAddress{
-							Type:    v1.NodeExternalIP,
-							Address: ip,
-						}, v1.NodeAddress{
-							Type:    v1.NodeInternalIP,
-							Address: ip,
-						},
-					)
-				}
-			}
-		}
-	}
-	return addrs, nil
+
+	// TODO: Need to see what to do if nodename and localNodeName are not matching.
+	return nil, cloudprovider.InstanceNotFound
 }
 
 // NodeAddressesByProviderID returns the node addresses of an instances with the specified unique providerID
@@ -358,7 +339,7 @@ func (vs *VSphere) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 
 // CurrentNodeName gives the current node name
 func (vs *VSphere) CurrentNodeName(hostname string) (k8stypes.NodeName, error) {
-	return vmNameToNodeName(vs.localInstanceID), nil
+	return vmNameToNodeName(vs.hostName), nil
 }
 
 // nodeNameToVMName maps a NodeName to the vmware infrastructure name
@@ -384,6 +365,18 @@ func (vs *VSphere) InstanceExistsByProviderID(providerID string) (bool, error) {
 
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
+	// TODO: Based on hostname, locate the VM in VC inventory and check for following cases.
+	// 1. Node Present.
+	// 2. Node Powered On/ Powered off.
+	// Based on these kubernetes core decides to take specific actions.
+	// Also verify if this logic is required only on master or also on worker nodes.
+	if vs.hostName == nodeNameToVMName(nodeName) {
+		return vs.hostName, nil
+	}
+
+	// TODO: Need to see what to do if nodename and localNodeName are not matching.
+	// return "", cloudprovider.InstanceNotFound
+
 	if vs.localInstanceID == nodeNameToVMName(nodeName) {
 		return vs.cfg.Global.WorkingDir + "/" + vs.localInstanceID, nil
 	}
@@ -460,7 +453,7 @@ func (vs *VSphere) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 	attachDiskInternal := func(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.localInstanceID)
+			nodeName = vmNameToNodeName(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -492,7 +485,7 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeNam
 func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error {
 	detachDiskInternal := func(volPath string, nodeName k8stypes.NodeName) error {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.localInstanceID)
+			nodeName = vmNameToNodeName(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
@@ -531,7 +524,7 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 	diskIsAttachedInternal := func(volPath string, nodeName k8stypes.NodeName) (bool, error) {
 		var vSphereInstance string
 		if nodeName == "" {
-			vSphereInstance = vs.localInstanceID
+			vSphereInstance = vs.hostName
 			nodeName = vmNameToNodeName(vSphereInstance)
 		} else {
 			vSphereInstance = nodeNameToVMName(nodeName)
@@ -578,7 +571,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 		}
 		var vSphereInstance string
 		if nodeName == "" {
-			vSphereInstance = vs.localInstanceID
+			vSphereInstance = vs.hostName
 			nodeName = vmNameToNodeName(vSphereInstance)
 		} else {
 			vSphereInstance = nodeNameToVMName(nodeName)
@@ -757,4 +750,14 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 // HasClusterID returns true if the cluster has a clusterID
 func (vs *VSphere) HasClusterID() bool {
 	return true
+}
+
+// Notification handler when node is registered.
+func (vs *VSphere) NodeRegistered(node *v1.Node) {
+	glog.V(4).Infof("Node Registered: %+v", node)
+}
+
+// Notification handler when node is unregistered.
+func (vs *VSphere) NodeUnregistered(node *v1.Node) {
+	glog.V(4).Infof("Node Unregistered: %+v", node)
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -48,7 +48,6 @@ const (
 	VolDir                        = "kubevols"
 	RoundTripperDefaultCount      = 3
 	DummyVMPrefixName             = "vsphere-k8s"
-	VSANDatastoreType             = "vsan"
 	MacOuiVC                      = "00:50:56"
 	MacOuiEsx                     = "00:0c:29"
 	CleanUpDummyVMRoutineInterval = 5
@@ -58,24 +57,51 @@ const (
 
 var cleanUpRoutineInitialized = false
 
-var clientLock sync.Mutex
 var cleanUpRoutineInitLock sync.Mutex
 var cleanUpDummyVMLock sync.RWMutex
 
 // VSphere is an implementation of cloud provider Interface for VSphere.
 type VSphere struct {
-	conn     *vclib.VSphereConnection
 	cfg      *VSphereConfig
 	hostName string
+	// Maps the VSphere IP address to VSphereInstance
+	vsphereInstanceMap map[string]*VSphereInstance
+	// Responsible for managing discovery of k8s node, their location etc.
+	nodeManager *NodeManager
 }
 
-// VSphereConfig information that is used by vSphere Cloud Provider to connect to VC
+// Represents a vSphere instance where one or more kubernetes nodes are running.
+type VSphereInstance struct {
+	conn *vclib.VSphereConnection
+	cfg  *VirtualCenterConfig
+}
+
+// Structure that represents Virtual Center configuration
+type VirtualCenterConfig struct {
+	// vCenter username.
+	User string `gcfg:"user"`
+	// vCenter password in clear text.
+	Password string `gcfg:"password"`
+	// vCenter port.
+	VCenterPort string `gcfg:"port"`
+	// True if vCenter uses self-signed cert.
+	InsecureFlag bool `gcfg:"insecure-flag"`
+	// Datacenter in which VMs are located.
+	Datacenters string `gcfg:"datacenters"`
+	// Soap round tripper count (retries = RoundTripper - 1)
+	RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+}
+
+// Structure that represents the content of vsphere.conf file.
+// Users specify the configuration of one or more Virtual Centers in vsphere.conf where
+// the Kubernetes master and worker nodes are running.
 type VSphereConfig struct {
 	Global struct {
 		// vCenter username.
 		User string `gcfg:"user"`
 		// vCenter password in clear text.
 		Password string `gcfg:"password"`
+		// Deprecated. Use VirtualCenter to specify multiple vCenter Servers.
 		// vCenter IP.
 		VCenterIP string `gcfg:"server"`
 		// vCenter port.
@@ -83,39 +109,30 @@ type VSphereConfig struct {
 		// True if vCenter uses self-signed cert.
 		InsecureFlag bool `gcfg:"insecure-flag"`
 		// Datacenter in which VMs are located.
+		// Deprecated. Use "datacenters" instead.
+		Datacenter string `gcfg:"datacenter"`
+		// Datacenter in which VMs are located.
 		Datacenters string `gcfg:"datacenters"`
 		// Datastore in which vmdks are stored.
-		DeafultDatastore string `gcfg:"default-datastore"`
-		// WorkingDir is path where VMs can be found.
+		DefaultDatastore string `gcfg:"datastore"`
+		// WorkingDir is path where VMs can be found. Also used to create dummy VMs.
+		// Deprecated.
 		WorkingDir string `gcfg:"working-dir"`
 		// Soap round tripper count (retries = RoundTripper - 1)
 		RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
+		// Deprecated as the virtual machines will be automatically discovered.
 		// VMUUID is the VM Instance UUID of virtual machine which can be retrieved from instanceUuid
 		// property in VmConfigInfo, or also set as vc.uuid in VMX file.
 		// If not set, will be fetched from the machine via sysfs (requires root)
 		VMUUID string `gcfg:"vm-uuid"`
+		// Deprecated as virtual machine will be automatically discovered.
 		// VMName is the VM name of virtual machine
 		// Combining the WorkingDir and VMName can form a unique InstanceID.
 		// When vm-name is set, no username/password is required on worker nodes.
 		VMName string `gcfg:"vm-name"`
 	}
 
-	VirtualCenter map[string]*struct {
-		// vCenter username.
-		User string `gcfg:"user"`
-		// vCenter password in clear text.
-		Password string `gcfg:"password"`
-		// vCenter port.
-		VCenterPort string `gcfg:"port"`
-		// True if vCenter uses self-signed cert.
-		InsecureFlag bool `gcfg:"insecure-flag"`
-		// Datacenter in which VMs are located.
-		Datacenters string `gcfg:"datacenters"`
-		// WorkingDir is path where VMs can be found.
-		WorkingDir string `gcfg:"working-dir"`
-		// Soap round tripper count (retries = RoundTripper - 1)
-		RoundTripperCount uint `gcfg:"soap-roundtrip-count"`
-	}
+	VirtualCenter map[string]*VirtualCenterConfig
 
 	Network struct {
 		// PublicNetwork is name of the network the VMs are joined to.
@@ -125,6 +142,12 @@ type VSphereConfig struct {
 	Disk struct {
 		// SCSIControllerType defines SCSI controller to be used.
 		SCSIControllerType string `dcfg:"scsicontrollertype"`
+	}
+
+	Workspace struct {
+		VCenterIP  string `gcfg:"server"`
+		Datacenter string `gcfg:"datacenter"`
+		Folder     string `gcfg:"folder"`
 	}
 }
 
@@ -196,12 +219,137 @@ func newWorkerNode() (*VSphere, error) {
 	return &vs, nil
 }
 
+func populateVsphereInstanceMap(cfg *VSphereConfig) (map[string]*VSphereInstance, error) {
+	vsphereInstanceMap := make(map[string]*VSphereInstance)
+
+	// Check if the vsphere.conf is in old format. In this
+	// format the cfg.VirtualCenter will be nil or empty.
+	if cfg.VirtualCenter == nil || len(cfg.VirtualCenter) == 0 {
+		glog.V(4).Infof("Config is not per virtual center and is in old format.")
+		if cfg.Global.User == "" {
+			glog.Error("Global.User is empty!")
+			return nil, errors.New("Global.User is empty!")
+		}
+		if cfg.Global.Password == "" {
+			glog.Error("Global.Password is empty!")
+			return nil, errors.New("Global.Password is empty!")
+		}
+		if cfg.Global.WorkingDir == "" {
+			glog.Error("Global.WorkingDir is empty!")
+			return nil, errors.New("Global.WorkingDir is empty!")
+		}
+		if cfg.Global.VCenterIP == "" {
+			glog.Error("Global.VCenterIP is empty!")
+			return nil, errors.New("Global.VCenterIP is empty!")
+		}
+		if cfg.Global.Datacenter == "" {
+			glog.Error("Global.Datacenter is empty!")
+			return nil, errors.New("Global.Datacenter is empty!")
+		}
+		cfg.Workspace.VCenterIP = cfg.Global.VCenterIP
+		cfg.Workspace.Datacenter = cfg.Global.Datacenter
+		cfg.Workspace.Folder = cfg.Global.WorkingDir
+
+		vcConfig := VirtualCenterConfig{
+			User:              cfg.Global.User,
+			Password:          cfg.Global.Password,
+			VCenterPort:       cfg.Global.VCenterPort,
+			Datacenters:       cfg.Global.Datacenter,
+			InsecureFlag:      cfg.Global.InsecureFlag,
+			RoundTripperCount: cfg.Global.RoundTripperCount,
+		}
+
+		vSphereConn := vclib.VSphereConnection{
+			Username:          vcConfig.User,
+			Password:          vcConfig.Password,
+			Hostname:          cfg.Global.VCenterIP,
+			Insecure:          vcConfig.InsecureFlag,
+			RoundTripperCount: vcConfig.RoundTripperCount,
+			Port:              vcConfig.VCenterPort,
+		}
+		vsphereIns := VSphereInstance{
+			conn: &vSphereConn,
+			cfg:  &vcConfig,
+		}
+		// TODO: Remove this log as it will print VC credentials in log.
+		glog.V(4).Infof("vcConfig for VC %s is %+v.", cfg.Global.VCenterIP, vcConfig)
+		glog.V(4).Infof("vSphereConn for VC %s is %+v.", cfg.Global.VCenterIP, vSphereConn)
+
+		vsphereInstanceMap[cfg.Global.VCenterIP] = &vsphereIns
+	} else {
+		// TODO: Remove this log
+		glog.V(4).Infof("Workspace is %+v.", cfg.Workspace)
+		if cfg.Workspace.VCenterIP == "" || cfg.Workspace.Folder == "" || cfg.Workspace.Datacenter == "" {
+			msg := fmt.Sprintf("All fields in workspace are mandatory."+
+				" vsphere.conf does not have the workspace specified correctly. cfg.Workspace: %+v", cfg.Workspace)
+			glog.Error(msg)
+			return nil, errors.New(msg)
+		}
+		for vcServer, vcConfig := range cfg.VirtualCenter {
+			glog.V(4).Infof("Initializing vc server %s and vcConfig %+v", vcServer, vcConfig)
+			if vcServer == "" {
+				glog.Error("vsphere.conf does not have the VirtualCenter IP address specified")
+				return nil, errors.New("vsphere.conf does not have the VirtualCenter IP address specified")
+			}
+			if vcConfig.User == "" {
+				vcConfig.User = cfg.Global.User
+			}
+			if vcConfig.Password == "" {
+				vcConfig.Password = cfg.Global.Password
+			}
+			if vcConfig.User == "" {
+				msg := fmt.Sprintf("vcConfig.User is empty for vc %s!", vcServer)
+				glog.Error(msg)
+				return nil, errors.New(msg)
+			}
+			if vcConfig.Password == "" {
+				msg := fmt.Sprintf("vcConfig.Password is empty for vc %s!", vcServer)
+				glog.Error(msg)
+				return nil, errors.New(msg)
+			}
+			if vcConfig.VCenterPort == "" {
+				vcConfig.VCenterPort = cfg.Global.VCenterPort
+			}
+			if vcConfig.Datacenters == "" {
+				if cfg.Global.Datacenters != "" {
+					vcConfig.Datacenters = cfg.Global.Datacenters
+				} else {
+					// cfg.Global.Datacenter is deprecated, so giving it the last preference.
+					vcConfig.Datacenters = cfg.Global.Datacenter
+				}
+			}
+			if vcConfig.RoundTripperCount == 0 {
+				vcConfig.RoundTripperCount = cfg.Global.RoundTripperCount
+			}
+
+			vSphereConn := vclib.VSphereConnection{
+				Username:          vcConfig.User,
+				Password:          vcConfig.Password,
+				Hostname:          vcServer,
+				Insecure:          vcConfig.InsecureFlag,
+				RoundTripperCount: vcConfig.RoundTripperCount,
+				Port:              vcConfig.VCenterPort,
+			}
+			vsphereIns := VSphereInstance{
+				conn: &vSphereConn,
+				cfg:  vcConfig,
+			}
+			// TODO: Remove this log as it will print VC credentials in log.
+			glog.V(4).Infof("vSphereConn for VC %s is %+v.", vcServer, vSphereConn)
+			glog.V(4).Infof("vcConfig for VC %s is %+v.", vcServer, vcConfig)
+
+			vsphereInstanceMap[vcServer] = &vsphereIns
+		}
+	}
+	return vsphereInstanceMap, nil
+}
+
 // Creates new Contreoller node interface and returns
 func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
 	var err error
 
 	// TODO: Remove this log as it will print VC credentials in log.
-	glog.V(4).Infof("cfg is %+v", cfg)
+	glog.V(4).Infof("VSphereConfig is %+v", cfg)
 	if cfg.Disk.SCSIControllerType == "" {
 		cfg.Disk.SCSIControllerType = vclib.PVSCSIControllerType
 	} else if !vclib.CheckControllerSupported(cfg.Disk.SCSIControllerType) {
@@ -225,34 +373,37 @@ func newControllerNode(cfg VSphereConfig) (*VSphere, error) {
 			return nil, err
 		}
 	}
-	vSphereConn := vclib.VSphereConnection{
-		Username:          cfg.Global.User,
-		Password:          cfg.Global.Password,
-		Hostname:          cfg.Global.VCenterIP,
-		Insecure:          cfg.Global.InsecureFlag,
-		RoundTripperCount: cfg.Global.RoundTripperCount,
-		Port:              cfg.Global.VCenterPort,
+	vsphereInstanceMap, err := populateVsphereInstanceMap(&cfg)
+	if err != nil {
+		return nil, err
 	}
 
 	vs := VSphere{
-		conn: &vSphereConn,
-		cfg:  &cfg,
+		vsphereInstanceMap: vsphereInstanceMap,
+		nodeManager: &NodeManager{
+			vsphereInstanceMap: vsphereInstanceMap,
+		},
+		cfg: &cfg,
 	}
+	// TODO: Remove this log as it will print VC credentials in log.
+	glog.V(4).Infof("VSphereConfig after init is %+v", cfg)
 
 	vs.hostName, err = os.Hostname()
 	if err != nil {
 		glog.Errorf("Failed to get hostname. err: %+v", err)
 		return nil, err
 	}
-
 	runtime.SetFinalizer(&vs, logout)
 	return &vs, nil
 }
 
 func logout(vs *VSphere) {
-	if vs.conn.GoVmomiClient != nil {
-		vs.conn.GoVmomiClient.Logout(context.TODO())
+	for _, vsphereIns := range vs.vsphereInstanceMap {
+		if vsphereIns.conn.GoVmomiClient != nil {
+			vsphereIns.conn.GoVmomiClient.Logout(context.TODO())
+		}
 	}
+
 }
 
 // Instances returns an implementation of Instances for vSphere.
@@ -299,24 +450,31 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 	return addrs, nil
 }
 
+func (vs *VSphere) getVSphereInstance(nodeName k8stypes.NodeName) (*VSphereInstance, error) {
+	vsphereIns, err := vs.nodeManager.getVSphereInstance(nodeName)
+	if err != nil {
+		glog.Errorf("Cannot find node %q in cache. Node not found!!!", nodeName)
+		return nil, errors.New(fmt.Sprintf("Cannot find node %q in vsphere configuration map", nodeName))
+	}
+	return vsphereIns, nil
+}
+
 // Get the VM Managed Object instance by from the node
 func (vs *VSphere) getVMByName(ctx context.Context, nodeName k8stypes.NodeName) (*vclib.VirtualMachine, error) {
-	dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
+	nodeInfo, err := vs.nodeManager.getNodeInfo(nodeName)
 	if err != nil {
 		return nil, err
 	}
-	vmPath := vs.cfg.Global.WorkingDir + "/" + nodeNameToVMName(nodeName)
-	vm, err := dc.GetVMByPath(ctx, vmPath)
-	if err != nil {
-		return nil, err
+	if nodeInfo == nil {
+		return nil, errors.New(fmt.Sprintf("Node %q not found in node manager!", nodeName))
 	}
-	return vm, nil
+	return nodeInfo.vm, nil
 }
 
 // NodeAddresses is an implementation of Instances.NodeAddresses.
 func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, error) {
 	// Get local IP addresses if node is local node
-	if vs.hostName == nodeNameToVMName(nodeName) {
+	if vs.hostName == convertToString(nodeName) {
 		return getLocalIP()
 	}
 
@@ -329,7 +487,7 @@ func (vs *VSphere) NodeAddresses(nodeName k8stypes.NodeName) ([]v1.NodeAddress, 
 // and other local methods cannot be used here
 func (vs *VSphere) NodeAddressesByProviderID(providerID string) ([]v1.NodeAddress, error) {
 	vmName := path.Base(providerID)
-	return vs.NodeAddresses(vmNameToNodeName(vmName))
+	return vs.NodeAddresses(convertToK8sType(vmName))
 }
 
 // AddSSHKeyToAllInstances add SSH key to all instances
@@ -339,16 +497,14 @@ func (vs *VSphere) AddSSHKeyToAllInstances(user string, keyData []byte) error {
 
 // CurrentNodeName gives the current node name
 func (vs *VSphere) CurrentNodeName(hostname string) (k8stypes.NodeName, error) {
-	return vmNameToNodeName(vs.hostName), nil
+	return convertToK8sType(vs.hostName), nil
 }
 
-// nodeNameToVMName maps a NodeName to the vmware infrastructure name
-func nodeNameToVMName(nodeName k8stypes.NodeName) string {
+func convertToString(nodeName k8stypes.NodeName) string {
 	return string(nodeName)
 }
 
-// nodeNameToVMName maps a vmware infrastructure name to a NodeName
-func vmNameToNodeName(vmName string) k8stypes.NodeName {
+func convertToK8sType(vmName string) k8stypes.NodeName {
 	return k8stypes.NodeName(vmName)
 }
 
@@ -370,24 +526,27 @@ func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 	// 2. Node Powered On/ Powered off.
 	// Based on these kubernetes core decides to take specific actions.
 	// Also verify if this logic is required only on master or also on worker nodes.
-	if vs.hostName == nodeNameToVMName(nodeName) {
+	if vs.hostName == convertToString(nodeName) {
 		return vs.hostName, nil
 	}
 
 	// TODO: Need to see what to do if nodename and localNodeName are not matching.
 	// return "", cloudprovider.InstanceNotFound
 
-
 	// TODO: Below logic is the existing logic.
-	//if vs.localInstanceID == nodeNameToVMName(nodeName) {
+	//if vs.localInstanceID == convertToString(nodeName) {
 	//	return vs.cfg.Global.WorkingDir + "/" + vs.localInstanceID, nil
 	//}
 
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	vsi, err := vs.getVSphereInstance(nodeName)
+	if err != nil {
+		return "", err
+	}
 	// Ensure client is logged in and session is valid
-	err := vs.conn.Connect(ctx)
+	err = vsi.conn.Connect(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -396,19 +555,19 @@ func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 		if vclib.IsNotFound(err) {
 			return "", cloudprovider.InstanceNotFound
 		}
-		glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
+		glog.Errorf("Failed to get VM object for node: %q. err: +%v", convertToString(nodeName), err)
 		return "", err
 	}
 	isActive, err := vm.IsActive(ctx)
 	if err != nil {
-		glog.Errorf("Failed to check whether node %q is active. err: %+v.", nodeNameToVMName(nodeName), err)
+		glog.Errorf("Failed to check whether node %q is active. err: %+v.", convertToString(nodeName), err)
 		return "", err
 	}
 	if isActive {
 		return "/" + vm.InventoryPath, nil
 	}
 
-	return "", fmt.Errorf("The node %q is not active", nodeNameToVMName(nodeName))
+	return "", fmt.Errorf("The node %q is not active", convertToString(nodeName))
 }
 
 // InstanceTypeByProviderID returns the cloudprovider instance type of the node with the specified unique providerID
@@ -456,24 +615,28 @@ func (vs *VSphere) ScrubDNS(nameservers, searches []string) (nsOut, srchOut []st
 func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 	attachDiskInternal := func(vmDiskPath string, storagePolicyID string, nodeName k8stypes.NodeName) (diskUUID string, err error) {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.hostName)
+			nodeName = convertToK8sType(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		vsi, err := vs.getVSphereInstance(nodeName)
+		if err != nil {
+			return "", err
+		}
 		// Ensure client is logged in and session is valid
-		err = vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			return "", err
 		}
 		vm, err := vs.getVMByName(ctx, nodeName)
 		if err != nil {
-			glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
+			glog.Errorf("Failed to get VM object for node: %q. err: +%v", convertToString(nodeName), err)
 			return "", err
 		}
 		diskUUID, err = vm.AttachDisk(ctx, vmDiskPath, &vclib.VolumeOptions{SCSIControllerType: vclib.PVSCSIControllerType, StoragePolicyID: storagePolicyID})
 		if err != nil {
-			glog.Errorf("Failed to attach disk: %s for node: %s. err: +%v", vmDiskPath, nodeNameToVMName(nodeName), err)
+			glog.Errorf("Failed to attach disk: %s for node: %s. err: +%v", vmDiskPath, convertToString(nodeName), err)
 			return "", err
 		}
 		return diskUUID, nil
@@ -488,13 +651,17 @@ func (vs *VSphere) AttachDisk(vmDiskPath string, storagePolicyID string, nodeNam
 func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error {
 	detachDiskInternal := func(volPath string, nodeName k8stypes.NodeName) error {
 		if nodeName == "" {
-			nodeName = vmNameToNodeName(vs.hostName)
+			nodeName = convertToK8sType(vs.hostName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		vsi, err := vs.getVSphereInstance(nodeName)
+		if err != nil {
+			return err
+		}
 		// Ensure client is logged in and session is valid
-		err := vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			return err
 		}
@@ -502,16 +669,16 @@ func (vs *VSphere) DetachDisk(volPath string, nodeName k8stypes.NodeName) error 
 		if err != nil {
 			// If node doesn't exist, disk is already detached from node.
 			if vclib.IsNotFound(err) {
-				glog.Infof("Node %q does not exist, disk %s is already detached from node.", nodeNameToVMName(nodeName), volPath)
+				glog.Infof("Node %q does not exist, disk %s is already detached from node.", convertToString(nodeName), volPath)
 				return nil
 			}
 
-			glog.Errorf("Failed to get VM object for node: %q. err: +%v", nodeNameToVMName(nodeName), err)
+			glog.Errorf("Failed to get VM object for node: %q. err: +%v", convertToString(nodeName), err)
 			return err
 		}
 		err = vm.DetachDisk(ctx, volPath)
 		if err != nil {
-			glog.Errorf("Failed to detach disk: %s for node: %s. err: +%v", volPath, nodeNameToVMName(nodeName), err)
+			glog.Errorf("Failed to detach disk: %s for node: %s. err: +%v", volPath, convertToString(nodeName), err)
 			return err
 		}
 		return nil
@@ -528,15 +695,19 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 		var vSphereInstance string
 		if nodeName == "" {
 			vSphereInstance = vs.hostName
-			nodeName = vmNameToNodeName(vSphereInstance)
+			nodeName = convertToK8sType(vSphereInstance)
 		} else {
-			vSphereInstance = nodeNameToVMName(nodeName)
+			vSphereInstance = convertToString(nodeName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		vsi, err := vs.getVSphereInstance(nodeName)
+		if err != nil {
+			return false, err
+		}
 		// Ensure client is logged in and session is valid
-		err := vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			return false, err
 		}
@@ -572,18 +743,22 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 		if len(volPaths) == 0 {
 			return attached, nil
 		}
-		var vSphereInstance string
+		var vSphereIns string
 		if nodeName == "" {
-			vSphereInstance = vs.hostName
-			nodeName = vmNameToNodeName(vSphereInstance)
+			vSphereIns = vs.hostName
+			nodeName = convertToK8sType(vSphereIns)
 		} else {
-			vSphereInstance = nodeNameToVMName(nodeName)
+			vSphereIns = convertToString(nodeName)
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		vsi, err := vs.getVSphereInstance(nodeName)
+		if err != nil {
+			return nil, err
+		}
 		// Ensure client is logged in and session is valid
-		err := vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -598,7 +773,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 				}
 				return attached, nil
 			}
-			glog.Errorf("Failed to get VM object for node: %q. err: +%v", vSphereInstance, err)
+			glog.Errorf("Failed to get VM object for node: %q. err: +%v", vSphereIns, err)
 			return nil, err
 		}
 
@@ -614,7 +789,7 @@ func (vs *VSphere) DisksAreAttached(volPaths []string, nodeName k8stypes.NodeNam
 				glog.Errorf("DisksAreAttached failed to determine whether disk %q from volPaths %+v is still attached on node %q",
 					volPath,
 					volPaths,
-					vSphereInstance)
+					vSphereIns)
 				return nil, err
 			}
 		}
@@ -636,19 +811,23 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (volumePath 
 		var datastore string
 		// Default datastore is the datastore in the vSphere config file that is used to initialize vSphere cloud provider.
 		if volumeOptions.Datastore == "" {
-			datastore = vs.cfg.Global.DeafultDatastore
+			datastore = vs.cfg.Global.DefaultDatastore
 		} else {
 			datastore = volumeOptions.Datastore
 		}
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		// Ensure client is logged in and session is valid
-		err = vs.conn.Connect(ctx)
+		vsi, err := vs.getVSphereInstance(convertToK8sType(vs.hostName))
 		if err != nil {
 			return "", err
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
+		// Ensure client is logged in and session is valid
+		err = vsi.conn.Connect(ctx)
+		if err != nil {
+			return "", err
+		}
+		dc, err := vclib.GetDatacenter(ctx, vsi.conn, vs.cfg.Global.Datacenter)
 		if err != nil {
 			return "", err
 		}
@@ -720,16 +899,20 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 		// Create context
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+		vsi, err := vs.getVSphereInstance(convertToK8sType(vs.hostName))
+		if err != nil {
+			return err
+		}
 		// Ensure client is logged in and session is valid
-		err := vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			return err
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
+		dc, err := vclib.GetDatacenter(ctx, vsi.conn, vs.cfg.Global.Datacenter)
 		if err != nil {
 			return err
 		}
-		ds, err := dc.GetDatastoreByName(ctx, vs.cfg.Global.DeafultDatastore)
+		ds, err := dc.GetDatastoreByName(ctx, vs.cfg.Global.DefaultDatastore)
 		if err != nil {
 			return err
 		}
@@ -758,9 +941,11 @@ func (vs *VSphere) HasClusterID() bool {
 // Notification handler when node is registered.
 func (vs *VSphere) NodeRegistered(node *v1.Node) {
 	glog.V(4).Infof("Node Registered: %+v", node)
+	vs.nodeManager.registerNode(node)
 }
 
 // Notification handler when node is unregistered.
 func (vs *VSphere) NodeUnregistered(node *v1.Node) {
 	glog.V(4).Infof("Node Unregistered: %+v", node)
+	vs.nodeManager.unregisterNode(node)
 }

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -301,7 +301,7 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 
 // Get the VM Managed Object instance by from the node
 func (vs *VSphere) getVMByName(ctx context.Context, nodeName k8stypes.NodeName) (*vclib.VirtualMachine, error) {
-	dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenter)
+	dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
 	if err != nil {
 		return nil, err
 	}
@@ -633,7 +633,7 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (volumePath 
 		var datastore string
 		// Default datastore is the datastore in the vSphere config file that is used to initialize vSphere cloud provider.
 		if volumeOptions.Datastore == "" {
-			datastore = vs.cfg.Global.Datastore
+			datastore = vs.cfg.Global.DeafultDatastore
 		} else {
 			datastore = volumeOptions.Datastore
 		}
@@ -645,7 +645,7 @@ func (vs *VSphere) CreateVolume(volumeOptions *vclib.VolumeOptions) (volumePath 
 		if err != nil {
 			return "", err
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenter)
+		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
 		if err != nil {
 			return "", err
 		}
@@ -722,11 +722,11 @@ func (vs *VSphere) DeleteVolume(vmDiskPath string) error {
 		if err != nil {
 			return err
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenter)
+		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
 		if err != nil {
 			return err
 		}
-		ds, err := dc.GetDatastoreByName(ctx, vs.cfg.Global.Datastore)
+		ds, err := dc.GetDatastoreByName(ctx, vs.cfg.Global.DeafultDatastore)
 		if err != nil {
 			return err
 		}

--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -377,9 +377,12 @@ func (vs *VSphere) InstanceID(nodeName k8stypes.NodeName) (string, error) {
 	// TODO: Need to see what to do if nodename and localNodeName are not matching.
 	// return "", cloudprovider.InstanceNotFound
 
-	if vs.localInstanceID == nodeNameToVMName(nodeName) {
-		return vs.cfg.Global.WorkingDir + "/" + vs.localInstanceID, nil
-	}
+
+	// TODO: Below logic is the existing logic.
+	//if vs.localInstanceID == nodeNameToVMName(nodeName) {
+	//	return vs.cfg.Global.WorkingDir + "/" + vs.localInstanceID, nil
+	//}
+
 	// Create context
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -53,10 +53,27 @@ func GetVSphere() (*VSphere, error) {
 		return nil, err
 	}
 	vSphereConn.GoVmomiClient = client
+	vsphereIns := &VSphereInstance{
+		conn: vSphereConn,
+		cfg: &VirtualCenterConfig{
+			User:              cfg.Global.User,
+			Password:          cfg.Global.Password,
+			VCenterPort:       cfg.Global.VCenterPort,
+			Datacenters:       cfg.Global.Datacenters,
+			RoundTripperCount: cfg.Global.RoundTripperCount,
+			InsecureFlag:      cfg.Global.InsecureFlag,
+		},
+	}
+	vsphereInsMap := make(map[string]*VSphereInstance)
+	vsphereInsMap[""] = vsphereIns
+	// TODO: Initialize nodeManager and set it in VSphere.
 	vs := &VSphere{
-		conn:     vSphereConn,
-		cfg:      cfg,
-		hostName: "",
+		vsphereInstanceMap: vsphereInsMap,
+		hostName:           "",
+		cfg:                cfg,
+		nodeManager: &NodeManager{
+			vsphereInstanceMap: vsphereInsMap,
+		},
 	}
 	runtime.SetFinalizer(vs, logout)
 	return vs, nil
@@ -69,7 +86,7 @@ func getVSphereConfig() *VSphereConfig {
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
 	cfg.Global.Datacenters = os.Getenv("VSPHERE_DATACENTER")
-	cfg.Global.DeafultDatastore = os.Getenv("VSPHERE_DATASTORE")
+	cfg.Global.DefaultDatastore = os.Getenv("VSPHERE_DATASTORE")
 	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
 	cfg.Global.VMName = os.Getenv("VSPHERE_VM_NAME")
 	cfg.Global.InsecureFlag = false
@@ -244,11 +261,11 @@ func getPbmCompatibleDatastore(ctx context.Context, client *vim25.Client, storag
 
 func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter) (*vclib.VMOptions, error) {
 	var vmOptions vclib.VMOptions
-	vm, err := dc.GetVMByPath(ctx, vs.cfg.Global.WorkingDir+"/"+vs.hostName)
+	nodeInfo, err := vs.nodeManager.getNodeInfo(convertToK8sType(vs.hostName))
 	if err != nil {
 		return nil, err
 	}
-	resourcePool, err := vm.GetResourcePool(ctx)
+	resourcePool, err := nodeInfo.vm.GetResourcePool(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -268,15 +285,20 @@ func (vs *VSphere) cleanUpDummyVMs(dummyVMPrefix string) {
 	defer cancel()
 	for {
 		time.Sleep(CleanUpDummyVMRoutineInterval * time.Minute)
+		vsi, err := vs.getVSphereInstance(convertToK8sType(vs.hostName))
+		if err != nil {
+			glog.V(4).Infof("Failed to get VSphere instance with err: %+v. Retrying again...", err)
+			continue
+		}
 		// Ensure client is logged in and session is valid
-		err := vs.conn.Connect(ctx)
+		err = vsi.conn.Connect(ctx)
 		if err != nil {
 			glog.V(4).Infof("Failed to connect to VC with err: %+v. Retrying again...", err)
 			continue
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
+		dc, err := vclib.GetDatacenter(ctx, vsi.conn, vs.cfg.Global.Datacenter)
 		if err != nil {
-			glog.V(4).Infof("Failed to get the datacenter: %s from VC. err: %+v", vs.cfg.Global.Datacenters, err)
+			glog.V(4).Infof("Failed to get the datacenter: %s from VC. err: %+v", vs.cfg.Global.Datacenter, err)
 			continue
 		}
 		// Get the folder reference for global working directory where the dummy VM needs to be created.

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -54,9 +54,9 @@ func GetVSphere() (*VSphere, error) {
 	}
 	vSphereConn.GoVmomiClient = client
 	vs := &VSphere{
-		conn:            vSphereConn,
-		cfg:             cfg,
-		localInstanceID: "",
+		conn:     vSphereConn,
+		cfg:      cfg,
+		hostName: "",
 	}
 	runtime.SetFinalizer(vs, logout)
 	return vs, nil
@@ -244,7 +244,7 @@ func getPbmCompatibleDatastore(ctx context.Context, client *vim25.Client, storag
 
 func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter) (*vclib.VMOptions, error) {
 	var vmOptions vclib.VMOptions
-	vm, err := dc.GetVMByPath(ctx, vs.cfg.Global.WorkingDir+"/"+vs.localInstanceID)
+	vm, err := dc.GetVMByPath(ctx, vs.cfg.Global.WorkingDir+"/"+vs.hostName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -68,8 +68,8 @@ func getVSphereConfig() *VSphereConfig {
 	cfg.Global.VCenterPort = os.Getenv("VSPHERE_VCENTER_PORT")
 	cfg.Global.User = os.Getenv("VSPHERE_USER")
 	cfg.Global.Password = os.Getenv("VSPHERE_PASSWORD")
-	cfg.Global.Datacenter = os.Getenv("VSPHERE_DATACENTER")
-	cfg.Global.Datastore = os.Getenv("VSPHERE_DATASTORE")
+	cfg.Global.Datacenters = os.Getenv("VSPHERE_DATACENTER")
+	cfg.Global.DeafultDatastore = os.Getenv("VSPHERE_DATASTORE")
 	cfg.Global.WorkingDir = os.Getenv("VSPHERE_WORKING_DIR")
 	cfg.Global.VMName = os.Getenv("VSPHERE_VM_NAME")
 	cfg.Global.InsecureFlag = false
@@ -274,9 +274,9 @@ func (vs *VSphere) cleanUpDummyVMs(dummyVMPrefix string) {
 			glog.V(4).Infof("Failed to connect to VC with err: %+v. Retrying again...", err)
 			continue
 		}
-		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenter)
+		dc, err := vclib.GetDatacenter(ctx, vs.conn, vs.cfg.Global.Datacenters)
 		if err != nil {
-			glog.V(4).Infof("Failed to get the datacenter: %s from VC. err: %+v", vs.cfg.Global.Datacenter, err)
+			glog.V(4).Infof("Failed to get the datacenter: %s from VC. err: %+v", vs.cfg.Global.Datacenters, err)
 			continue
 		}
 		// Get the folder reference for global working directory where the dummy VM needs to be created.

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -61,7 +61,6 @@ func GetVSphere() (*VSphere, error) {
 			VCenterPort:       cfg.Global.VCenterPort,
 			Datacenters:       cfg.Global.Datacenters,
 			RoundTripperCount: cfg.Global.RoundTripperCount,
-			InsecureFlag:      cfg.Global.InsecureFlag,
 		},
 	}
 	vsphereInsMap := make(map[string]*VSphereInstance)
@@ -261,7 +260,7 @@ func getPbmCompatibleDatastore(ctx context.Context, client *vim25.Client, storag
 
 func (vs *VSphere) setVMOptions(ctx context.Context, dc *vclib.Datacenter) (*vclib.VMOptions, error) {
 	var vmOptions vclib.VMOptions
-	nodeInfo, err := vs.nodeManager.getNodeInfo(convertToK8sType(vs.hostName))
+	nodeInfo, err := vs.nodeManager.GetNodeInfo(convertToK8sType(vs.hostName))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -591,12 +591,20 @@ func (nc *Controller) monitorNodeStatus() error {
 		} else {
 			nc.cancelPodEviction(added[i])
 		}
+		instance, isSupported := nc.cloud.Instances()
+		if isSupported {
+			instance.NodeRegistered(added[i])
+		}
 	}
 
 	for i := range deleted {
 		glog.V(1).Infof("Controller observed a Node deletion: %v", deleted[i].Name)
 		util.RecordNodeEvent(nc.recorder, deleted[i].Name, string(deleted[i].UID), v1.EventTypeNormal, "RemovingNode", fmt.Sprintf("Removing Node %v from Controller", deleted[i].Name))
 		delete(nc.knownNodeSet, deleted[i].Name)
+		instance, isSupported := nc.cloud.Instances()
+		if isSupported {
+			instance.NodeUnregistered(deleted[i])
+		}
 	}
 
 	zoneToNodeConditions := map[string][]*v1.NodeCondition{}


### PR DESCRIPTION
Summary:
- Updated the DeleteVolume implementation to use the datacenter from Workspace in vsphere.conf for performing volume deletion.
- Removed some logs that were marked for removal.

Testing done:
- Created storage class and PVC that uses the storage class. Validated that this created the disk successfully. Deleted the PVC and validated that the DeleteVolume is deleting the disk properly.