### PR TITLE
Don't log error in getInstanceFromProjectInZoneByName()

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_instances.go
+++ b/pkg/cloudprovider/providers/gce/gce_instances.go
@@ -488,6 +488,7 @@ func (gce *GCECloud) getInstanceByName(name string) (*gceInstance, error) {
 			if isHTTPErrorCode(err, http.StatusNotFound) {
 				continue
 			}
+			glog.Errorf("getInstanceByName: failed to get instance %s in zone %s; err: %v", name, zone, err)
 			return nil, err
 		}
 		return instance, nil
@@ -502,7 +503,6 @@ func (gce *GCECloud) getInstanceFromProjectInZoneByName(project, zone, name stri
 	res, err := gce.service.Instances.Get(project, zone, name).Do()
 	mc.Observe(err)
 	if err != nil {
-		glog.Errorf("getInstanceFromProjectInZoneByName: failed to get instance %s; err: %v", name, err)
 		return nil, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In function `getInstanceByName()` we attempt to get instance by name from all zones, presumably we might hit multiple not-found errors. Logging every such error seems misleading while debugging.

This PR makes it only logs non not-found errors while getting instance. If eventually no instance is found, 
an InstanceNotFound error will be returned as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #NONE

**Special notes for your reviewer**:
/assign @dnardo @nicksardo 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
