### PR TITLE
Adding config option to add additional SANs to the master's certificate.

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -7,6 +7,12 @@ options:
     type: string
     default: cluster.local
     description: The local domain for cluster dns
+  extra_sans:
+    type: string
+    default: ""
+    description: |
+      Space-separated list of extra SAN entries to add to the x509 certificate
+      created for the master nodes.
   service-cidr:
     type: string
     default: 10.152.183.0/24

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -461,7 +461,7 @@ def send_data(tls):
     # maybe they have extra names they want as SANs
     extra_sans = hookenv.config('extra_sans')
     if extra_sans and not extra_sans == "":
-      sans.extend(extra_sans.split())
+        sans.extend(extra_sans.split())
 
     # Create a path safe name by removing path characters from the unit name.
     certificate_name = hookenv.local_unit().replace('/', '_')

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -469,7 +469,7 @@ def send_data(tls):
     tls.request_server_cert(common_name, sans, certificate_name)
 
 
-@when('config.changed', 'certificates.available')
+@when('config.changed.extra_sans', 'certificates.available')
 def update_certificate(tls):
     # I using the config.changed flag instead of something more
     # specific to try and catch ip changes. Being a little

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -356,7 +356,7 @@ def start_master(etcd):
                        'Configuring the Kubernetes master services.')
     freeze_service_cidr()
     if not etcd.get_connection_string():
-        # etcd is not returning a connection string. This hapens when
+        # etcd is not returning a connection string. This happens when
         # the master unit disconnects from etcd and is ready to terminate.
         # No point in trying to start master services and fail. Just return.
         return
@@ -457,10 +457,36 @@ def send_data(tls):
         'kubernetes.default.svc',
         'kubernetes.default.svc.{0}'.format(domain)
     ]
+
+    # maybe they have extra names they want as SANs
+    extra_sans = hookenv.config('extra_sans')
+    if extra_sans and not extra_sans == "":
+      sans.extend(extra_sans.split())
+
     # Create a path safe name by removing path characters from the unit name.
     certificate_name = hookenv.local_unit().replace('/', '_')
     # Request a server cert with this information.
     tls.request_server_cert(common_name, sans, certificate_name)
+
+
+@when('config.changed', 'certificates.available')
+def update_certificate(tls):
+    # I using the config.changed flag instead of something more
+    # specific to try and catch ip changes. Being a little
+    # spammy here is ok because the cert layer checks for
+    # changes to the cert before issuing a new one
+    send_data(tls)
+
+
+@when('certificates.server.cert.available',
+      'kubernetes-master.components.started')
+def kick_api_server(tls):
+    # need to be idempotent and don't want to kick the api server
+    # without need
+    if data_changed('cert', tls.get_server_cert()):
+        # certificate changed, so restart the api server
+        hookenv.log("Certificate information changed, restarting api server")
+        set_state('kube-apiserver.do-restart')
 
 
 @when('kubernetes-master.components.started')


### PR DESCRIPTION
Regenerate certificate if data on certificate changes. This includes IP address and SANs.
Restart API server after updating certificate.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This allows users to add addition SAN entries to the certificate generated.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/426
**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added support for SAN entries in the master node certificate via juju kubernetes-master config.
```
