### PR TITLE
ResourceQuota support for Hugepages

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -37,6 +37,12 @@ func IsHugePageResourceName(name core.ResourceName) bool {
 	return strings.HasPrefix(string(name), core.ResourceHugePagesPrefix)
 }
 
+// IsQuotaHugePageResourceName returns true if the resource name has the quota
+// related huge page resource prefix.
+func IsQuotaHugePageResourceName(name core.ResourceName) bool {
+	return strings.HasPrefix(string(name), core.ResourceHugePagesPrefix) || strings.HasPrefix(string(name), core.ResourceRequestsHugePagesPrefix)
+}
+
 // HugePageResourceName returns a ResourceName with the canonical hugepage
 // prefix prepended for the specified page size.  The page size is converted
 // to its canonical representation.
@@ -217,7 +223,7 @@ var standardQuotaResources = sets.NewString(
 // IsStandardQuotaResourceName returns true if the resource is known to
 // the quota tracking system
 func IsStandardQuotaResourceName(str string) bool {
-	return standardQuotaResources.Has(str)
+	return standardQuotaResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
 }
 
 var standardResources = sets.NewString(
@@ -245,7 +251,7 @@ var standardResources = sets.NewString(
 
 // IsStandardResourceName returns true if the resource is known to the system
 func IsStandardResourceName(str string) bool {
-	return standardResources.Has(str) || IsHugePageResourceName(core.ResourceName(str))
+	return standardResources.Has(str) || IsQuotaHugePageResourceName(core.ResourceName(str))
 }
 
 var integerResources = sets.NewString(

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -59,6 +59,7 @@ func TestIsStandardResource(t *testing.T) {
 		{"blah", false},
 		{"x.y.z", false},
 		{"hugepages-2Mi", true},
+		{"requests.hugepages-2Mi", true},
 	}
 	for i, tc := range testCases {
 		if IsStandardResourceName(tc.input) != tc.output {

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3968,6 +3968,13 @@ const (
 	ResourceLimitsEphemeralStorage ResourceName = "limits.ephemeral-storage"
 )
 
+// The following identify resource prefix for Kubernetes object types
+const (
+	// HugePages request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	// As burst is not supported for HugePages, we would only quota its request, and ignore the limit.
+	ResourceRequestsHugePagesPrefix = "requests.hugepages-"
+)
+
 // A ResourceQuotaScope defines a filter that must match each object tracked by a quota
 type ResourceQuotaScope string
 

--- a/pkg/quota/evaluator/core/pods_test.go
+++ b/pkg/quota/evaluator/core/pods_test.go
@@ -175,6 +175,23 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},
+		"init container hugepages": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					InitContainers: []api.Container{{
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"): resource.MustParse("100Mi")},
+						},
+					}},
+				},
+			},
+			usage: api.ResourceList{
+				api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"):         resource.MustParse("100Mi"),
+				api.ResourceName(api.ResourceRequestsHugePagesPrefix + "2Mi"): resource.MustParse("100Mi"),
+				api.ResourcePods:                                              resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
 		"container CPU": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
@@ -229,6 +246,23 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				api.ResourceRequestsEphemeralStorage: resource.MustParse("32Mi"),
 				api.ResourceLimitsEphemeralStorage:   resource.MustParse("64Mi"),
 				api.ResourcePods:                     resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
+		"container hugepages": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{{
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"): resource.MustParse("100Mi")},
+						},
+					}},
+				},
+			},
+			usage: api.ResourceList{
+				api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"):         resource.MustParse("100Mi"),
+				api.ResourceName(api.ResourceRequestsHugePagesPrefix + "2Mi"): resource.MustParse("100Mi"),
+				api.ResourcePods:                                              resource.MustParse("1"),
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},

--- a/pkg/quota/resources.go
+++ b/pkg/quota/resources.go
@@ -17,6 +17,8 @@ limitations under the License.
 package quota
 
 import (
+	"strings"
+
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -194,6 +196,16 @@ func ResourceNames(resources api.ResourceList) []api.ResourceName {
 // Contains returns true if the specified item is in the list of items
 func Contains(items []api.ResourceName, item api.ResourceName) bool {
 	return ToSet(items).Has(string(item))
+}
+
+// ContainsPrefix returns true if the specified item has a prefix that contained in given prefix Set
+func ContainsPrefix(prefixSet []string, item api.ResourceName) bool {
+	for _, prefix := range prefixSet {
+		if strings.HasPrefix(string(item), prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // Intersection returns the intersection of both list of resources

--- a/pkg/quota/resources_test.go
+++ b/pkg/quota/resources_test.go
@@ -226,6 +226,30 @@ func TestContains(t *testing.T) {
 	}
 }
 
+func TestContainsPrefix(t *testing.T) {
+	testCases := map[string]struct {
+		a        []string
+		b        api.ResourceName
+		expected bool
+	}{
+		"does-not-contain": {
+			a:        []string{api.ResourceHugePagesPrefix},
+			b:        api.ResourceCPU,
+			expected: false,
+		},
+		"does-contain": {
+			a:        []string{api.ResourceHugePagesPrefix},
+			b:        api.ResourceName(api.ResourceHugePagesPrefix + "2Mi"),
+			expected: true,
+		},
+	}
+	for testName, testCase := range testCases {
+		if actual := ContainsPrefix(testCase.a, testCase.b); actual != testCase.expected {
+			t.Errorf("%s expected: %v, actual: %v", testName, testCase.expected, actual)
+		}
+	}
+}
+
 func TestIsZero(t *testing.T) {
 	testCases := map[string]struct {
 		a        api.ResourceList

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4496,6 +4496,13 @@ const (
 	ResourceLimitsEphemeralStorage ResourceName = "limits.ephemeral-storage"
 )
 
+// The following identify resource prefix for Kubernetes object types
+const (
+	// HugePages request, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+	// As burst is not supported for HugePages, we would only quota its request, and ignore the limit.
+	ResourceRequestsHugePagesPrefix = "requests.hugepages-"
+)
+
 // A ResourceQuotaScope defines a filter that must match each object tracked by a quota
 type ResourceQuotaScope string
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Hugepage resourceQuota support

**Which issue this PR fixes** 
fixes #53672 ResourceQuota part

**Special notes for your reviewer**:
What I'm concerned most is the change in quota evaluator:
Rather than add check especially for resource hugage, I would prefer add a check list, that could be easily extended by adding corresponding prefix into the list (As far as I know, pluginResources  will also support ResourceQuota in later versions)
@derekwaynecarr What's your opinion?

/cc @derekwaynecarr 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
