### PR TITLE
fix azure pv crash due to volumeSource.ReadOnly value nil

### DIFF
--- a/pkg/volume/azure_dd/azure_mounter.go
+++ b/pkg/volume/azure_dd/azure_mounter.go
@@ -43,10 +43,14 @@ var _ volume.Unmounter = &azureDiskUnmounter{}
 var _ volume.Mounter = &azureDiskMounter{}
 
 func (m *azureDiskMounter) GetAttributes() volume.Attributes {
-	volumeSource, _ := getVolumeSource(m.spec)
+	readOnly := false
+	volumeSource, err := getVolumeSource(m.spec)
+	if err != nil && volumeSource.ReadOnly != nil {
+		readOnly = *volumeSource.ReadOnly
+	}
 	return volume.Attributes{
-		ReadOnly:        *volumeSource.ReadOnly,
-		Managed:         !*volumeSource.ReadOnly,
+		ReadOnly:        readOnly,
+		Managed:         !readOnly,
 		SupportsSELinux: true,
 	}
 }
@@ -94,7 +98,7 @@ func (m *azureDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 
 	options := []string{"bind"}
 
-	if *volumeSource.ReadOnly {
+	if volumeSource.ReadOnly != nil && *volumeSource.ReadOnly {
 		options = append(options, "ro")
 	}
 
@@ -138,7 +142,7 @@ func (m *azureDiskMounter) SetUpAt(dir string, fsGroup *int64) error {
 		return mountErr
 	}
 
-	if !*volumeSource.ReadOnly {
+	if volumeSource.ReadOnly == nil || !*volumeSource.ReadOnly {
 		volume.SetVolumeOwnership(m, fsGroup)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
kubelet in agent would crash due to volumeSource.ReadOnly is nil in some condition 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54149, #55199

**Special notes for your reviewer**:
#54149 is the issue: volumeSource.ReadOnly is nil, make kubelet in azure agent node crash.
"volumeSource.ReadOnly is nil" could be regarded as `false` value
@rootfs 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix azure pv crash due to volumeSource.ReadOnly value nil
```

/sig azure