### PR TITLE
Migrate cluster dns test to sig network

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -39,7 +39,6 @@ go_library(
     srcs = [
         "e2e.go",
         "events.go",
-        "example_cluster_dns.go",
         "examples.go",
         "gke_local_ssd.go",
         "gke_node_pools.go",

--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -598,17 +598,6 @@ func makeHttpRequestToService(c clientset.Interface, ns, service, path string, t
 	return string(result), err
 }
 
-// pass enough context with the 'old' parameter so that it replaces what your really intended.
-func prepareResourceWithReplacedString(inputFile, old, new string) string {
-	f, err := os.Open(inputFile)
-	Expect(err).NotTo(HaveOccurred())
-	defer f.Close()
-	data, err := ioutil.ReadAll(f)
-	Expect(err).NotTo(HaveOccurred())
-	podYaml := strings.Replace(string(data), old, new, 1)
-	return podYaml
-}
-
 func createFileForGoBinData(gobindataPath, outputFilename string) error {
 	data := generated.ReadOrDie(gobindataPath)
 	if len(data) == 0 {

--- a/test/e2e/network/BUILD
+++ b/test/e2e/network/BUILD
@@ -12,6 +12,7 @@ go_library(
         "dns_common.go",
         "dns_configmap.go",
         "doc.go",
+        "example_cluster_dns.go",
         "firewall.go",
         "framework.go",
         "ingress.go",

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package network
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -44,7 +47,7 @@ try:
 except:
 	print 'err'`
 
-var _ = framework.KubeDescribe("ClusterDns [Feature:Example]", func() {
+var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 	f := framework.NewDefaultFramework("cluster-dns")
 
 	var c clientset.Interface
@@ -155,4 +158,15 @@ var _ = framework.KubeDescribe("ClusterDns [Feature:Example]", func() {
 
 func getNsCmdFlag(ns *v1.Namespace) string {
 	return fmt.Sprintf("--namespace=%v", ns.Name)
+}
+
+// pass enough context with the 'old' parameter so that it replaces what your really intended.
+func prepareResourceWithReplacedString(inputFile, old, new string) string {
+	f, err := os.Open(inputFile)
+	Expect(err).NotTo(HaveOccurred())
+	defer f.Close()
+	data, err := ioutil.ReadAll(f)
+	Expect(err).NotTo(HaveOccurred())
+	podYaml := strings.Replace(string(data), old, new, 1)
+	return podYaml
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Just migrate dns relevant e2e test files to sig network. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Ref Umbrella issue #49161

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```