### PR TITLE
make sure of deleting archive

### DIFF
--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -354,6 +354,7 @@ func main() {
 	if !exitOk {
 		fmt.Printf("Failure: %d errors encountered.\n", errCount)
 		callGubernator(*gubernator)
+		arc.deleteArchive()
 		os.Exit(1)
 	}
 	callGubernator(*gubernator)


### PR DESCRIPTION
**What this PR does / why we need it**:

Exit() causes the current program to exit with the given status code, but deferred function does not run.