### PR TITLE
Add kubelet etchosts, host path, and empty dir conformance annotations

### DIFF
--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -68,59 +68,142 @@ var _ = framework.KubeDescribe("EmptyDir volumes", func() {
 		})
 	})
 
-	framework.ConformanceIt("volume on tmpfs should have the correct mode  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-mode-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure the volume has 0777 unix file permissions and tmpfs
+			mount type.
+	*/
+	framework.ConformanceIt("volume on tmpfs should have the correct mode [Conformance] [sig-storage]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (root,0644,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0644-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a root owned file with 0644 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (root,0644,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (root,0666,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0666-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a root owned file with 0666 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (root,0666,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (root,0777,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0777-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a root owned file with 0777 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (root,0777,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (non-root,0644,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0644-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a user owned file with 0644 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (non-root,0644,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (non-root,0666,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0666-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a user owned file with 0666 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (non-root,0666,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("should support (non-root,0777,tmpfs)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0777-tmpfs
+		    Description: For a Pod created with an 'emptyDir' Volume with 'medium'
+			of 'Memory', ensure a user owned file with 0777 unix file permissions
+			is created correctly, has tmpfs mount type, and enforces the permissions.
+	*/
+	framework.ConformanceIt("should support (non-root,0777,tmpfs) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
 	})
 
-	framework.ConformanceIt("volume on default medium should have the correct mode  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-mode
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure the
+			volume has 0777 unix file permissions.
+	*/
+	framework.ConformanceIt("volume on default medium should have the correct mode [Conformance] [sig-storage]", func() {
 		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (root,0644,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0644
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			root owned file with 0644 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (root,0644,default) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (root,0666,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0666
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			root owned file with 0666 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (root,0666,default) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (root,0777,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-root-0777
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			root owned file with 0777 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (root,0777,default) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (non-root,0644,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0644
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			user owned file with 0644 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (non-root,0644,default) [Conformance] [sig-storage]", func() {
 		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (non-root,0666,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0666
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			user owned file with 0666 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (non-root,0666,default) [Conformance] [sig-storage]", func() {
 		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 
-	framework.ConformanceIt("should support (non-root,0777,default)  [sig-storage]", func() {
+	/*
+		    Testname: volume-emptydir-user-0777
+		    Description: For a Pod created with an 'emptyDir' Volume, ensure a
+			user owned file with 0777 unix file permissions is created and enforced
+			correctly.
+	*/
+	framework.ConformanceIt("should support (non-root,0777,default) [Conformance] [sig-storage]", func() {
 		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)
 	})
 })

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -40,6 +40,12 @@ var _ = framework.KubeDescribe("HostPath", func() {
 		_ = os.Remove("/tmp/test-file")
 	})
 
+	/*
+		    Testname: volume-hostpath-mode
+		    Description: For a Pod created with a 'HostPath' Volume, ensure the
+			volume is a directory with 0777 unix file permissions and that is has
+			the sticky bit (mode flag t) set.
+	*/
 	framework.ConformanceIt("should give a volume the correct mode  [sig-storage]", func() {
 		source := &v1.HostPathVolumeSource{
 			Path: "/tmp",

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -48,6 +48,11 @@ var _ = framework.KubeDescribe("KubeletManagedEtcHosts", func() {
 		f: f,
 	}
 
+	/*
+		    Testname: kubelet-managed-etc-hosts
+		    Description: Make sure Kubelet correctly manages /etc/hosts and mounts
+			it into container.
+	*/
 	framework.ConformanceIt("should test kubelet managed /etc/hosts file ", func() {
 		By("Setting up the test")
 		config.setup()


### PR DESCRIPTION


Signed-off-by: Brad Topol <btopol@us.ibm.com>
Add kubelet etchosts, host path, and empty dir conformance annotations

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds kubelet etchosts, host path, and empty dir related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the pod based e2e conformance tests.
Special notes for your reviewer:
Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
