### PR TITLE
Cluster Autoscaler 1.0.1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.1-beta1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
```release-note
Cluster Autoscaler 1.0.1
```
Minor fixes around scale up. More on [CA page](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler). 
