### PR TITLE
audit policy: reject audit policy files without apiVersion and kind

### DIFF
--- a/CHANGELOG-1.8.md
+++ b/CHANGELOG-1.8.md
@@ -490,7 +490,7 @@ Consider the following changes, limitations, and guidelines before you upgrade:
 
   * The `--audit-policy-file` option is required if the `AdvancedAudit` feature is not explicitly turned off (`--feature-gates=AdvancedAudit=false`) on the API server.
   * The audit log file defaults to JSON encoding when using the advanced auditing feature gate.
-  * The `--audit-policy-file` option requires `kind` and `apiVersion` fields specifying what format version the `Policy` is using.
+  * An audit policy file without either an `apiVersion` or a `kind` field may be treated as invalid.
   * The webhook and log file now output the `v1beta1` event format.
 
     For more details, see [Advanced audit](https://kubernetes.io/docs/tasks/debug-application-cluster/audit/#advanced-audit).

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/BUILD
@@ -34,7 +34,7 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/audit/policy",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/audit/v1beta1:go_default_library",


### PR DESCRIPTION
Closes https://github.com/kubernetes/kubernetes/issues/54254

/cc @sttts @CaoShuFeng @crassirostris @tallclair

/sig auth
/kind cleanup

```release-note
Audit policy files without apiVersion and kind are treated as invalid.
```