### PR TITLE
apply/strategy: Improve test performance

### DIFF
--- a/pkg/kubectl/apply/strategy/merge_map_list_test.go
+++ b/pkg/kubectl/apply/strategy/merge_map_list_test.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
+	tst "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/testing"
 )
 
 var _ = Describe("Merging fields of type list-of-map with openapi", func() {
@@ -431,6 +433,11 @@ spec:
 })
 
 var _ = Describe("Merging fields of type list-of-map with openapi containing a multi-field mergekey", func() {
+	var resources openapi.Resources
+	BeforeEach(func() {
+		resources = tst.NewFakeResources("test_swagger.json")
+	})
+
 	Context("where one of the items has been deleted", func() {
 		It("should delete the item", func() {
 			recorded := create(`
@@ -492,7 +499,7 @@ spec:
           protocol: TCP
           hostPort: 2020
 `)
-			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, "test_swagger.json")
+			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, resources)
 		})
 	})
 
@@ -564,7 +571,7 @@ spec:
           hostPort: 2022
           hostIP: "127.0.0.1"
 `)
-			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, "test_swagger.json")
+			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, resources)
 		})
 	})
 
@@ -630,7 +637,7 @@ spec:
           protocol: UDP
           hostPort: 2022
 `)
-			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, "test_swagger.json")
+			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, resources)
 		})
 	})
 })

--- a/pkg/kubectl/apply/strategy/merge_visitor.go
+++ b/pkg/kubectl/apply/strategy/merge_visitor.go
@@ -51,7 +51,6 @@ func (v mergeStrategy) MergeList(e apply.ListElement) (apply.Result, error) {
 			return apply.Result{}, err
 		}
 
-		fmt.Printf("\nResult %+v\n%+v\n", m.MergedResult, value)
 		switch m.Operation {
 		case apply.SET:
 			// Keep the list item value

--- a/pkg/kubectl/apply/strategy/replace_map_test.go
+++ b/pkg/kubectl/apply/strategy/replace_map_test.go
@@ -20,9 +20,16 @@ import (
 	. "github.com/onsi/ginkgo"
 
 	"k8s.io/kubernetes/pkg/kubectl/apply/strategy"
+	"k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi"
+	tst "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/testing"
 )
 
 var _ = Describe("Replacing fields of type map with openapi for some fields", func() {
+	var resources openapi.Resources
+	BeforeEach(func() {
+		resources = tst.NewFakeResources("test_swagger.json")
+	})
+
 	Context("where a field is has been updated", func() {
 		It("should update the field", func() {
 			recorded := create(`
@@ -67,7 +74,7 @@ spec:
 `)
 
 			// Use modified swagger for ReplicaSet spec
-			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, "test_swagger.json")
+			runWith(strategy.Create(strategy.Options{}), recorded, local, remote, expected, resources)
 		})
 	})
 })

--- a/pkg/kubectl/apply/strategy/utils_test.go
+++ b/pkg/kubectl/apply/strategy/utils_test.go
@@ -32,18 +32,14 @@ import (
 	tst "k8s.io/kubernetes/pkg/kubectl/cmd/util/openapi/testing"
 )
 
+var fakeResources = tst.NewFakeResources(filepath.Join("..", "..", "..", "..", "api", "openapi-spec", "swagger.json"))
+
 // run parses the openapi and runs the tests
 func run(instance apply.Strategy, recorded, local, remote, expected map[string]interface{}) {
-	runWith(instance, recorded, local, remote, expected,
-		filepath.Join("..", "..", "..", "..", "api", "openapi-spec", "swagger.json"))
+	runWith(instance, recorded, local, remote, expected, fakeResources)
 }
 
-func runWith(instance apply.Strategy, recorded, local, remote, expected map[string]interface{}, swaggerPath string) {
-	fakeSchema := tst.Fake{Path: swaggerPath}
-	s, err := fakeSchema.OpenAPISchema()
-	Expect(err).To(BeNil())
-	resources, err := openapi.NewOpenAPIData(s)
-	Expect(err).To(BeNil())
+func runWith(instance apply.Strategy, recorded, local, remote, expected map[string]interface{}, resources openapi.Resources) {
 	parseFactory := parse.Factory{Resources: resources}
 
 	parsed, err := parseFactory.CreateElement(recorded, local, remote)


### PR DESCRIPTION
**What this PR does / why we need it**:

Test running time goes from 150 seconds to 7 seconds with that one
simple trick. Do not re-parse openapi schema for every test, but keep
one version for the whole suite (specifically since it's read-only anyway).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
