### PR TITLE
add apply --force --overwrite deployment lables e2e test enhance

### DIFF
--- a/hack/testdata/deployment-label-change1.yaml
+++ b/hack/testdata/deployment-label-change1.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    name: nginx
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        name: nginx1
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google-containers/nginx:test-cmd
+        ports:
+        - containerPort: 80

--- a/hack/testdata/deployment-label-change2.yaml
+++ b/hack/testdata/deployment-label-change2.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  labels:
+    name: nginx
+spec:
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        name: nginx2
+    spec:
+      containers:
+      - name: nginx
+        image: gcr.io/google-containers/nginx:test-cmd
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
some tests e2e cases enhance, releated to previous bug https://github.com/openshift/origin/issues/15017 here. and fixed here https://github.com/kubernetes/kubernetes/pull/48481

/sig-cli
```release-note
NONE
```
