### PR TITLE
fix kubectl pod status when status.reason is NodeLost

### DIFF
--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -32,6 +32,7 @@ go_test(
         "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/kubectl/testing:go_default_library",
         "//pkg/printers:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -610,9 +610,7 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1alpha1.Table
 		}
 	}
 
-	if pod.DeletionTimestamp != nil && pod.Status.Reason == node.NodeUnreachablePodReason {
-		reason = "Unknown"
-	} else if pod.DeletionTimestamp != nil {
+	if pod.DeletionTimestamp != nil && pod.Status.Reason != node.NodeUnreachablePodReason {
 		reason = "Terminating"
 	}
 

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -53,6 +53,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/storage"
 	kubectltesting "k8s.io/kubernetes/pkg/kubectl/testing"
 	"k8s.io/kubernetes/pkg/printers"
+	"k8s.io/kubernetes/pkg/util/node"
 )
 
 func init() {
@@ -1656,6 +1657,25 @@ func TestPrintPod(t *testing.T) {
 				},
 			},
 			[]metav1alpha1.TableRow{{Cells: []interface{}{"test5", "1/2", "podReason", 6, "<unknown>"}}},
+		},
+		{
+			// Test pod status when deletion timestamp is not nil and status.reason is NodeLost
+			api.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test6",
+					DeletionTimestamp: &metav1.Time{Time: time.Now().AddDate(0, 0, 1)},
+				},
+				Spec: api.PodSpec{Containers: make([]api.Container, 2)},
+				Status: api.PodStatus{
+					Reason: node.NodeUnreachablePodReason,
+					Phase:  "podPhase",
+					ContainerStatuses: []api.ContainerStatus{
+						{Ready: true, RestartCount: 3, State: api.ContainerState{Running: &api.ContainerStateRunning{}}},
+						{Ready: true, RestartCount: 3},
+					},
+				},
+			},
+			[]metav1alpha1.TableRow{{Cells: []interface{}{"test6", "1/2", "NodeLost", 6, "<unknown>"}}},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
`kubectl get pod` should display pods status correct when `status.reason` is `NodeLost`

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54390

**Special notes for your reviewer**:
@kubernetes/sig-cli-bugs 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fix kubectl pod status when status.reason is NodeLost
```
