### PR TITLE
Update kube-dns 1.14.7

### DIFF
--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.6
+        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics


### PR DESCRIPTION
kube-adm change will be in a separate commit

```release-note
* Logging cleanups
* Updates kube-dns to use client-go 3
* Updates containers to use alpine as the base image on all platforms
* Adds support for IPv6
```