### PR TITLE
Allow absent Weight if PrioritizeVerb is empty

### DIFF
--- a/plugin/pkg/scheduler/api/validation/validation.go
+++ b/plugin/pkg/scheduler/api/validation/validation.go
@@ -36,7 +36,7 @@ func ValidatePolicy(policy schedulerapi.Policy) error {
 
 	binders := 0
 	for _, extender := range policy.ExtenderConfigs {
-		if extender.Weight <= 0 {
+		if len(extender.PrioritizeVerb) > 0 && extender.Weight <= 0 {
 			validationErrors = append(validationErrors, fmt.Errorf("Priority for extender %s should have a positive weight applied to it", extender.URLPrefix))
 		}
 		if extender.BindVerb != "" {

--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -50,18 +50,22 @@ func TestValidatePolicy(t *testing.T) {
 			expected: errors.New("Priority WeightPriority should have a positive weight applied to it or it has overflown"),
 		},
 		{
-			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: 2}}},
+			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: 2}}},
 			expected: nil,
 		},
 		{
-			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter", Weight: -2}}},
+			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", PrioritizeVerb: "prioritize", Weight: -2}}},
 			expected: errors.New("Priority for extender http://127.0.0.1:8081/extender should have a positive weight applied to it"),
+		},
+		{
+			policy:   api.Policy{ExtenderConfigs: []api.ExtenderConfig{{URLPrefix: "http://127.0.0.1:8081/extender", FilterVerb: "filter"}}},
+			expected: nil,
 		},
 		{
 			policy: api.Policy{
 				ExtenderConfigs: []api.ExtenderConfig{
-					{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind", Weight: 2},
-					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind", Weight: 2},
+					{URLPrefix: "http://127.0.0.1:8081/extender", BindVerb: "bind"},
+					{URLPrefix: "http://127.0.0.1:8082/extender", BindVerb: "bind"},
 				}},
 			expected: errors.New("Only one extender can implement bind, found 2"),
 		},


### PR DESCRIPTION
The scheduler currently validates `ExtenderConfig.Weight` (the weight applied to `Prioritize`) even when `ExtenderConfig.PrioritizeVerb` is empty, which is not correct. A configuration without these two fields should be allowed. 

**Release note**:
```
None
```

/sig scheduling
