### PR TITLE
Use CIDR-aware proxy resolver for SPDY RoundTripper

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -110,7 +110,7 @@ func (s *SpdyRoundTripper) Dial(req *http.Request) (net.Conn, error) {
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 	proxier := s.proxier
 	if proxier == nil {
-		proxier = http.ProxyFromEnvironment
+		proxier = utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 	}
 	proxyURL, err := proxier(req)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**: `kubectl attach` for example doesn't work if NO_PROXY specifies API endpoint IP via CIDR notation.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54407

**Special notes for your reviewer**: Potentially it will be good to get that change to 1.8.x

**Release note**:
```release-note
API machinery's httpstream/spdy calls now support CIDR notation for NO_PROXY
```
