### PR TITLE
fix leaderelection:renew lease shouldn't exit, follower maybe leader again

### DIFF
--- a/plugin/pkg/scheduler/scheduler.go
+++ b/plugin/pkg/scheduler/scheduler.go
@@ -26,6 +26,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
 	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
@@ -287,6 +288,10 @@ func (sched *Scheduler) bind(assumed *v1.Pod, b *v1.Binding) error {
 
 // scheduleOne does the entire scheduling workflow for a single pod.  It is serialized on the scheduling algorithm's host fitting.
 func (sched *Scheduler) scheduleOne() {
+	if !leaderelection.IsLeader() {
+		sched.StopEverything()
+	}
+
 	pod := sched.config.NextPod()
 	if pod.DeletionTimestamp != nil {
 		sched.config.Recorder.Eventf(pod, v1.EventTypeWarning, "FailedScheduling", "skip schedule deleting pod: %v/%v", pod.Namespace, pod.Name)

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -19,6 +19,7 @@ package scheduler
 import (
 	"errors"
 	"fmt"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -30,6 +31,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientcache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
@@ -85,6 +88,37 @@ func podWithResources(id, desiredHost string, limits v1.ResourceList, requests v
 		{Name: "ctr", Resources: v1.ResourceRequirements{Limits: limits, Requests: requests}},
 	}
 	return pod
+}
+
+func grantSchedulerLeadership() bool {
+	id, err := os.Hostname()
+	if err != nil {
+		return false
+	}
+
+	rl, err := resourcelock.New(resourcelock.EndpointsResourceLock, "", "", nil,
+		resourcelock.ResourceLockConfig{
+			Identity: id,
+		})
+	if err != nil {
+		return false
+	}
+	leaderElector, err := leaderelection.NewLeaderElector(
+		leaderelection.LeaderElectionConfig{
+			Lock:          rl,
+			LeaseDuration: time.Duration(15) * time.Second,
+			RenewDeadline: time.Duration(10) * time.Second,
+			RetryPeriod:   time.Duration(2) * time.Second,
+		},
+	)
+	if err != nil {
+		return false
+	}
+	leaderelection.Leader = leaderElector
+	leaderElector.SetLeaderElectionRecord(resourcelock.LeaderElectionRecord{
+		HolderIdentity: id,
+	})
+	return true
 }
 
 type mockScheduler struct {
@@ -198,6 +232,7 @@ func TestScheduler(t *testing.T) {
 			}
 			close(called)
 		})
+		grantSchedulerLeadership()
 		s.scheduleOne()
 		<-called
 		if e, a := item.expectAssumedPod, gotAssumedPod; !reflect.DeepEqual(e, a) {
@@ -262,6 +297,7 @@ func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
 	// We use conflicted pod ports to incur fit predicate failure if first pod not removed.
 	secondPod := podWithPort("bar", "", 8080)
 	queuedPodStore.Add(secondPod)
+	grantSchedulerLeadership()
 	scheduler.scheduleOne()
 	select {
 	case b := <-bindingChan:
@@ -295,6 +331,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 	// queuedPodStore: [bar:8080]
 	// cache: [(assumed)foo:8080]
 
+	grantSchedulerLeadership()
 	scheduler.scheduleOne()
 	select {
 	case err := <-errChan:
@@ -323,6 +360,7 @@ func TestSchedulerNoPhantomPodAfterDelete(t *testing.T) {
 	}
 
 	queuedPodStore.Add(secondPod)
+	grantSchedulerLeadership()
 	scheduler.scheduleOne()
 	select {
 	case b := <-bindingChan:
@@ -408,7 +446,9 @@ func setupTestSchedulerWithOnePodOnNode(t *testing.T, queuedPodStore *clientcach
 	// queuedPodStore: [foo:8080]
 	// cache: []
 
+	grantSchedulerLeadership()
 	scheduler.scheduleOne()
+
 	// queuedPodStore: []
 	// cache: [(assumed)foo:8080]
 
@@ -480,6 +520,7 @@ func TestSchedulerFailedSchedulingReasons(t *testing.T) {
 	scheduler, _, errChan := setupTestScheduler(queuedPodStore, scache, nodeLister, predicateMap)
 
 	queuedPodStore.Add(podWithTooBigResourceRequests)
+	grantSchedulerLeadership()
 	scheduler.scheduleOne()
 	select {
 	case err := <-errChan:


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This PR fix leader election bug.
If [leader election renew lease](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L204) fails, then this renew goroutine exit and [scheduler finish running](https://github.com/kubernetes/kubernetes/blob/master/plugin/cmd/kube-scheduler/app/server.go#L163).   

 For example, we have two scheduler instance A and B, A run on machine 10.192.168.1, B run on machine 10.192.168.2,  instance A is  leader at present. When 10.192.168.1 totally down, instance A lost lease and nolonger leader and not acquire lease any more, so this instance can never be leader. If 10.192.168.2 is down unfortunately, then no instances do schedule, this is terrible

2. This PR make `tryAcquireOrRenew()` goroutine never exit and follower instance can be leader again

**Release note**:
```release-note
NONE
```