### PR TITLE
Better error messages and logging while registering device plugins.

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/manager.go
+++ b/pkg/kubelet/cm/deviceplugin/manager.go
@@ -169,15 +169,18 @@ func (m *ManagerImpl) Allocate(resourceName string, devs []string) (*pluginapi.A
 }
 
 // Register registers a device plugin.
-func (m *ManagerImpl) Register(ctx context.Context,
-	r *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
-	glog.V(2).Infof("Got request for Device Plugin %s", r.ResourceName)
+func (m *ManagerImpl) Register(ctx context.Context, r *pluginapi.RegisterRequest) (*pluginapi.Empty, error) {
+	glog.Infof("Got registration request from device plugin with resource name %q", r.ResourceName)
 	if r.Version != pluginapi.Version {
-		return &pluginapi.Empty{}, fmt.Errorf(errUnsuportedVersion)
+		errorString := fmt.Sprintf(errUnsuportedVersion, r.Version, pluginapi.Version)
+		glog.Infof("Bad registration request from device plugin with resource name %q: %v", r.ResourceName, errorString)
+		return &pluginapi.Empty{}, fmt.Errorf(errorString)
 	}
 
 	if !v1helper.IsExtendedResourceName(v1.ResourceName(r.ResourceName)) {
-		return &pluginapi.Empty{}, fmt.Errorf(errInvalidResourceName, r.ResourceName)
+		errorString := fmt.Sprintf(errInvalidResourceName, r.ResourceName)
+		glog.Infof("Bad registration request from device plugin: %v", errorString)
+		return &pluginapi.Empty{}, fmt.Errorf(errorString)
 	}
 
 	// TODO: for now, always accepts newest device plugin. Later may consider to

--- a/pkg/kubelet/cm/deviceplugin/types.go
+++ b/pkg/kubelet/cm/deviceplugin/types.go
@@ -64,13 +64,13 @@ const (
 	errFailedToDialDevicePlugin = "failed to dial device plugin:"
 	// errUnsuportedVersion is the error raised when the device plugin uses an API version not
 	// supported by the Kubelet registry
-	errUnsuportedVersion = "unsupported API version by the Kubelet registry"
+	errUnsuportedVersion = "requested API version %q is not supported by kubelet. Supported version is %q"
 	// errDevicePluginAlreadyExists is the error raised when a device plugin with the
 	// same Resource Name tries to register itself
 	errDevicePluginAlreadyExists = "another device plugin already registered this Resource Name"
 	// errInvalidResourceName is the error raised when a device plugin is registering
 	// itself with an invalid ResourceName
-	errInvalidResourceName = "the ResourceName %s is invalid"
+	errInvalidResourceName = "the ResourceName %q is invalid"
 	// errEmptyResourceName is the error raised when the resource name field is empty
 	errEmptyResourceName = "invalid Empty ResourceName"
 


### PR DESCRIPTION
Related to: #51993

/sig scheduling

**Release note**:
```release-note
NONE
```
