### PR TITLE
Provide cfg to mutator functions

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/BUILD
+++ b/cmd/kubeadm/app/phases/selfhosting/BUILD
@@ -16,6 +16,7 @@ go_test(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/phases/selfhosting",
     library = ":go_default_library",
     deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",

--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation_test.go
@@ -22,8 +22,11 @@ import (
 	"testing"
 
 	"k8s.io/api/core/v1"
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
+
+var defaultCfg = &kubeadmapi.MasterConfiguration{}
 
 func TestMutatePodSpec(t *testing.T) {
 	var tests = []struct {
@@ -73,7 +76,8 @@ func TestMutatePodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		mutatePodSpec(GetDefaultMutators(), rt.component, rt.podSpec)
+		mutatators := GetDefault(defaultCfg)
+		mutatators.mutatePodSpec(rt.component, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed mutatePodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -110,7 +114,7 @@ func TestAddNodeSelectorToPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		addNodeSelectorToPodSpec(rt.podSpec)
+		addNodeSelectorToPodSpec(defaultCfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed addNodeSelectorToPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -147,7 +151,7 @@ func TestSetMasterTolerationOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setMasterTolerationOnPodSpec(rt.podSpec)
+		setMasterTolerationOnPodSpec(defaultCfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setMasterTolerationOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -177,7 +181,7 @@ func TestSetRightDNSPolicyOnPodSpec(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setRightDNSPolicyOnPodSpec(rt.podSpec)
+		setRightDNSPolicyOnPodSpec(defaultCfg, rt.podSpec)
 
 		if !reflect.DeepEqual(*rt.podSpec, rt.expected) {
 			t.Errorf("failed setRightDNSPolicyOnPodSpec:\nexpected:\n%v\nsaw:\n%v", rt.expected, *rt.podSpec)
@@ -269,7 +273,7 @@ func TestSetSelfHostedVolumesForAPIServer(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForAPIServer(rt.podSpec)
+		setSelfHostedVolumesForAPIServer(defaultCfg, rt.podSpec)
 		sort.Strings(rt.podSpec.Containers[0].Command)
 		sort.Strings(rt.expected.Containers[0].Command)
 
@@ -387,7 +391,7 @@ func TestSetSelfHostedVolumesForControllerManager(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForControllerManager(rt.podSpec)
+		setSelfHostedVolumesForControllerManager(defaultCfg, rt.podSpec)
 		sort.Strings(rt.podSpec.Containers[0].Command)
 		sort.Strings(rt.expected.Containers[0].Command)
 
@@ -457,7 +461,7 @@ func TestSetSelfHostedVolumesForScheduler(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		setSelfHostedVolumesForScheduler(rt.podSpec)
+		setSelfHostedVolumesForScheduler(defaultCfg, rt.podSpec)
 		sort.Strings(rt.podSpec.Containers[0].Command)
 		sort.Strings(rt.expected.Containers[0].Command)
 

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -60,7 +60,7 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 	waiter.SetTimeout(selfHostingWaitTimeout)
 
 	// Here the map of different mutators to use for the control plane's podspec is stored
-	mutators := GetMutatorsFromFeatureGates(cfg.FeatureGates)
+	mutators := GetMutatorsFromFeatureGates(cfg)
 
 	// Some extra work to be done if we should store the control plane certificates in Secrets
 	if features.Enabled(cfg.FeatureGates, features.StoreCertsInSecrets) {
@@ -129,10 +129,10 @@ func CreateSelfHostedControlPlane(manifestsDir, kubeConfigDir string, cfg *kubea
 }
 
 // BuildDaemonSet is responsible for mutating the PodSpec and return a DaemonSet which is suitable for the self-hosting purporse
-func BuildDaemonSet(name string, podSpec *v1.PodSpec, mutators map[string][]PodSpecMutatorFunc) *apps.DaemonSet {
+func BuildDaemonSet(name string, podSpec *v1.PodSpec, mutator PodSpecMutator) *apps.DaemonSet {
 
 	// Mutate the PodSpec so it's suitable for self-hosting
-	mutatePodSpec(mutators, name, podSpec)
+	mutator.mutatePodSpec(name, podSpec)
 
 	// Return a DaemonSet based on that Spec
 	return &apps.DaemonSet{

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -481,7 +481,7 @@ func TestBuildDaemonSet(t *testing.T) {
 			t.Fatalf("couldn't load the specified Pod")
 		}
 
-		ds := BuildDaemonSet(rt.component, podSpec, GetDefaultMutators())
+		ds := BuildDaemonSet(rt.component, podSpec, GetDefault(defaultCfg))
 		dsBytes, err := util.MarshalToYaml(ds, apps.SchemeGroupVersion)
 		if err != nil {
 			t.Fatalf("failed to marshal daemonset to YAML: %v", err)

--- a/cmd/kubeadm/app/phases/upgrade/selfhosted.go
+++ b/cmd/kubeadm/app/phases/upgrade/selfhosted.go
@@ -160,7 +160,7 @@ func SelfHostedControlPlane(client clientset.Interface, waiter apiclient.Waiter,
 // BuildUpgradedDaemonSetsFromConfig takes a config object and the current version and returns the DaemonSet objects to post to the master
 func BuildUpgradedDaemonSetsFromConfig(cfg *kubeadmapi.MasterConfiguration, k8sVersion *version.Version) map[string]*apps.DaemonSet {
 	// Here the map of different mutators to use for the control plane's podspec is stored
-	mutators := selfhosting.GetMutatorsFromFeatureGates(cfg.FeatureGates)
+	mutators := selfhosting.GetMutatorsFromFeatureGates(cfg)
 	// Get the new PodSpecs to use
 	controlPlanePods := controlplane.GetStaticPodSpecs(cfg, k8sVersion)
 	// Store the created DaemonSets in this map


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors pod spec mutation so that every mutator function now has access to config. This is needed for self-hosted etcd because we need a new mutator to update the apiserver's `--etcd-servers` and etcd TLS flags with config defined values.

**Release note**:
```release-note
NONE
```

/cc @luxas 