### PR TITLE
Fix service session affinity e2e failure cases

### DIFF
--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -201,7 +201,7 @@ var _ = SIGDescribe("Networking", func() {
 			config.DialFromNode("udp", config.NodeIP, config.NodeUdpPort, config.MaxTries, config.MaxTries, sets.NewString())
 		})
 
-		It("should function for client IP based session affinity: http", func() {
+		It("should function for client IP based session affinity: http [Slow]", func() {
 			config := framework.NewNetworkingTestConfig(f)
 			By(fmt.Sprintf("dialing(http) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterHttpPort))
 			updateSessionAffinity := func(svc *v1.Service) {
@@ -212,24 +212,20 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Failf("Failed to update service session affinity, error: %v", err)
 			}
 
-			// Fetch first endpoints when visiting service
-			firstEndpoints, err := config.GetEndpointsFromTestContainer("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries)
+			// Check if number of endpoints returned are exactly one.
+			eps, err := config.GetEndpointsFromTestContainer("http", config.ClusterIP, framework.ClusterHttpPort, framework.SessionAffinityChecks)
 			if err != nil {
-				framework.Failf("Unable to get endpoints from test container: %v", err)
+				framework.Failf("Failed to get endpoints from test container, error: %v", err)
 			}
-			// Check if first endpoints are equal to endpoints which are fetched later
-			for i := 0; i < framework.SessionAffinityChecks; i++ {
-				eps, err := config.GetEndpointsFromTestContainer("http", config.ClusterIP, framework.ClusterHttpPort, config.MaxTries)
-				if err != nil {
-					framework.Failf("Unable to get endpoints from test container: %v", err)
-				}
-				if !eps.Equal(firstEndpoints) {
-					framework.Failf("Expect endpoints: %v, got: %v", firstEndpoints, eps)
-				}
+			if len(eps) == 0 {
+				framework.Failf("Unexpected no endpoints return")
+			}
+			if len(eps) > 1 {
+				framework.Failf("Unexpected endpoints return: %v, expect 1 endpoints", eps)
 			}
 		})
 
-		It("should function for client IP based session affinity: udp", func() {
+		It("should function for client IP based session affinity: udp [Slow]", func() {
 			config := framework.NewNetworkingTestConfig(f)
 			By(fmt.Sprintf("dialing(udp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, framework.ClusterUdpPort))
 			updateSessionAffinity := func(svc *v1.Service) {
@@ -240,20 +236,16 @@ var _ = SIGDescribe("Networking", func() {
 				framework.Failf("Failed to update service session affinity, error: %v", err)
 			}
 
-			// Fetch first endpoints when visiting service
-			firstEndpoints, err := config.GetEndpointsFromTestContainer("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries)
+			// Check if number of endpoints returned are exactly one.
+			eps, err := config.GetEndpointsFromTestContainer("udp", config.ClusterIP, framework.ClusterUdpPort, framework.SessionAffinityChecks)
 			if err != nil {
-				framework.Failf("Unable to get endpoints from test containers: %v", err)
+				framework.Failf("Failed to get endpoints from test container, error: %v", err)
 			}
-			// Check if first endpoints are equal to endpoints which are fetched later
-			for i := 0; i < framework.SessionAffinityChecks; i++ {
-				eps, err := config.GetEndpointsFromTestContainer("udp", config.ClusterIP, framework.ClusterUdpPort, config.MaxTries)
-				if err != nil {
-					framework.Failf("Unable to get endpoints from test containers: %v", err)
-				}
-				if !eps.Equal(firstEndpoints) {
-					framework.Failf("Expect endpoints: %v, got: %v", firstEndpoints, eps)
-				}
+			if len(eps) == 0 {
+				framework.Failf("Unexpected no endpoints return")
+			}
+			if len(eps) > 1 {
+				framework.Failf("Unexpected endpoints return: %v, expect 1 endpoints", eps)
 			}
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Fix service session affinity e2e failure cases - debuging...

**Which issue this PR fixes**:

xref #54571 #54524

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/sig network