### PR TITLE
Improve webhook error message

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//vendor/k8s.io/api/admissionregistration/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/admission.go
@@ -218,11 +218,11 @@ func (a *GenericAdmissionWebhook) Admit(attr admission.Attributes) error {
 				}
 
 				glog.Warningf("Failed calling webhook, failing closed %v: %v", hook.Name, err)
-				errCh <- err
+				errCh <- apierrors.NewInternalError(err)
 				return
 			}
 
-			glog.Warningf("rejected by webhook %v %t: %v", hook.Name, err, err)
+			glog.Warningf("rejected by webhook %q: %#v", hook.Name, err)
 			errCh <- err
 		}(&hooks[i])
 	}
@@ -273,12 +273,29 @@ func (a *GenericAdmissionWebhook) callHook(ctx context.Context, h *v1alpha1.Exte
 		return nil
 	}
 
-	if response.Status.Result == nil {
-		return fmt.Errorf("admission webhook %q denied the request without explanation", h.Name)
+	return toStatusErr(h.Name, response.Status.Result)
+}
+
+// toStatusErr returns a StatusError with information about the webhook controller
+func toStatusErr(name string, result *metav1.Status) *apierrors.StatusError {
+	deniedBy := fmt.Sprintf("admission webhook %q denied the request", name)
+	const noExp = "without explanation"
+
+	if result == nil {
+		result = &metav1.Status{Status: metav1.StatusFailure}
+	}
+
+	switch {
+	case len(result.Message) > 0:
+		result.Message = fmt.Sprintf("%s: %s", deniedBy, result.Message)
+	case len(result.Reason) > 0:
+		result.Message = fmt.Sprintf("%s: %s", deniedBy, result.Reason)
+	default:
+		result.Message = fmt.Sprintf("%s %s", deniedBy, noExp)
 	}
 
 	return &apierrors.StatusError{
-		ErrStatus: *response.Status.Result,
+		ErrStatus: *result,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
Currently, apiserver only prints message of review status returned by a rejecting webhook controller. If the message is empty, users will see this in event message: 
`create Pod <pod-name> failed error:<empty-string>`. Hook name should be included in the error message as well.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**: @kubernetes/sig-api-machinery-bugs 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
