### PR TITLE
Automated cherry pick of #54250

### DIFF
--- a/build/debian-hyperkube-base/Dockerfile
+++ b/build/debian-hyperkube-base/Dockerfile
@@ -20,20 +20,21 @@ FROM BASEIMAGE
 RUN ln -s /bin/sh /bin/bash
 
 RUN echo CACHEBUST>/dev/null && clean-install \
-    iptables \
+    ca-certificates \
+    ceph-common \
+    cifs-utils \
+    conntrack \
     e2fsprogs \
     ebtables \
     ethtool \
-    kmod \
-    ca-certificates \
-    conntrack \
-    util-linux \
-    socat \
     git \
-    jq \
-    nfs-common \
     glusterfs-client \
-    cifs-utils \
-    ceph-common
+    iptables \
+    jq \
+    kmod \
+    openssh-client \
+    nfs-common \
+    socat \
+    util-linux
 
 COPY cni-bin/bin /opt/cni/bin

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -19,7 +19,7 @@
 
 REGISTRY?=gcr.io/google-containers
 IMAGE?=debian-hyperkube-base
-TAG=0.4
+TAG=0.4.1
 ARCH?=amd64
 CACHEBUST?=1
 

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -21,7 +21,7 @@ REGISTRY?=gcr.io/google-containers
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.4
+BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.4.1
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build


### PR DESCRIPTION
Cherry pick of #54250 on release-1.8.

#54250: Add openssh-client to the debian-hyperkube-base image

```release-note
Adds modprobe and openssh-client back into the hyperkube image. 
```