### PR TITLE
Implement Node poweroff test

### DIFF
--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -304,20 +304,6 @@ func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[
 	if err != nil {
 		return nil, fmt.Errorf("deployment %q failed to complete: %v", deploymentSpec.Name, err)
 	}
-	// pod, err := client.CoreV1().Pods(namespace).Create(pod)
-	// if err != nil {
-	//     return nil, fmt.Errorf("pod Create API error: %v", err)
-	// }
-	// // Waiting for pod to be running
-	// err = WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
-	// if err != nil {
-	//     return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
-	// }
-	// // get fresh pod info
-	// pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
-	// if err != nil {
-	//     return pod, fmt.Errorf("pod Get API error: %v", err)
-	// }
 	return deployment, nil
 }
 

--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -22,9 +22,11 @@ import (
 
 	. "github.com/onsi/ginkgo"
 
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	clientset "k8s.io/client-go/kubernetes"
@@ -33,6 +35,7 @@ import (
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	testutils "k8s.io/kubernetes/test/utils"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func UpdateDeploymentWithRetries(c clientset.Interface, namespace, name string, applyUpdate testutils.UpdateDeploymentFunc) (*extensions.Deployment, error) {
@@ -288,4 +291,101 @@ func RunDeployment(config testutils.DeploymentConfig) error {
 
 func logPodsOfDeployment(c clientset.Interface, deployment *extensions.Deployment, rsList []*extensions.ReplicaSet) {
 	testutils.LogPodsOfDeployment(c, deployment, rsList, Logf)
+}
+
+func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, command string) (*extensions.Deployment, error) {
+	deploymentSpec := MakeDeployment(replicas, podLabels, namespace, pvclaims, false, command)
+	deployment, err := client.Extensions().Deployments(namespace).Create(deploymentSpec)
+	if err != nil {
+		return nil, fmt.Errorf("deployment %q Create API error: %v", deploymentSpec.Name, err)
+	}
+	glog.Infof(fmt.Sprintf("Waiting deployment %q to complete", deploymentSpec.Name))
+	err = WaitForDeploymentStatusValid(client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("deployment %q failed to complete: %v", deploymentSpec.Name, err)
+	}
+	// pod, err := client.CoreV1().Pods(namespace).Create(pod)
+	// if err != nil {
+	//     return nil, fmt.Errorf("pod Create API error: %v", err)
+	// }
+	// // Waiting for pod to be running
+	// err = WaitForPodNameRunningInNamespace(client, pod.Name, namespace)
+	// if err != nil {
+	//     return pod, fmt.Errorf("pod %q is not Running: %v", pod.Name, err)
+	// }
+	// // get fresh pod info
+	// pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+	// if err != nil {
+	//     return pod, fmt.Errorf("pod Get API error: %v", err)
+	// }
+	return deployment, nil
+}
+
+// MakeDeployment creates a deployment definition based on the namespace. The deployment references the PVC's
+// name.  A slice of BASH commands can be supplied as args to be run by the pod
+func MakeDeployment(replicas int32, podLabels map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bool, command string) *extensions.Deployment {
+	if len(command) == 0 {
+		command = "while true; do sleep 1; done"
+	}
+	zero := int64(0)
+	deploymentName := "deployment-" + string(uuid.NewUUID())
+	deploymentSpec := &extensions.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+		Spec: extensions.DeploymentSpec{
+			Replicas: &replicas,
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: podLabels,
+				},
+				Spec: v1.PodSpec{
+					TerminationGracePeriodSeconds: &zero,
+					Containers: []v1.Container{
+						{
+							Name:    "write-pod",
+							Image:   imageutils.GetBusyBoxImage(),
+							Command: []string{"/bin/sh"},
+							Args:    []string{"-c", command},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &isPrivileged,
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+			},
+		},
+	}
+	var volumeMounts = make([]v1.VolumeMount, len(pvclaims))
+	var volumes = make([]v1.Volume, len(pvclaims))
+	for index, pvclaim := range pvclaims {
+		volumename := fmt.Sprintf("volume%v", index+1)
+		volumeMounts[index] = v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename}
+		volumes[index] = v1.Volume{Name: volumename, VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: false}}}
+	}
+	deploymentSpec.Spec.Template.Spec.Containers[0].VolumeMounts = volumeMounts
+	deploymentSpec.Spec.Template.Spec.Volumes = volumes
+	return deploymentSpec
+}
+
+// GetPodsForDeployment gets pods for the given deployment
+func GetPodsForDeployment(client clientset.Interface, deployment *extensions.Deployment) (*v1.PodList, error) {
+	replicaSet, err := deploymentutil.GetNewReplicaSet(deployment, client.ExtensionsV1beta1())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get new replica set for deployment %q: %v", deployment.Name, err)
+	}
+	if replicaSet == nil {
+		return nil, fmt.Errorf("expected a new replica set for deployment %q, found none", deployment.Name)
+	}
+	podListFunc := func(namespace string, options metav1.ListOptions) (*v1.PodList, error) {
+		return client.Core().Pods(namespace).List(options)
+	}
+	rsList := []*extensions.ReplicaSet{replicaSet}
+	podList, err := deploymentutil.ListPods(deployment, rsList, podListFunc)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to list Pods of Deployment %q: %v", deployment.Name, err)
+	}
+	return podList, nil
 }

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -26,6 +26,7 @@ go_library(
         "vsphere_utils.go",
         "vsphere_volume_diskformat.go",
         "vsphere_volume_fstype.go",
+        "vsphere_volume_node_poweroff.go",
         "vsphere_volume_ops_storm.go",
         "vsphere_volume_placement.go",
         "vsphere_volume_vsan_policy.go",

--- a/test/e2e/storage/vsphere_utils.go
+++ b/test/e2e/storage/vsphere_utils.go
@@ -39,6 +39,14 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
+// volumeState represents the state of a volume.
+type volumeState int32
+
+const (
+	volumeStateDetached volumeState = 1
+	volumeStateAttached volumeState = 2
+)
+
 // Sanity check for vSphere testing.  Verify the persistent disk attached to the node.
 func verifyVSphereDiskAttached(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) (bool, error) {
 	var (
@@ -54,40 +62,66 @@ func verifyVSphereDiskAttached(vsp *vsphere.VSphere, volumePath string, nodeName
 	return isAttached, err
 }
 
-// Wait until vsphere vmdk is deteched from the given node or time out after 5 minutes
-func waitForVSphereDiskToDetach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+// Wait until vsphere vmdk moves to expected state on the given node, or time out after 6 minutes
+func waitForVSphereDiskStatus(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName, expectedState volumeState) error {
 	var (
-		err            error
-		diskAttached   = true
-		detachTimeout  = 5 * time.Minute
-		detachPollTime = 10 * time.Second
+		err          error
+		diskAttached bool
+		currentState volumeState
+		timeout      = 6 * time.Minute
+		pollTime     = 10 * time.Second
 	)
-	if vsp == nil {
-		vsp, err = vsphere.GetVSphere()
-		if err != nil {
-			return err
-		}
-	}
-	err = wait.Poll(detachPollTime, detachTimeout, func() (bool, error) {
+	err = wait.Poll(pollTime, timeout, func() (bool, error) {
 		diskAttached, err = verifyVSphereDiskAttached(vsp, volumePath, nodeName)
 		if err != nil {
 			return true, err
 		}
-		if !diskAttached {
-			framework.Logf("Volume %q appears to have successfully detached from %q.",
-				volumePath, nodeName)
+
+		if diskAttached {
+			currentState = volumeStateAttached
+		} else {
+			currentState = volumeStateDetached
+		}
+
+		if currentState == expectedState {
+			if expectedState == volumeStateDetached {
+				framework.Logf("Volume %q has successfully detached from %q.", volumePath, nodeName)
+			} else {
+				framework.Logf("Volume %q has successfully attached to %q.", volumePath, nodeName)
+			}
 			return true, nil
 		}
-		framework.Logf("Waiting for Volume %q to detach from %q.", volumePath, nodeName)
+
+		if expectedState == volumeStateDetached {
+			framework.Logf("Waiting for Volume %q to detach from %q.", volumePath, nodeName)
+		} else {
+			framework.Logf("Waiting for Volume %q to attach to %q.", volumePath, nodeName)
+		}
 		return false, nil
 	})
+
 	if err != nil {
 		return err
 	}
-	if diskAttached {
-		return fmt.Errorf("Gave up waiting for Volume %q to detach from %q after %v", volumePath, nodeName, detachTimeout)
+
+	if currentState != expectedState {
+		if expectedState == volumeStateDetached {
+			err = fmt.Errorf("Gave up waiting for Volume %q to detach from %q after %v", volumePath, nodeName, timeout)
+		} else {
+			err = fmt.Errorf("Gave up waiting for Volume %q to attach to %q after %v", volumePath, nodeName, timeout)
+		}
 	}
-	return nil
+	return err
+}
+
+// Wait until vsphere vmdk is attached from the given node or time out after 6 minutes
+func waitForVSphereDiskToAttach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+	return waitForVSphereDiskStatus(vsp, volumePath, nodeName, volumeStateAttached)
+}
+
+// Wait until vsphere vmdk is detached from the given node or time out after 6 minutes
+func waitForVSphereDiskToDetach(vsp *vsphere.VSphere, volumePath string, nodeName types.NodeName) error {
+	return waitForVSphereDiskStatus(vsp, volumePath, nodeName, volumeStateDetached)
 }
 
 // function to create vsphere volume spec with given VMDK volume path, Reclaim Policy and labels

--- a/test/e2e/storage/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere_volume_node_poweroff.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	vsphere "k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere"
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+/*
+	Test to verify volume status after node power off:
+	1. Verify the pod got provisioned on a different node with volume attached to it
+	2. Verify the volume is detached from the powered off node
+*/
+var _ = SIGDescribe("Node Poweroff [Feature:vsphere]", func() {
+	f := framework.NewDefaultFramework("node-poweroff")
+	var (
+		client    clientset.Interface
+		namespace string
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("vsphere")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+	})
+
+	/*
+		Steps:
+		1. Create a StorageClass
+		2. Create a PVC with the StorageClass
+		3. Create a Deployment with 1 replica, using the PVC
+		4. Verify the pod got provisioned on a node
+		5. Verify the volume is attached to the node
+		6. Power off the node where pod got provisioned
+		7. Verify the pod got provisioned on a different node
+		8. Verify the volume is attached to the new node
+		9. Verify the volume is detached from the old node
+		10. Delete the Deployment and wait for the volume to be detached
+		11. Delete the PVC
+		12. Delete the StorageClass
+	*/
+	It("verify volume status after node power off", func() {
+		By("Creating s Storage Class")
+		//scParameters := make(map[string]string)
+		//scParameters["diskformat"] = "thin"
+		storageClassSpec := getVSphereStorageClassSpec("test-sc", nil)
+		storageclass, err := client.StorageV1().StorageClasses().Create(storageClassSpec)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+		defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+		By("Creating PVC using the Storage Class")
+		pvclaimSpec := getVSphereClaimSpecWithStorageClassAnnotation(namespace, storageclass)
+		//pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(pvclaimSpec)
+		pvclaim, err := framework.CreatePVC(client, namespace, pvclaimSpec)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create PVC with err: %v", err))
+		//defer client.CoreV1().PersistentVolumeClaims(namespace).Delete(pvclaimSpec.Name, nil)
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		By("Waiting for claim to be in bound phase")
+		pvclaims := []*v1.PersistentVolumeClaim{pvclaim}
+		pvs, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to wait until pvc phase set to bound: %v", err))
+		volumePath := pvs[0].Spec.VsphereVolume.VolumePath
+
+		By("Creating a Deployment")
+		deployment, err := framework.CreateDeployment(client, int32(1), map[string]string{"test": "app"}, namespace, pvclaims, "")
+		Expect(err).NotTo(HaveOccurred())
+		defer client.Extensions().Deployments(namespace).Delete(deployment.Name, &metav1.DeleteOptions{})
+
+		By("Get pod from the deployement")
+		podList, err := framework.GetPodsForDeployment(client, deployment)
+		clientPod := podList.Items[0]
+		node1 := types.NodeName(clientPod.Spec.NodeName)
+
+		By("Verify disk is attached to the node")
+		vsp, err := vsphere.GetVSphere()
+		Expect(err).NotTo(HaveOccurred())
+		isAttached, err := vsp.DiskIsAttached(volumePath, node1)
+		//isAttached, err := verifyVSphereDiskAttached(vsp, volumePath, node1)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), "Disk is not attached with the node")
+
+		// By("Power off the node where pod got provisioned")
+		// govMoMiClient, err := vsphere.GetgovmomiClient(nil)
+		// Expect(err).NotTo(HaveOccurred())
+
+		// f := find.NewFinder(govMoMiClient.Client, true)
+		// ctx, _ := context.WithCancel(context.Background())
+
+		// workingDir := os.Getenv("VSPHERE_WORKING_DIR")
+		// Expect(workingDir).NotTo(BeEmpty())
+
+		// vmPath := workingDir + string(node1)
+		// vm, err := f.VirtualMachine(ctx, vmPath)
+		// Expect(err).NotTo(HaveOccurred())
+
+		// _, err = vm.PowerOff(ctx)
+		// Expect(err).NotTo(HaveOccurred())
+
+		// err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOff)
+		// Expect(err).NotTo(HaveOccurred(), "Unable to power off the node")
+
+		// By("Get pod from the deployement") // Is this correct?
+		// podList, err = framework.GetPodsForDeployment(client, deployment)
+		// clientPod = podList.Items[0]
+		// node2 := types.NodeName(clientPod.Spec.NodeName)
+
+		// By(fmt.Sprintf("Verify disk is attached to the current node: %v", node2))
+		// isAttached, err = verifyVSphereDiskAttached(vsp, volumePath, node2)
+		// Expect(err).NotTo(HaveOccurred())
+		// Expect(isAttached).To(BeTrue(), "Disk is not attached with the node")
+
+		// By(fmt.Sprintf("Waiting for disk to be detached from the previous node: %v", node1))
+		// err = waitForVSphereDiskToDetach(vsp, volumePath, node1)
+		// Expect(err).NotTo(HaveOccurred(), "Disk is not detached from the node")
+
+		// By("Power on the previous node")
+		// vm.PowerOn(ctx)
+		// err = vm.WaitForPowerState(ctx, vimtypes.VirtualMachinePowerStatePoweredOn)
+		// Expect(err).NotTo(HaveOccurred(), "Unable to power on the node")
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds test to verify volume status after the node being powed off and failed over to a different node.

**Which issue this PR fixes**
Fixes https://github.com/vmware/kubernetes/issues/272 and https://github.com/vmware/kubernetes/issues/326

**Special notes for your reviewer**:
This PR includes the following changes:
1. Add new utility functions to support k8s Deployment operations
2. Implement new e2e test for node poweroff / failover scenario
3. Refactor existing utility functions to handle new testing scenarios

Testing logs will be attached shortly.

**Release note**:

