### PR TITLE
Remove redundant code of checking path

### DIFF
--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -36,7 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
-	volutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
 type RecycleEventRecorder func(eventtype, message string)
@@ -423,13 +422,6 @@ func getPVCNameHashAndIndexOffset(pvcName string) (hash uint32, index uint32) {
 // to empty_dir
 func UnmountViaEmptyDir(dir string, host VolumeHost, volName string, volSpec Spec, podUID types.UID) error {
 	glog.V(3).Infof("Tearing down volume %v for pod %v at %v", volName, podUID, dir)
-
-	if pathExists, pathErr := volutil.PathExists(dir); pathErr != nil {
-		return fmt.Errorf("Error checking if path exists: %v", pathErr)
-	} else if !pathExists {
-		glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
-		return nil
-	}
 
 	// Wrap EmptyDir, let it do the teardown.
 	wrapped, err := host.NewWrapperUnmounter(volName, volSpec, podUID)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove redundant code of checking path
the checking is not necessary here,WrapperUnmounter#TearDownAt always do that


	func UnmountViaEmptyDir(dir string, host VolumeHost, volName string, volSpec Spec, podUID types.UID) error {
	    glog.V(3).Infof("Tearing down volume %v for pod %v at %v", volName, podUID, dir)

        if pathExists, pathErr := volutil.PathExists(dir); pathErr != nil {
	   	    return fmt.Errorf("Error checking if path exists: %v", pathErr)
	    } else if !pathExists {
		    glog.Warningf("Warning: Unmount skipped because path does not exist: %v", dir)
		    return nil
	    }

	    // Wrap EmptyDir, let it do the teardown.
	    wrapped, err := host.NewWrapperUnmounter(volName, volSpec, podUID)
	    if err != nil {
		    return err
	    }
	    return wrapped.TearDownAt(dir)
    }


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
NONE

**Release note**:
NONE
