### PR TITLE
unit tests for syncRolloutStatus in pkg/controller/deployment

### DIFF
--- a/pkg/controller/deployment/progress_test.go
+++ b/pkg/controller/deployment/progress_test.go
@@ -280,6 +280,14 @@ func TestSyncRolloutStatus(t *testing.T) {
 			conditionReason: util.NewRSAvailableReason,
 		},
 		{
+			name:            "DeploymentComplete: defend against NPE when newRS=nil",
+			d:               currentDeployment(&pds, 0, 3, 3, 3, []extensions.DeploymentCondition{replicaSetUpdated}),
+			allRSs:          []*extensions.ReplicaSet{newRSWithAvailable("foo", 0, 0, 0)},
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.NewRSAvailableReason,
+		},
+		{
 			name:            "DeploymentTimedOut: update status if rollout exceeds Progress Deadline",
 			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{replicaSetUpdated}),
 			allRSs:          []*extensions.ReplicaSet{},
@@ -301,12 +309,12 @@ func TestSyncRolloutStatus(t *testing.T) {
 		},
 	}
 
-	fake := fake.Clientset{}
-	dc := &DeploymentController{
-		client: &fake,
-	}
-
 	for _, test := range tests {
+		fake := fake.Clientset{}
+		dc := &DeploymentController{
+			client: &fake,
+		}
+
 		if test.newRS != nil {
 			test.allRSs = append(test.allRSs, test.newRS)
 		}

--- a/pkg/controller/deployment/progress_test.go
+++ b/pkg/controller/deployment/progress_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller/deployment/util"
 )
@@ -52,6 +53,16 @@ func currentDeployment(pds *int32, replicas, statusReplicas, updatedReplicas, av
 	}
 	d.Status.Conditions = conditions
 	return d
