### PR TITLE
Add a notice for node e2e config files

### DIFF
--- a/test/e2e_node/jenkins/OWNERS
+++ b/test/e2e_node/jenkins/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- dashpole
+- krzyzacy
+- Random-Liu
+- yguo0905
+- yujuhong

--- a/test/e2e_node/jenkins/README.md
+++ b/test/e2e_node/jenkins/README.md
@@ -1,0 +1,20 @@
+# Node e2e job migration notice:
+
+Sig-testing is actively migrating node e2e jobs from Jenkins to [Prow],
+and we are moving *.property and image-config.yaml files to [test-infra]
+
+If you want to update those files, please also update them in [test-infra].
+
+If you have any questions, please contact @krzyzacy or #sig-testing.
+
+
+## Test-infra Links:
+Here's where the existing node e2e job config live:
+
+[Image config files](https://github.com/kubernetes/test-infra/tree/master/jobs/e2e_node)
+
+[Node test job args (.properties equivalent)](https://github.com/kubernetes/test-infra/blob/master/jobs/config.json)
+
+
+[test-infra]: https://github.com/kubernetes/test-infra
+[Prow]: https://github.com/kubernetes/test-infra/tree/master/prow


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/pull/53542 and patched up with https://github.com/kubernetes/test-infra/pull/5107

So while migrating the jobs to prow, I haven't kill the `*.properties` files yet because some lingering jobs, and possibly local tests are still using them. We have a copy of image-config.yaml in test-infra, and all *.properties file is merged into job configs.

Add a notice to remind people also update the job configs in test-infra. Also add myself as a reviewer here so I can subscribe some notice. I'll remove them once I cleaned up all legacy files here.

/assign @yguo0905 @dashpole @yujuhong 


