### PR TITLE
codegen: allow to easely extended namer exceptions

### DIFF
--- a/hack/codegen-naming-exceptions.yaml
+++ b/hack/codegen-naming-exceptions.yaml
@@ -1,0 +1,8 @@
+plural:
+  # These exceptions are used to avoid bad pluralization (Endpoints->Endpointses, etc..)
+  Endpoints: Endpoints
+public:
+  # These exceptions are used to deconflict the generated code. You can put your
+  # fully qualified package to generate a name that does not conflict with your
+  # group.
+private:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -59,10 +59,10 @@ GV_DIRS_CSV=$(IFS=',';echo "${GV_DIRS[*]// /,}";IFS=$)
 
 # This can be called with one flag, --verify-only, so it works for both the
 # update- and verify- scripts.
-${clientgen} "$@"
-${clientgen} --output-base "${KUBE_ROOT}/vendor" --clientset-path="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" "$@"
+${clientgen} --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" "$@"
+${clientgen} --output-base "${KUBE_ROOT}/vendor" --clientset-path="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" "$@"
 # Clientgen for federation clientset.
-${clientgen} --clientset-name=federation_clientset --clientset-path=k8s.io/kubernetes/federation/client/clientset_generated --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="../../../federation/apis/federation/v1beta1","core/v1","extensions/v1beta1","batch/v1","autoscaling/v1" --included-types-overrides="core/v1/Service,core/v1/Namespace,extensions/v1beta1/ReplicaSet,core/v1/Secret,extensions/v1beta1/Ingress,extensions/v1beta1/Deployment,extensions/v1beta1/DaemonSet,core/v1/ConfigMap,core/v1/Event,batch/v1/Job,autoscaling/v1/HorizontalPodAutoscaler"   "$@"
+${clientgen} --clientset-name=federation_clientset --clientset-path=k8s.io/kubernetes/federation/client/clientset_generated --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="../../../federation/apis/federation/v1beta1","core/v1","extensions/v1beta1","batch/v1","autoscaling/v1" --included-types-overrides="core/v1/Service,core/v1/Namespace,extensions/v1beta1/ReplicaSet,core/v1/Secret,extensions/v1beta1/Ingress,extensions/v1beta1/Deployment,extensions/v1beta1/DaemonSet,core/v1/ConfigMap,core/v1/Event,batch/v1/Job,autoscaling/v1/HorizontalPodAutoscaler" --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" "$@"
 
 listergen_internal_apis=(
 pkg/api
@@ -73,7 +73,7 @@ $(
 )
 listergen_internal_apis=(${listergen_internal_apis[@]/#/k8s.io/kubernetes/})
 listergen_internal_apis_csv=$(IFS=,; echo "${listergen_internal_apis[*]}")
-${listergen} --input-dirs "${listergen_internal_apis_csv}" "$@"
+${listergen} --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" --input-dirs "${listergen_internal_apis_csv}" "$@"
 
 listergen_external_apis=(
 $(
@@ -83,7 +83,12 @@ $(
 )
 )
 listergen_external_apis_csv=$(IFS=,; echo "${listergen_external_apis[*]}")
-${listergen} --output-base "${KUBE_ROOT}/vendor" --output-package "k8s.io/client-go/listers" --input-dirs "${listergen_external_apis_csv}" "$@"
+${listergen} \
+  --output-base "${KUBE_ROOT}/vendor" \
+  --output-package "k8s.io/client-go/listers" \
+  --input-dirs "${listergen_external_apis_csv}" \
+  --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" \
+  "$@"
 
 informergen_internal_apis=(
 pkg/api
@@ -98,6 +103,7 @@ ${informergen} \
   --input-dirs "${informergen_internal_apis_csv}" \
   --internal-clientset-package k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset \
   --listers-package k8s.io/kubernetes/pkg/client/listers \
+  --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" \
   "$@"
 
 informergen_external_apis=(
@@ -117,6 +123,7 @@ ${informergen} \
   --input-dirs "${informergen_external_apis_csv}" \
   --versioned-clientset-package k8s.io/client-go/kubernetes \
   --listers-package k8s.io/client-go/listers \
+  --namer-exceptions-file "${KUBE_ROOT}/hack/codegen-naming-exceptions.yaml" \
   "$@"
 
 # You may add additional calls of code generators like set-gen above.

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/BUILD
@@ -16,6 +16,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/client-gen/args",
     deps = [
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/types:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -17,10 +17,21 @@ limitations under the License.
 package args
 
 import (
+	"io/ioutil"
+
 	"github.com/spf13/pflag"
+	yaml "gopkg.in/yaml.v2"
 
 	"k8s.io/code-generator/cmd/client-gen/types"
 )
+
+// NamerExceptions contains public, private and plural name exceptions for
+// custom types.
+type NamerExceptions struct {
+	PublicNamerExceptions  map[string]string `yaml:"public"`
+	PrivateNamerExceptions map[string]string `yaml:"private"`
+	PluralNamerExceptions  map[string]string `yaml:"plural"`
+}
 
 // ClientGenArgs is a wrapper for arguments to client-gen.
 type CustomArgs struct {
@@ -80,4 +91,20 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
 	pflag.StringVar(&ca.ClientsetOutputPath, "clientset-path", "k8s.io/kubernetes/pkg/client/clientset_generated/", "the generated clientset will be output to <clientset-path>/<clientset-name>.")
 	pflag.BoolVar(&ca.ClientsetOnly, "clientset-only", false, "when set, client-gen only generates the clientset shell, without generating the individual typed clients")
 	pflag.BoolVar(&ca.FakeClient, "fake-clientset", true, "when set, client-gen will generate the fake clientset that can be used in tests")
+}
+
+// LoadNamerExceptions loads the namer exception from provided YAML file.
+func LoadNamerExceptions(fileName string) (NamerExceptions, error) {
+	var result NamerExceptions
+	if len(fileName) == 0 {
+		return result, nil
+	}
+	f, err := ioutil.ReadFile(fileName)
+	if err != nil {
+		return result, err
+	}
+	if err := yaml.Unmarshal(f, &result); err != nil {
+		return result, err
+	}
+	return result, err
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -36,31 +36,19 @@ import (
 )
 
 // NameSystems returns the name system used by the generators in this package.
-func NameSystems() namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+func NameSystems(exceptions clientgenargs.NamerExceptions) namer.NameSystems {
+	pluralExceptions := exceptions.PluralNamerExceptions
 	lowercaseNamer := namer.NewAllLowercasePluralNamer(pluralExceptions)
 
 	publicNamer := &ExceptionNamer{
-		Exceptions: map[string]string{
-		// these exceptions are used to deconflict the generated code
-		// you can put your fully qualified package like
-		// to generate a name that doesn't conflict with your group.
-		// "k8s.io/apis/events/v1alpha1.Event": "EventResource"
-		},
+		Exceptions: exceptions.PublicNamerExceptions,
 		KeyFunc: func(t *types.Type) string {
 			return t.Name.Package + "." + t.Name.Name
 		},
 		Delegate: namer.NewPublicNamer(0),
 	}
 	privateNamer := &ExceptionNamer{
-		Exceptions: map[string]string{
-		// these exceptions are used to deconflict the generated code
-		// you can put your fully qualified package like
-		// to generate a name that doesn't conflict with your group.
-		// "k8s.io/apis/events/v1alpha1.Event": "eventResource"
-		},
+		Exceptions: exceptions.PrivateNamerExceptions,
 		KeyFunc: func(t *types.Type) string {
 			return t.Name.Package + "." + t.Name.Name
 		},

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -37,6 +37,8 @@ func main() {
 	customArgs := &clientgenargs.CustomArgs{}
 	customArgs.AddFlags(pflag.CommandLine)
 
+	namerExceptionFile := pflag.StringP("namer-exceptions-file", "", "", "a YAML file that contains namer exceptions.")
+
 	// Override defaults.
 	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
 	arguments.CustomArgs = customArgs
@@ -61,8 +63,13 @@ func main() {
 		arguments.InputDirs = append(arguments.InputDirs, pkg)
 	}
 
+	exceptions, err := clientgenargs.LoadNamerExceptions(*namerExceptionFile)
+	if err != nil {
+		glog.Fatalf("Unable to load namer exceptions from %q: %v", namerExceptionFile, err)
+	}
+
 	if err := arguments.Execute(
-		generators.NameSystems(),
+		generators.NameSystems(exceptions),
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/code-generator/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/informer-gen/generators:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/BUILD
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/code-generator/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/types:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/customargs.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/customargs.go
@@ -16,13 +16,20 @@ limitations under the License.
 
 package generators
 
-import "github.com/spf13/pflag"
+import (
+	"github.com/spf13/pflag"
+
+	clientgenargs "k8s.io/code-generator/cmd/client-gen/args"
+)
 
 type CustomArgs struct {
 	VersionedClientSetPackage string
 	InternalClientSetPackage  string
 	ListersPackage            string
 	SingleDirectory           bool
+
+	// We need to pass this to Packages()
+	NamerExceptions clientgenargs.NamerExceptions
 }
 
 func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	clientgenargs "k8s.io/code-generator/cmd/client-gen/args"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -35,6 +36,7 @@ type genericGenerator struct {
 	groupVersions        map[string]clientgentypes.GroupVersions
 	typesForGroupVersion map[clientgentypes.GroupVersion][]*types.Type
 	filtered             bool
+	exceptions           clientgenargs.NamerExceptions
 }
 
 var _ generator.Generator = &genericGenerator{}
@@ -48,9 +50,7 @@ func (g *genericGenerator) Filter(c *generator.Context, t *types.Type) bool {
 }
 
 func (g *genericGenerator) Namers(c *generator.Context) namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+	pluralExceptions := g.exceptions.PluralNamerExceptions
 	return namer.NameSystems{
 		"raw":                namer.NewRawNamer(g.outputPackage, g.imports),
 		"allLowercasePlural": namer.NewAllLowercasePluralNamer(pluralExceptions),

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/BUILD
@@ -18,6 +18,8 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/lister-gen",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/code-generator/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/lister-gen/generators:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
     ],

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/lister-gen/generators",
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/code-generator/cmd/client-gen/args:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/generators/util:go_default_library",
         "//vendor/k8s.io/code-generator/cmd/client-gen/types:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/gengo/namer"
 	"k8s.io/gengo/types"
 
+	clientgenargs "k8s.io/code-generator/cmd/client-gen/args"
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 
@@ -34,16 +35,13 @@ import (
 )
 
 // NameSystems returns the name system used by the generators in this package.
-func NameSystems() namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+func NameSystems(exceptions clientgenargs.NamerExceptions) namer.NameSystems {
 	return namer.NameSystems{
 		"public":             namer.NewPublicNamer(0),
 		"private":            namer.NewPrivateNamer(0),
 		"raw":                namer.NewRawNamer("", nil),
-		"publicPlural":       namer.NewPublicPluralNamer(pluralExceptions),
-		"allLowercasePlural": namer.NewAllLowercasePluralNamer(pluralExceptions),
+		"publicPlural":       namer.NewPublicPluralNamer(exceptions.PluralNamerExceptions),
+		"allLowercasePlural": namer.NewAllLowercasePluralNamer(exceptions.PluralNamerExceptions),
 		"lowercaseSingular":  &lowercaseSingularNamer{},
 	}
 }

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
@@ -17,24 +17,38 @@ limitations under the License.
 package main
 
 import (
+	"flag"
 	"path/filepath"
 
+	"github.com/golang/glog"
+	"github.com/spf13/pflag"
+
+	clientgenargs "k8s.io/code-generator/cmd/client-gen/args"
 	"k8s.io/code-generator/cmd/lister-gen/generators"
 	"k8s.io/gengo/args"
-
-	"github.com/golang/glog"
 )
 
 func main() {
-	arguments := args.Default()
+	arguments := args.Default().WithoutDefaultFlagParsing()
+
+	namerExceptionFile := pflag.StringP("namer-exceptions-file", "", "", "a YAML file that contains namer exceptions.")
 
 	// Override defaults.
 	arguments.GoHeaderFilePath = filepath.Join(args.DefaultSourceTree(), "k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt")
 	arguments.OutputPackagePath = "k8s.io/kubernetes/pkg/client/listers"
 
+	arguments.AddFlags(pflag.CommandLine)
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.Parse()
+
+	exceptions, err := clientgenargs.LoadNamerExceptions(*namerExceptionFile)
+	if err != nil {
+		glog.Fatalf("Unable to load namer exceptions from %s: %v", namerExceptionFile, err)
+	}
+
 	// Run it.
 	if err := arguments.Execute(
-		generators.NameSystems(),
+		generators.NameSystems(exceptions),
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow to extended the *-gen namer exception definitions using the `--namer-exceptions-file` flag that points to a YAML file with public, private and plural naming exceptions for custom types.

For now I kept the hardcoded `Endpoints` in place to not break anyone. 

The format of the YAML file is:

```yaml
public:
  "github.com/openshift/origin/pkg/build/apis/build/v1.Build": BuildResource
private:
  "github.com/openshift/origin/pkg/build/apis/build/v1.Build": buildResource
plural:
  Endpoints: Endpoints
  SecurityContextConstraints: SecurityContextConstraints
```

**Release note**:
```release-note
```
