### PR TITLE
Add openssh-client back into the debian-hyperkube-base image

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -20,20 +20,21 @@ FROM BASEIMAGE
 RUN ln -s /bin/sh /bin/bash
 
 RUN echo CACHEBUST>/dev/null && clean-install \
-    iptables \
+    ca-certificates \
+    ceph-common \
+    cifs-utils \
+    conntrack \
     e2fsprogs \
     ebtables \
     ethtool \
-    kmod \
-    ca-certificates \
-    conntrack \
-    util-linux \
-    socat \
     git \
-    jq \
-    nfs-common \
     glusterfs-client \
-    cifs-utils \
-    ceph-common
+    iptables \
+    jq \
+    kmod \
+    openssh-client \
+    nfs-common \
+    socat \
+    util-linux
 
 COPY cni-bin/bin /opt/cni/bin

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=gcr.io/google-containers
 IMAGE?=debian-hyperkube-base
-TAG=0.5
+TAG=0.6
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -70,10 +70,10 @@ docker_pull(
 
 docker_pull(
     name = "debian-hyperkube-base-amd64",
-    digest = "sha256:d216b425004fcb6d8047f74e81b30e7ead55f73e73511ca53a329c358786b6c9",
+    digest = "sha256:10546d592e58d5fdb2e25d79f291b8ac62c8d3a3d83337ad7309cca766dbebce",
     registry = "gcr.io",
     repository = "google-containers/debian-hyperkube-base-amd64",
-    tag = "0.5",  # ignored, but kept here for documentation
+    tag = "0.6",  # ignored, but kept here for documentation
 )
 
 docker_pull(

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.5
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.6
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
**What this PR does / why we need it**: adds `openssh-client` back into the `debian-hyperkube-base` image. This was removed in #48365, but is apparently needed by the gitRepo volume plugin.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54129

**Special notes for your reviewer**:
I haven't yet pushed this image, so builds will fail. If this looks good, I'll push and re-trigger tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add openssh-client back into the hyperkube image. This allows the gitRepo volume plugin to work properly.
```

/assign @luxas @tallclair 