### PR TITLE
Automated cherry pick of #54257

### DIFF
--- a/pkg/client/listers/admissionregistration/internalversion/BUILD
+++ b/pkg/client/listers/admissionregistration/internalversion/BUILD
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//pkg/apis/admissionregistration:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/externaladmissionhookconfiguration.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
@@ -55,8 +54,7 @@ func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector
 
 // Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 func (s *externalAdmissionHookConfigurationLister) Get(name string) (*admissionregistration.ExternalAdmissionHookConfiguration, error) {
-	key := &admissionregistration.ExternalAdmissionHookConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
+++ b/pkg/client/listers/admissionregistration/internalversion/initializerconfiguration.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	admissionregistration "k8s.io/kubernetes/pkg/apis/admissionregistration"
@@ -55,8 +54,7 @@ func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the InitializerConfiguration from the index for a given name.
 func (s *initializerConfigurationLister) Get(name string) (*admissionregistration.InitializerConfiguration, error) {
-	key := &admissionregistration.InitializerConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authentication/internalversion/BUILD
+++ b/pkg/client/listers/authentication/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/apis/authentication:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/authentication/internalversion/tokenreview.go
+++ b/pkg/client/listers/authentication/internalversion/tokenreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authentication "k8s.io/kubernetes/pkg/apis/authentication"
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*authenticatio
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*authentication.TokenReview, error) {
-	key := &authentication.TokenReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/internalversion/BUILD
+++ b/pkg/client/listers/authorization/internalversion/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//pkg/apis/authorization:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/selfsubjectaccessreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*a
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*authorization.SelfSubjectAccessReview, error) {
-	key := &authorization.SelfSubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/internalversion/selfsubjectrulesreview.go
+++ b/pkg/client/listers/authorization/internalversion/selfsubjectrulesreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -55,8 +54,7 @@ func (s *selfSubjectRulesReviewLister) List(selector labels.Selector) (ret []*au
 
 // Get retrieves the SelfSubjectRulesReview from the index for a given name.
 func (s *selfSubjectRulesReviewLister) Get(name string) (*authorization.SelfSubjectRulesReview, error) {
-	key := &authorization.SelfSubjectRulesReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
+++ b/pkg/client/listers/authorization/internalversion/subjectaccessreview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	authorization "k8s.io/kubernetes/pkg/apis/authorization"
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*autho
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*authorization.SubjectAccessReview, error) {
-	key := &authorization.SubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/certificates/internalversion/BUILD
+++ b/pkg/client/listers/certificates/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/apis/certificates:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
+++ b/pkg/client/listers/certificates/internalversion/certificatesigningrequest.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	certificates "k8s.io/kubernetes/pkg/apis/certificates"
@@ -55,8 +54,7 @@ func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*certificates.CertificateSigningRequest, error) {
-	key := &certificates.CertificateSigningRequest{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/BUILD
+++ b/pkg/client/listers/core/internalversion/BUILD
@@ -32,7 +32,6 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/core/internalversion/componentstatus.go
+++ b/pkg/client/listers/core/internalversion/componentstatus.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *componentStatusLister) List(selector labels.Selector) (ret []*api.Compo
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*api.ComponentStatus, error) {
-	key := &api.ComponentStatus{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/namespace.go
+++ b/pkg/client/listers/core/internalversion/namespace.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *namespaceLister) List(selector labels.Selector) (ret []*api.Namespace, 
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*api.Namespace, error) {
-	key := &api.Namespace{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/node.go
+++ b/pkg/client/listers/core/internalversion/node.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *nodeLister) List(selector labels.Selector) (ret []*api.Node, err error)
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*api.Node, error) {
-	key := &api.Node{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/core/internalversion/persistentvolume.go
+++ b/pkg/client/listers/core/internalversion/persistentvolume.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	api "k8s.io/kubernetes/pkg/api"
@@ -55,8 +54,7 @@ func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*api.Pers
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*api.PersistentVolume, error) {
-	key := &api.PersistentVolume{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
+++ b/pkg/client/listers/extensions/internalversion/podsecuritypolicy.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -55,8 +54,7 @@ func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*extensi
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*extensions.PodSecurityPolicy, error) {
-	key := &extensions.PodSecurityPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
+++ b/pkg/client/listers/extensions/internalversion/thirdpartyresource.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	extensions "k8s.io/kubernetes/pkg/apis/extensions"
@@ -55,8 +54,7 @@ func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*extens
 
 // Get retrieves the ThirdPartyResource from the index for a given name.
 func (s *thirdPartyResourceLister) Get(name string) (*extensions.ThirdPartyResource, error) {
-	key := &extensions.ThirdPartyResource{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/imagepolicy/internalversion/BUILD
+++ b/pkg/client/listers/imagepolicy/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/apis/imagepolicy:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/imagepolicy/internalversion/imagereview.go
+++ b/pkg/client/listers/imagepolicy/internalversion/imagereview.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	imagepolicy "k8s.io/kubernetes/pkg/apis/imagepolicy"
@@ -55,8 +54,7 @@ func (s *imageReviewLister) List(selector labels.Selector) (ret []*imagepolicy.I
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*imagepolicy.ImageReview, error) {
-	key := &imagepolicy.ImageReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/internalversion/BUILD
+++ b/pkg/client/listers/rbac/internalversion/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//pkg/apis/rbac:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/rbac/internalversion/clusterrole.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrole.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*rbac.ClusterR
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*rbac.ClusterRole, error) {
-	key := &rbac.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
+++ b/pkg/client/listers/rbac/internalversion/clusterrolebinding.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	rbac "k8s.io/kubernetes/pkg/apis/rbac"
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*rbac.C
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*rbac.ClusterRoleBinding, error) {
-	key := &rbac.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/scheduling/internalversion/BUILD
+++ b/pkg/client/listers/scheduling/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/apis/scheduling:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/scheduling/internalversion/priorityclass.go
+++ b/pkg/client/listers/scheduling/internalversion/priorityclass.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling"
@@ -55,8 +54,7 @@ func (s *priorityClassLister) List(selector labels.Selector) (ret []*scheduling.
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*scheduling.PriorityClass, error) {
-	key := &scheduling.PriorityClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/listers/storage/internalversion/BUILD
+++ b/pkg/client/listers/storage/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/apis/storage:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/pkg/client/listers/storage/internalversion/storageclass.go
+++ b/pkg/client/listers/storage/internalversion/storageclass.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	storage "k8s.io/kubernetes/pkg/apis/storage"
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*storage.Stor
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*storage.StorageClass, error) {
-	key := &storage.StorageClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/internalversion/customresourcedefinition.go
@@ -21,7 +21,6 @@ package internalversion
 import (
 	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*apiextensions.CustomResourceDefinition, error) {
-	key := &apiextensions.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/listers/apiextensions/v1beta1/customresourcedefinition.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *customResourceDefinitionLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the CustomResourceDefinition from the index for a given name.
 func (s *customResourceDefinitionLister) Get(name string) (*v1beta1.CustomResourceDefinition, error) {
-	key := &v1beta1.CustomResourceDefinition{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/BUILD
@@ -15,7 +15,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/externaladmissionhookconfiguration.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *externalAdmissionHookConfigurationLister) List(selector labels.Selector
 
 // Get retrieves the ExternalAdmissionHookConfiguration from the index for a given name.
 func (s *externalAdmissionHookConfigurationLister) Get(name string) (*v1alpha1.ExternalAdmissionHookConfiguration, error) {
-	key := &v1alpha1.ExternalAdmissionHookConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
+++ b/staging/src/k8s.io/client-go/listers/admissionregistration/v1alpha1/initializerconfiguration.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/admissionregistration/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *initializerConfigurationLister) List(selector labels.Selector) (ret []*
 
 // Get retrieves the InitializerConfiguration from the index for a given name.
 func (s *initializerConfigurationLister) Get(name string) (*v1alpha1.InitializerConfiguration, error) {
-	key := &v1alpha1.InitializerConfiguration{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authentication/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authentication/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/authentication/v1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1/tokenreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authentication/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1.TokenRevie
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1.TokenReview, error) {
-	key := &v1.TokenReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authentication/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authentication/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
+++ b/staging/src/k8s.io/client-go/listers/authentication/v1beta1/tokenreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authentication/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *tokenReviewLister) List(selector labels.Selector) (ret []*v1beta1.Token
 
 // Get retrieves the TokenReview from the index for a given name.
 func (s *tokenReviewLister) Get(name string) (*v1beta1.TokenReview, error) {
-	key := &v1beta1.TokenReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectaccessreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1.SelfSubjectAccessReview, error) {
-	key := &v1.SelfSubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/selfsubjectrulesreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectRulesReviewLister) List(selector labels.Selector) (ret []*v1
 
 // Get retrieves the SelfSubjectRulesReview from the index for a given name.
 func (s *selfSubjectRulesReviewLister) Get(name string) (*v1.SelfSubjectRulesReview, error) {
-	key := &v1.SelfSubjectRulesReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1/subjectaccessreview.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1.Su
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1.SubjectAccessReview, error) {
-	key := &v1.SubjectAccessReview{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/authorization/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectaccessreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectAccessReviewLister) List(selector labels.Selector) (ret []*v
 
 // Get retrieves the SelfSubjectAccessReview from the index for a given name.
 func (s *selfSubjectAccessReviewLister) Get(name string) (*v1beta1.SelfSubjectAccessReview, error) {
-	key := &v1beta1.SelfSubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectrulesreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/selfsubjectrulesreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *selfSubjectRulesReviewLister) List(selector labels.Selector) (ret []*v1
 
 // Get retrieves the SelfSubjectRulesReview from the index for a given name.
 func (s *selfSubjectRulesReviewLister) Get(name string) (*v1beta1.SelfSubjectRulesReview, error) {
-	key := &v1beta1.SelfSubjectRulesReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
+++ b/staging/src/k8s.io/client-go/listers/authorization/v1beta1/subjectaccessreview.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/authorization/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *subjectAccessReviewLister) List(selector labels.Selector) (ret []*v1bet
 
 // Get retrieves the SubjectAccessReview from the index for a given name.
 func (s *subjectAccessReviewLister) Get(name string) (*v1beta1.SubjectAccessReview, error) {
-	key := &v1beta1.SubjectAccessReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/certificates/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/listers/certificates/v1beta1/certificatesigningrequest.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *certificateSigningRequestLister) List(selector labels.Selector) (ret []
 
 // Get retrieves the CertificateSigningRequest from the index for a given name.
 func (s *certificateSigningRequestLister) Get(name string) (*v1beta1.CertificateSigningRequest, error) {
-	key := &v1beta1.CertificateSigningRequest{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/core/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/core/v1/BUILD
@@ -32,7 +32,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/componentstatus.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *componentStatusLister) List(selector labels.Selector) (ret []*v1.Compon
 
 // Get retrieves the ComponentStatus from the index for a given name.
 func (s *componentStatusLister) Get(name string) (*v1.ComponentStatus, error) {
-	key := &v1.ComponentStatus{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/namespace.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *namespaceLister) List(selector labels.Selector) (ret []*v1.Namespace, e
 
 // Get retrieves the Namespace from the index for a given name.
 func (s *namespaceLister) Get(name string) (*v1.Namespace, error) {
-	key := &v1.Namespace{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/node.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *nodeLister) List(selector labels.Selector) (ret []*v1.Node, err error) 
 
 // Get retrieves the Node from the index for a given name.
 func (s *nodeLister) Get(name string) (*v1.Node, error) {
-	key := &v1.Node{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/listers/core/v1/persistentvolume.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *persistentVolumeLister) List(selector labels.Selector) (ret []*v1.Persi
 
 // Get retrieves the PersistentVolume from the index for a given name.
 func (s *persistentVolumeLister) Get(name string) (*v1.PersistentVolume, error) {
-	key := &v1.PersistentVolume{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/podsecuritypolicy.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *podSecurityPolicyLister) List(selector labels.Selector) (ret []*v1beta1
 
 // Get retrieves the PodSecurityPolicy from the index for a given name.
 func (s *podSecurityPolicyLister) Get(name string) (*v1beta1.PodSecurityPolicy, error) {
-	key := &v1beta1.PodSecurityPolicy{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
+++ b/staging/src/k8s.io/client-go/listers/extensions/v1beta1/thirdpartyresource.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *thirdPartyResourceLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ThirdPartyResource from the index for a given name.
 func (s *thirdPartyResourceLister) Get(name string) (*v1beta1.ThirdPartyResource, error) {
-	key := &v1beta1.ThirdPartyResource{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/imagepolicy/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
+++ b/staging/src/k8s.io/client-go/listers/imagepolicy/v1alpha1/imagereview.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/imagepolicy/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *imageReviewLister) List(selector labels.Selector) (ret []*v1alpha1.Imag
 
 // Get retrieves the ImageReview from the index for a given name.
 func (s *imageReviewLister) Get(name string) (*v1alpha1.ImageReview, error) {
-	key := &v1alpha1.ImageReview{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrole.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1.ClusterRol
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1.ClusterRole, error) {
-	key := &v1.ClusterRole{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1.Clu
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1.ClusterRoleBinding, error) {
-	key := &v1.ClusterRoleBinding{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrole.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1alpha1.Clus
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1alpha1.ClusterRole, error) {
-	key := &v1alpha1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1alpha1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1alph
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1alpha1.ClusterRoleBinding, error) {
-	key := &v1alpha1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/BUILD
@@ -17,7 +17,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/rbac/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrole.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleLister) List(selector labels.Selector) (ret []*v1beta1.Clust
 
 // Get retrieves the ClusterRole from the index for a given name.
 func (s *clusterRoleLister) Get(name string) (*v1beta1.ClusterRole, error) {
-	key := &v1beta1.ClusterRole{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/listers/rbac/v1beta1/clusterrolebinding.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/rbac/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *clusterRoleBindingLister) List(selector labels.Selector) (ret []*v1beta
 
 // Get retrieves the ClusterRoleBinding from the index for a given name.
 func (s *clusterRoleBindingLister) Get(name string) (*v1beta1.ClusterRoleBinding, error) {
-	key := &v1beta1.ClusterRoleBinding{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/scheduling/v1alpha1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/listers/scheduling/v1alpha1/priorityclass.go
@@ -21,7 +21,6 @@ package v1alpha1
 import (
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *priorityClassLister) List(selector labels.Selector) (ret []*v1alpha1.Pr
 
 // Get retrieves the PriorityClass from the index for a given name.
 func (s *priorityClassLister) Get(name string) (*v1alpha1.PriorityClass, error) {
-	key := &v1alpha1.PriorityClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/storage/v1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1/storageclass.go
@@ -21,7 +21,6 @@ package v1
 import (
 	v1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1.StorageCl
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1.StorageClass, error) {
-	key := &v1.StorageClass{ObjectMeta: meta_v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/BUILD
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/BUILD
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//vendor/k8s.io/api/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/listers/storage/v1beta1/storageclass.go
@@ -21,7 +21,6 @@ package v1beta1
 import (
 	v1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 )
@@ -55,8 +54,7 @@ func (s *storageClassLister) List(selector labels.Selector) (ret []*v1beta1.Stor
 
 // Get retrieves the StorageClass from the index for a given name.
 func (s *storageClassLister) Get(name string) (*v1beta1.StorageClass, error) {
-	key := &v1beta1.StorageClass{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -322,8 +322,7 @@ func (s *$.type|private$Lister) $.type|publicPlural$(namespace string) $.type|pu
 var typeLister_NonNamespacedGet = `
 // Get retrieves the $.type|public$ from the index for a given name.
 func (s *$.type|private$Lister) Get(name string) (*$.type|raw$, error) {
-  key := &$.type|raw${ObjectMeta: $.objectMeta|raw${Name: name}}
-  obj, exists, err := s.indexer.Get(key)
+  obj, exists, err := s.indexer.GetByKey(name)
   if err != nil {
     return nil, err
   }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/internalversion/apiservice.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration"
@@ -55,8 +54,7 @@ func (s *aPIServiceLister) List(selector labels.Selector) (ret []*apiregistratio
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*apiregistration.APIService, error) {
-	key := &apiregistration.APIService{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/BUILD
@@ -13,7 +13,6 @@ go_library(
     ],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/listers/apiregistration/v1beta1/apiservice.go
@@ -20,7 +20,6 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1beta1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -55,8 +54,7 @@ func (s *aPIServiceLister) List(selector labels.Selector) (ret []*v1beta1.APISer
 
 // Get retrieves the APIService from the index for a given name.
 func (s *aPIServiceLister) Get(name string) (*v1beta1.APIService, error) {
-	key := &v1beta1.APIService{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/internalversion/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/internalversion/BUILD
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/internalversion/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/internalversion/fischer.go
@@ -20,7 +20,6 @@ package internalversion
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	wardle "k8s.io/sample-apiserver/pkg/apis/wardle"
@@ -55,8 +54,7 @@ func (s *fischerLister) List(selector labels.Selector) (ret []*wardle.Fischer, e
 
 // Get retrieves the Fischer from the index for a given name.
 func (s *fischerLister) Get(name string) (*wardle.Fischer, error) {
-	key := &wardle.Fischer{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/v1alpha1/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/v1alpha1/BUILD
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/listers/wardle/v1alpha1/fischer.go
@@ -20,7 +20,6 @@ package v1alpha1
 
 import (
 	"k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	v1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
@@ -55,8 +54,7 @@ func (s *fischerLister) List(selector labels.Selector) (ret []*v1alpha1.Fischer,
 
 // Get retrieves the Fischer from the index for a given name.
 func (s *fischerLister) Get(name string) (*v1alpha1.Fischer, error) {
-	key := &v1alpha1.Fischer{ObjectMeta: v1.ObjectMeta{Name: name}}
-	obj, exists, err := s.indexer.Get(key)
+	obj, exists, err := s.indexer.GetByKey(name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Cherry pick of #54257 on release-1.8.

#54257: Use GetByKey() in typeLister_NonNamespacedGet

**Release note**:
```
Optimize excessive memory allocation in resource listers on GET requests
```