### PR TITLE
delete the hostport from usedmap

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/cache_test.go
+++ b/plugin/pkg/scheduler/schedulercache/cache_test.go
@@ -228,7 +228,7 @@ func TestExpirePod(t *testing.T) {
 			},
 			allocatableResource: &Resource{},
 			pods:                []*v1.Pod{testPods[1]},
-			usedPorts:           map[int]bool{80: false, 8080: true},
+			usedPorts:           map[int]bool{8080: true},
 		},
 	}}
 
@@ -277,7 +277,7 @@ func TestAddPodWillConfirm(t *testing.T) {
 			},
 			allocatableResource: &Resource{},
 			pods:                []*v1.Pod{testPods[0]},
-			usedPorts:           map[int]bool{80: true, 8080: false},
+			usedPorts:           map[int]bool{80: true},
 		},
 	}}
 

--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -403,7 +403,11 @@ func (n *NodeInfo) updateUsedPorts(pod *v1.Pod, used bool) {
 			// "0" is explicitly ignored in PodFitsHostPorts,
 			// which is the only function that uses this value.
 			if podPort.HostPort != 0 {
-				n.usedPorts[int(podPort.HostPort)] = used
+				if used {
+					n.usedPorts[int(podPort.HostPort)] = used
+				} else {
+					delete(n.usedPorts, int(podPort.HostPort))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
delete the hostport record when pod is not on the host

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Facilitate the further pr https://github.com/kubernetes/kubernetes/pull/52421. Because the code which detects the conflict between wantports and existingports is not quite clean now.
Besides remove the unused port from map will save the memory.

**Special notes for your reviewer**:

I and the original coder @k82cn agreed to make this change

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```