### PR TITLE
Deprecate using cloud provider to set host address feature

### DIFF
--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -81,6 +81,8 @@ func (s *CloudProviderOptions) DefaultExternalHost(genericoptions *genericoption
 			for _, addr := range addrs {
 				if addr.Type == v1.NodeExternalIP {
 					genericoptions.ExternalHost = addr.Address
+					glog.Warning("[Deprecated] Getting host address using cloud provider is " +
+						"now deprecated. Please use --external-hostname explicitly")
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Long term plan is to remove all uses of cloud provider from kube api
server. As part of that, we need to remove the dependency on
figuring out the host address of the node running the kube api server
using the cloud provider. In this review, we log a warning that this
feature that is usually used for example with swagger generation
will go away in the future.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Part of fix for 54077

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
If you are using the cloud provider API to determine the external host address of the apiserver, set --external-hostname explicitly instead. The cloud provider detection has been deprecated and will be removed in the future
```