### PR TITLE
fix azure storage account num exhausting issue

### DIFF
--- a/pkg/volume/azure_dd/azure_common.go
+++ b/pkg/volume/azure_dd/azure_common.go
@@ -37,6 +37,7 @@ import (
 const (
 	defaultFSType             = "ext4"
 	defaultStorageAccountType = storage.StandardLRS
+	defaultAzureDiskKind      = v1.AzureSharedBlobDisk
 )
 
 type dataDisk struct {
@@ -116,7 +117,7 @@ func normalizeFsType(fsType string) string {
 
 func normalizeKind(kind string) (v1.AzureDataDiskKind, error) {
 	if kind == "" {
-		return v1.AzureDedicatedBlobDisk, nil
+		return defaultAzureDiskKind, nil
 	}
 
 	if !supportedDiskKinds.Has(kind) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
If customer is using the default storage class of azure-disk, create lots of azure disk pvs by using default storage class of azure-disk, the storage account num would be exhausted in the azure subscription. Change default `kind` value of azure disk storge class from `Dedicated` to `Shared`, which means only a few storage accounts would be created even there are even hundreds of azure disk PVs.

**Which issue this PR fixes**:
fixes #54669
fix storage account num exhausting issue when lots of azure disk pvs are created by using the default storage class of azure-disk

**Special notes for your reviewer**:
fix azure storage account num exhausting issue when lots of azure disk pvs are created by using the default storage class of azure-disk
I would suggest also cherry pick this fix to v1.7, v1.8

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
none
```

/sig azure
@karataliu @rootfs @brendanburns 