### PR TITLE
examples/podsecuritypolicy/rbac: fix names in comments and sync with examples repository

### DIFF
--- a/examples/podsecuritypolicy/rbac/bindings.yaml
+++ b/examples/podsecuritypolicy/rbac/bindings.yaml
@@ -1,5 +1,5 @@
-# privilegedPSP gives the privilegedPSP role
-# to the group privileged.
+# privileged-psp-users gives the privileged-psp-user role
+# to the group privileged-psp-users.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -13,8 +13,8 @@ roleRef:
    kind: ClusterRole
    name: privileged-psp-user
 ---
-# restrictedPSP grants the restrictedPSP role to
-# the groups restricted and privileged.
+# restricted-psp-users grants the restricted-psp-user role to
+# the groups restricted-psp-users and privileged-psp-users.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -32,7 +32,7 @@ roleRef:
    name: restricted-psp-user
 ---
 # edit grants edit role to the groups
-# restricted and privileged.
+# restricted-psp-users and privileged-psp-users.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/podsecuritypolicy/rbac/policies.yaml
+++ b/examples/podsecuritypolicy/rbac/policies.yaml
@@ -16,6 +16,12 @@ spec:
   - '*'
   allowedCapabilities:
   - '*'
+  hostPID: true
+  hostIPC: true
+  hostNetwork: true
+  hostPorts:
+  - min: 1
+    max: 65536
 ---
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
@@ -38,4 +44,6 @@ spec:
   - 'configMap'
   - 'persistentVolumeClaim'
   - 'projected'
-
+  hostPID: false
+  hostIPC: false
+  hostNetwork: false

--- a/examples/podsecuritypolicy/rbac/roles.yaml
+++ b/examples/podsecuritypolicy/rbac/roles.yaml
@@ -1,10 +1,9 @@
-# restrictedPSP grants access to use
-# the restricted PSP.
+# restricted-psp-user grants access to use the restricted PSP.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: restricted-psp-user
-rules: 
+rules:
 - apiGroups:
   - extensions
   resources:
@@ -14,13 +13,12 @@ rules:
   verbs:
   - use
 ---
-# privilegedPSP grants access to use the privileged
-# PSP.
+# privileged-psp-user grants access to use the privileged PSP.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: privileged-psp-user
-rules: 
+rules:
 - apiGroups:
   - extensions
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes policies, roles, and bindings names in the comments. Also it sync examples with the examples from https://github.com/kubernetes/examples/tree/master/staging/podsecuritypolicy/rbac 

**Release note**:
```release-note
NONE
```

CC @simo5 