### PR TITLE
Add conformance annotations for expansion and service tests

### DIFF
--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -31,6 +31,11 @@ import (
 var _ = framework.KubeDescribe("Variable Expansion", func() {
 	f := framework.NewDefaultFramework("var-expansion")
 
+	/*
+		    Testname: var-expansion-env
+		    Description: Make sure environment variables can be set using an
+			expansion of previously defined environment variables
+	*/
 	It("should allow composing env vars into new env vars [Conformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
@@ -71,6 +76,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		})
 	})
 
+	/*
+		    Testname: var-expansion-command
+		    Description: Make sure a container's commands can be set using an
+			expansion of environment variables.
+	*/
 	It("should allow substituting values in a container's command [Conformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
@@ -101,6 +111,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		})
 	})
 
+	/*
+		    Testname: var-expansion-arg
+		    Description: Make sure a container's args can be set using an
+			expansion of environment variables.
+	*/
 	It("should allow substituting values in a container's args [Conformance]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -65,11 +65,20 @@ var _ = SIGDescribe("Services", func() {
 
 	// TODO: We get coverage of TCP/UDP and multi-port services through the DNS test. We should have a simpler test for multi-port TCP here.
 
+	/*
+	   Testname: service-kubernetes-exists
+	   Description: Make sure kubernetes service does exist.
+	*/
 	It("should provide secure master service [Conformance]", func() {
 		_, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	/*
+		    Testname: service-valid-endpoints
+		    Description: Ensure a service with no pod, one pod or two pods has
+			valid/accessible endpoints (same port number for service and pods).
+	*/
 	It("should serve a basic endpoint from pods [Conformance]", func() {
 		// TODO: use the ServiceTestJig here
 		serviceName := "endpoint-test2"
@@ -130,6 +139,11 @@ var _ = SIGDescribe("Services", func() {
 		framework.ValidateEndpointsOrFail(cs, ns, serviceName, framework.PortsByPodName{})
 	})
 
+	/*
+		    Testname: service-valid-endpoints-multiple-ports
+		    Description: Ensure a service with no pod, one pod or two pods has
+			valid/accessible endpoints (different port number for pods).
+	*/
 	It("should serve multiport endpoints from pods [Conformance]", func() {
 		// TODO: use the ServiceTestJig here
 		// repacking functionality is intentionally not tested here - it's better to test it in an integration test.


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds expansion and service test conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests.
Special notes for your reviewer:
Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.


<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
