### PR TITLE
set pod phase when deleting pods

### DIFF
--- a/pkg/controller/node/util/controller_utils.go
+++ b/pkg/controller/node/util/controller_utils.go
@@ -60,7 +60,7 @@ func DeletePods(kubeClient clientset.Interface, recorder record.EventRecorder, n
 	remaining := false
 	selector := fields.OneTermEqualSelector(api.PodHostField, nodeName).String()
 	options := metav1.ListOptions{FieldSelector: selector}
-	pods, err := kubeClient.Core().Pods(metav1.NamespaceAll).List(options)
+	pods, err := kubeClient.CoreV1().Pods(metav1.NamespaceAll).List(options)
 	var updateErrList []error
 
 	if err != nil {
@@ -76,6 +76,9 @@ func DeletePods(kubeClient clientset.Interface, recorder record.EventRecorder, n
 		if pod.Spec.NodeName != nodeName {
 			continue
 		}
+
+		// Set pod phase to Unknown, since it may caused by node unresponsive
+		pod.Status.Phase = v1.PodUnknown
 
 		// Set reason and message in the pod object.
 		if _, err = SetPodTerminationReason(kubeClient, &pod, nodeName); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When working on #54368, I found `status.phase` had not been set correctly.
```json
        "message": "Node server-02 which was running pod web-0 is unresponsive",
        "phase": "Running",
        "podIP": "172.17.0.2",
        "qosClass": "BestEffort",
        "reason": "NodeLost",
        "startTime": "2017-10-23T05:15:39Z"
```

Please refer to [completed pod in json](https://github.com/kubernetes/kubernetes/issues/54390).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
/assign @smarterclayton @bowei 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
set pod phase when deleting pods
```
