### PR TITLE
Move of unreachable taint key out of alpha

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -454,25 +454,31 @@ func (nc *Controller) doFixDeprecatedTaintKeyPass(node *v1.Node) error {
 
 	for _, taint := range node.Spec.Taints {
 		if taint.Key == algorithm.DeprecatedTaintNodeNotReady {
-			// delete old taint
 			tDel := taint
 			taintsToDel = append(taintsToDel, &tDel)
 
-			// add right taint
 			tAdd := taint
 			tAdd.Key = algorithm.TaintNodeNotReady
 			taintsToAdd = append(taintsToAdd, &tAdd)
+		}
 
-			glog.Warningf("Detected deprecated taint key: %v on node: %v, will substitute it with %v",
-				algorithm.DeprecatedTaintNodeNotReady, node.GetName(), algorithm.TaintNodeNotReady)
+		if taint.Key == algorithm.DeprecatedTaintNodeUnreachable {
+			tDel := taint
+			taintsToDel = append(taintsToDel, &tDel)
 
-			break
+			tAdd := taint
+			tAdd.Key = algorithm.TaintNodeUnreachable
+			taintsToAdd = append(taintsToAdd, &tAdd)
 		}
 	}
 
 	if len(taintsToAdd) == 0 && len(taintsToDel) == 0 {
 		return nil
 	}
+
+	glog.Warningf("Detected deprecated taint keys: %v on node: %v, will substitute them with %v",
+		taintsToDel, node.GetName(), taintsToAdd)
+
 	if !util.SwapNodeControllerTaint(nc.kubeClient, taintsToAdd, taintsToDel, node) {
 		return fmt.Errorf("failed to swap taints of node %+v", node)
 	}

--- a/plugin/pkg/admission/defaulttolerationseconds/admission_test.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission_test.go
@@ -33,13 +33,14 @@ func TestForgivenessAdmission(t *testing.T) {
 	}
 
 	handler := NewDefaultTolerationSeconds()
+	// NOTE: for anyone who want to modify this test, the order of tolerations matters!
 	tests := []struct {
 		description  string
 		requestedPod api.Pod
 		expectedPod  api.Pod
 	}{
 		{
-			description: "pod has no tolerations, expect add tolerations for `notReady:NoExecute` and `unreachable:NoExecute`",
+			description: "pod has no tolerations, expect add tolerations for `not-ready:NoExecute` and `unreachable:NoExecute`",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{},
 			},
@@ -63,7 +64,139 @@ func TestForgivenessAdmission(t *testing.T) {
 			},
 		},
 		{
-			description: "pod has tolerations, but none is for taint `notReady:NoExecute` or `unreachable:NoExecute`, expect add tolerations for `notReady:NoExecute` and `unreachable:NoExecute`",
+			description: "pod has alpha tolerations, expect add tolerations for `not-ready:NoExecute` and `unreachable:NoExecute`" +
+				", the alpha tolerations will not be touched",
+			requestedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.DeprecatedTaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+			expectedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.DeprecatedTaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "pod has alpha not-ready toleration, expect add tolerations for `not-ready:NoExecute` and `unreachable:NoExecute`" +
+				", the alpha tolerations will not be touched",
+			requestedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+			expectedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "pod has alpha unreachable toleration, expect add tolerations for `not-ready:NoExecute` and `unreachable:NoExecute`" +
+				", the alpha tolerations will not be touched",
+			requestedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+			expectedPod: api.Pod{
+				Spec: api.PodSpec{
+					Tolerations: []api.Toleration{
+						{
+							Key:               algorithm.DeprecatedTaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeNotReady,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+						{
+							Key:               algorithm.TaintNodeUnreachable,
+							Operator:          api.TolerationOpExists,
+							Effect:            api.TaintEffectNoExecute,
+							TolerationSeconds: &defaultTolerationSeconds,
+						},
+					},
+				},
+			},
+		},
+		{
+			description: "pod has tolerations, but none is for taint `not-ready:NoExecute` or `unreachable:NoExecute`, expect add tolerations for `not-ready:NoExecute` and `unreachable:NoExecute`",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{
 					Tolerations: []api.Toleration{
@@ -104,7 +237,7 @@ func TestForgivenessAdmission(t *testing.T) {
 			},
 		},
 		{
-			description: "pod specified a toleration for taint `notReady:NoExecute`, expect add toleration for `unreachable:NoExecute`",
+			description: "pod specified a toleration for taint `not-ready:NoExecute`, expect add toleration for `unreachable:NoExecute`",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{
 					Tolerations: []api.Toleration{
@@ -137,7 +270,7 @@ func TestForgivenessAdmission(t *testing.T) {
 			},
 		},
 		{
-			description: "pod specified a toleration for taint `unreachable:NoExecute`, expect add toleration for `notReady:NoExecute`",
+			description: "pod specified a toleration for taint `unreachable:NoExecute`, expect add toleration for `not-ready:NoExecute`",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{
 					Tolerations: []api.Toleration{
@@ -170,7 +303,7 @@ func TestForgivenessAdmission(t *testing.T) {
 			},
 		},
 		{
-			description: "pod specified tolerations for both `notReady:NoExecute` and `unreachable:NoExecute`, expect no change",
+			description: "pod specified tolerations for both `not-ready:NoExecute` and `unreachable:NoExecute`, expect no change",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{
 					Tolerations: []api.Toleration{
@@ -209,7 +342,7 @@ func TestForgivenessAdmission(t *testing.T) {
 			},
 		},
 		{
-			description: "pod specified toleration for taint `unreachable`, expect add toleration for `notReady:NoExecute`",
+			description: "pod specified toleration for taint `unreachable`, expect add toleration for `not-ready:NoExecute`",
 			requestedPod: api.Pod{
 				Spec: api.PodSpec{
 					Tolerations: []api.Toleration{

--- a/plugin/pkg/scheduler/algorithm/well_known_labels.go
+++ b/plugin/pkg/scheduler/algorithm/well_known_labels.go
@@ -30,7 +30,11 @@ const (
 	// TaintNodeUnreachable would be automatically added by node controller
 	// when node becomes unreachable (corresponding to NodeReady status ConditionUnknown)
 	// and removed when node becomes reachable (NodeReady status ConditionTrue).
-	TaintNodeUnreachable = "node.alpha.kubernetes.io/unreachable"
+	TaintNodeUnreachable = "node.kubernetes.io/unreachable"
+
+	// DeprecatedTaintNodeUnreachable is the deprecated version of TaintNodeUnreachable.
+	// It is deprecated since 1.9
+	DeprecatedTaintNodeUnreachable = "node.alpha.kubernetes.io/unreachable"
 
 	// When feature-gate for TaintBasedEvictions=true flag is enabled,
 	// TaintNodeOutOfDisk would be automatically added by node controller


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Move of unreachable taint key out of alpha, which already happened in community doc.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54198

**Special notes for your reviewer**:
Please see #54198 for the context of this inconsistency.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Move unreachable taint key out of alpha. 
Please note the existing pods with the alpha toleration should be updated by user himself to tolerate the GA taint.
```
