### PR TITLE
add ProxyModeIPVS in proxy mode validation

### DIFF
--- a/cmd/kube-proxy/app/validation.go
+++ b/cmd/kube-proxy/app/validation.go
@@ -120,9 +120,10 @@ func validateProxyMode(mode componentconfig.ProxyMode, fldPath *field.Path) fiel
 	switch mode {
 	case componentconfig.ProxyModeUserspace:
 	case componentconfig.ProxyModeIPTables:
+	case componentconfig.ProxyModeIPVS:
 	case "":
 	default:
-		modes := []string{string(componentconfig.ProxyModeUserspace), string(componentconfig.ProxyModeIPTables)}
+		modes := []string{string(componentconfig.ProxyModeUserspace), string(componentconfig.ProxyModeIPTables), string(componentconfig.ProxyModeIPVS)}
 		errMsg := fmt.Sprintf("must be %s or blank (blank means the best-available proxy (currently iptables)", strings.Join(modes, ","))
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ProxyMode"), string(mode), errMsg))
 	}

--- a/cmd/kube-proxy/app/validation_test.go
+++ b/cmd/kube-proxy/app/validation_test.go
@@ -374,6 +374,7 @@ func TestValidateProxyMode(t *testing.T) {
 	successCases := []componentconfig.ProxyMode{
 		componentconfig.ProxyModeUserspace,
 		componentconfig.ProxyModeIPTables,
+		componentconfig.ProxyModeIPVS,
 		componentconfig.ProxyMode(""),
 	}
 

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -158,6 +158,7 @@ type ProxyMode string
 const (
 	ProxyModeUserspace ProxyMode = "userspace"
 	ProxyModeIPTables  ProxyMode = "iptables"
+	ProxyModeIPVS      ProxyMode = "ipvs"
 )
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION

**What this PR does / why we need it**:
Currently didn't add "ipvs" in proxy mode check, then if we use "ipvs" mode, will get this error:
'error: KubeProxyConfiguration.Mode.ProxyMode: Invalid value: "ipvs": must be userspace,iptables or blank (blank means the best-available proxy (currently iptables)'
So I added it. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
