### PR TITLE
Add probe, pre_stop, and networking related container annotations.

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -49,6 +49,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		podClient = f.PodClient()
 	})
 
+	/*
+		    Testname: pods-readiness-probe-initial-delay
+		    Description: Make sure that pod with readiness probe should not be
+			ready before initial delay and never restart.
+	*/
 	It("with readiness probe should not be ready before initial delay and never restart [Conformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withInitialDelay().build(), nil))
 		f.WaitForPodReady(p.Name)
@@ -76,6 +81,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Expect(restartCount == 0).To(BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)
 	})
 
+	/*
+		    Testname: pods-readiness-probe-failure
+		    Description: Make sure that pod with readiness probe that fails should
+			never be ready and never restart.
+	*/
 	It("with readiness probe that fails should never be ready and never restart [Conformance]", func() {
 		p := podClient.Create(makePodSpec(probe.withFailing().build(), nil))
 		Consistently(func() (bool, error) {
@@ -96,6 +106,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		Expect(restartCount == 0).To(BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)
 	})
 
+	/*
+		    Testname: pods-cat-liveness-probe-restarted
+		    Description: Make sure the pod is restarted with a cat /tmp/health
+			liveness probe.
+	*/
 	It("should be restarted with a exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -123,6 +138,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}, 1, defaultObservationTimeout)
 	})
 
+	/*
+		    Testname: pods-cat-liveness-probe-not-restarted
+		    Description: Make sure the pod is not restarted with a cat /tmp/health
+			liveness probe.
+	*/
 	It("should *not* be restarted with a exec \"cat /tmp/health\" liveness probe [Conformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -150,6 +170,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}, 0, defaultObservationTimeout)
 	})
 
+	/*
+		    Testname: pods-http-liveness-probe-restarted
+		    Description: Make sure when http liveness probe fails, the pod should
+			be restarted.
+	*/
 	It("should be restarted with a /healthz http liveness probe [Conformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -179,6 +204,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	// Slow by design (5 min)
+	/*
+		    Testname: pods-restart-count
+		    Description: Make sure when a pod gets restarted, its start count
+			should increase.
+	*/
 	It("should have monotonically increasing restart count [Conformance] [Slow]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -207,6 +237,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}, 5, time.Minute*5)
 	})
 
+	/*
+		    Testname: pods-http-liveness-probe-not-restarted
+		    Description: Make sure when http liveness probe succeeds, the pod
+			should not be restarted.
+	*/
 	It("should *not* be restarted with a /healthz http liveness probe [Conformance]", func() {
 		runLivenessTest(f, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -236,6 +271,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}, 0, defaultObservationTimeout)
 	})
 
+	/*
+		    Testname: pods-docker-liveness-probe-timeout
+		    Description: Make sure that the pod is restarted with a docker exec
+			liveness probe with timeout.
+	*/
 	It("should be restarted with a docker exec liveness probe with timeout [Conformance]", func() {
 		// TODO: enable this test once the default exec handler supports timeout.
 		framework.Skipf("The default exec handler, dockertools.NativeExecHandler, does not support timeouts due to a limitation in the Docker Remote API")

--- a/test/e2e/common/networking.go
+++ b/test/e2e/common/networking.go
@@ -30,6 +30,11 @@ var _ = Describe("[sig-network] Networking", func() {
 		// Try to hit all endpoints through a test container, retry 5 times,
 		// expect exactly one unique hostname. Each of these endpoints reports
 		// its own hostname.
+		/*
+			    Testname: networking-intra-pod-http
+			    Description: Try to hit test endpoints from a test container and make
+				sure each of them can report a unique hostname.
+		*/
 		It("should function for intra-pod communication: http [Conformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
@@ -37,6 +42,11 @@ var _ = Describe("[sig-network] Networking", func() {
 			}
 		})
 
+		/*
+			    Testname: networking-intra-pod-udp
+			    Description: Try to hit test endpoints from a test container using udp
+				and make sure each of them can report a unique hostname.
+		*/
 		It("should function for intra-pod communication: udp [Conformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
@@ -44,6 +54,11 @@ var _ = Describe("[sig-network] Networking", func() {
 			}
 		})
 
+		/*
+			    Testname: networking-node-pod-http
+			    Description: Try to hit test endpoints from the pod and make sure each
+				of them can report a unique hostname.
+		*/
 		It("should function for node-pod communication: http [Conformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {
@@ -51,6 +66,11 @@ var _ = Describe("[sig-network] Networking", func() {
 			}
 		})
 
+		/*
+			    Testname: networking-node-pod-udp
+			    Description: Try to hit test endpoints from the pod using udp and make sure
+				each of them can report a unique hostname.
+		*/
 		It("should function for node-pod communication: udp [Conformance]", func() {
 			config := framework.NewCoreNetworkingTestConfig(f)
 			for _, endpointPod := range config.EndpointPods {

--- a/test/e2e/pre_stop.go
+++ b/test/e2e/pre_stop.go
@@ -175,6 +175,11 @@ func testPreStop(c clientset.Interface, ns string) {
 var _ = framework.KubeDescribe("PreStop", func() {
 	f := framework.NewDefaultFramework("prestop")
 
+	/*
+		    Testname: pods-prestop-handler-invoked
+		    Description: Makes sure a pod's preStop handler is successfully
+			invoked immediately before a container is terminated.
+	*/
 	It("should call prestop when killing a pod [Conformance]", func() {
 		testPreStop(f.ClientSet, f.Namespace.Name)
 	})


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>

Add probe, pre_stop, and networking related container annotations.

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds probe, pre_stop, and networking related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests.
Special notes for your reviewer:

Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
