### PR TITLE
Add HA feature gate and minVersion validation

### DIFF
--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -231,6 +231,10 @@ func NewInit(cfgPath string, cfg *kubeadmapi.MasterConfiguration, skipPreFlight,
 		return nil, err
 	}
 
+	if err := features.ValidateVersion(features.InitFeatureGates, cfg.FeatureGates, cfg.KubernetesVersion); err != nil {
+		return nil, err
+	}
+
 	fmt.Printf("[init] Using Kubernetes version: %s\n", cfg.KubernetesVersion)
 	fmt.Printf("[init] Using Authorization modes: %v\n", cfg.AuthorizationModes)
 

--- a/cmd/kubeadm/app/features/BUILD
+++ b/cmd/kubeadm/app/features/BUILD
@@ -10,7 +10,10 @@ go_library(
     name = "go_default_library",
     srcs = ["features.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/features",
-    deps = ["//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library"],
+    deps = [
+        "//pkg/util/version:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -25,9 +25,9 @@ import (
 
 func TestKnownFeatures(t *testing.T) {
 	var someFeatures = FeatureList{
-		"feature2": {Default: true, PreRelease: utilfeature.Alpha},
-		"feature1": {Default: false, PreRelease: utilfeature.Beta},
-		"feature3": {Default: false, PreRelease: utilfeature.GA},
+		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}},
+		"feature1": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
+		"feature3": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.GA}},
 	}
 
 	r := KnownFeatures(&someFeatures)
@@ -55,8 +55,8 @@ func TestKnownFeatures(t *testing.T) {
 
 func TestNewFeatureGate(t *testing.T) {
 	var someFeatures = FeatureList{
-		"feature1": {Default: false, PreRelease: utilfeature.Beta},
-		"feature2": {Default: true, PreRelease: utilfeature.Alpha},
+		"feature1": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
+		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}},
 	}
 
 	var tests = []struct {
@@ -114,6 +114,45 @@ func TestNewFeatureGate(t *testing.T) {
 
 		if !reflect.DeepEqual(r, test.expectedFeaturesGate) {
 			t.Errorf("NewFeatureGate returned a unexpected value")
+		}
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	var someFeatures = FeatureList{
+		"feature1": {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
+		"feature2": {FeatureSpec: utilfeature.FeatureSpec{Default: true, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
+	}
+
+	var tests = []struct {
+		requestedVersion  string
+		requestedFeatures map[string]bool
+		expectedError     bool
+	}{
+		{ //no min version
+			requestedFeatures: map[string]bool{"feature1": true},
+			expectedError:     false,
+		},
+		{ //min version but correct value given
+			requestedFeatures: map[string]bool{"feature2": true},
+			requestedVersion:  "v1.9.0",
+			expectedError:     false,
+		},
+		{ //min version and incorrect value given
+			requestedFeatures: map[string]bool{"feature2": true},
+			requestedVersion:  "v1.8.2",
+			expectedError:     true,
+		},
+	}
+
+	for _, test := range tests {
+		err := ValidateVersion(someFeatures, test.requestedFeatures, test.requestedVersion)
+		if !test.expectedError && err != nil {
+			t.Errorf("ValidateVersion failed when not expected: %v", err)
+			continue
+		} else if test.expectedError && err == nil {
+			t.Error("ValidateVersion didn't failed when expected")
+			continue
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

As we add more feature gates, there might be occasions where a feature is only available on newer releases of K8s. If a user makes a mistake, we should notify them as soon as possible in the init procedure and not them go down the path of hard-to-debug component issues.

Specifically with HA, we ideally need the new `TaintNodesByCondition` (added in v1.8.0 but working in v1.9.0).

**Which issue this PR fixes:**

kubernetes/kubeadm#261
kubernetes/kubeadm#277

**Release note**:
```release-note
Feature gates now check minimum versions
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews @luxas @timothysc 