### PR TITLE
Add conformance annotations for projected volume tests

### DIFF
--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -35,15 +35,28 @@ var _ = framework.KubeDescribe("Projected", func() {
 	// Part 1/3 - Secrets
 	f := framework.NewDefaultFramework("projected")
 
+	/*
+	   Testname: projected-secret-no-defaultMode
+	   Description: Simple projected Secret test with no defaultMode set.
+	*/
 	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
+	/*
+	   Testname: projected-secret-with-defaultMode
+	   Description: Simple projected Secret test with defaultMode set.
+	*/
 	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), nil, nil)
 	})
 
+	/*
+		    Testname: projected-secret-with-nonroot-defaultMode-fsGroup
+		    Description: Simple projected Secret test as non-root with
+			defaultMode and fsGroup set.
+	*/
 	It("should be consumable from pods in volume as non-root with defaultMode and fsGroup set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0440) /* setting fsGroup sets mode to at least 440 */
 		fsGroup := int64(1001)
@@ -51,10 +64,21 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedSecretE2EWithoutMapping(f, &defaultMode, "projected-secret-test-"+string(uuid.NewUUID()), &fsGroup, &uid)
 	})
 
+	/*
+		    Testname: projected-secret-simple-mapped
+		    Description: Simple projected Secret test, by setting a secret and
+			mounting it to a volume with a custom path (mapping) on the pod with
+			no other settings and make sure the pod actually consumes it.
+	*/
 	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doProjectedSecretE2EWithMapping(f, nil)
 	})
 
+	/*
+		    Testname: projected-secret-with-item-mode-mapped
+		    Description: Repeat the projected-secret-simple-mapped but this time
+			with an item mode (e.g. 0400) for the secret map item.
+	*/
 	It("should be consumable from pods in volume with mappings and Item Mode set [Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doProjectedSecretE2EWithMapping(f, &mode)
@@ -81,6 +105,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedSecretE2EWithoutMapping(f, nil /* default mode */, secret2.Name, nil, nil)
 	})
 
