### PR TITLE
Update openapi bazel build to support vendored build

### DIFF
--- a/build/openapi.bzl
+++ b/build/openapi.bzl
@@ -1,0 +1,9 @@
+# A project wanting to generate openapi code for vendored
+# k8s.io/kubernetes will need to set the following variables in
+# //build/openapi.bzl in their project and customize the go prefix:
+#
+# openapi_go_prefix = "k8s.io/myproject/"
+# openapi_vendor_prefix = "vendor/k8s.io/kubernetes/"
+
+openapi_go_prefix = "k8s.io/kubernetes/"
+openapi_vendor_prefix = ""

--- a/pkg/generated/openapi/BUILD
+++ b/pkg/generated/openapi/BUILD
@@ -4,10 +4,12 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//pkg/generated/openapi:def.bzl", "openapi_library")
+load("//build:openapi.bzl", "openapi_go_prefix", "openapi_vendor_prefix")
 
 openapi_library(
     name = "go_default_library",
     srcs = ["doc.go"],
+    go_prefix = openapi_go_prefix,
     openapi_targets = [
         "federation/apis/federation/v1beta1",
         "pkg/apis/abac/v0",
@@ -17,6 +19,7 @@ openapi_library(
         "pkg/version",
     ],
     tags = ["automanaged"],
+    vendor_prefix = openapi_vendor_prefix,
     vendor_targets = [
         "k8s.io/api/admission/v1alpha1",
         "k8s.io/api/admissionregistration/v1alpha1",

--- a/pkg/generated/openapi/def.bzl
+++ b/pkg/generated/openapi/def.bzl
@@ -1,7 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_kubernetes_build//defs:go.bzl", "go_genrule")
 
-def openapi_library(name, tags, srcs, openapi_targets=[], vendor_targets=[]):
+def openapi_library(name, tags, srcs, go_prefix, vendor_prefix="", openapi_targets=[], vendor_targets=[]):
   deps = [
       "//vendor/github.com/go-openapi/spec:go_default_library",
       "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
@@ -14,17 +14,17 @@ def openapi_library(name, tags, srcs, openapi_targets=[], vendor_targets=[]):
   )
   go_genrule(
       name = "zz_generated.openapi",
-      srcs = srcs + ["//hack/boilerplate:boilerplate.go.txt"],
+      srcs = srcs + ["//" + vendor_prefix + "hack/boilerplate:boilerplate.go.txt"],
       outs = ["zz_generated.openapi.go"],
       cmd = " ".join([
         "$(location //vendor/k8s.io/code-generator/cmd/openapi-gen)",
         "--v 1",
         "--logtostderr",
-        "--go-header-file $(location //hack/boilerplate:boilerplate.go.txt)",
+        "--go-header-file $(location //" + vendor_prefix + "hack/boilerplate:boilerplate.go.txt)",
         "--output-file-base zz_generated.openapi",
-        "--output-package k8s.io/kubernetes/pkg/generated/openapi",
-        "--input-dirs " + ",".join(["k8s.io/kubernetes/" + target for target in openapi_targets] + ["k8s.io/kubernetes/vendor/" + target for target in vendor_targets]),
-        "&& cp pkg/generated/openapi/zz_generated.openapi.go $(location :zz_generated.openapi.go)",
+        "--output-package " + go_prefix + vendor_prefix + "pkg/generated/openapi",
+        "--input-dirs " + ",".join([go_prefix + target for target in openapi_targets] + [go_prefix + "vendor/" + target for target in vendor_targets]),
+        "&& cp " + vendor_prefix + "pkg/generated/openapi/zz_generated.openapi.go $(location :zz_generated.openapi.go)",
       ]),
       go_deps = deps,
       tools = ["//vendor/k8s.io/code-generator/cmd/openapi-gen"],


### PR DESCRIPTION
This is one part (see #54335) of enabling vendoring projects like federation to generate openapi code for k8s.io/kubernetes.

edit: These changes are necessary for a project to correctly generate ``vendor/k8s.io/kubernetes/pkg/generated/openapi/zz_generated.openapi.go`` for vendored ``k8s.io/kubernetes``.  Without the changes, the vendored output location for ``zz_generated.openapi.go`` would be ``k8s.io/kubernetes`` instead of ``vendor/k8s.io/kubernetes`` and the input files would similarly be from ``k8s.io/kubernetes`` instead of ``k8s.io/myproject``.

/sig testing
/release-note-none