### PR TITLE
fix TestDescribeServiceAccount fail

### DIFF
--- a/pkg/printers/internalversion/describe_test.go
+++ b/pkg/printers/internalversion/describe_test.go
@@ -1682,18 +1682,22 @@ func TestDescribeServiceAccount(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	expectedOut := `Name:                bar
-Namespace:           foo
-Labels:              <none>
-Annotations:         <none>
-Image pull secrets:  test-local-ref (not found)
-Mountable secrets:   test-objectref (not found)
-Tokens:              <none>
-Events:              <none>` + "\n"
-	if out != expectedOut {
-		t.Errorf("expected : %q\n but got output:\n %q", expectedOut, out)
-	}
 
+	expectedElements := []string{
+		"Name:                bar",
+		"Namespace:           foo",
+		"Labels:              <none>",
+		"Annotations:         <none>",
+		"Image pull secrets:  test-local-ref (not found)",
+		"Mountable secrets:   test-objectref (not found)",
+		"Tokens:              <none>",
+		"Events:              <none>",
+	}
+	for _, expected := range expectedElements {
+		if !strings.Contains(out, expected) {
+			t.Errorf("expected to find %q in output: %q", expected, out)
+		}
+	}
 }
 
 // boolPtr returns a pointer to a bool


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54619 

**Special notes for your reviewer**:
unit test case `TestDescribeServiceAccount` probabilisticly fail because of map key sequence is not guaranteed 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
