### PR TITLE
Add service latency and secret related conformance annotations

### DIFF
--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -30,6 +30,11 @@ import (
 var _ = Describe("[sig-api-machinery] Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
+	/*
+		    Testname: secret-env-vars
+		    Description: Ensure that secret can be consumed via environment
+			variables.
+	*/
 	It("should be consumable from pods in env vars [Conformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := secretForTest(f.Namespace.Name, name)
@@ -74,6 +79,11 @@ var _ = Describe("[sig-api-machinery] Secrets", func() {
 		})
 	})
 
+	/*
+		    Testname: secret-configmaps-source
+		    Description: Ensure that secret can be consumed via source of a set
+			of ConfigMaps.
+	*/
 	It("should be consumable via the environment [Conformance]", func() {
 		name := "secret-test-" + string(uuid.NewUUID())
 		secret := newEnvFromSecret(f.Namespace.Name, name)

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -33,15 +33,30 @@ import (
 var _ = Describe("[sig-storage] Secrets", func() {
 	f := framework.NewDefaultFramework("secrets")
 
+	/*
+		    Testname: secret-volume-mount-without-mapping
+		    Description: Ensure that secret can be mounted without mapping to a
+			pod volume.
+	*/
 	It("should be consumable from pods in volume [Conformance]", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
+	/*
+		    Testname: secret-volume-mount-without-mapping-default-mode
+		    Description: Ensure that secret can be mounted without mapping to a
+			pod volume in default mode.
+	*/
 	It("should be consumable from pods in volume with defaultMode set [Conformance]", func() {
 		defaultMode := int32(0400)
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
+	/*
+		    Testname: secret-volume-mount-without-mapping-non-root-default-mode-fsgroup
+		    Description: Ensure that secret can be mounted without mapping to a pod
+			volume as non-root in default mode with fsGroup set.
+	*/
 	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
@@ -49,10 +64,20 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		doSecretE2EWithoutMapping(f, &defaultMode, "secret-test-"+string(uuid.NewUUID()), &fsGroup, &uid)
 	})
 
+	/*
+		    Testname: secret-volume-mount-with-mapping
+		    Description: Ensure that secret can be mounted with mapping to a pod
+			volume.
+	*/
 	It("should be consumable from pods in volume with mappings [Conformance]", func() {
 		doSecretE2EWithMapping(f, nil)
 	})
 
+	/*
+		    Testname: secret-volume-mount-with-mapping-item-mode
+		    Description: Ensure that secret can be mounted with mapping to a pod
+			volume in item mode.
+	*/
 	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance]", func() {
 		mode := int32(0400)
 		doSecretE2EWithMapping(f, &mode)
@@ -79,6 +104,10 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		doSecretE2EWithoutMapping(f, nil /* default mode */, secret2.Name, nil, nil)
 	})
 
+	/*
+	   Testname: secret-multiple-volume-mounts
+	   Description: Ensure that secret can be mounted to multiple pod volumes.
+	*/
 	It("should be consumable in multiple volumes in a pod [Conformance]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
@@ -152,6 +181,11 @@ var _ = Describe("[sig-storage] Secrets", func() {
 		})
 	})
 
+	/*
+		    Testname: secret-mounted-volume-optional-update-change
+		    Description: Ensure that optional update change to secret can be
+			reflected on a mounted volume.
+	*/
 	It("optional updates should be reflected in volume [Conformance]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))

--- a/test/e2e/network/service_latency.go
+++ b/test/e2e/network/service_latency.go
@@ -45,6 +45,12 @@ func (d durations) Swap(i, j int)      { d[i], d[j] = d[j], d[i] }
 var _ = SIGDescribe("Service endpoints latency", func() {
 	f := framework.NewDefaultFramework("svc-latency")
 
+	/*
+		    Testname: service-endpoint-latency
+		    Description: Ensure service endpoint's latency is not high
+		    (e.g. p50 < 20 seconds and p99 < 50 seconds). If any call to the
+			service endpoint fails, the test will also fail.
+	*/
 	It("should not be very high [Conformance]", func() {
 		const (
 			// These are very generous criteria. Ideally we will


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds service latency and secret related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests.
Special notes for your reviewer:

Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
