### PR TITLE
fix azure disk mount failure on coreos and some other distros

### DIFF
--- a/pkg/volume/azure_dd/azure_common_linux.go
+++ b/pkg/volume/azure_dd/azure_common_linux.go
@@ -77,6 +77,19 @@ func findDiskByLunWithConstraint(lun int, io ioHandler, azureDisks []string) (st
 			if len(arr) < 4 {
 				continue
 			}
+			if len(azureDisks) == 0 {
+				glog.V(4).Infof("/dev/disk/azure is not populated, now try to parse %v directly", name)
+				target, err := strconv.Atoi(arr[0])
+				if err != nil {
+					glog.Errorf("failed to parse target from %v (%v), err %v", arr[0], name, err)
+					continue
+				}
+				// as observed, targets 0-3 are used by OS disks. Skip them
+				if target <= 3 {
+					continue
+				}
+			}
+
 			// extract LUN from the path.
 			// LUN is the last index of the array, i.e. 1 in /sys/bus/scsi/devices/3:0:0:1
 			l, err := strconv.Atoi(arr[3])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
azure disk mount failure on coreos due to `/dev/disk/azure` not populated on coreos, and also on some other distros.
After a long time back and forth discussion, I have decided to fix this issue on k8s side. Customers are leaving azure because of this udev issue, you could read details from #50150 . I have verifed the code works well on current coreos on azure.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #50150: azure_dd: managed disks don't pass "FormatAndMount"
In coreos on azure and some old distros, one udev rule is not applied, which means `/dev/disk/azure` not populated, while current disk detection code logic relies on `/dev/disk/azure`, so it would lead to azure disk mount failure, for more details, pls refer to #50150

**Special notes for your reviewer**:
In v1.6, there is no such issue becuase it's not using /dev/azure/disk to detect the LUN of new disk, so I refer the code logic of v1.6:
https://github.com/kubernetes/kubernetes/blob/release-1.6/pkg/volume/azure_dd/vhd_util.go#L59-L66

while from v1.7, it's using /dev/azure/disk, the code logic does not apply to distro which does not have udev rules(/dev/azure/disk), see:
https://github.com/kubernetes/kubernetes/blob/release-1.7/pkg/volume/azure_dd/azure_common.go#L231-L236

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix azure disk mount failure on coreos and some other distro due to udev rule not applied
```
/sig azure
@rootfs @brendanburns @colemickens 
@tlyng @karataliu @szarkos