### PR TITLE
Updates the expected default Quobyte plugin mount path

### DIFF
--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -59,6 +59,10 @@ var _ volume.ProvisionableVolumePlugin = &quobytePlugin{}
 var _ volume.Provisioner = &quobyteVolumeProvisioner{}
 var _ volume.Deleter = &quobyteVolumeDeleter{}
 
+// default name for mount point dir
+var qbMountPointName = "mnt"
+var qbPluginDirName = strings.EscapeQualifiedNameForDisk(quobytePluginName)
+
 const (
 	quobytePluginName = "kubernetes.io/quobyte"
 )
@@ -93,7 +97,7 @@ func (plugin *quobytePlugin) CanSupport(spec *volume.Spec) bool {
 	// If Quobyte is already mounted we don't need to check if the binary is installed
 	if mounter, err := plugin.newMounterInternal(spec, nil, plugin.host.GetMounter(plugin.GetPluginName())); err == nil {
 		qm, _ := mounter.(*quobyteMounter)
-		pluginDir := plugin.host.GetPluginDir(strings.EscapeQualifiedNameForDisk(quobytePluginName))
+		pluginDir := plugin.host.GetPluginDir(qbPluginDirName)
 		if mounted, err := qm.pluginDirIsMounted(pluginDir); mounted && err == nil {
 			glog.V(4).Infof("quobyte: can support")
 			return true
@@ -235,7 +239,7 @@ func (mounter *quobyteMounter) CanMount() error {
 
 // SetUp attaches the disk and bind mounts to the volume path.
 func (mounter *quobyteMounter) SetUp(fsGroup *int64) error {
-	pluginDir := mounter.plugin.host.GetPluginDir(strings.EscapeQualifiedNameForDisk(quobytePluginName))
+	pluginDir := mounter.plugin.host.GetPluginDir(qbPluginDirName)
 	return mounter.SetUpAt(pluginDir, fsGroup)
 }
 
@@ -281,8 +285,8 @@ func (quobyteVolume *quobyte) GetPath() string {
 
 	// Quobyte has only one mount in the PluginDir where all Volumes are mounted
 	// The Quobyte client does a fixed-user mapping
-	pluginDir := quobyteVolume.plugin.host.GetPluginDir(strings.EscapeQualifiedNameForDisk(quobytePluginName))
-	return path.Join(pluginDir, fmt.Sprintf("%s#%s@%s", user, group, quobyteVolume.volume))
+	mntDir := strings.JoinQualifiedName(quobyteVolume.plugin.host.GetPluginDir(qbPluginDirName), qbMountPointName)
+	return path.Join(mntDir, fmt.Sprintf("%s#%s@%s", user, group, quobyteVolume.volume))
 }
 
 type quobyteUnmounter struct {

--- a/pkg/volume/quobyte/quobyte_test.go
+++ b/pkg/volume/quobyte/quobyte_test.go
@@ -98,8 +98,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Error("Got a nil Mounter")
 	}
 
-	if volumePath != fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/root#root@vol", tmpDir) {
-		t.Errorf("Got unexpected path: %s expected: %s", volumePath, fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/root#root@vol", tmpDir))
+	expectedPath := fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/mnt/root#root@vol", tmpDir)
+	if volumePath != expectedPath {
+		t.Errorf("Got unexpected path: %s expected: %s", volumePath, expectedPath)
 	}
 	if err := mounter.SetUp(nil); err != nil {
 		t.Errorf("Expected success, got: %v", err)


### PR DESCRIPTION
So far the plugin expects the Quobyte mount to reside at
"<plugins_dir>/kubernetes.io~quobyte".

This updates to a subdir "<plugins_dir>/kubernetes.io~quobyte/mnt" in order
to prevent mapping the plugins dir itself into containers
when using the Quobyte volume plugin.

This is handled by a subdir name variable in order to easily
allow updating the implementation to a configurable subdir
in a follow up change.

This change is related to a change in the Quobyte kubernetes deployment configs in order to prevent issues with blocked mount point locks. Related change at: https://github.com/quobyte/kubernetes/commit/e755424ff097dd87848bdb0741bd6355283fbbb7
