### PR TITLE
Support passing a proxy to client-go with --proxy-network-type and --proxy-address

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types.go
@@ -77,6 +77,12 @@ type Cluster struct {
 	// Extensions holds additional information. This is useful for extenders so that reads and writes don't clobber unknown fields
 	// +optional
 	Extensions map[string]runtime.Object `json:"extensions,omitempty"`
+	// ProxyNetworkType is a network type to proxy requests over. See https://golang.org/pkg/net/#Dial for known network types.
+	// +optional
+	ProxyNetworkType string `json:"proxy-network-type,omitempty"`
+	// Proxy is an address to proxy outbound requests over. See https://golang.org/pkg/net/#Dial for examples.
+	// +optional
+	ProxyAddress string `json:"proxy-address,omitempty"`
 }
 
 // AuthInfo contains information that describes identity information.  This is use to tell the kubernetes cluster who you are.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/types_test.go
@@ -51,6 +51,11 @@ func Example_ofOptionsConfig() {
 		Server:                "https://bravo.org:8080",
 		InsecureSkipTLSVerify: false,
 	}
+	defaultConfig.Clusters["charlie"] = &Cluster{
+		Server:           "https://charlie.org:8080",
+		ProxyNetworkType: "unix",
+		ProxyAddress:     "/tmp/sock",
+	}
 	defaultConfig.AuthInfos["white-mage-via-cert"] = &AuthInfo{
 		ClientCertificate: "path/to/my/client-cert-filename",
 		ClientKey:         "path/to/my/client-key-filename",
@@ -99,6 +104,11 @@ func Example_ofOptionsConfig() {
 	//   bravo:
 	//     LocationOfOrigin: ""
 	//     server: https://bravo.org:8080
+	//   charlie:
+	//     LocationOfOrigin: ""
+	//     proxy-address: /tmp/sock
+	//     proxy-network-type: unix
+	//     server: https://charlie.org:8080
 	// contexts:
 	//   alfa-as-black-mage:
 	//     LocationOfOrigin: ""

--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -71,6 +71,8 @@ type ClusterOverrideFlags struct {
 	APIVersion            FlagInfo
 	CertificateAuthority  FlagInfo
 	InsecureSkipTLSVerify FlagInfo
+	ProxyNetworkType      FlagInfo
+	ProxyAddress          FlagInfo
 }
 
 // FlagInfo contains information about how to register a flag.  This struct is useful if you want to provide a way for an extender to
@@ -146,6 +148,8 @@ const (
 	FlagNamespace        = "namespace"
 	FlagAPIServer        = "server"
 	FlagInsecure         = "insecure-skip-tls-verify"
+	FlagProxyNetworkType = "proxy-network-type"
+	FlagProxyAddress     = "proxy-address"
 	FlagCertFile         = "client-certificate"
 	FlagKeyFile          = "client-key"
 	FlagCAFile           = "certificate-authority"
@@ -189,6 +193,8 @@ func RecommendedClusterOverrideFlags(prefix string) ClusterOverrideFlags {
 		APIServer:             FlagInfo{prefix + FlagAPIServer, "", "", "The address and port of the Kubernetes API server"},
 		CertificateAuthority:  FlagInfo{prefix + FlagCAFile, "", "", "Path to a cert file for the certificate authority"},
 		InsecureSkipTLSVerify: FlagInfo{prefix + FlagInsecure, "", "false", "If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure"},
+		ProxyNetworkType:      FlagInfo{prefix + FlagProxyNetworkType, "", "", "A type of network to proxy outgoing requests over. Examples are tcp and udp. See https://golang.org/pkg/net/#Dial for all options. If this flag is provided, proxy-address must also be provided"},
+		ProxyAddress:          FlagInfo{prefix + FlagProxyAddress, "", "", "An address to proxy outbound requests over. For example, localhost:3000. See https://golang.org/pkg/net/#Dial for other options. If this flag is provided, proxy-network-type must also be provided"},
 	}
 }
 
@@ -226,6 +232,8 @@ func BindClusterFlags(clusterInfo *clientcmdapi.Cluster, flags *pflag.FlagSet, f
 	flagNames.APIServer.BindStringFlag(flags, &clusterInfo.Server)
 	flagNames.CertificateAuthority.BindStringFlag(flags, &clusterInfo.CertificateAuthority)
 	flagNames.InsecureSkipTLSVerify.BindBoolFlag(flags, &clusterInfo.InsecureSkipTLSVerify)
+	flagNames.ProxyAddress.BindStringFlag(flags, &clusterInfo.ProxyAddress)
+	flagNames.ProxyNetworkType.BindStringFlag(flags, &clusterInfo.ProxyNetworkType)
 }
 
 // BindFlags is a convenience method to bind the specified flags to their associated variables

--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -58,8 +58,8 @@ func (c *tlsTransportCache) get(config *Config) (http.RoundTripper, error) {
 	if err != nil {
 		return nil, err
 	}
-	// The options didn't require a custom TLS config
-	if tlsConfig == nil {
+	// The options didn't require a custom TLS config or a custom Dial function
+	if tlsConfig == nil && config.Dial == nil {
 		return http.DefaultTransport, nil
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This PR adds the ability to route client-go traffic through a proxy. This allows users of e.g. kubectl to route traffic through a unix socket with `--proxy-network-type=unix --proxy-address=/tmp/sock`, similar to how curl supports a `--unix-socket` option.

**Special notes for your reviewer**:
Unfortunately kubernetes is quite behind on mergo versions, and mergo is used quite extensively. Given that mergo functionality is different in newer versions and we actually _rely_ on the old functionality, I put in a small hack with a TODO to avoid upgrading mergo. Upgrading will probably be a big job, and I hope it won't block this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds a via-unix-socket option to client-go to allow routing outgoing client-go traffic through a unix-socket
```
