### PR TITLE
correct the error info when resourceName equals to hugepage

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -4008,7 +4008,7 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 		if exists {
 			// For GPUs, not only requests can't exceed limits, they also can't be lower, i.e. must be equal.
 			if quantity.Cmp(limitQuantity) != 0 && !helper.IsOvercommitAllowed(resourceName) {
-				allErrs = append(allErrs, field.Invalid(reqPath, quantity.String(), fmt.Sprintf("must be equal to %s limit", api.ResourceNvidiaGPU)))
+				allErrs = append(allErrs, field.Invalid(reqPath, quantity.String(), fmt.Sprintf("must be equal to %s limit", resourceName)))
 			} else if quantity.Cmp(limitQuantity) > 0 {
 				allErrs = append(allErrs, field.Invalid(reqPath, quantity.String(), fmt.Sprintf("must be less than or equal to %s limit", resourceName)))
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
when the resourceName eqauls to hugepage, the error info outputs as NvidiaGPU, which should be corrected.
