### PR TITLE
Fixes spam from node status updates

### DIFF
--- a/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
+++ b/pkg/controller/volume/attachdetach/cache/actual_state_of_world.go
@@ -475,7 +475,6 @@ func (asw *actualStateOfWorld) updateNodeStatusUpdateNeeded(nodeName types.NodeN
 		// should not happen
 		errMsg := fmt.Sprintf("Failed to set statusUpdateNeeded to needed %t because nodeName=%q  does not exist",
 			needed, nodeName)
-		glog.Errorf(errMsg)
 		return fmt.Errorf(errMsg)
 	}
 


### PR DESCRIPTION
Some of us are looking at reducing unncessary logging spam which happens in k8s.  This message is anyway logged by caller of the function and hence we should not log it again.

cc @kubernetes/sig-storage-pr-reviews @eparis 