### PR TITLE
Fix `kubeadm init --token-ttl=0`/config `tokenTTL: "0"`.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -17,8 +17,11 @@ limitations under the License.
 package fuzzer
 
 import (
+	"time"
+
 	"github.com/google/gofuzz"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
@@ -30,6 +33,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			c.FuzzNoCustom(obj)
 			obj.KubernetesVersion = "v10"
 			obj.API.BindPort = 20
+			obj.TokenTTL = &metav1.Duration{Duration: 1 * time.Hour}
 			obj.API.AdvertiseAddress = "foo"
 			obj.Networking.ServiceSubnet = "foo"
 			obj.Networking.DNSDomain = "foo"

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -36,7 +36,7 @@ type MasterConfiguration struct {
 	AuthorizationModes []string
 
 	Token    string
-	TokenTTL metav1.Duration
+	TokenTTL *metav1.Duration
 
 	APIServerExtraArgs         map[string]string
 	ControllerManagerExtraArgs map[string]string

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -83,8 +83,8 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 		obj.CertificatesDir = DefaultCertificatesDir
 	}
 
-	if obj.TokenTTL.Duration == 0 {
-		obj.TokenTTL = metav1.Duration{
+	if obj.TokenTTL == nil {
+		obj.TokenTTL = &metav1.Duration{
 			Duration: constants.DefaultTokenDuration,
 		}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -35,8 +35,8 @@ type MasterConfiguration struct {
 	NodeName           string     `json:"nodeName"`
 	AuthorizationModes []string   `json:"authorizationModes,omitempty"`
 
-	Token    string          `json:"token"`
-	TokenTTL metav1.Duration `json:"tokenTTL"`
+	Token    string           `json:"token"`
+	TokenTTL *metav1.Duration `json:"tokenTTL,omitempty"`
 
 	APIServerExtraArgs         map[string]string `json:"apiServerExtraArgs,omitempty"`
 	ControllerManagerExtraArgs map[string]string `json:"controllerManagerExtraArgs,omitempty"`

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -149,7 +150,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.NodeName = in.NodeName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
-	out.TokenTTL = in.TokenTTL
+	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.APIServerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.APIServerExtraArgs))
 	out.ControllerManagerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.ControllerManagerExtraArgs))
 	out.SchedulerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.SchedulerExtraArgs))
