### PR TITLE
Fix kubeadm e2e CI build

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -82,7 +82,7 @@ deb_data(
 
 pkg_tar(
     name = "kubernetes-cni-data",
-    package_dir = "/opt/cni",
+    package_dir = "/opt/cni/bin",
     deps = ["@kubernetes_cni//file"],
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This fixes kubeadm e2e tests; the tarfile was extracted to the wrong directory in #51250.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes: https://github.com/kubernetes/kubernetes/issues/54330

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
@ixdy @pipejakob @kubernetes/sig-cluster-lifecycle-bugs @medinatiger @dims @cmluciano @dixudx 