### PR TITLE
Set the webhook client Content-Type to JSON

### DIFF
--- a/plugin/pkg/admission/webhook/admission.go
+++ b/plugin/pkg/admission/webhook/admission.go
@@ -278,5 +278,7 @@ func (a *GenericAdmissionWebhook) hookClient(h *v1alpha1.ExternalAdmissionHook) 
 	cfg.TLSClientConfig.ServerName = h.ClientConfig.Service.Name + "." + h.ClientConfig.Service.Namespace + ".svc"
 	cfg.TLSClientConfig.CAData = h.ClientConfig.CABundle
 	cfg.ContentConfig.NegotiatedSerializer = a.negotiatedSerializer
+	// TODO: remove the hard-coding when we figure out how to dynamically decide the content-type
+	cfg.ContentConfig.ContentType = runtime.ContentTypeJSON
 	return rest.UnversionedRESTClientFor(cfg)
 }


### PR DESCRIPTION
This is for backwards compatibility. Existing examples are expecting json. Blocking https://github.com/kubernetes/kubernetes/pull/54165.

TODO: we need to let webhooks support negotiation, or register the content type in the webhook configuration.