### PR TITLE
After device is attached, pass the right device path to volume manager

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -73,7 +73,8 @@ type ActualStateOfWorld interface {
 	// must unmounted prior to detach.
 	// If a volume with the name volumeName does not exist in the list of
 	// attached volumes, an error is returned.
-	SetVolumeGloballyMounted(volumeName v1.UniqueVolumeName, globallyMounted bool) error
+	// If a non-empty device path is provided, use it to update the volume's device path
+	SetVolumeGloballyMounted(volumeName v1.UniqueVolumeName, devicePath string, globallyMounted bool) error
 
 	// DeletePodFromVolume removes the given pod from the given volume in the
 	// cache indicating the volume has been successfully unmounted from the pod.
@@ -313,13 +314,13 @@ func (asw *actualStateOfWorld) MarkVolumeAsUnmounted(
 }
 
 func (asw *actualStateOfWorld) MarkDeviceAsMounted(
-	volumeName v1.UniqueVolumeName) error {
-	return asw.SetVolumeGloballyMounted(volumeName, true /* globallyMounted */)
+	volumeName v1.UniqueVolumeName, devicePath string) error {
+	return asw.SetVolumeGloballyMounted(volumeName, devicePath, true /* globallyMounted */)
 }
 
 func (asw *actualStateOfWorld) MarkDeviceAsUnmounted(
 	volumeName v1.UniqueVolumeName) error {
-	return asw.SetVolumeGloballyMounted(volumeName, false /* globallyMounted */)
+	return asw.SetVolumeGloballyMounted(volumeName, "" /* device path */, false /* globallyMounted */)
 }
 
 // addVolume adds the given volume to the cache indicating the specified
@@ -447,7 +448,7 @@ func (asw *actualStateOfWorld) MarkRemountRequired(
 }
 
 func (asw *actualStateOfWorld) SetVolumeGloballyMounted(
-	volumeName v1.UniqueVolumeName, globallyMounted bool) error {
+	volumeName v1.UniqueVolumeName, devicePath string, globallyMounted bool) error {
 	asw.Lock()
 	defer asw.Unlock()
 
@@ -459,6 +460,9 @@ func (asw *actualStateOfWorld) SetVolumeGloballyMounted(
 	}
 
 	volumeObj.globallyMounted = globallyMounted
+	if len(devicePath) > 0 {
+		volumeObj.devicePath = devicePath
+	}
 	asw.attachedVolumes[volumeName] = volumeObj
 	return nil
 }

--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world_test.go
@@ -384,7 +384,7 @@ func Test_MarkDeviceAsMounted_Positive_NewVolume(t *testing.T) {
 	}
 
 	// Act
-	err = asw.MarkDeviceAsMounted(generatedVolumeName)
+	err = asw.MarkDeviceAsMounted(generatedVolumeName, devicePath)
 
 	// Assert
 	if err != nil {
@@ -394,6 +394,7 @@ func Test_MarkDeviceAsMounted_Positive_NewVolume(t *testing.T) {
 	verifyVolumeExistsAsw(t, generatedVolumeName, true /* shouldExist */, asw)
 	verifyVolumeExistsInUnmountedVolumes(t, generatedVolumeName, asw)
 	verifyVolumeExistsInGloballyMountedVolumes(t, generatedVolumeName, asw)
+	verifyVolumeDevicePath(t, generatedVolumeName, devicePath, asw)
 }
 
 func verifyVolumeExistsInGloballyMountedVolumes(
@@ -521,4 +522,20 @@ func verifyPodDoesntExistInVolumeAsw(
 			"Invalid devicePath. Expected: <\"\"> Actual: <%q> ",
 			devicePath)
 	}
+}
+
+func verifyVolumeDevicePath(
+	t *testing.T, expectedVolumeName v1.UniqueVolumeName, devicePath string, asw ActualStateOfWorld) {
+	globallyMountedVolumes := asw.GetGloballyMountedVolumes()
+	for _, volume := range globallyMountedVolumes {
+		if volume.VolumeName == expectedVolumeName && volume.DevicePath == devicePath {
+			return
+		}
+	}
+
+	t.Fatalf(
+		"Could not find volume %v in the list of GloballyMountedVolumes for actual state of world %+v and devicePath is %v",
+		expectedVolumeName,
+		globallyMountedVolumes,
+		devicePath)
 }

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -145,7 +145,7 @@ type ActualStateOfWorldMounterUpdater interface {
 	MarkVolumeAsUnmounted(podName volumetypes.UniquePodName, volumeName v1.UniqueVolumeName) error
 
 	// Marks the specified volume as having been globally mounted.
-	MarkDeviceAsMounted(volumeName v1.UniqueVolumeName) error
+	MarkDeviceAsMounted(volumeName v1.UniqueVolumeName, devicePath string) error
 
 	// Marks the specified volume as having its global mount unmounted.
 	MarkDeviceAsUnmounted(volumeName v1.UniqueVolumeName) error


### PR DESCRIPTION
**What this PR does / why we need it**:

For volume plugins such as FC and iSCSI that are not able to fetch device path during Attach() call, they can get the device path during WaitForAttach() on the node. 

In this PR, kubelet passes and updates the right device path into asw.attachedVolumes object at volume manager after device is attached.

**Which issue this PR fixes** : fixes #54108

**Special notes for your reviewer**:

This patch is previously proposed via #35433 but wasn't merged.
But the problem still exists as I reported at #54108 

/sig storage
/cc @jingxu97 @rootfs 
@kubernetes/sig-storage-pr-reviews

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
