### PR TITLE
migrate kubelet and scheduler event test to sig instrumentation

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -38,7 +38,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "e2e.go",
-        "events.go",
         "examples.go",
         "gke_local_ssd.go",
         "gke_node_pools.go",

--- a/test/e2e/instrumentation/BUILD
+++ b/test/e2e/instrumentation/BUILD
@@ -7,11 +7,24 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["imports.go"],
+    srcs = [
+        "events.go",
+        "imports.go",
+    ],
     importpath = "k8s.io/kubernetes/test/e2e/instrumentation",
     deps = [
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/instrumentation/common:go_default_library",
         "//test/e2e/instrumentation/logging:go_default_library",
         "//test/e2e/instrumentation/monitoring:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )
 

--- a/test/e2e/instrumentation/events.go
+++ b/test/e2e/instrumentation/events.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package e2e
+package instrumentation
 
 import (
 	"fmt"
@@ -28,12 +28,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/instrumentation/common"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Events", func() {
+var _ = common.SIGDescribe("Events", func() {
 	f := framework.NewDefaultFramework("events")
 
 	It("should be sent by kubelets and the scheduler about pods scheduling and running [Conformance]", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Migrate event relevant e2e tests to sig-instrumentation. Not fully sure, please feel free to contact me if you have better solution.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Ref Umbrella issue #49161

**Special notes for your reviewer**:

**Release note**:
```release-note
none
```