@@ -184,7 +185,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.NodeName = in.NodeName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
-	out.TokenTTL = in.TokenTTL
+	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.APIServerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.APIServerExtraArgs))
 	out.ControllerManagerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.ControllerManagerExtraArgs))
 	out.SchedulerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.SchedulerExtraArgs))

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
@@ -147,7 +148,15 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.TokenTTL = in.TokenTTL
+	if in.TokenTTL != nil {
+		in, out := &in.TokenTTL, &out.TokenTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.APIServerExtraArgs != nil {
 		in, out := &in.APIServerExtraArgs, &out.APIServerExtraArgs
 		*out = make(map[string]string, len(*in))

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package kubeadm
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
@@ -152,7 +153,15 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.TokenTTL = in.TokenTTL
+	if in.TokenTTL != nil {
+		in, out := &in.TokenTTL, &out.TokenTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.APIServerExtraArgs != nil {
 		in, out := &in.APIServerExtraArgs, &out.APIServerExtraArgs
 		*out = make(map[string]string, len(*in))

--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -21,6 +21,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/install:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/phases:go_default_library",

--- a/cmd/kubeadm/app/cmd/cmd.go
+++ b/cmd/kubeadm/app/cmd/cmd.go
@@ -25,6 +25,10 @@ import (
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/upgrade"
+
+	// Register the kubeadm configuration types because CLI flag generation
+	// depends on the generated defaults.
+	_ "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/install"
 )
 
 // NewKubeadmCommand return cobra.Command to run kubeadm command

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -58,7 +58,6 @@ func TestPrintConfiguration(t *testing.T) {
 	  serviceSubnet: ""
 	nodeName: ""
 	token: ""
-	tokenTTL: 0s
 	unifiedControlPlaneImage: ""
 `),
 		},
@@ -90,7 +89,6 @@ func TestPrintConfiguration(t *testing.T) {
 	  serviceSubnet: 10.96.0.1/12
 	nodeName: ""
 	token: ""
-	tokenTTL: 0s
 	unifiedControlPlaneImage: ""
 `),
 		},
@@ -132,7 +130,6 @@ func TestPrintConfiguration(t *testing.T) {
 	  serviceSubnet: ""
 	nodeName: ""
 	token: ""
-	tokenTTL: 0s
 	unifiedControlPlaneImage: ""
 `),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug that was introduced in https://github.com/kubernetes/kubernetes/pull/48783 when we reduced the default token TTL from infinite to 24 hours.

This change worked for `kubeadm token create` but was broken for `kubeadm init` because the API machinery defaulting mechanism couldn't differentiate between an unset value (which should default to 24 hours) and a value explicitly set to 0 (which should mean infinite).

The fix is to change `TokenTTL` from a `metav1.Duration` to `*metav1.Duration` so that `nil` can represent the unspecified value.

This bug was introduced in https://github.com/kubernetes/kubernetes/pull/48783.

**Which issue this PR fixes**: fixes https://github.com/kubernetes/kubeadm/issues/509

**Special notes for your reviewer**:
This should be a cherry pick candidate for 1.8.x.

Here is some example output for each case:

<details><summary><b>Unspecified TTL using the `kubeadm init --token-ttl [...]` flag</b></summary>


```
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init >/dev/null && ./kubeadm token list
TOKEN                     TTL       EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
abbd6a.389f44259787c5cb   23h       2017-10-27T16:00:32Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>

<details><summary><b>1 hour TTL using the `kubeadm init --token-ttl [...]` flag</b></summary>


```
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init --token-ttl 1h >/dev/null && ./kubeadm token list
TOKEN                     TTL       EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
cb3368.9087edaf99b28c32   59m       2017-10-26T17:01:33Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>

<details><summary><b>Infinite TTL using the `kubeadm init --token-ttl [...]` flag</b></summary>


```
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init --token-ttl 0 >/dev/null && ./kubeadm token list
TOKEN                     TTL         EXPIRES   USAGES                   DESCRIPTION                                                EXTRA GROUPS
2f709c.972cf789c277671a   <forever>   <never>   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>


<details><summary><b>Unspecified TTL using the `tokenTTL` configuration value</b></summary>


```
root@master:/vagrant# cat kubeadm-default.yaml
---
apiVersion: kubeadm.k8s.io/v1alpha1
kind: MasterConfiguration
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init --config ./kubeadm-default.yaml >/dev/null && ./kubeadm token list
TOKEN                     TTL       EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
e4171c.74a2582c4df88c6e   23h       2017-10-27T16:03:39Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>

<details><summary><b>1 hour TTL using the `tokenTTL` configuration value</b></summary>


```
root@master:/vagrant# cat kubeadm-1h.yaml
---
apiVersion: kubeadm.k8s.io/v1alpha1
kind: MasterConfiguration
tokenTTL: "1h"
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init --config ./kubeadm-1h.yaml >/dev/null && ./kubeadm token list
TOKEN                     TTL       EXPIRES                USAGES                   DESCRIPTION                                                EXTRA GROUPS
8f8722.ef80f0370dfd866b   59m       2017-10-26T17:04:42Z   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>

<details><summary><b>Infinite TTL using the `tokenTTL` configuration value</b></summary>


```
root@master:/vagrant# cat kubeadm-infinite.yaml
---
apiVersion: kubeadm.k8s.io/v1alpha1
kind: MasterConfiguration
tokenTTL: "0"
root@master:/vagrant# ./kubeadm reset >/dev/null && ./kubeadm init --config ./kubeadm-infinite.yaml >/dev/null && ./kubeadm token list
TOKEN                     TTL         EXPIRES   USAGES                   DESCRIPTION                                                EXTRA GROUPS
6e6f32.833465c25c175c38   <forever>   <never>   authentication,signing   The default bootstrap token generated by 'kubeadm init'.   system:bootstrappers:kubeadm:default-node-token
```
</details>

<p></p>
<p></p>

**Release note**:
```release-note
kubeadm init: fix a bug that prevented the --token-ttl flag and tokenTTL configuration value from working as expected for infinite (0) values.
```

/kind bug
cc @kubernetes/sig-cluster-lifecycle-bugs @luxas @jbeda @wackxu