### PR TITLE
remove mutual exclusivity check - local, unstructured builder attrs

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -68,9 +68,6 @@ type Builder struct {
 	defaultNamespace bool
 	requireNamespace bool
 
-	isLocal        bool
-	isUnstructured bool
-
 	flatten bool
 	latest  bool
 
@@ -85,8 +82,6 @@ type Builder struct {
 
 	schema validation.Schema
 }
-
-var LocalUnstructuredBuilderError = fmt.Errorf("Unstructured objects cannot be handled with a local builder - Local and Unstructured attributes cannot be used in conjunction")
 
 var missingResourceError = fmt.Errorf(`You must provide one or more resources by argument or filename.
 Example resource specifications include:
@@ -169,12 +164,6 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 
 // Local wraps the builder's clientMapper in a DisabledClientMapperForMapping
 func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
-	if b.isUnstructured {
-		b.errs = append(b.errs, LocalUnstructuredBuilderError)
-		return b
-	}
-
-	b.isLocal = true
 	b.mapper.ClientMapper = DisabledClientForMapping{ClientMapper: ClientMapperFunc(mapperFunc)}
 	return b
 }
@@ -182,12 +171,6 @@ func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
 // Unstructured updates the builder's ClientMapper, RESTMapper,
 // ObjectTyper, and codec for working with unstructured api objects
 func (b *Builder) Unstructured(mapperFunc ClientMapperFunc, mapper meta.RESTMapper, typer runtime.ObjectTyper) *Builder {
-	if b.isLocal {
-		b.errs = append(b.errs, LocalUnstructuredBuilderError)
-		return b
-	}
-
-	b.isUnstructured = true
 	b.mapper.RESTMapper = mapper
 	b.mapper.ObjectTyper = typer
 	b.mapper.Decoder = unstructured.UnstructuredJSONScheme


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```
Remove incorrect mutual exclusivity check between the resource builder `Local` and `Unstructured` attributes.

Related comment: https://github.com/kubernetes/kubernetes/pull/48763#discussion_r146437490
Followup to https://github.com/kubernetes/kubernetes/pull/48763

cc @smarterclayton 