### PR TITLE
force deleting sts pods when nodes get lost

### DIFF
--- a/pkg/controller/statefulset/BUILD
+++ b/pkg/controller/statefulset/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/history:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -402,7 +402,7 @@ func TestStatefulPodControlDeletesStatefulPod(t *testing.T) {
 	fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, nil
 	})
-	if err := control.DeleteStatefulPod(set, pod); err != nil {
+	if err := control.DeleteStatefulPod(set, pod, nil); err != nil {
 		t.Errorf("Error returned on successful delete: %s", err)
 	}
 	events := collectEvents(recorder.Events)
@@ -422,7 +422,7 @@ func TestStatefulPodControlDeleteFailure(t *testing.T) {
 	fakeClient.AddReactor("delete", "pods", func(action core.Action) (bool, runtime.Object, error) {
 		return true, nil, apierrors.NewInternalError(errors.New("API server down"))
 	})
-	if err := control.DeleteStatefulPod(set, pod); err == nil {
+	if err := control.DeleteStatefulPod(set, pod, nil); err == nil {
 		t.Error("Failed to return error on failed delete")
 	}
 	events := collectEvents(recorder.Events)

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -1666,7 +1666,7 @@ func (spc *fakeStatefulPodControl) UpdateStatefulPod(set *apps.StatefulSet, pod 
 	return nil
 }
 
-func (spc *fakeStatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod) error {
+func (spc *fakeStatefulPodControl) DeleteStatefulPod(set *apps.StatefulSet, pod *v1.Pod, options *metav1.DeleteOptions) error {
 	defer spc.deletePodTracker.inc()
 	if spc.deletePodTracker.errorReady() {
 		defer spc.deletePodTracker.reset()

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -113,8 +113,8 @@ func TestStatefulSetControllerRespectsTermination(t *testing.T) {
 		t.Error("StatefulSet does not respect termination")
 	}
 	sort.Sort(ascendingOrdinal(pods))
-	spc.DeleteStatefulPod(set, pods[3])
-	spc.DeleteStatefulPod(set, pods[4])
+	spc.DeleteStatefulPod(set, pods[3], nil)
+	spc.DeleteStatefulPod(set, pods[4], nil)
 	*set.Spec.Replicas = 0
 	if err := scaleDownStatefulSetController(set, ssc, spc); err != nil {
 		t.Errorf("Failed to turn down StatefulSet : %s", err)
@@ -164,7 +164,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 		t.Error("StatefulSet does not block scaling")
 	}
 	sort.Sort(ascendingOrdinal(pods))
-	spc.DeleteStatefulPod(set, pods[0])
+	spc.DeleteStatefulPod(set, pods[0], nil)
 	ssc.enqueueStatefulSet(set)
 	fakeWorker(ssc)
 	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
@@ -678,7 +678,7 @@ func scaleDownStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetContr
 	pod = getPodAtOrdinal(pods, ord)
 	ssc.updatePod(&prev, pod)
 	fakeWorker(ssc)
-	spc.DeleteStatefulPod(set, pod)
+	spc.DeleteStatefulPod(set, pod, nil)
 	ssc.deletePod(pod)
 	fakeWorker(ssc)
 	for set.Status.Replicas > *set.Spec.Replicas {
@@ -695,7 +695,7 @@ func scaleDownStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetContr
 		pod = getPodAtOrdinal(pods, ord)
 		ssc.updatePod(&prev, pod)
 		fakeWorker(ssc)
-		spc.DeleteStatefulPod(set, pod)
+		spc.DeleteStatefulPod(set, pod, nil)
 		ssc.deletePod(pod)
 		fakeWorker(ssc)
 		if obj, _, err := spc.setsIndexer.Get(set); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
When nodes get lost, `NodeControllerEviction` will evict pods, but cannot delete them thoroughly. The pods will still be there. This is because `pod.spec.terminationGracePeriodSeconds` is set to a non-zero value, which keeps pods from being deleted immediately.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54368

**Special notes for your reviewer**:
/assign @dims @smarterclayton

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
forcing deleting sts pods when nodes get lost
```
