### PR TITLE
Remove iptables log on restore failure

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -1578,20 +1578,6 @@ func (proxier *Proxier) syncProxyRules() {
 	err = proxier.iptables.RestoreAll(proxier.iptablesData.Bytes(), utiliptables.NoFlushTables, utiliptables.RestoreCounters)
 	if err != nil {
 		glog.Errorf("Failed to execute iptables-restore: %v", err)
-		// ~rough approximation, assume ~100 chars per line
-		// we log first 1000 bytes, but full list at higher levels
-		rules := proxier.iptablesData.Bytes()
-		if len(rules) > 1000 {
-			abridgedRules := rules[:1000]
-			if glog.V(4) {
-				glog.V(4).Infof("Rules:\n%s", rules)
-			} else {
-				glog.V(2).Infof("Rules (abridged):\n%s", abridgedRules)
-			}
-		} else {
-			glog.V(2).Infof("Rules:\n%s", rules)
-		}
-
 		// Revert new local ports.
 		glog.V(2).Infof("Closing local ports after iptables-restore failure")
 		utilproxy.RevertPorts(replacementPortsMap, proxier.portsMap)


### PR DESCRIPTION
Don't log the set of rules at v2 in kube-proxy on error.
The rules are displayed at v5 before the restore is attempted.

In a large cluster the report can generate up to 100000 lines.
A partial report is only helpful if the problem is displayed
in the partial report.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
