### PR TITLE
Adds support for v4/v6 loopback dns bind address.

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -91,10 +91,11 @@ func TestCompileManifests(t *testing.T) {
 	}{
 		{
 			manifest: v180AndAboveKubeDNSDeployment,
-			data: struct{ ImageRepository, Arch, Version, DNSDomain, DNSProbeType, MasterTaintKey string }{
+			data: struct{ ImageRepository, Arch, Version, DNSBindAddr, DNSDomain, DNSProbeType, MasterTaintKey string }{
 				ImageRepository: "foo",
 				Arch:            "foo",
 				Version:         "foo",
+				DNSBindAddr:     "foo",
 				DNSDomain:       "foo",
 				DNSProbeType:    "foo",
 				MasterTaintKey:  "foo",

--- a/cmd/kubeadm/app/phases/addons/dns/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/dns/manifests.go
@@ -123,9 +123,9 @@ spec:
         - --cache-size=1000
         - --no-negcache
         - --log-facility=-
-        - --server=/{{ .DNSDomain }}/127.0.0.1#10053
-        - --server=/in-addr.arpa/127.0.0.1#10053
-        - --server=/ip6.arpa/127.0.0.1#10053
+        - --server=/{{ .DNSDomain }}/{{ .DNSBindAddr }}#10053
+        - --server=/in-addr.arpa/{{ .DNSBindAddr }}#10053
+        - --server=/ip6.arpa/{{ .DNSBindAddr }}#10053
         ports:
         - containerPort: 53
           name: dns
@@ -156,8 +156,8 @@ spec:
         args:
         - --v=2
         - --logtostderr
-        - --probe=kubedns,127.0.0.1:10053,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
-        - --probe=dnsmasq,127.0.0.1:53,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
+        - --probe=kubedns,{{ .DNSBindAddr }}:10053,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
+        - --probe=dnsmasq,{{ .DNSBindAddr }}:53,kubernetes.default.svc.{{ .DNSDomain }},5,{{ .DNSProbeType }}
         ports:
         - containerPort: 10054
           name: metrics


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously, IPv4 Loopback addresses (127.0.0.1) were hard coded into the kubeadm dns deployment manifest. This PR adds support for using an IPv6 Loopback (::1) when the kube-dns Service IP is an IPv6 address.

**Special notes for your reviewer**:
Required for IPv6-only deployments.

**Release note**:
```NONE
```

/area ipv6
/sig network
