### PR TITLE
Allow nodeName of worker nodes to be IP address

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -18,6 +18,7 @@ package scheduling
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -286,7 +287,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		for nodeName, cpu := range nodeToAllocatableMap {
 			requestedCPU := cpu * 7 / 10
 			fillerPods = append(fillerPods, createPausePod(f, pausePodConfig{
-				Name: "filler-pod-" + nodeName,
+				// To avoid denying invalid name which include "." if nodeName is IP address.
+				Name: "filler-pod-" + strings.Replace(nodeName, ".", "-", -1),
 				Resources: &v1.ResourceRequirements{
 					Limits: v1.ResourceList{
 						v1.ResourceCPU: *resource.NewMilliQuantity(requestedCPU, "DecimalSI"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

On the environment DNS doesn't work for hostnames of worker nodes,
the conformance test "validates resource limits of pods that are allowed
to run" can fail, because a pod name contains "." which is invalid name
when trying to create name.
This PR replaces "." with "-" if containing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes: #54658

**Release note**: `NONE`
