### PR TITLE
importverifier: fix isPathUnder for base == path

### DIFF
--- a/cmd/importverifier/importverifier.go
+++ b/cmd/importverifier/importverifier.go
@@ -110,7 +110,7 @@ func isPathUnder(base, path string) (bool, error) {
 
 	// if path is below base, the relative path
 	// from base to path will not start with `../`
-	return !strings.HasPrefix(relPath, "."), nil
+	return !strings.HasPrefix(relPath, ".."), nil
 }
 
 // forbiddenImportsFor determines all of the forbidden


### PR DESCRIPTION
isPathUnder returned false for base == path, but should return true.