### PR TITLE
convert testFailedDeployment e2e test to integration test

### DIFF
--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -343,3 +343,11 @@ func (d *deploymentTester) waitForDeploymentRollbackCleared() error {
 func (d *deploymentTester) checkDeploymentRevisionAndImage(revision, image string) error {
 	return testutil.CheckDeploymentRevisionAndImage(d.c, d.deployment.Namespace, d.deployment.Name, revision, image)
 }
+
+func (d *deploymentTester) waitForDeploymentUpdatedReplicasLTE(minUpdatedReplicas int32) error {
+	return testutil.WaitForDeploymentUpdatedReplicasLTE(d.c, d.deployment.Namespace, d.deployment.Name, minUpdatedReplicas, d.deployment.Generation, pollInterval, pollTimeout)
+}
+
+func (d *deploymentTester) waitForDeploymentWithCondition(reason string, condType v1beta1.DeploymentConditionType) error {
+	return testutil.WaitForDeploymentWithCondition(d.c, d.deployment.Namespace, d.deployment.Name, reason, condType, d.t.Logf, pollInterval, pollTimeout)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR convert a deployment e2e test named "testFailedDeployment" to integration test.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: xref #52113 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/assign