### PR TITLE
Automated cherry pick of #54395

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -24,7 +24,6 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
-      hostNetwork: true
       containers:
       - name: fluentd-gcp
         image: gcr.io/google-containers/fluentd-gcp:2.0.9


### PR DESCRIPTION
Cherry pick of #54395 on release-1.8.

#54395: Move fluentd-gcp out of host network

```release-note
[fluentd-gcp addon] Fluentd now runs in its own network, not in the host one.
```