### PR TITLE
WIP: Kubectl result.Object() returns VersionedObject instead of Object

### DIFF
--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -141,7 +141,7 @@ func (r *Result) Object() (runtime.Object, error) {
 	objects := []runtime.Object{}
 	for _, info := range infos {
 		if info.Object != nil {
-			objects = append(objects, info.Object)
+			objects = append(objects, info.VersionedObject)
 			versions.Insert(info.ResourceVersion)
 		}
 	}


### PR DESCRIPTION
Switch pkg/kubectl/resource result.Object() function to return VersionedObject instead of Object

```release-note
NONE
```

kubernetes/kubectl#81