### PR TITLE
Mark --pod as deprecated for kubectl exec and port-forward

### DIFF
--- a/pkg/kubectl/cmd/exec.go
+++ b/pkg/kubectl/cmd/exec.go
@@ -85,6 +85,8 @@ func NewCmdExec(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer) *c
 		},
 	}
 	cmd.Flags().StringVarP(&options.PodName, "pod", "p", "", "Pod name")
+	// TODO It's deprecated and will be removed in a future release. (kubernetes/kubectl#104)
+	cmd.Flags().MarkDeprecated("pod", "This flag is DEPRECATED and will be removed in a future version. Use exec POD_NAME instead.")
 	// TODO support UID
 	cmd.Flags().StringVarP(&options.ContainerName, "container", "c", "", "Container name. If omitted, the first container in the pod will be chosen")
 	cmd.Flags().BoolVarP(&options.Stdin, "stdin", "i", false, "Pass stdin to the container")

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -87,6 +87,8 @@ func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Comma
 		},
 	}
 	cmd.Flags().StringP("pod", "p", "", "Pod name")
+	// TODO It's deprecated and will be removed in a future release. (kubernetes/kubectl#104)
+	cmd.Flags().MarkDeprecated("pod", "This flag is DEPRECATED and will be removed in a future version. Use port-forward POD instead.")
 	// TODO support UID
 	return cmd
 }


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes https://github.com/kubernetes/kubectl/issues/104

**Special notes for your reviewer**:
@apelisse @php-coder 

**Release note**:
```release-note
Deprecation: The flag `pod ` of kubectl exec and port-forward is deprecated and will be removed in a future release.
```
