### PR TITLE
[WIP] Clean up reconcileAutoscaling calculations of desiredReplicas

### DIFF
--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -410,46 +410,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 			rescaleReason = "All metrics below target"
 		}
 
-		// Do not upscale too much to prevent incorrect rapid increase of the number of master replicas caused by
-		// bogus CPU usage report from heapster/kubelet (like in issue #32304).
-		scaleUpLimit := calculateScaleUpLimit(currentReplicas)
-
-		switch {
-		case desiredReplicas > scaleUpLimit:
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "ScaleUpLimit", "the desired replica count is increasing faster than the maximum scale rate")
-			desiredReplicas = scaleUpLimit
-
-			// Ensure that even if the scaleUpLimit is greater
-			// than the maximum number of replicas, we only
-			// set the max number of replicas as desired.
-			if scaleUpLimit > hpa.Spec.MaxReplicas {
-				setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooManyReplicas", "the desired replica count was more than the maximum replica count")
-				desiredReplicas = hpa.Spec.MaxReplicas
-			}
-
-		case hpa.Spec.MinReplicas != nil && desiredReplicas < *hpa.Spec.MinReplicas:
-			// make sure we aren't below our minimum
-			var statusMsg string
-			if desiredReplicas == 0 {
-				statusMsg = "the desired replica count was zero"
-			} else {
-				statusMsg = "the desired replica count was less than the minimum replica count"
-			}
-
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", statusMsg)
-			desiredReplicas = *hpa.Spec.MinReplicas
-		case desiredReplicas == 0:
-			//  never scale down to 0, reserved for disabling autoscaling
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was zero")
-			desiredReplicas = 1
-		case desiredReplicas > hpa.Spec.MaxReplicas:
-			// make sure we aren't above our maximum
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooManyReplicas", "the desired replica count was more than the maximum replica count")
-			desiredReplicas = hpa.Spec.MaxReplicas
-		default:
-			// mark that we're within acceptible limits
-			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionFalse, "DesiredWithinRange", "the desired replica count is within the acceptible range")
-		}
+		desiredReplicas = a.normalizeDesiredReplicas(hpa, currentReplicas, desiredReplicas)
 
 		rescale = a.shouldScale(hpa, currentReplicas, desiredReplicas, timestamp)
 		backoffDown := false
@@ -500,6 +461,54 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 
 	a.setStatus(hpa, currentReplicas, desiredReplicas, metricStatuses, rescale)
 	return a.updateStatusIfNeeded(hpaStatusOriginal, hpa)
+}
+
+// normalizeDesiredReplicas takes the metrics desired replicas value and
+// normalizes it based on the appropriate conditions (i.e. < maxReplicas, >
+// minReplicas, etc...)
+func (a *HorizontalController) normalizeDesiredReplicas(hpa *autoscalingv2.HorizontalPodAutoscaler, currentReplicas int32, desiredReplicas int32) int32 {
+	// Do not upscale too much to prevent incorrect rapid increase of the number of master replicas caused by
+	// bogus CPU usage report from heapster/kubelet (like in issue #32304).
+	scaleUpLimit := calculateScaleUpLimit(currentReplicas)
+
+	switch {
+	case desiredReplicas > scaleUpLimit:
+		setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "ScaleUpLimit", "the desired replica count is increasing faster than the maximum scale rate")
+		desiredReplicas = scaleUpLimit
+
+		// Ensure that even if the scaleUpLimit is greater
+		// than the maximum number of replicas, we only
+		// set the max number of replicas as desired.
+		if scaleUpLimit > hpa.Spec.MaxReplicas {
+			setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooManyReplicas", "the desired replica count was more than the maximum replica count")
+			desiredReplicas = hpa.Spec.MaxReplicas
+		}
+
+	case hpa.Spec.MinReplicas != nil && desiredReplicas < *hpa.Spec.MinReplicas:
+		// make sure we aren't below our minimum
+		var statusMsg string
+		if desiredReplicas == 0 {
+			statusMsg = "the desired replica count was zero"
+		} else {
+			statusMsg = "the desired replica count was less than the minimum replica count"
+		}
+
+		setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", statusMsg)
+		desiredReplicas = *hpa.Spec.MinReplicas
+	case desiredReplicas == 0:
+		//  never scale down to 0, reserved for disabling autoscaling
+		setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooFewReplicas", "the desired replica count was zero")
+		desiredReplicas = 1
+	case desiredReplicas > hpa.Spec.MaxReplicas:
+		// make sure we aren't above our maximum
+		setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionTrue, "TooManyReplicas", "the desired replica count was more than the maximum replica count")
+		desiredReplicas = hpa.Spec.MaxReplicas
+	default:
+		// mark that we're within acceptible limits
+		setCondition(hpa, autoscalingv2.ScalingLimited, v1.ConditionFalse, "DesiredWithinRange", "the desired replica count is within the acceptible range")
+	}
+
+	return desiredReplicas
 }
 
 func (a *HorizontalController) shouldScale(hpa *autoscalingv2.HorizontalPodAutoscaler, currentReplicas, desiredReplicas int32, timestamp time.Time) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
Re #53728, we've seen a couple of issues with bugs in the part of `reconcileAutoscaling` that converts `metricDesiredReplicas` into `desiredReplicas`, based on constraints such as min/max replicas, etc.

This commit cleans up the code in this area by extracting it into a separate recursive function, and also expands unit test coverage.

**Which issue this PR fixes**:
Fixes #53728

```release-note
NONE
```
