### PR TITLE
convert testOverlappingDeployment e2e test to integration test

### DIFF
--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -206,27 +206,23 @@ func markPodReady(c clientset.Interface, ns string, pod *v1.Pod) error {
 	return err
 }
 
-// markAllPodsReady manually updates all Deployment pods status to ready
-func (d *deploymentTester) markAllPodsReady() {
+// markUpdatedPodsReady manually marks updated Deployment pods status to ready
+func (d *deploymentTester) markUpdatedPodsReady() {
 	ns := d.deployment.Namespace
-	selector, err := metav1.LabelSelectorAsSelector(d.deployment.Spec.Selector)
-	if err != nil {
-		d.t.Fatalf("failed to parse Deployment selector: %v", err)
-	}
 	var readyPods int32
-	err = wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
+	err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		readyPods = 0
-		pods, err := d.c.CoreV1().Pods(ns).List(metav1.ListOptions{LabelSelector: selector.String()})
+		pods, err := d.listUpdatedPods()
 		if err != nil {
-			d.t.Logf("failed to list Deployment pods, will retry later: %v", err)
+			d.t.Log(err)
 			return false, nil
 		}
-		if len(pods.Items) != int(*d.deployment.Spec.Replicas) {
-			d.t.Logf("%d/%d of deployment pods are created", len(pods.Items), *d.deployment.Spec.Replicas)
+		if len(pods) != int(*d.deployment.Spec.Replicas) {
+			d.t.Logf("%d/%d of deployment pods are created", len(pods), *d.deployment.Spec.Replicas)
 			return false, nil
 		}
-		for i := range pods.Items {
-			pod := pods.Items[i]
+		for i := range pods {
+			pod := pods[i]
 			if podutil.IsPodReady(&pod) {
 				readyPods++
 				continue
@@ -237,13 +233,10 @@ func (d *deploymentTester) markAllPodsReady() {
 				readyPods++
 			}
 		}
-		if readyPods >= *d.deployment.Spec.Replicas {
-			return true, nil
-		}
-		return false, nil
+		return readyPods >= *d.deployment.Spec.Replicas, nil
 	})
 	if err != nil {
-		d.t.Fatalf("failed to mark all Deployment pods to ready: %v", err)
+		d.t.Fatalf("failed to mark updated Deployment pods to ready: %v", err)
 	}
 }
 
@@ -261,11 +254,11 @@ func (d *deploymentTester) waitForDeploymentComplete() error {
 }
 
 // waitForDeploymentCompleteAndCheckRollingAndMarkPodsReady waits for the Deployment to complete
-// while marking all Deployment pods as ready at the same time.
+// while marking updated Deployment pods as ready at the same time.
 // Uses hard check to make sure rolling update strategy is not violated at any times.
 func (d *deploymentTester) waitForDeploymentCompleteAndCheckRollingAndMarkPodsReady() error {
-	// Manually mark all Deployment pods as ready in a separate goroutine
-	go d.markAllPodsReady()
+	// Manually mark updated Deployment pods as ready in a separate goroutine
+	go d.markUpdatedPodsReady()
 
 	// Wait for the Deployment status to complete while Deployment pods are becoming ready
 	err := d.waitForDeploymentCompleteAndCheckRolling()
@@ -276,10 +269,10 @@ func (d *deploymentTester) waitForDeploymentCompleteAndCheckRollingAndMarkPodsRe
 }
 
 // waitForDeploymentCompleteAndMarkPodsReady waits for the Deployment to complete
-// while marking all Deployment pods as ready at the same time.
+// while marking updated Deployment pods as ready at the same time.
 func (d *deploymentTester) waitForDeploymentCompleteAndMarkPodsReady() error {
-	// Manually mark all Deployment pods as ready in a separate goroutine
-	go d.markAllPodsReady()
+	// Manually mark updated Deployment pods as ready in a separate goroutine
+	go d.markUpdatedPodsReady()
 
 	// Wait for the Deployment status to complete using soft check, while Deployment pods are becoming ready
 	err := d.waitForDeploymentComplete()
@@ -301,7 +294,11 @@ func (d *deploymentTester) waitForObservedDeployment(desiredGeneration int64) er
 }
 
 func (d *deploymentTester) getNewReplicaSet() (*v1beta1.ReplicaSet, error) {
-	rs, err := deploymentutil.GetNewReplicaSet(d.deployment, d.c.ExtensionsV1beta1())
+	deployment, err := d.c.ExtensionsV1beta1().Deployments(d.deployment.Namespace).Get(d.deployment.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed retrieving deployment %s: %v", d.deployment.Name, err)
+	}
+	rs, err := deploymentutil.GetNewReplicaSet(deployment, d.c.ExtensionsV1beta1())
 	if err != nil {
 		return nil, fmt.Errorf("failed retrieving new replicaset of deployment %s: %v", d.deployment.Name, err)
 	}
@@ -350,4 +347,31 @@ func (d *deploymentTester) waitForDeploymentUpdatedReplicasLTE(minUpdatedReplica
 
 func (d *deploymentTester) waitForDeploymentWithCondition(reason string, condType v1beta1.DeploymentConditionType) error {
 	return testutil.WaitForDeploymentWithCondition(d.c, d.deployment.Namespace, d.deployment.Name, reason, condType, d.t.Logf, pollInterval, pollTimeout)
+}
+
+func (d *deploymentTester) listUpdatedPods() ([]v1.Pod, error) {
+	selector, err := metav1.LabelSelectorAsSelector(d.deployment.Spec.Selector)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse deployment selector: %v", err)
+	}
+	pods, err := d.c.CoreV1().Pods(d.deployment.Namespace).List(metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list deployment pods, will retry later: %v", err)
+	}
+	newRS, err := d.getNewReplicaSet()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get new replicaset of deployment %q: %v", d.deployment.Name, err)
+	}
+	if newRS == nil {
+		return nil, fmt.Errorf("unable to find new replicaset of deployment %q", d.deployment.Name)
+	}
+
+	var ownedPods []v1.Pod
+	for _, pod := range pods.Items {
+		rs := metav1.GetControllerOf(&pod)
+		if rs.UID == newRS.UID {
+			ownedPods = append(ownedPods, pod)
+		}
+	}
+	return ownedPods, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR convert a deployment e2e test named "testOverlappingDeployment" to integration test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #52113 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```