### PR TITLE
Validation for CRD custom resources: feature gate promotion alpha->beta

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -80339,7 +80339,7 @@
       "type": "string"
      },
      "validation": {
-      "description": "Validation describes the validation methods for CustomResources This field is alpha-level and should only be sent to servers that enable the CustomResourceValidation feature.",
+      "description": "Validation describes the validation methods for CustomResources",
       "$ref": "#/definitions/io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation"
      },
      "version": {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -212,6 +212,6 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	apiextensionsfeatures.CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha},
+	apiextensionsfeatures.CustomResourceValidation: {Default: true, PreRelease: utilfeature.Beta},
 	SupportIPVSProxyMode:                           {Default: false, PreRelease: utilfeature.Alpha},
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -105,7 +105,6 @@ message CustomResourceDefinitionSpec {
   optional string scope = 4;
 
   // Validation describes the validation methods for CustomResources
-  // This field is alpha-level and should only be sent to servers that enable the CustomResourceValidation feature.
   // +optional
   optional CustomResourceValidation validation = 5;
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -29,7 +29,6 @@ type CustomResourceDefinitionSpec struct {
 	// Scope indicates whether this resource is cluster or namespace scoped.  Default is namespaced
 	Scope ResourceScope `json:"scope" protobuf:"bytes,4,opt,name=scope,casttype=ResourceScope"`
 	// Validation describes the validation methods for CustomResources
-	// This field is alpha-level and should only be sent to servers that enable the CustomResourceValidation feature.
 	// +optional
 	Validation *CustomResourceValidation `json:"validation,omitempty" protobuf:"bytes,5,opt,name=validation"`
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -29,6 +29,7 @@ const (
 
 	// owner: @sttts, @nikhita
 	// alpha: v1.8
+	// beta: v1.9
 	//
 	// CustomResourceValidation is a list of validation methods for CustomResources
 	CustomResourceValidation utilfeature.Feature = "CustomResourceValidation"
@@ -42,5 +43,5 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha},
+	CustomResourceValidation: {Default: true, PreRelease: utilfeature.Beta},
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
@@ -29,7 +29,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -25,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/test/integration/testserver"
@@ -176,12 +175,6 @@ func TestCustomResourceValidation(t *testing.T) {
 	}
 	defer close(stopCh)
 
-	// enable alpha feature CustomResourceValidation
-	err = utilfeature.DefaultFeatureGate.Set("CustomResourceValidation=true")
-	if err != nil {
-		t.Errorf("failed to enable feature gate for CustomResourceValidation: %v", err)
-	}
-
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
 	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
 	if err != nil {
@@ -202,12 +195,6 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
-
-	// enable alpha feature CustomResourceValidation
-	err = utilfeature.DefaultFeatureGate.Set("CustomResourceValidation=true")
-	if err != nil {
-		t.Errorf("failed to enable feature gate for CustomResourceValidation: %v", err)
-	}
 
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
 	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
@@ -251,12 +238,6 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
-
-	// enable alpha feature CustomResourceValidation
-	err = utilfeature.DefaultFeatureGate.Set("CustomResourceValidation=true")
-	if err != nil {
-		t.Errorf("failed to enable feature gate for CustomResourceValidation: %v", err)
-	}
 
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
 	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
@@ -349,12 +330,6 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 	}
 	defer close(stopCh)
 
-	// enable alpha feature CustomResourceValidation
-	err = utilfeature.DefaultFeatureGate.Set("CustomResourceValidation=true")
-	if err != nil {
-		t.Errorf("failed to enable feature gate for CustomResourceValidation: %v", err)
-	}
-
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
 
 	// set stricter schema
@@ -408,12 +383,6 @@ func TestForbiddenFieldsInSchema(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer close(stopCh)
-
-	// enable alpha feature CustomResourceValidation
-	err = utilfeature.DefaultFeatureGate.Set("CustomResourceValidation=true")
-	if err != nil {
-		t.Errorf("failed to enable feature gate for CustomResourceValidation: %v", err)
-	}
 
 	noxuDefinition := newNoxuValidationCRD(apiextensionsv1beta1.NamespaceScoped)
 	noxuDefinition.Spec.Validation.OpenAPIV3Schema.AdditionalProperties.Allows = false


### PR DESCRIPTION
**What this PR does / why we need it**: This promotes CRD Validation from **alpha** to **beta**.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #53829

**Special notes for your reviewer**: Issue #53829 discusses potential blockers to promoting CRD Validation to beta. None of the potential blockers are actual blockers, as they can all be accomplished without backward incompatible changes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Promote validation for custom resources defined through CRD to beta
```

cc: @sttts @nikhita @mbohlool 
