### PR TITLE
Set kubelet user agent

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -625,6 +625,10 @@ func CreateAPIServerClientConfig(s *options.KubeletServer) (*restclient.Config, 
 		return nil, err
 	}
 
+	// Hardcode "kubelet" instead of os.Args[0] as the os.Args[0] in some cases
+	// might be different than "kubelet" (in case kubelet is vendored in
+	// third-party project).
+	clientConfig.UserAgent = restclient.UserAgentForComponent(componentKubelet)
 	clientConfig.ContentType = s.ContentType
 	// Override kubeconfig qps/burst settings from flags
 	clientConfig.QPS = float32(s.KubeAPIQPS)

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -300,14 +300,20 @@ func buildUserAgent(command, version, os, arch, commit string) string {
 		"%s/%s (%s/%s) kubernetes/%s", command, version, os, arch, commit)
 }
 
-// DefaultKubernetesUserAgent returns a User-Agent string built from static global vars.
-func DefaultKubernetesUserAgent() string {
+// UserAgentForComponent returns a User-Agent string with custom component
+// prefix.
+func UserAgentForComponent(name string) string {
 	return buildUserAgent(
-		adjustCommand(os.Args[0]),
+		adjustCommand(name),
 		adjustVersion(version.Get().GitVersion),
 		gruntime.GOOS,
 		gruntime.GOARCH,
 		adjustCommit(version.Get().GitCommit))
+}
+
+// DefaultKubernetesUserAgent returns a User-Agent string built from static global vars.
+func DefaultKubernetesUserAgent() string {
+	return UserAgentForComponent(os.Args[0])
 }
 
 // InClusterConfig returns a config object which uses the service account


### PR DESCRIPTION
**What this PR does / why we need it**:

Change the user-agent for kubelet to start with "kubelet" prefix.
This allows to differentiate out node vs. master requests in prometheus metrics.

**Special notes for your reviewer**:

**Release note**:
```release-note
The kubelet API client now sets the prefix in User-Agent to "kubelet" which allows to identify node API requests in prometheus metrics. 
```
