### PR TITLE
Use jsoniter to encode object

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1889,8 +1889,8 @@
 		},
 		{
 			"ImportPath": "github.com/json-iterator/go",
-			"Comment": "1.0.0",
-			"Rev": "36b14963da70d11297d313183d7e6388c8510e1e"
+			"Comment": "1.0.3",
+			"Rev": "06b2a7cf1d30701d2d1b37547ac732b8a7508f66"
 		},
 		{
 			"ImportPath": "github.com/jteeuwen/go-bindata",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1890,7 +1890,7 @@
 		{
 			"ImportPath": "github.com/json-iterator/go",
 			"Comment": "1.0.3",
-			"Rev": "06b2a7cf1d30701d2d1b37547ac732b8a7508f66"
+			"Rev": "fbd210edfcc4a947bd86b68701590990ca3d6036"
 		},
 		{
 			"ImportPath": "github.com/jteeuwen/go-bindata",

--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -1011,7 +1011,7 @@ func checkPatchString(t *testing.T, req *http.Request) {
 
 	resultString := annotationsMap["kubectl.kubernetes.io/last-applied-configuration"]
 	if resultString != checkString {
-		t.Fatalf("patch annotation is not correct, expect:%s\n but got:%s\n", checkString, resultString)
+		t.Fatalf("patch annotation is not correct, expect:|%s|\n but got:|%s|\n", checkString, resultString)
 	}
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -215,7 +215,7 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 		_, err = w.Write(data)
 		return err
 	}
-	encoder := jsoniter.ConfigFastest.NewEncoder(w)
+	encoder := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(w)
 	return encoder.Encode(obj)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -17,7 +17,6 @@ limitations under the License.
 package json
 
 import (
-	"encoding/json"
 	"io"
 	"strconv"
 	"unsafe"
@@ -73,19 +72,19 @@ func init() {
 	decodeNumberAsInt64IfPossible := func(ptr unsafe.Pointer, iter *jsoniter.Iterator) {
 		switch iter.WhatIsNext() {
 		case jsoniter.NumberValue:
-			var number json.Number
+			var number string
 			iter.ReadVal(&number)
-			u64, err := strconv.ParseUint(string(number), 10, 64)
+			u64, err := strconv.ParseUint(number, 10, 64)
 			if err == nil {
 				*(*interface{})(ptr) = u64
 				return
 			}
-			i64, err := strconv.ParseInt(string(number), 10, 64)
+			i64, err := strconv.ParseInt(number, 10, 64)
 			if err == nil {
 				*(*interface{})(ptr) = i64
 				return
 			}
-			f64, err := strconv.ParseFloat(string(number), 64)
+			f64, err := strconv.ParseFloat(number, 64)
 			if err == nil {
 				*(*interface{})(ptr) = f64
 				return

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -216,7 +216,7 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 		_, err = w.Write(data)
 		return err
 	}
-	encoder := json.NewEncoder(w)
+	encoder := jsoniter.ConfigFastest.NewEncoder(w)
 	return encoder.Encode(obj)
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_bench_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_bench_test.go
@@ -1,0 +1,27 @@
+package json
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func BenchmarkJsonEncoding(b *testing.B) {
+	obj := schema.GroupVersionKind{Kind: "foo", Group: "bar", Version: "baz"}
+	encoder := json.NewEncoder(bytes.NewBuffer(nil))
+	for i := 0; i < b.N; i++ {
+		encoder.Encode(obj)
+	}
+}
+
+func BenchmarkJsoniterEncoding(b *testing.B) {
+	obj := schema.GroupVersionKind{Kind: "foo", Group: "bar", Version: "baz"}
+	encoder := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(bytes.NewBuffer(nil))
+	for i := 0; i < b.N; i++ {
+		encoder.Encode(obj)
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_bench_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_bench_test.go
@@ -7,11 +7,63 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/api"
 )
 
+func testLargePod() api.Pod {
+	obj := api.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ubuntu",
+			Namespace: "default",
+			Labels: map[string]string{
+				"name": "ubuntu",
+			},
+			SelfLink: "/api/v1/namespaces/default/pods/ubuntu",
+			Annotations: map[string]string{
+				"foo.bar.baz": "foo",
+				"baz.bar.foo": "bar",
+				"bar.foo.baz": "baz",
+			},
+		},
+		Spec: api.PodSpec{
+			Containers: []api.Container{
+				{
+					Name:       "ubuntu",
+					Image:      "foo.io/ubuntu",
+					Command:    []string{"sleep"},
+					Args:       []string{"1d"},
+					WorkingDir: "/data/tmp",
+					Ports: []api.ContainerPort{
+						{
+							Name:          "port",
+							HostPort:      1,
+							ContainerPort: 2,
+							Protocol:      api.ProtocolTCP,
+							HostIP:        "127.0.0.1",
+						},
+					},
+					VolumeMounts: []api.VolumeMount{
+						{
+							Name:      "default-token-p0000",
+							ReadOnly:  true,
+							MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+						},
+					},
+				},
+			},
+			RestartPolicy: api.RestartPolicyAlways,
+		},
+	}
+	return obj
+}
+
 func BenchmarkJsonEncoding(b *testing.B) {
-	obj := schema.GroupVersionKind{Kind: "foo", Group: "bar", Version: "baz"}
+	obj := testLargePod()
 	encoder := json.NewEncoder(bytes.NewBuffer(nil))
 	for i := 0; i < b.N; i++ {
 		encoder.Encode(obj)
@@ -19,7 +71,7 @@ func BenchmarkJsonEncoding(b *testing.B) {
 }
 
 func BenchmarkJsoniterEncoding(b *testing.B) {
-	obj := schema.GroupVersionKind{Kind: "foo", Group: "bar", Version: "baz"}
+	obj := testLargePod()
 	encoder := jsoniter.ConfigCompatibleWithStandardLibrary.NewEncoder(bytes.NewBuffer(nil))
 	for i := 0; i < b.N; i++ {
 		encoder.Encode(obj)

--- a/vendor/github.com/json-iterator/go/feature_adapter.go
+++ b/vendor/github.com/json-iterator/go/feature_adapter.go
@@ -110,6 +110,9 @@ type Encoder struct {
 // Encode encode interface{} as JSON to io.Writer
 func (adapter *Encoder) Encode(val interface{}) error {
 	adapter.stream.WriteVal(val)
+	if adapter.stream.cfg.addNewline {
+		adapter.stream.WriteRaw("\n")
+	}
 	adapter.stream.Flush()
 	return adapter.stream.Error
 }
@@ -124,4 +127,9 @@ func (adapter *Encoder) SetEscapeHTML(escapeHTML bool) {
 	config := adapter.stream.cfg.configBeforeFrozen
 	config.EscapeHTML = escapeHTML
 	adapter.stream.cfg = config.Froze().(*frozenConfig)
+}
+
+// Valid reports whether data is a valid JSON encoding.
+func Valid(data []byte) bool {
+	return ConfigDefault.Valid(data)
 }

--- a/vendor/github.com/json-iterator/go/feature_iter.go
+++ b/vendor/github.com/json-iterator/go/feature_iter.go
@@ -200,8 +200,22 @@ func (iter *Iterator) ReportError(operation string, msg string) {
 	if peekStart < 0 {
 		peekStart = 0
 	}
-	iter.Error = fmt.Errorf("%s: %s, parsing %v ...%s... at %s", operation, msg, iter.head,
-		string(iter.buf[peekStart:iter.head]), string(iter.buf[0:iter.tail]))
+	peekEnd := iter.head + 10
+	if peekEnd > iter.tail {
+		peekEnd = iter.tail
+	}
+	parsing := string(iter.buf[peekStart:peekEnd])
+	contextStart := iter.head - 50
+	if contextStart < 0 {
+		contextStart = 0
+	}
+	contextEnd := iter.head + 50
+	if contextEnd > iter.tail {
+		contextEnd = iter.tail
+	}
+	context := string(iter.buf[contextStart:contextEnd])
+	iter.Error = fmt.Errorf("%s: %s, error found in #%v byte of ...|%s|..., bigger context ...|%s|...",
+		operation, msg, iter.head-peekStart, parsing, context)
 }
 
 // CurrentBuffer gets current buffer as string for debugging purpose
@@ -210,7 +224,7 @@ func (iter *Iterator) CurrentBuffer() string {
 	if peekStart < 0 {
 		peekStart = 0
 	}
-	return fmt.Sprintf("parsing %v ...|%s|... at %s", iter.head,
+	return fmt.Sprintf("parsing #%v byte, around ...|%s|..., whole buffer ...|%s|...", iter.head,
 		string(iter.buf[peekStart:iter.head]), string(iter.buf[0:iter.tail]))
 }
 

--- a/vendor/github.com/json-iterator/go/feature_iter_array.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_array.go
@@ -19,7 +19,7 @@ func (iter *Iterator) ReadArray() (ret bool) {
 	case ',':
 		return true
 	default:
-		iter.ReportError("ReadArray", "expect [ or , or ] or n, but found: "+string([]byte{c}))
+		iter.ReportError("ReadArray", "expect [ or , or ] or n, but found "+string([]byte{c}))
 		return
 	}
 }
@@ -42,7 +42,7 @@ func (iter *Iterator) ReadArrayCB(callback func(*Iterator) bool) (ret bool) {
 				c = iter.nextToken()
 			}
 			if c != ']' {
-				iter.ReportError("ReadArrayCB", "expect ] in the end")
+				iter.ReportError("ReadArrayCB", "expect ] in the end, but found "+string([]byte{c}))
 				return false
 			}
 			return true
@@ -53,6 +53,6 @@ func (iter *Iterator) ReadArrayCB(callback func(*Iterator) bool) (ret bool) {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return true // null
 	}
-	iter.ReportError("ReadArrayCB", "expect [ or n, but found: "+string([]byte{c}))
+	iter.ReportError("ReadArrayCB", "expect [ or n, but found "+string([]byte{c}))
 	return false
 }

--- a/vendor/github.com/json-iterator/go/feature_iter_object.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_object.go
@@ -24,7 +24,7 @@ func (iter *Iterator) ReadObject() (ret string) {
 		if c == '}' {
 			return "" // end of object
 		}
-		iter.ReportError("ReadObject", `expect " after {`)
+		iter.ReportError("ReadObject", `expect " after {, but found `+string([]byte{c}))
 		return
 	case ',':
 		return string(iter.readObjectFieldAsBytes())
@@ -105,14 +105,14 @@ func (iter *Iterator) ReadObjectCB(callback func(*Iterator, string) bool) bool {
 		if c == '}' {
 			return true
 		}
-		iter.ReportError("ReadObjectCB", `expect " after }`)
+		iter.ReportError("ReadObjectCB", `expect " after }, but found `+string([]byte{c}))
 		return false
 	}
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return true // null
 	}
-	iter.ReportError("ReadObjectCB", `expect { or n`)
+	iter.ReportError("ReadObjectCB", `expect { or n, but found `+string([]byte{c}))
 	return false
 }
 
@@ -125,7 +125,7 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 			iter.unreadByte()
 			field := iter.ReadString()
 			if iter.nextToken() != ':' {
-				iter.ReportError("ReadMapCB", "expect : after object field")
+				iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 				return false
 			}
 			if !callback(iter, field) {
@@ -135,7 +135,7 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 			for c == ',' {
 				field = iter.ReadString()
 				if iter.nextToken() != ':' {
-					iter.ReportError("ReadMapCB", "expect : after object field")
+					iter.ReportError("ReadMapCB", "expect : after object field, but found "+string([]byte{c}))
 					return false
 				}
 				if !callback(iter, field) {
@@ -152,14 +152,14 @@ func (iter *Iterator) ReadMapCB(callback func(*Iterator, string) bool) bool {
 		if c == '}' {
 			return true
 		}
-		iter.ReportError("ReadMapCB", `expect " after }`)
+		iter.ReportError("ReadMapCB", `expect " after }, but found `+string([]byte{c}))
 		return false
 	}
 	if c == 'n' {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return true // null
 	}
-	iter.ReportError("ReadMapCB", `expect { or n`)
+	iter.ReportError("ReadMapCB", `expect { or n, but found `+string([]byte{c}))
 	return false
 }
 
@@ -176,7 +176,7 @@ func (iter *Iterator) readObjectStart() bool {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return false
 	}
-	iter.ReportError("readObjectStart", "expect { or n")
+	iter.ReportError("readObjectStart", "expect { or n, but found "+string([]byte{c}))
 	return false
 }
 
@@ -192,7 +192,7 @@ func (iter *Iterator) readObjectFieldAsBytes() (ret []byte) {
 		}
 	}
 	if iter.buf[iter.head] != ':' {
-		iter.ReportError("readObjectFieldAsBytes", "expect : after object field")
+		iter.ReportError("readObjectFieldAsBytes", "expect : after object field, but found "+string([]byte{iter.buf[iter.head]}))
 		return
 	}
 	iter.head++

--- a/vendor/github.com/json-iterator/go/feature_iter_skip.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_skip.go
@@ -25,7 +25,7 @@ func (iter *Iterator) ReadBool() (ret bool) {
 		iter.skipFourBytes('a', 'l', 's', 'e')
 		return false
 	}
-	iter.ReportError("ReadBool", "expect t or f")
+	iter.ReportError("ReadBool", "expect t or f, but found "+string([]byte{c}))
 	return
 }
 
@@ -59,7 +59,9 @@ func (iter *Iterator) stopCapture() []byte {
 	iter.captureStartedAt = -1
 	iter.captured = nil
 	if len(captured) == 0 {
-		return remaining
+		copied := make([]byte, len(remaining))
+		copy(copied, remaining)
+		return copied
 	}
 	captured = append(captured, remaining...)
 	return captured

--- a/vendor/github.com/json-iterator/go/feature_iter_skip_sloppy.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_skip_sloppy.go
@@ -1,4 +1,4 @@
-//+build jsoniter-sloppy
+//+build jsoniter_sloppy
 
 package jsoniter
 

--- a/vendor/github.com/json-iterator/go/feature_iter_skip_strict.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_skip_strict.go
@@ -1,4 +1,4 @@
-//+build !jsoniter-sloppy
+//+build !jsoniter_sloppy
 
 package jsoniter
 
@@ -64,7 +64,7 @@ func (iter *Iterator) trySkipString() bool {
 		} else if c == '\\' {
 			return false
 		} else if c < ' ' {
-			iter.ReportError("ReadString",
+			iter.ReportError("trySkipString",
 				fmt.Sprintf(`invalid control character found: %d`, c))
 			return true // already failed
 		}

--- a/vendor/github.com/json-iterator/go/feature_iter_string.go
+++ b/vendor/github.com/json-iterator/go/feature_iter_string.go
@@ -28,7 +28,7 @@ func (iter *Iterator) ReadString() (ret string) {
 		iter.skipThreeBytes('u', 'l', 'l')
 		return ""
 	}
-	iter.ReportError("ReadString", `expects " or n`)
+	iter.ReportError("ReadString", `expects " or n, but found `+string([]byte{c}))
 	return
 }
 
@@ -47,7 +47,7 @@ func (iter *Iterator) readStringSlowPath() (ret string) {
 			str = append(str, c)
 		}
 	}
-	iter.ReportError("ReadString", "unexpected end of input")
+	iter.ReportError("readStringSlowPath", "unexpected end of input")
 	return
 }
 
@@ -104,7 +104,7 @@ func (iter *Iterator) readEscapedChar(c byte, str []byte) []byte {
 	case 't':
 		str = append(str, '\t')
 	default:
-		iter.ReportError("ReadString",
+		iter.ReportError("readEscapedChar",
 			`invalid escape char after \`)
 		return nil
 	}
@@ -139,7 +139,7 @@ func (iter *Iterator) ReadStringAsSlice() (ret []byte) {
 		}
 		return copied
 	}
-	iter.ReportError("ReadString", `expects " or n`)
+	iter.ReportError("ReadStringAsSlice", `expects " or n, but found `+string([]byte{c}))
 	return
 }
 
@@ -156,7 +156,7 @@ func (iter *Iterator) readU4() (ret rune) {
 		} else if c >= 'A' && c <= 'F' {
 			ret = ret*16 + rune(c-'A'+10)
 		} else {
-			iter.ReportError("readU4", "expects 0~9 or a~f")
+			iter.ReportError("readU4", "expects 0~9 or a~f, but found "+string([]byte{c}))
 			return
 		}
 	}

--- a/vendor/github.com/json-iterator/go/feature_json_number.go
+++ b/vendor/github.com/json-iterator/go/feature_json_number.go
@@ -1,8 +1,24 @@
 package jsoniter
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"strconv"
+)
 
 type Number string
+
+// String returns the literal text of the number.
+func (n Number) String() string { return string(n) }
+
+// Float64 returns the number as a float64.
+func (n Number) Float64() (float64, error) {
+	return strconv.ParseFloat(string(n), 64)
+}
+
+// Int64 returns the number as an int64.
+func (n Number) Int64() (int64, error) {
+	return strconv.ParseInt(string(n), 10, 64)
+}
 
 func CastJsonNumber(val interface{}) (string, bool) {
 	switch typedVal := val.(type) {

--- a/vendor/github.com/json-iterator/go/feature_reflect.go
+++ b/vendor/github.com/json-iterator/go/feature_reflect.go
@@ -154,11 +154,11 @@ func (encoder *placeholderEncoder) IsEmpty(ptr unsafe.Pointer) bool {
 }
 
 func (encoder *placeholderEncoder) getRealEncoder() ValEncoder {
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 500; i++ {
 		realDecoder := encoder.cfg.getEncoderFromCache(encoder.cacheKey)
 		_, isPlaceholder := realDecoder.(*placeholderEncoder)
 		if isPlaceholder {
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 		} else {
 			return realDecoder
 		}
@@ -172,11 +172,11 @@ type placeholderDecoder struct {
 }
 
 func (decoder *placeholderDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	for i := 0; i < 30; i++ {
+	for i := 0; i < 500; i++ {
 		realDecoder := decoder.cfg.getDecoderFromCache(decoder.cacheKey)
 		_, isPlaceholder := realDecoder.(*placeholderDecoder)
 		if isPlaceholder {
-			time.Sleep(time.Second)
+			time.Sleep(10 * time.Millisecond)
 		} else {
 			realDecoder.Decode(ptr, iter)
 			return
@@ -463,6 +463,18 @@ func createEncoderOfType(cfg *frozenConfig, typ reflect.Type) (ValEncoder, error
 		}
 		if typ.Kind() == reflect.Ptr {
 			encoder = &optionalEncoder{encoder}
+		}
+		return encoder, nil
+	}
+	if reflect.PtrTo(typ).Implements(marshalerType) {
+		checkIsEmpty, err := createCheckIsEmpty(reflect.PtrTo(typ))
+		if err != nil {
+			return nil, err
+		}
+		templateInterface := reflect.New(typ).Interface()
+		var encoder ValEncoder = &marshalerEncoder{
+			templateInterface: extractInterface(templateInterface),
+			checkIsEmpty:      checkIsEmpty,
 		}
 		return encoder, nil
 	}

--- a/vendor/github.com/json-iterator/go/feature_reflect.go
+++ b/vendor/github.com/json-iterator/go/feature_reflect.go
@@ -130,10 +130,28 @@ func (encoder *optionalEncoder) EncodeInterface(val interface{}, stream *Stream)
 }
 
 func (encoder *optionalEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	return *((*unsafe.Pointer)(ptr)) == nil
+}
+
+type optionalMapEncoder struct {
+	valueEncoder ValEncoder
+}
+
+func (encoder *optionalMapEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	if *((*unsafe.Pointer)(ptr)) == nil {
-		return true
+		stream.WriteNil()
+	} else {
+		encoder.valueEncoder.Encode(*((*unsafe.Pointer)(ptr)), stream)
 	}
-	return false
+}
+
+func (encoder *optionalMapEncoder) EncodeInterface(val interface{}, stream *Stream) {
+	WriteToStream(val, stream, encoder)
+}
+
+func (encoder *optionalMapEncoder) IsEmpty(ptr unsafe.Pointer) bool {
+	p := *((*unsafe.Pointer)(ptr))
+	return p == nil || encoder.valueEncoder.IsEmpty(p)
 }
 
 type placeholderEncoder struct {

--- a/vendor/github.com/json-iterator/go/feature_reflect_extension.go
+++ b/vendor/github.com/json-iterator/go/feature_reflect_extension.go
@@ -269,7 +269,7 @@ func describeStruct(cfg *frozenConfig, typ reflect.Type) (*StructDescriptor, err
 		if decoder == nil {
 			var err error
 			decoder, err = decoderOfType(cfg, field.Type)
-			if err != nil {
+			if len(fieldNames) > 0 && err != nil {
 				return nil, err
 			}
 		}
@@ -277,11 +277,11 @@ func describeStruct(cfg *frozenConfig, typ reflect.Type) (*StructDescriptor, err
 		if encoder == nil {
 			var err error
 			encoder, err = encoderOfType(cfg, field.Type)
-			if err != nil {
+			if len(fieldNames) > 0 && err != nil {
 				return nil, err
 			}
 			// map is stored as pointer in the struct
-			if field.Type.Kind() == reflect.Map {
+			if encoder != nil && field.Type.Kind() == reflect.Map {
 				encoder = &optionalEncoder{encoder}
 			}
 		}

--- a/vendor/github.com/json-iterator/go/feature_reflect_extension.go
+++ b/vendor/github.com/json-iterator/go/feature_reflect_extension.go
@@ -280,9 +280,10 @@ func describeStruct(cfg *frozenConfig, typ reflect.Type) (*StructDescriptor, err
 			if len(fieldNames) > 0 && err != nil {
 				return nil, err
 			}
-			// map is stored as pointer in the struct
+			// map is stored as pointer in the struct,
+			// and treat nil or empty map as empty field
 			if encoder != nil && field.Type.Kind() == reflect.Map {
-				encoder = &optionalEncoder{encoder}
+				encoder = &optionalMapEncoder{encoder}
 			}
 		}
 		binding := &Binding{

--- a/vendor/github.com/json-iterator/go/feature_reflect_native.go
+++ b/vendor/github.com/json-iterator/go/feature_reflect_native.go
@@ -4,6 +4,7 @@ import (
 	"encoding"
 	"encoding/base64"
 	"encoding/json"
+	"reflect"
 	"unsafe"
 )
 
@@ -31,7 +32,9 @@ type intCodec struct {
 }
 
 func (codec *intCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*int)(ptr)) = iter.ReadInt()
+	if !iter.ReadNil() {
+		*((*int)(ptr)) = iter.ReadInt()
+	}
 }
 
 func (codec *intCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -50,7 +53,9 @@ type uintptrCodec struct {
 }
 
 func (codec *uintptrCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uintptr)(ptr)) = uintptr(iter.ReadUint64())
+	if !iter.ReadNil() {
+		*((*uintptr)(ptr)) = uintptr(iter.ReadUint64())
+	}
 }
 
 func (codec *uintptrCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -69,7 +74,9 @@ type int8Codec struct {
 }
 
 func (codec *int8Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*int8)(ptr)) = iter.ReadInt8()
+	if !iter.ReadNil() {
+		*((*int8)(ptr)) = iter.ReadInt8()
+	}
 }
 
 func (codec *int8Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -88,7 +95,9 @@ type int16Codec struct {
 }
 
 func (codec *int16Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*int16)(ptr)) = iter.ReadInt16()
+	if !iter.ReadNil() {
+		*((*int16)(ptr)) = iter.ReadInt16()
+	}
 }
 
 func (codec *int16Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -107,7 +116,9 @@ type int32Codec struct {
 }
 
 func (codec *int32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*int32)(ptr)) = iter.ReadInt32()
+	if !iter.ReadNil() {
+		*((*int32)(ptr)) = iter.ReadInt32()
+	}
 }
 
 func (codec *int32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -126,7 +137,9 @@ type int64Codec struct {
 }
 
 func (codec *int64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*int64)(ptr)) = iter.ReadInt64()
+	if !iter.ReadNil() {
+		*((*int64)(ptr)) = iter.ReadInt64()
+	}
 }
 
 func (codec *int64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -145,7 +158,10 @@ type uintCodec struct {
 }
 
 func (codec *uintCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uint)(ptr)) = iter.ReadUint()
+	if !iter.ReadNil() {
+		*((*uint)(ptr)) = iter.ReadUint()
+		return
+	}
 }
 
 func (codec *uintCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -164,7 +180,9 @@ type uint8Codec struct {
 }
 
 func (codec *uint8Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uint8)(ptr)) = iter.ReadUint8()
+	if !iter.ReadNil() {
+		*((*uint8)(ptr)) = iter.ReadUint8()
+	}
 }
 
 func (codec *uint8Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -183,7 +201,9 @@ type uint16Codec struct {
 }
 
 func (codec *uint16Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uint16)(ptr)) = iter.ReadUint16()
+	if !iter.ReadNil() {
+		*((*uint16)(ptr)) = iter.ReadUint16()
+	}
 }
 
 func (codec *uint16Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -202,7 +222,9 @@ type uint32Codec struct {
 }
 
 func (codec *uint32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uint32)(ptr)) = iter.ReadUint32()
+	if !iter.ReadNil() {
+		*((*uint32)(ptr)) = iter.ReadUint32()
+	}
 }
 
 func (codec *uint32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -221,7 +243,9 @@ type uint64Codec struct {
 }
 
 func (codec *uint64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*uint64)(ptr)) = iter.ReadUint64()
+	if !iter.ReadNil() {
+		*((*uint64)(ptr)) = iter.ReadUint64()
+	}
 }
 
 func (codec *uint64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -240,7 +264,9 @@ type float32Codec struct {
 }
 
 func (codec *float32Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*float32)(ptr)) = iter.ReadFloat32()
+	if !iter.ReadNil() {
+		*((*float32)(ptr)) = iter.ReadFloat32()
+	}
 }
 
 func (codec *float32Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -259,7 +285,9 @@ type float64Codec struct {
 }
 
 func (codec *float64Codec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*float64)(ptr)) = iter.ReadFloat64()
+	if !iter.ReadNil() {
+		*((*float64)(ptr)) = iter.ReadFloat64()
+	}
 }
 
 func (codec *float64Codec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -278,7 +306,9 @@ type boolCodec struct {
 }
 
 func (codec *boolCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*bool)(ptr)) = iter.ReadBool()
+	if !iter.ReadNil() {
+		*((*bool)(ptr)) = iter.ReadBool()
+	}
 }
 
 func (codec *boolCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -297,7 +327,42 @@ type emptyInterfaceCodec struct {
 }
 
 func (codec *emptyInterfaceCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*interface{})(ptr)) = iter.Read()
+	existing := *((*interface{})(ptr))
+
+	// Checking for both typed and untyped nil pointers.
+	if existing != nil &&
+		reflect.TypeOf(existing).Kind() == reflect.Ptr &&
+		!reflect.ValueOf(existing).IsNil() {
+
+		var ptrToExisting interface{}
+		for {
+			elem := reflect.ValueOf(existing).Elem()
+			if elem.Kind() != reflect.Ptr || elem.IsNil() {
+				break
+			}
+			ptrToExisting = existing
+			existing = elem.Interface()
+		}
+
+		if iter.ReadNil() {
+			if ptrToExisting != nil {
+				nilPtr := reflect.Zero(reflect.TypeOf(ptrToExisting).Elem())
+				reflect.ValueOf(ptrToExisting).Elem().Set(nilPtr)
+			} else {
+				*((*interface{})(ptr)) = nil
+			}
+		} else {
+			iter.ReadVal(existing)
+		}
+
+		return
+	}
+
+	if iter.ReadNil() {
+		*((*interface{})(ptr)) = nil
+	} else {
+		*((*interface{})(ptr)) = iter.Read()
+	}
 }
 
 func (codec *emptyInterfaceCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -309,7 +374,8 @@ func (codec *emptyInterfaceCodec) EncodeInterface(val interface{}, stream *Strea
 }
 
 func (codec *emptyInterfaceCodec) IsEmpty(ptr unsafe.Pointer) bool {
-	return ptr == nil
+	emptyInterface := (*emptyInterface)(ptr)
+	return emptyInterface.typ == nil
 }
 
 type nonEmptyInterfaceCodec struct {
@@ -326,15 +392,20 @@ func (codec *nonEmptyInterfaceCodec) Decode(ptr unsafe.Pointer, iter *Iterator) 
 	e.typ = nonEmptyInterface.itab.typ
 	e.word = nonEmptyInterface.word
 	iter.ReadVal(&i)
+	if e.word == nil {
+		nonEmptyInterface.itab = nil
+	}
 	nonEmptyInterface.word = e.word
 }
 
 func (codec *nonEmptyInterfaceCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
 	nonEmptyInterface := (*nonEmptyInterface)(ptr)
 	var i interface{}
-	e := (*emptyInterface)(unsafe.Pointer(&i))
-	e.typ = nonEmptyInterface.itab.typ
-	e.word = nonEmptyInterface.word
+	if nonEmptyInterface.itab != nil {
+		e := (*emptyInterface)(unsafe.Pointer(&i))
+		e.typ = nonEmptyInterface.itab.typ
+		e.word = nonEmptyInterface.word
+	}
 	stream.WriteVal(i)
 }
 
@@ -370,7 +441,15 @@ type jsonNumberCodec struct {
 }
 
 func (codec *jsonNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*json.Number)(ptr)) = json.Number([]byte(iter.readNumberAsString()))
+	switch iter.WhatIsNext() {
+	case StringValue:
+		*((*json.Number)(ptr)) = json.Number(iter.ReadString())
+	case NilValue:
+		iter.skipFourBytes('n', 'u', 'l', 'l')
+		*((*json.Number)(ptr)) = ""
+	default:
+		*((*json.Number)(ptr)) = json.Number([]byte(iter.readNumberAsString()))
+	}
 }
 
 func (codec *jsonNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -389,7 +468,15 @@ type jsoniterNumberCodec struct {
 }
 
 func (codec *jsoniterNumberCodec) Decode(ptr unsafe.Pointer, iter *Iterator) {
-	*((*Number)(ptr)) = Number([]byte(iter.readNumberAsString()))
+	switch iter.WhatIsNext() {
+	case StringValue:
+		*((*Number)(ptr)) = Number(iter.ReadString())
+	case NilValue:
+		iter.skipFourBytes('n', 'u', 'l', 'l')
+		*((*Number)(ptr)) = ""
+	default:
+		*((*Number)(ptr)) = Number([]byte(iter.readNumberAsString()))
+	}
 }
 
 func (codec *jsoniterNumberCodec) Encode(ptr unsafe.Pointer, stream *Stream) {
@@ -521,7 +608,7 @@ type stringModeNumberDecoder struct {
 func (decoder *stringModeNumberDecoder) Decode(ptr unsafe.Pointer, iter *Iterator) {
 	c := iter.nextToken()
 	if c != '"' {
-		iter.ReportError("stringModeNumberDecoder", `expect "`)
+		iter.ReportError("stringModeNumberDecoder", `expect ", but found `+string([]byte{c}))
 		return
 	}
 	decoder.elemDecoder.Decode(ptr, iter)
@@ -530,7 +617,7 @@ func (decoder *stringModeNumberDecoder) Decode(ptr unsafe.Pointer, iter *Iterato
 	}
 	c = iter.readByte()
 	if c != '"' {
-		iter.ReportError("stringModeNumberDecoder", `expect "`)
+		iter.ReportError("stringModeNumberDecoder", `expect ", but found `+string([]byte{c}))
 		return
 	}
 }
@@ -595,7 +682,12 @@ func (encoder *marshalerEncoder) Encode(ptr unsafe.Pointer, stream *Stream) {
 	templateInterface := encoder.templateInterface
 	templateInterface.word = ptr
 	realInterface := (*interface{})(unsafe.Pointer(&templateInterface))
-	marshaler := (*realInterface).(json.Marshaler)
+	marshaler, ok := (*realInterface).(json.Marshaler)
+	if !ok {
+		stream.WriteVal(nil)
+		return
+	}
+
 	bytes, err := marshaler.MarshalJSON()
 	if err != nil {
 		stream.Error = err

--- a/vendor/github.com/json-iterator/go/feature_stream.go
+++ b/vendor/github.com/json-iterator/go/feature_stream.go
@@ -191,6 +191,9 @@ func (stream *Stream) ensure(minimal int) {
 func (stream *Stream) growAtLeast(minimal int) {
 	if stream.out != nil {
 		stream.Flush()
+		if stream.Available() >= minimal {
+			return
+		}
 	}
 	toGrow := len(stream.buf)
 	if toGrow < minimal {
@@ -280,8 +283,7 @@ func (stream *Stream) WriteArrayStart() {
 
 // WriteEmptyArray write []
 func (stream *Stream) WriteEmptyArray() {
-	stream.writeByte('[')
-	stream.writeByte(']')
+	stream.writeTwoBytes('[', ']')
 }
 
 // WriteArrayEnd write ] with possible indention


### PR DESCRIPTION
standard encoding/json has performance issue,  use jsoniter
can help to reduce half of the encoding time.

Signed-off-by: Peng Gao <peng.gao.dut@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR change encoding/json to jsoniter, from the profiling it reduce the half of processing time.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/sig api-machinery