### PR TITLE
Fix getting log dumps in ci/pull-kubeadm-gce jobs

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -84,7 +84,12 @@ if [[ "${ENABLE_CLUSTER_AUTOSCALER}" == "true" ]]; then
   fi
 fi
 
-NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-minion"
+if [[ "${KUBERNETES_PROVIDER}" == "kubernetes-anywhere" ]]; then
+  NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-node"
+else
+  NODE_INSTANCE_PREFIX="${INSTANCE_PREFIX}-minion"
+fi
+
 NODE_TAGS="${NODE_TAG}"
 
 ALLOCATE_NODE_CIDRS=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Currently log collection is disable for the kubeadm-gce jobs as they are broken. The first fix is when detect-node-names we do not find the names as the node prefix(es) have "minion" and not "node" in these jobs. So let's make sure NODE_INSTANCE_PREFIX is set correctly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
