### PR TITLE
Use constants for CEPH container startup sleep.

### DIFF
--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -72,6 +72,9 @@ const (
 	MiB int64 = 1024 * KiB
 	GiB int64 = 1024 * MiB
 	TiB int64 = 1024 * GiB
+
+	// Waiting period for volume server (Ceph, ...) to initialize itself.
+	VolumeServerPodStartupSleep = 20 * time.Second
 )
 
 // Configuration of one tests. The test consist of:
@@ -343,7 +346,7 @@ func VolumeTestCleanup(f *Framework, config VolumeTestConfig) {
 		// See issue #24100.
 		// Prevent umount errors by making sure making sure the client pod exits cleanly *before* the volume server pod exits.
 		By("sleeping a bit so client can stop and unmount")
-		time.Sleep(20 * time.Second)
+		time.Sleep(VolumeServerPodStartupSleep)
 
 		err = podClient.Delete(config.Prefix+"-server", nil)
 		if err != nil {

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -288,7 +288,7 @@ var _ = SIGDescribe("Volumes", func() {
 			}()
 			_, serverIP := framework.CreateStorageServer(cs, config)
 			By("sleeping a bit to give ceph server time to initialize")
-			time.Sleep(20 * time.Second)
+			time.Sleep(framework.VolumeServerPodStartupSleep)
 
 			// create ceph secret
 			secret := &v1.Secret{


### PR DESCRIPTION
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/assign @jeffvance 
/sig storage