+	/*
+		    Testname: projected-secret-multiple-volumes
+		    Description: Make sure secrets works when mounted as two different
+			volumes on the same node.
+	*/
 	It("should be consumable in multiple volumes in a pod [Conformance] [sig-storage]", func() {
 		// This test ensures that the same secret can be mounted in multiple
 		// volumes in the same pod.  This test case exists to prevent
@@ -170,6 +199,10 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+	   Testname: projected-secret-simple-optional
+	   Description: Make sure secrets works when optional updates included.
+	*/
 	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
@@ -367,10 +400,20 @@ var _ = framework.KubeDescribe("Projected", func() {
 	})
 
 	// Part 2/3 - ConfigMaps
+	/*
+		    Testname: projected-volume-configMap-nomappings-succeeds
+		    Description: Make sure that a projected volume with a configMap with
+			no mappings succeeds properly.
+	*/
 	It("should be consumable from pods in volume [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
+	/*
+		    Testname: projected-volume-configMap-consumable-defaultMode
+		    Description: Make sure that a projected volume configMap is consumable
+			with defaultMode set.
+	*/
 	It("should be consumable from pods in volume with defaultMode set [Conformance] [sig-storage]", func() {
 		defaultMode := int32(0400)
 		doProjectedConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
@@ -381,6 +424,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
 
+	/*
+		    Testname: projected-volume-configMap-consumable-nonroot
+		    Description: Make sure that a projected volume configMap is consumable
+			by a non-root userID.
+	*/
 	It("should be consumable from pods in volume as non-root [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
@@ -389,15 +437,31 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
+	/*
+		    Testname: projected-configmap-simple-mapped
+		    Description: Simplest projected ConfigMap test, by setting a config
+			map and mounting it to a volume with a custom path (mapping) on the
+			pod with no other settings and make sure the pod actually consumes it.
+	*/
 	It("should be consumable from pods in volume with mappings [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
+	/*
+		    Testname: projected-secret-with-item-mode-mapped
+		    Description: Repeat the projected-secret-simple-mapped but this time
+			with an item mode (e.g. 0400) for the secret map item
+	*/
 	It("should be consumable from pods in volume with mappings and Item mode set[Conformance] [sig-storage]", func() {
 		mode := int32(0400)
 		doProjectedConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
 
+	/*
+		    Testname: projected-configmap-simpler-user-mapped
+		    Description: Repeat the projected-config-map-simple-mapped but this
+			time with a user other than root.
+	*/
 	It("should be consumable from pods in volume with mappings as non-root [Conformance] [sig-storage]", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
@@ -406,6 +470,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		doProjectedConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
+	/*
+		    Testname: projected-volume-configMaps-updated-succesfully
+		    Description: Make sure that if a projected volume has configMaps,
+			that the values in these configMaps can be updated, deleted,
+			and created.
+	*/
 	It("updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
@@ -489,6 +559,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
+	/*
+		    Testname: projected-volume-optional-configMaps-updated-succesfully
+		    Description: Make sure that if a projected volume has optional
+			configMaps, that the values in these configMaps can be updated,
+			deleted, and created.
+	*/
 	It("optional updates should be reflected in volume [Conformance] [sig-storage]", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
@@ -685,6 +761,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("Error reading file /etc/projected-configmap-volumes/delete/data-1"))
 	})
 
+	/*
+		    Testname: projected-configmap-multiple-volumes
+		    Description: Make sure config map works when it mounted as two
+			different volumes on the same node.
+	*/
 	It("should be consumable in multiple volumes in the same pod [Conformance] [sig-storage]", func() {
 		var (
 			name             = "projected-configmap-test-volume-" + string(uuid.NewUUID())
@@ -778,6 +859,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		podClient = f.PodClient()
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-podname
+		    Description: Ensure that downward API can provide pod's name through
+			DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should provide podname only [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
@@ -787,6 +873,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-set-default-mode
+		    Description: Ensure that downward API can set default file premission
+			mode for DownwardAPIVolumeFiles if no mode is specified in a projected
+			volume.
+	*/
 	It("should set DefaultMode on files [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
@@ -797,6 +889,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-set-mode
+		    Description: Ensure that downward API can set file premission mode for
+			DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should set mode on item file [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
@@ -836,6 +933,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-update-label
+		    Description: Ensure that downward API updates labels in
+			DownwardAPIVolumeFiles when pod's labels get modified in a projected
+			volume.
+	*/
 	It("should update labels on modification [Conformance] [sig-storage]", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
@@ -863,6 +966,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-update-annotation
+		    Description: Ensure that downward API updates annotations in
+			DownwardAPIVolumeFiles when pod's annotations get modified in a
+			projected volume.
+	*/
 	It("should update annotations on modification [Conformance] [sig-storage]", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
@@ -892,6 +1001,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"foo\"\n"))
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-cpu-limit
+		    Description: Ensure that downward API can provide container's CPU
+			limit through DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should provide container's cpu limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
@@ -901,6 +1015,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-memory-limit
+		    Description: Ensure that downward API can provide container's memory
+			limit through DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should provide container's memory limit [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
@@ -910,6 +1029,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-cpu-request
+		    Description: Ensure that downward API can provide container's CPU
+			request through DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should provide container's cpu request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
@@ -919,6 +1043,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-memory-request
+		    Description: Ensure that downward API can provide container's memory
+			request through DownwardAPIVolumeFiles in a projected volume.
+	*/
 	It("should provide container's memory request [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
@@ -928,6 +1057,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-default-cpu
+		    Description: Ensure that downward API can provide default node
+			allocatable value for CPU through DownwardAPIVolumeFiles if CPU limit
+			is not specified for a container in a projected volume.
+	*/
 	It("should provide node allocatable (cpu) as default cpu limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
@@ -935,6 +1070,12 @@ var _ = framework.KubeDescribe("Projected", func() {
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
+	/*
+		    Testname: projected-downwardapi-volume-default-memory
+		    Description: Ensure that downward API can provide default node
+			allocatable value for memory through DownwardAPIVolumeFiles if memory
+			limit is not specified for a container in a projected volume.
+	*/
 	It("should provide node allocatable (memory) as default memory limit if the limit is not set [Conformance] [sig-storage]", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")
@@ -943,6 +1084,11 @@ var _ = framework.KubeDescribe("Projected", func() {
 	})
 
 	// Test multiple projections
+	/*
+		    Testname: projected-configmap-secret-same-dir
+		    Description: This test projects a secret and configmap into the same
+			directory to ensure projection is working as intended.
+	*/
 	It("should project all components that make up the projection API [Conformance] [sig-storage] [Projection]", func() {
 		var err error
 		podName := "projected-volume-" + string(uuid.NewUUID())


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>
Add projected volume related conformance annotations

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds projected volume related related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests.
Special notes for your reviewer:
Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
