### PR TITLE
conversion-gen: cut off kube dependencies in extra-peer-dirs

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -628,6 +628,7 @@ CONVERSION_DIRS := $(shell                                              \
 )
 
 CONVERSION_FILES := $(addsuffix /$(CONVERSION_FILENAME), $(CONVERSION_DIRS))
+CONVERSION_EXTRA_PEER_DIRS := k8s.io/kubernetes/pkg/api,k8s.io/kubernetes/pkg/api/v1,k8s.io/api/core/v1
 
 # Shell function for reuse in rules.
 RUN_GEN_CONVERSION =                                                         \
@@ -638,6 +639,7 @@ RUN_GEN_CONVERSION =                                                         \
                 echo "DBG: running $(CONVERSION_GEN) for $$pkgs";            \
             fi;                                                              \
             ./hack/run-in-gopath.sh $(CONVERSION_GEN)                        \
+                --extra-peer-dirs $(CONVERSION_EXTRA_PEER_DIRS)              \
                 --v $(KUBE_VERBOSE)                                          \
                 --logtostderr                                                \
                 -i "$$pkgs"                                                  \

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -32,9 +32,23 @@ import (
 	"github.com/golang/glog"
 )
 
+// DefaultBasePeerDirs are the peer-dirs nearly everybody will use, i.e. those coming from
+// apimachinery.
+var DefaultBasePeerDirs = []string{
+	"k8s.io/apimachinery/pkg/apis/meta/v1",
+	"k8s.io/apimachinery/pkg/conversion",
+	"k8s.io/apimachinery/pkg/runtime",
+}
+
 // CustomArgs is used by the gengo framework to pass args specific to this generator.
 type CustomArgs struct {
-	ExtraPeerDirs []string // Always consider these as last-ditch possibilities for conversions.
+	// Base peer dirs which nearly everybody will use, i.e. outside of Kubernetes core.
+	BasePeerDirs []string
+
+	// Custom peer dirs which are application specific. Always consider these as
+	// last-ditch possibilities for conversions.
+	ExtraPeerDirs []string //
+
 	// Skipunsafe indicates whether to generate unsafe conversions to improve the efficiency
 	// of these operations. The unsafe operation is a direct pointer assignment via unsafe
 	// (within the allowed uses of unsafe) and is equivalent to a proposed Golang change to
@@ -247,9 +261,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		}
 		skipUnsafe := false
 		if customArgs, ok := arguments.CustomArgs.(*CustomArgs); ok {
-			if len(customArgs.ExtraPeerDirs) > 0 {
-				peerPkgs = append(peerPkgs, customArgs.ExtraPeerDirs...)
-			}
+			peerPkgs = append(peerPkgs, customArgs.BasePeerDirs...)
+			peerPkgs = append(peerPkgs, customArgs.ExtraPeerDirs...)
 			skipUnsafe = customArgs.SkipUnsafe
 		}
 

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/main.go
@@ -48,21 +48,14 @@ func main() {
 	arguments := args.Default()
 
 	// Custom args.
-	// TODO: make callers pass this in.  It is too opaque here, and any use of
-	// the flag that DOESN'T include these is broken.
 	customArgs := &generators.CustomArgs{
-		ExtraPeerDirs: []string{
-			"k8s.io/kubernetes/pkg/api",
-			"k8s.io/kubernetes/pkg/api/v1",
-			"k8s.io/api/core/v1",
-			"k8s.io/apimachinery/pkg/apis/meta/v1",
-			"k8s.io/apimachinery/pkg/conversion",
-			"k8s.io/apimachinery/pkg/runtime",
-		},
-		SkipUnsafe: false,
+		BasePeerDirs: generators.DefaultBasePeerDirs,
+		SkipUnsafe:   false,
 	}
+	pflag.CommandLine.StringSliceVar(&customArgs.BasePeerDirs, "base-peer-dirs", customArgs.BasePeerDirs,
+		"Comma-separated list of apimachinery import paths which are considered, after tag-specified peers, for conversions. Only change these if you have very good reasons.")
 	pflag.CommandLine.StringSliceVar(&customArgs.ExtraPeerDirs, "extra-peer-dirs", customArgs.ExtraPeerDirs,
-		"Comma-separated list of import paths which are considered, after tag-specified peers, for conversions.")
+		"Application specific comma-separated list of import paths which are considered, after tag-specified peers and base-peer-dirs, for conversions.")
 	pflag.CommandLine.BoolVar(&customArgs.SkipUnsafe, "skip-unsafe", customArgs.SkipUnsafe,
 		"If true, will not generate code using unsafe pointer conversions; resulting code may be slower.")
 


### PR DESCRIPTION
Fixes #54301

This makes conversion-gen usable in a context without a vendored k8s.io/kubernetes.

```release-note
In conversion-gen removed Kubernetes core API from default extra-peer-dirs.
```