### PR TITLE
Add GKE-specific kube-dns deployment

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1783,6 +1783,7 @@ function start-kube-addons {
       cat > "${dns_controller_file}" <<EOF
 $(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT" | sed -e "s/'/''/g")
 EOF
+    fi
     mv "${dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.
     sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_controller_file}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1776,6 +1776,9 @@ function start-kube-addons {
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
     local -r dns_controller_file="${dst_dir}/dns/kubedns-controller.yaml"
+    # Replace with custom GKE deployment
+    echo <<EOF >${dns_controller_file}
+$(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT" | sed -e "s/'/''/g")
     local -r dns_svc_file="${dst_dir}/dns/kubedns-svc.yaml"
     mv "${dst_dir}/dns/kubedns-controller.yaml.in" "${dns_controller_file}"
     mv "${dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1776,11 +1776,13 @@ function start-kube-addons {
   if [[ "${ENABLE_CLUSTER_DNS:-}" == "true" ]]; then
     setup-addon-manifests "addons" "dns"
     local -r dns_controller_file="${dst_dir}/dns/kubedns-controller.yaml"
-    # Replace with custom GKE deployment
-    echo <<EOF >${dns_controller_file}
-$(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT" | sed -e "s/'/''/g")
     local -r dns_svc_file="${dst_dir}/dns/kubedns-svc.yaml"
     mv "${dst_dir}/dns/kubedns-controller.yaml.in" "${dns_controller_file}"
+    if [ -n "${CUSTOM_KUBE_DNS_DEPLOYMENT:-}" ]; then
+      # Replace with custom GKE deployment
+      cat > "${dns_controller_file}" <<EOF
+$(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT" | sed -e "s/'/''/g")
+EOF
     mv "${dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.
     sed -i -e "s@{{ *pillar\['dns_domain'\] *}}@${DNS_DOMAIN}@g" "${dns_controller_file}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1779,10 +1779,11 @@ function start-kube-addons {
     local -r dns_svc_file="${dst_dir}/dns/kubedns-svc.yaml"
     mv "${dst_dir}/dns/kubedns-controller.yaml.in" "${dns_controller_file}"
     if [ -n "${CUSTOM_KUBE_DNS_DEPLOYMENT:-}" ]; then
-      # Replace with custom GKE deployment
+      # Replace with custom GKE kubedns deployment.
       cat > "${dns_controller_file}" <<EOF
-$(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT" | sed -e "s/'/''/g")
+$(echo "$CUSTOM_KUBE_DNS_DEPLOYMENT")
 EOF
+      update-prometheus-to-sd-parameters ${dns_controller_file}
     fi
     mv "${dst_dir}/dns/kubedns-svc.yaml.in" "${dns_svc_file}"
     # Replace the salt configurations with variable values.


### PR DESCRIPTION
This PR adds logic in the configuration scripts to replace the default kube-dns deployment with a custom one specific for GKE. 

Release Note: 
```release-note
NONE
```
