### PR TITLE
Remove +linux restriction in ipvs/fake for running UTs in !linux platform

### DIFF
--- a/pkg/proxy/ipvs/testing/BUILD
+++ b/pkg/proxy/ipvs/testing/BUILD
@@ -9,12 +9,7 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = select({
-        "@io_bazel_rules_go//go/platform:linux_amd64": [
-            "fake.go",
-        ],
-        "//conditions:default": [],
-    }),
+    srcs = ["fake.go"],
     importpath = "k8s.io/kubernetes/pkg/proxy/ipvs/testing",
     tags = ["automanaged"],
 )

--- a/pkg/proxy/ipvs/testing/fake.go
+++ b/pkg/proxy/ipvs/testing/fake.go
@@ -1,5 +1,3 @@
-// +build linux
-
 /*
 Copyright 2017 The Kubernetes Authors.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Remove +linux restriction in ipvs/fake for running UTs in !linux platform

**Which issue this PR fixes**: 

fixes #54667

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/sig network

/kind bug
