### PR TITLE
Skip ILB e2e test on GCP if cluster size exceeds limit

### DIFF
--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -89,6 +89,10 @@ const (
 
 	// ServiceTestTimeout is used for most polling/waiting activities
 	ServiceTestTimeout = 60 * time.Second
+
+	// GCPMaxInstancesInInstanceGroup is the maximum number of instances supported in
+	// one instance group on GCP.
+	GCPMaxInstancesInInstanceGroup = 2000
 )
 
 // This should match whatever the default/configured range is

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1339,8 +1339,15 @@ var _ = SIGDescribe("Services", func() {
 
 	It("should be able to create an internal type load balancer [Slow]", func() {
 		framework.SkipUnlessProviderIs("azure", "gke", "gce")
+		if framework.ProviderIs("gke", "gce") {
+			framework.SkipUnlessNodeCountIsAtMost(framework.GCPMaxInstancesInInstanceGroup)
+		}
 
 		createTimeout := framework.LoadBalancerCreateTimeoutDefault
+		if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > framework.LargeClusterMinNodesNumber {
+			createTimeout = framework.LoadBalancerCreateTimeoutLarge
+		}
+
 		pollInterval := framework.Poll * 10
 
 		namespace := f.Namespace.Name


### PR DESCRIPTION
**What this PR does / why we need it**: Ack https://github.com/kubernetes/kubernetes/issues/52495#issuecomment-337293615, ILB test will fail on large cluster.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref https://github.com/kubernetes/kubernetes/issues/52495

**Special notes for your reviewer**:
/assign @nicksardo @bowei 
cc @shyamjvs 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
