### PR TITLE
Bump version of prometheus-to-sd to 0.2.2.

### DIFF
--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -65,7 +65,7 @@ spec:
               readOnly: true
         # BEGIN_PROMETHEUS_TO_SD
         - name: prom-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
+          image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
           command:
             - /monitor
             - --source=heapster:http://localhost:8082?whitelisted=stackdriver_requests_count,stackdriver_timeseries_count
@@ -73,9 +73,6 @@ spec:
             - --api-override={{ prometheus_to_sd_endpoint }}
             - --pod-id=$(POD_NAME)
             - --namespace-id=$(POD_NAMESPACE)
-          volumeMounts:
-          - name: ssl-certs
-            mountPath: /etc/ssl/certs
           env:
             - name: POD_NAME
               valueFrom:

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -52,16 +52,23 @@ spec:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --component=event_exporter
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
           - --api-override={{ prometheus_to_sd_endpoint }}
-          - --whitelisted-metrics=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
-        volumeMounts:
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
+          - --source=event_exported:http://localhost:80?whitelisted=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       # END_PROMETHEUS_TO_SD
       terminationGracePeriodSeconds: 30
       volumes:

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -92,14 +92,23 @@ spec:
               fi;
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.1.3
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --component=fluentd
-          - --target-port=31337
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
           - --api-override={{ prometheus_to_sd_endpoint }}
-          - --whitelisted-metrics=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
+          - --source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/fluentd-ds-ready: "true"


### PR DESCRIPTION
Bump version of prometheus-to-sd to improve logging, add pod_name and
pod_namespace flags and remove deprecated flags.

Fixes #54583 

```release-note
Reduce log noise produced by prometheus-to-sd, by bumping it to version 0.2.2.
```