### PR TITLE
Rename body-size to proxy-body-size

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/actions/registry
+++ b/cluster/juju/layers/kubernetes-worker/actions/registry
@@ -98,7 +98,7 @@ if create_response == 0:
 
     if check_cm_response == 0:
         # There is an existing ConfigMap, patch it
-        patch = '{"data":{"body-size":"1024m"}}'
+        patch = '{"data":{"proxy-body-size":"1024m"}}'
         patch_cm_command = kubectl + ['patch', 'cm', cm_name, '-p', patch]
         patch_cm_response = call(patch_cm_command)
 

--- a/cluster/juju/layers/kubernetes-worker/registry-configmap.yaml
+++ b/cluster/juju/layers/kubernetes-worker/registry-configmap.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  body-size: 1024m
+  proxy-body-size: 1024m
 kind: ConfigMap
 metadata:
   name: nginx-load-balancer-conf


### PR DESCRIPTION
ingress-nginx renamed the 'body-size' configmap to 'proxy-body-size',
requiring changes here.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
