### PR TITLE
Pass user _proxy variables to docker build and run invocations

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -54,7 +54,9 @@ RUN mkdir -p /usr/local/src/protobuf \
 # Use dynamic cgo linking for architectures other than amd64 for the server platforms
 # To install crossbuild essential for other architectures add the following repository.
 RUN echo "deb http://archive.ubuntu.com/ubuntu xenial main universe" > /etc/apt/sources.list.d/cgocrosscompiling.list \
-  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
+  && if [ -n "$http_proxy" ]; then PROXY="--keyserver-options http-proxy=$http_proxy"; fi \
+  && if [ -n "$HTTP_PROXY" ]; then PROXY="--keyserver-options http-proxy=$HTTP_PROXY"; fi \
+  && apt-key adv --keyserver keyserver.ubuntu.com $PROXY --recv-keys 40976EAF437D05B5 3B4FE6ACC0B21F32 \
   && apt-get update \
   && apt-get install -y build-essential \
   && for platform in ${KUBE_DYNAMIC_CROSSPLATFORMS}; do apt-get install -y crossbuild-essential-${platform}; done \

--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -21,7 +21,7 @@ TAG=$(shell cat VERSION)
 all: push
 
 build:
-	docker build --pull -t staging-k8s.gcr.io/$(IMAGE):$(TAG) .
+	docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --pull -t staging-k8s.gcr.io/$(IMAGE):$(TAG) .
 
 push: build
 	gcloud docker -- push staging-k8s.gcr.io/$(IMAGE):$(TAG)

--- a/build/common.sh
+++ b/build/common.sh
@@ -478,7 +478,10 @@ function kube::build::docker_build() {
   local -r image=$1
   local -r context_dir=$2
   local -r pull="${3:-true}"
-  local -ra build_cmd=("${DOCKER[@]}" build -t "${image}" "--pull=${pull}" "${context_dir}")
+  local -ra build_cmd=("${DOCKER[@]}" build --build-arg HTTP_PROXY \
+      --build-arg HTTPS_PROXY --build-arg NO_PROXY \
+      --build-arg http_proxy --build-arg https_proxy \
+      --build-arg no_proxy -t "${image}" "--pull=${pull}" "${context_dir}")
 
   kube::log::status "Building Docker image ${image}"
   local docker_output
@@ -535,6 +538,12 @@ function kube::build::ensure_data_container() {
       --volume /usr/local/go/pkg/windows_386_cgo
       --name "${KUBE_DATA_CONTAINER_NAME}"
       --hostname "${HOSTNAME}"
+      --env HTTP_PROXY
+      --env HTTPS_PROXY
+      --env NO_PROXY
+      --env http_proxy
+      --env https_proxy
+      --env no_proxy
       "${KUBE_BUILD_IMAGE}"
       chown -R ${USER_ID}:${GROUP_ID}
         "${REMOTE_ROOT}"
@@ -599,6 +608,12 @@ function kube::build::run_build_command_ex() {
     --env "GOFLAGS=${GOFLAGS:-}"
     --env "GOLDFLAGS=${GOLDFLAGS:-}"
     --env "GOGCFLAGS=${GOGCFLAGS:-}"
+    --env HTTP_PROXY
+    --env HTTPS_PROXY
+    --env NO_PROXY
+    --env http_proxy
+    --env https_proxy
+    --env no_proxy
   )
 
   if [[ -n "${DOCKER_CGROUP_PARENT:-}" ]]; then

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -64,10 +64,10 @@ else
 endif
 	mv $(TEMP_DIR)/Dockerfile.build.tmp $(TEMP_DIR)/Dockerfile.build
 
-	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
+	docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(TAR_FILE)
-	docker build -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -53,7 +53,7 @@ endif
 
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -52,7 +52,7 @@ else
 	cd $(TEMP_DIR) && sed -i "s/CROSS_BUILD_//g" Dockerfile
 endif
 
-	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	docker build --build-arg HTTP_PROXY --build-arg HTTPS_PROXY --build-arg NO_PROXY --build-arg http_proxy --build-arg https_proxy --build-arg no_proxy --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 
 push: build
 	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)

--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -116,7 +116,9 @@ kube::swagger::gen_api_ref_docs() {
       --rm -v "${tmp_in_host}":/output:z \
       -v "${swagger_spec_path}":/swagger-source:z \
       -v "${register_file}":/register.go:z \
-      --net=host -e "https_proxy=${KUBERNETES_HTTPS_PROXY:-}" \
+      --net=host \
+      --env HTTP_PROXY --env HTTPS_PROXY --env NO_PROXY \
+      --env http_proxy --env https_proxy --env no_proxy \
       k8s.gcr.io/gen-swagger-docs:v8 \
       "${swagger_json_name}"
   done


### PR DESCRIPTION
**What this PR does / why we need it**:
Many docker build and run operations require access to the network.
This makes it impossible to rebuild multiple images from build/
in the environment with restricted internet access. This patch
adds passing inside built or run container user proxy environments,
thus allows to access network during build and run steps without
modifying either container images or Dockerfiles.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #49921 in few more places, improves solution made in #50587

**Special notes for your reviewer**:
cc @CaoShuFeng, @cblecker

**Release note**:
```release-note
NONE
```
