### PR TITLE
RBD Plugin: Fix bug in checking command not found error.

### DIFF
--- a/pkg/volume/rbd/rbd_util.go
+++ b/pkg/volume/rbd/rbd_util.go
@@ -27,6 +27,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"os/exec"
 	"path"
 	"regexp"
 	"strings"
@@ -43,7 +44,6 @@ import (
 const (
 	imageWatcherStr = "watcher="
 	kubeLockMagic   = "kubelet_lock_magic_"
-	rbdCmdErr       = "executable file not found in $PATH"
 )
 
 // search /sys/bus for rbd device that matches given pool and image
@@ -117,8 +117,10 @@ func (util *RBDUtil) MakeGlobalPDName(rbd rbd) string {
 }
 
 func rbdErrors(runErr, resultErr error) error {
-	if runErr.Error() == rbdCmdErr {
-		return fmt.Errorf("rbd: rbd cmd not found")
+	if err, ok := runErr.(*exec.Error); ok {
+		if err.Err == exec.ErrNotFound {
+			return fmt.Errorf("rbd: rbd cmd not found")
+		}
 	}
 	return resultErr
 }
@@ -479,10 +481,12 @@ func (util *RBDUtil) rbdStatus(b *rbdMounter) (bool, string, error) {
 			break
 		}
 
-		if err.Error() == rbdCmdErr {
-			glog.Errorf("rbd cmd not found")
-			// fail fast if command not found
-			return false, output, err
+		if err, ok := err.(*exec.Error); ok {
+			if err.Err == exec.ErrNotFound {
+				glog.Errorf("rbd cmd not found")
+				// fail fast if command not found
+				return false, output, err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix bug in error checking logic. 

`Error()` method of command not found error returned from `command.Run/Output` is not "executable file not found in $PATH". Actually, it's `exec: "<command>": executable file not found in $PATH`.

I followed the logic in https://github.com/kubernetes/kubernetes/blob/v1.9.0-alpha.1/pkg/kubectl/cmd/util/editor/editor.go#L129 to detect command not found error.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

https://play.golang.org/p/yZJxtouUQL

**Release note**:

```release-note
NONE
```
