### PR TITLE
Allow Ceph server some time to start

### DIFF
--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -72,6 +72,9 @@ const (
 	MiB int64 = 1024 * KiB
 	GiB int64 = 1024 * MiB
 	TiB int64 = 1024 * GiB
+
+	// Waiting period for volume server (Ceph, ...) to initialize itself.
+	VolumeServerPodStartupSleep = 20 * time.Second
 )
 
 // Configuration of one tests. The test consist of:
@@ -196,6 +199,14 @@ func NewRBDServer(cs clientset.Interface, namespace string) (config VolumeTestCo
 		},
 	}
 	pod, ip = CreateStorageServer(cs, config)
+
+	// Ceph server container needs some time to start. Tests continue working if
+	// this sleep is removed, however kubelet logs (and kubectl describe
+	// <client pod>) would be cluttered with error messages about non-existing
+	// image.
+	Logf("sleeping a bit to give ceph server time to initialize")
+	time.Sleep(VolumeServerPodStartupSleep)
+
 	return config, pod, ip
 }
 

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -288,7 +288,7 @@ var _ = SIGDescribe("Volumes", func() {
 			}()
 			_, serverIP := framework.CreateStorageServer(cs, config)
 			By("sleeping a bit to give ceph server time to initialize")
-			time.Sleep(20 * time.Second)
+			time.Sleep(framework.VolumeServerPodStartupSleep)
 
 			// create ceph secret
 			secret := &v1.Secret{


### PR DESCRIPTION
Ceph server needs to create our "foo" volume on startup. It keeps the image small, however it makes the server container start slow.

Add sleep before the server is usable. Without this PR, all pods that use Ceph fail to start for couple of seconds with cryptic "image foo not found" error and it clutters logs and pod logs and makes it harder to spot real errors.

```release-note
NONE
```

/sig storage
/sig testing
/assign @jeffvance @copejon 
