### PR TITLE
support mount options in azure file

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -222,7 +222,7 @@ func (b *azureFileMounter) SetUpAt(dir string, fsGroup *int64) error {
 	} else {
 		os.MkdirAll(dir, 0700)
 		// parameters suggested by https://azure.microsoft.com/en-us/documentation/articles/storage-how-to-use-files-linux/
-		options := []string{fmt.Sprintf("vers=3.0,username=%s,password=%s", accountName, accountKey)}
+		options := []string{fmt.Sprintf("username=%s,password=%s", accountName, accountKey)}
 		if b.readOnly {
 			options = append(options, "ro")
 		}

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -222,11 +222,12 @@ func (b *azureFileMounter) SetUpAt(dir string, fsGroup *int64) error {
 	} else {
 		os.MkdirAll(dir, 0700)
 		// parameters suggested by https://azure.microsoft.com/en-us/documentation/articles/storage-how-to-use-files-linux/
-		options := []string{fmt.Sprintf("vers=3.0,username=%s,password=%s,dir_mode=0700,file_mode=0700", accountName, accountKey)}
+		options := []string{fmt.Sprintf("vers=3.0,username=%s,password=%s", accountName, accountKey)}
 		if b.readOnly {
 			options = append(options, "ro")
 		}
 		mountOptions = volume.JoinMountOptions(b.mountOptions, options)
+		mountOptions = appendDefaultMountOptions(mountOptions)
 	}
 
 	err = b.mounter.Mount(source, dir, "cifs", mountOptions)

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -17,9 +17,11 @@ limitations under the License.
 package azure_file
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -357,4 +359,35 @@ func TestGetSecretNameAndNamespaceForPV(t *testing.T) {
 		}
 	}
 
+}
+
+func TestAppendDefaultMountOptions(t *testing.T) {
+	tests := []struct {
+		options  []string
+		expected []string
+	}{
+		{
+			options:  []string{"dir_mode=0777"},
+			expected: []string{"dir_mode=0777", fmt.Sprintf("%s=%s", fileModeName, defaultFileMode)},
+		},
+		{
+			options:  []string{"file_mode=0777"},
+			expected: []string{"file_mode=0777", fmt.Sprintf("%s=%s", dirModeName, defaultDirMode)},
+		},
+		{
+			options:  []string{""},
+			expected: []string{"", fmt.Sprintf("%s=%s", fileModeName, defaultFileMode), fmt.Sprintf("%s=%s", dirModeName, defaultDirMode)},
+		},
+		{
+			options:  []string{"file_mode=0777", "dir_mode=0777"},
+			expected: []string{"file_mode=0777", "dir_mode=0777"},
+		},
+	}
+
+	for _, test := range tests {
+		result := appendDefaultMountOptions(test.options)
+		if !reflect.DeepEqual(result, test.expected) {
+			t.Errorf("input: %q, appendDefaultMountOptions result: %q, expected: %q", test.options, result, test.expected)
+		}
+	}
 }

--- a/pkg/volume/azure_file/azure_file_test.go
+++ b/pkg/volume/azure_file/azure_file_test.go
@@ -368,19 +368,23 @@ func TestAppendDefaultMountOptions(t *testing.T) {
 	}{
 		{
 			options:  []string{"dir_mode=0777"},
-			expected: []string{"dir_mode=0777", fmt.Sprintf("%s=%s", fileModeName, defaultFileMode)},
+			expected: []string{"dir_mode=0777", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
 		{
 			options:  []string{"file_mode=0777"},
-			expected: []string{"file_mode=0777", fmt.Sprintf("%s=%s", dirModeName, defaultDirMode)},
+			expected: []string{"file_mode=0777", fmt.Sprintf("%s=%s", dirMode, defaultDirMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
+		},
+		{
+			options:  []string{"vers=2.1"},
+			expected: []string{"vers=2.1", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", dirMode, defaultDirMode)},
 		},
 		{
 			options:  []string{""},
-			expected: []string{"", fmt.Sprintf("%s=%s", fileModeName, defaultFileMode), fmt.Sprintf("%s=%s", dirModeName, defaultDirMode)},
+			expected: []string{"", fmt.Sprintf("%s=%s", fileMode, defaultFileMode), fmt.Sprintf("%s=%s", dirMode, defaultDirMode), fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
 		{
 			options:  []string{"file_mode=0777", "dir_mode=0777"},
-			expected: []string{"file_mode=0777", "dir_mode=0777"},
+			expected: []string{"file_mode=0777", "dir_mode=0777", fmt.Sprintf("%s=%s", vers, defaultVers)},
 		},
 	}
 

--- a/pkg/volume/azure_file/azure_util.go
+++ b/pkg/volume/azure_file/azure_util.go
@@ -27,10 +27,12 @@ import (
 )
 
 const (
-	fileModeName    = "file_mode"
-	dirModeName     = "dir_mode"
-	defaultFileMode = "700"
-	defaultDirMode  = "700"
+	fileMode        = "file_mode"
+	dirMode         = "dir_mode"
+	vers            = "vers"
+	defaultFileMode = "0700"
+	defaultDirMode  = "0700"
+	defaultVers     = "3.0"
 )
 
 // Abstract interface to azure file operations.
@@ -93,28 +95,35 @@ func (s *azureSvc) SetAzureCredentials(host volume.VolumeHost, nameSpace, accoun
 	return secretName, err
 }
 
-// check whether mountOptions contains file_mode and dir_mode, if not, append default mode
+// check whether mountOptions contain file_mode and dir_mode, if not, append default mode
 func appendDefaultMountOptions(mountOptions []string) []string {
 	fileModeFlag := false
 	dirModeFlag := false
+	versFlag := false
 
 	for _, mountOption := range mountOptions {
-		if strings.HasPrefix(mountOption, fileModeName) {
+		if strings.HasPrefix(mountOption, fileMode) {
 			fileModeFlag = true
 		}
-		if strings.HasPrefix(mountOption, dirModeName) {
+		if strings.HasPrefix(mountOption, dirMode) {
 			dirModeFlag = true
+		}
+		if strings.HasPrefix(mountOption, vers) {
+			versFlag = true
 		}
 	}
 
 	allMountOptions := mountOptions
 	if !fileModeFlag {
-		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", fileModeName, defaultFileMode))
+		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", fileMode, defaultFileMode))
 	}
 
 	if !dirModeFlag {
-		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", dirModeName, defaultDirMode))
+		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", dirMode, defaultDirMode))
 	}
 
+	if !versFlag {
+		allMountOptions = append(allMountOptions, fmt.Sprintf("%s=%s", vers, defaultVers))
+	}
 	return allMountOptions
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
support mount options in azure file

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #37005, #54610

**Special notes for your reviewer**:
@rootfs @karataliu @feiskyer 
By default, the dir_mode and file_mode would be 0700, vers would be 3.0, while if user specify `dir_mode`, `file_mode`, `vers` in storage class in `mountOptions` field(see below), then azure file should use user specified mount options.
```
---
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: azurefile
provisioner: kubernetes.io/azure-file
mountOptions:
  - dir_mode=0377
  - file_mode=0350
  - vers=2.1
  - uid=1000
  - gid=1000
parameters:
  skuName: Standard_LRS
  location: westus2
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Support mount options in azure file
```
/sig azure