### PR TITLE
Automated cherry pick of #54315

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -81,7 +81,12 @@ func NewProxyServer(config *componentconfig.KubeProxyConfiguration, cleanupAndEx
 
 	// We omit creation of pretty much everything if we run in cleanup mode
 	if cleanupAndExit {
-		return &ProxyServer{IptInterface: iptInterface, IpvsInterface: ipvsInterface, CleanupAndExit: cleanupAndExit}, nil
+		return &ProxyServer{
+			execer:         execer,
+			IptInterface:   iptInterface,
+			IpvsInterface:  ipvsInterface,
+			CleanupAndExit: cleanupAndExit,
+		}, nil
 	}
 
 	client, eventClient, err := createClients(config.ClientConnection, master)


### PR DESCRIPTION
Cherry pick of #54315 on release-1.8.

#54315: Fix kube-proxy panic on cleanup

```release-note
Fix a problem when running `kube-proxy --cleanup`
```