### PR TITLE
stop the channel

### DIFF
--- a/pkg/kubectl/rollback.go
+++ b/pkg/kubectl/rollback.go
@@ -113,6 +113,10 @@ func (r *DeploymentRollbacker) Rollback(obj runtime.Object, updatedAnnotations m
 func watchRollbackEvent(w watch.Interface) string {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, os.Kill, syscall.SIGTERM)
+	defer func() {
+		signal.Stop(signals)
+		close(signals)
+	}()
 	for {
 		select {
 		case event, ok := <-w.ResultChan():


### PR DESCRIPTION
**What this PR does / why we need it**:

stop and close the channel of os.Signal after using it
