### PR TITLE
Fix nil pointer panic in service LB e2e tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -4860,7 +4860,7 @@ func CleanupGCEResources(c clientset.Interface, loadBalancerName, zone string) (
 	if hc != nil {
 		hcNames = append(hcNames, hc.Name)
 	}
-	if err := gceCloud.DeleteExternalTargetPoolAndChecks(nil, loadBalancerName, region, clusterID, hcNames...); err != nil &&
+	if err := gceCloud.DeleteExternalTargetPoolAndChecks(&v1.Service{}, loadBalancerName, region, clusterID, hcNames...); err != nil &&
 		!IsGoogleAPIHTTPErrorCode(err, http.StatusNotFound) {
 		retErr = fmt.Errorf("%v\n%v", retErr, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
/priority failing-test
LB tests on https://k8s-testgrid.appspot.com/sig-network#gci-gce-slow&sort-by-failures= are panicing because of https://github.com/kubernetes/kubernetes/pull/54500.

This PR removes the nil pointer passed in by test. I might later send out fix to harden GCE LB codes to check for nil pointer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: ref https://github.com/kubernetes/kubernetes/pull/54500

**Special notes for your reviewer**:
Sorry for the noise.
/assign @bowei @nicksardo 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
