### PR TITLE
add kubectl create --raw -f

### DIFF
--- a/pkg/kubectl/cmd/create_test.go
+++ b/pkg/kubectl/cmd/create_test.go
@@ -33,7 +33,8 @@ func TestExtraArgsFail(t *testing.T) {
 
 	f, _, _, _ := cmdtesting.NewAPIFactory()
 	c := NewCmdCreate(f, buf, errBuf)
-	if ValidateArgs(c, []string{"rc"}) == nil {
+	options := CreateOptions{}
+	if options.ValidateArgs(c, []string{"rc"}) == nil {
 		t.Errorf("unexpected non-error")
 	}
 }


### PR DESCRIPTION
Adds `--raw` to `kubectl create` to match `kubectl get --raw`.  It re-uses the transport, reads the input stream (stdin or a single file for now) and posts directly to the endpoint specified.  This let's you direct data directly at a subresource (as a for instance).  I'd like to see this extended to `kubectl replace` too, so that we have full access to subresources via scripting without having to reproduce the transports.

@kubernetes/sig-cli-pr-reviews 

```release-note
add `--raw` to `kubectl create` to POST using the normal transport
```