### PR TITLE
Ensure port on resolved service host

### DIFF
--- a/plugin/pkg/admission/webhook/serviceresolver.go
+++ b/plugin/pkg/admission/webhook/serviceresolver.go
@@ -32,11 +32,10 @@ var _ admissioninit.ServiceResolver = defaultServiceResolver{}
 // ResolveEndpoint constructs a service URL from a given namespace and name
 // note that the name and namespace are required and by default all created addresses use HTTPS scheme.
 // for example:
-//  name=ross namespace=andromeda resolves to https://ross.andromeda.svc
+//  name=ross namespace=andromeda resolves to https://ross.andromeda.svc:443
 func (sr defaultServiceResolver) ResolveEndpoint(namespace, name string) (*url.URL, error) {
 	if len(name) == 0 || len(namespace) == 0 {
-		return &url.URL{}, errors.New("cannot resolve an empty service name or namespace")
+		return nil, errors.New("cannot resolve an empty service name or namespace")
 	}
-
-	return url.Parse(fmt.Sprintf("https://%s.%s.svc", name, namespace))
+	return &url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s.svc:443", name, namespace)}, nil
 }

--- a/plugin/pkg/admission/webhook/serviceresolver_test.go
+++ b/plugin/pkg/admission/webhook/serviceresolver_test.go
@@ -30,7 +30,7 @@ func TestDefaultServiceResolver(t *testing.T) {
 		expectError      bool
 	}{
 		// scenario 1: a service name along with a namespace resolves
-		{serviceName: "ross", serviceNamespace: "andromeda", expectedOutput: "https://ross.andromeda.svc"},
+		{serviceName: "ross", serviceNamespace: "andromeda", expectedOutput: "https://ross.andromeda.svc:443"},
 		// scenario 2: a service name without a namespace does not resolve
 		{serviceName: "ross", expectError: true},
 		// scenario 3: cannot resolve an empty service name
@@ -49,8 +49,10 @@ func TestDefaultServiceResolver(t *testing.T) {
 			if err == nil && scenario.expectError {
 				t.Error("expected an error but got nothing")
 			}
-			if serviceURL.String() != scenario.expectedOutput {
-				t.Errorf("expected = %s, got = %s", scenario.expectedOutput, serviceURL.String())
+			if !scenario.expectError {
+				if serviceURL.String() != scenario.expectedOutput {
+					t.Errorf("expected = %s, got = %s", scenario.expectedOutput, serviceURL.String())
+				}
 			}
 		})
 	}


### PR DESCRIPTION
The resolved host should include a port so it can be used by dialers directly. It's also not necessary to reparse the URL when constructing directly.

```release-note
NONE
```