+}
+
+// helper to create RS with given availableReplicas
+func newRSWithAvailable(name string, specReplicas, statusReplicas, availableReplicas int) *extensions.ReplicaSet {
+	rs := rs(name, specReplicas, nil, metav1.Time{})
+	rs.Status = extensions.ReplicaSetStatus{
+		Replicas:          int32(statusReplicas),
+		AvailableReplicas: int32(availableReplicas),
+	}
+	return rs
 }
 
 func TestRequeueStuckDeployment(t *testing.T) {
@@ -158,6 +169,165 @@ func TestRequeueStuckDeployment(t *testing.T) {
 		got := dc.requeueStuckDeployment(test.d, test.status)
 		if got != test.expected {
 			t.Errorf("%s: got duration: %v, expected duration: %v", test.name, got, test.expected)
+		}
+	}
+}
+
+func TestSyncRolloutStatus(t *testing.T) {
+	pds := int32(60)
+	testTime := metav1.Date(2017, 2, 15, 18, 49, 00, 00, time.UTC)
+	failedTimedOut := extensions.DeploymentCondition{
+		Type:   extensions.DeploymentProgressing,
+		Status: v1.ConditionFalse,
+		Reason: util.TimedOutReason,
+	}
+	newRSAvailable := extensions.DeploymentCondition{
+		Type:               extensions.DeploymentProgressing,
+		Status:             v1.ConditionTrue,
+		Reason:             util.NewRSAvailableReason,
+		LastUpdateTime:     testTime,
+		LastTransitionTime: testTime,
+	}
+	replicaSetUpdated := extensions.DeploymentCondition{
+		Type:               extensions.DeploymentProgressing,
+		Status:             v1.ConditionTrue,
+		Reason:             util.ReplicaSetUpdatedReason,
+		LastUpdateTime:     testTime,
+		LastTransitionTime: testTime,
+	}
+
+	tests := []struct {
+		name            string
+		d               *extensions.Deployment
+		allRSs          []*extensions.ReplicaSet
+		newRS           *extensions.ReplicaSet
+		conditionType   extensions.DeploymentConditionType
+		conditionStatus v1.ConditionStatus
+		conditionReason string
+		lastUpdate      metav1.Time
+		lastTransition  metav1.Time
+	}{
+		{
+			name:   "General: remove Progressing condition and do not estimate progress if deployment has no Progress Deadline",
+			d:      currentDeployment(nil, 3, 2, 2, 2, []extensions.DeploymentCondition{replicaSetUpdated}),
+			allRSs: []*extensions.ReplicaSet{newRSWithAvailable("bar", 0, 1, 1)},
+			newRS:  newRSWithAvailable("foo", 3, 2, 2),
+		},
+		{
+			name:            "General: do not estimate progress of deployment with only one active ReplicaSet",
+			d:               currentDeployment(&pds, 3, 3, 3, 3, []extensions.DeploymentCondition{newRSAvailable}),
+			allRSs:          []*extensions.ReplicaSet{newRSWithAvailable("bar", 3, 3, 3)},
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.NewRSAvailableReason,
+			lastUpdate:      testTime,
+			lastTransition:  testTime,
+		},
+		{
+			name:            "DeploymentProgressing: dont update lastTransitionTime if deployment already has Progressing=True",
+			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{replicaSetUpdated}),
+			allRSs:          []*extensions.ReplicaSet{newRSWithAvailable("bar", 0, 1, 1)},
+			newRS:           newRSWithAvailable("foo", 3, 2, 2),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.ReplicaSetUpdatedReason,
+			lastTransition:  testTime,
+		},
+		{
+			name:            "DeploymentProgressing: update everything if deployment has Progressing=False",
+			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{failedTimedOut}),
+			allRSs:          []*extensions.ReplicaSet{newRSWithAvailable("bar", 0, 1, 1)},
+			newRS:           newRSWithAvailable("foo", 3, 2, 2),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.ReplicaSetUpdatedReason,
+		},
+		{
+			name:            "DeploymentProgressing: create Progressing condition if it does not exist",
+			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{}),
+			allRSs:          []*extensions.ReplicaSet{newRSWithAvailable("bar", 0, 1, 1)},
+			newRS:           newRSWithAvailable("foo", 3, 2, 2),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.ReplicaSetUpdatedReason,
+		},
+		{
+			name:            "DeploymentComplete: dont update lastTransitionTime if deployment already has Progressing=True",
+			d:               currentDeployment(&pds, 3, 3, 3, 3, []extensions.DeploymentCondition{replicaSetUpdated}),
+			allRSs:          []*extensions.ReplicaSet{},
+			newRS:           newRSWithAvailable("foo", 3, 3, 3),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.NewRSAvailableReason,
+			lastTransition:  testTime,
+		},
+		{
+			name:            "DeploymentComplete: update everything if deployment has Progressing=False",
+			d:               currentDeployment(&pds, 3, 3, 3, 3, []extensions.DeploymentCondition{failedTimedOut}),
+			allRSs:          []*extensions.ReplicaSet{},
+			newRS:           newRSWithAvailable("foo", 3, 3, 3),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.NewRSAvailableReason,
+		},
+		{
+			name:            "DeploymentComplete: create Progressing condition if it does not exist",
+			d:               currentDeployment(&pds, 3, 3, 3, 3, []extensions.DeploymentCondition{}),
+			allRSs:          []*extensions.ReplicaSet{},
+			newRS:           newRSWithAvailable("foo", 3, 3, 3),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionTrue,
+			conditionReason: util.NewRSAvailableReason,
+		},
+		{
+			name:            "DeploymentTimedOut: update status if rollout exceeds Progress Deadline",
+			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{replicaSetUpdated}),
+			allRSs:          []*extensions.ReplicaSet{},
+			newRS:           newRSWithAvailable("foo", 3, 2, 2),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionFalse,
+			conditionReason: util.TimedOutReason,
+		},
+		{
+			name:            "DeploymentTimedOut: do not update status if deployment has existing timedOut condition",
+			d:               currentDeployment(&pds, 3, 2, 2, 2, []extensions.DeploymentCondition{failedTimedOut}),
+			allRSs:          []*extensions.ReplicaSet{},
+			newRS:           newRSWithAvailable("foo", 3, 2, 2),
+			conditionType:   extensions.DeploymentProgressing,
+			conditionStatus: v1.ConditionFalse,
+			conditionReason: util.TimedOutReason,
+			lastUpdate:      testTime,
+			lastTransition:  testTime,
+		},
+	}
+
+	fake := fake.Clientset{}
+	dc := &DeploymentController{
+		client: &fake,
+	}
+
+	for _, test := range tests {
+		if test.newRS != nil {
+			test.allRSs = append(test.allRSs, test.newRS)
+		}
+
+		err := dc.syncRolloutStatus(test.allRSs, test.newRS, test.d)
+		if err != nil {
+			t.Error(err)
+		}
+
+		newCond := util.GetDeploymentCondition(test.d.Status, test.conditionType)
+		switch {
+		case newCond == nil:
+			if test.d.Spec.ProgressDeadlineSeconds != nil {
+				t.Errorf("%s: expected deployment condition: %s", test.name, test.conditionType)
+			}
+		case newCond.Status != test.conditionStatus || newCond.Reason != test.conditionReason:
+			t.Errorf("%s: DeploymentProgressing has status %s with reason %s. Expected %s with %s.", test.name, newCond.Status, newCond.Reason, test.conditionStatus, test.conditionReason)
+		case !test.lastUpdate.IsZero() && test.lastUpdate != testTime:
+			t.Errorf("%s: LastUpdateTime was changed to %s but expected %s;", test.name, test.lastUpdate, testTime)
+		case !test.lastTransition.IsZero() && test.lastTransition != testTime:
+			t.Errorf("%s: LastTransitionTime was changed to %s but expected %s;", test.name, test.lastTransition, testTime)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Adds unit tests for syncRolloutStatus func in controller/deployment package.

**Which issue this PR fixes**: 
fixes #53663 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
