### PR TITLE
extracted elasticsearch-logging service name as environment variable

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
+++ b/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go
@@ -81,10 +81,15 @@ func main() {
 	}
 
 	var elasticsearch *api.Service
+	serviceName := os.Getenv("ELASTICSEARCH_SERVICE_NAME")
+	if serviceName == "" {
+		serviceName = "elasticsearch-logging"
+	}
+
 	// Look for endpoints associated with the Elasticsearch loggging service.
 	// First wait for the service to become available.
 	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
-		elasticsearch, err = client.Core().Services(namespace).Get("elasticsearch-logging", metav1.GetOptions{})
+		elasticsearch, err = client.Core().Services(namespace).Get(serviceName, metav1.GetOptions{})
 		if err == nil {
 			break
 		}
@@ -101,7 +106,7 @@ func main() {
 	// Wait for some endpoints.
 	count := 0
 	for t := time.Now(); time.Since(t) < 5*time.Minute; time.Sleep(10 * time.Second) {
-		endpoints, err = client.Core().Endpoints(namespace).Get("elasticsearch-logging", metav1.GetOptions{})
+		endpoints, err = client.Core().Endpoints(namespace).Get(serviceName, metav1.GetOptions{})
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Deploying the cluster-addon fluentd-elasticsearch with customized resource definitions can cause elasticsearch discovery to fail because the service name `elasticsearch-logging` is hard-coded in  cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
-> none yet

**Special notes for your reviewer**:
The name of the  environment variable is ELASTICSEARCH_SERVICE_NAME. When non is given the fallback service-name  fallback is  `elasticsearch-logging`

```release-note
[fluentd-elasticsearch addon] Elasticsearch service name can be overridden via env variable ELASTICSEARCH_SERVICE_NAME
```
