### PR TITLE
Expose cache.Reflector errors as a metric and method

### DIFF
--- a/pkg/util/reflector/prometheus/prometheus.go
+++ b/pkg/util/reflector/prometheus/prometheus.go
@@ -68,6 +68,12 @@ var (
 		Name:      "items_per_watch",
 		Help:      "How many items an API watch returns to the reflectors",
 	}, []string{"name"})
+
+	listWatchError = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: reflectorSubsystem,
+		Name:      "list_watch_error",
+		Help:      "Whether or not the reflector received an error on its last list or watch attempt",
+	}, []string{"name"})
 )
 
 func init() {
@@ -78,6 +84,7 @@ func init() {
 	prometheus.MustRegister(shortWatchesTotal)
 	prometheus.MustRegister(watchDuration)
 	prometheus.MustRegister(itemsPerWatch)
+	prometheus.MustRegister(listWatchError)
 
 	cache.SetReflectorMetricsProvider(prometheusMetricsProvider{})
 }
@@ -124,4 +131,8 @@ func (prometheusMetricsProvider) NewLastResourceVersionMetric(name string) cache
 	})
 	prometheus.MustRegister(rv)
 	return rv
+}
+
+func (prometheusMetricsProvider) NewListWatchErrorMetric(name string) cache.GaugeMetric {
+	return listWatchError.WithLabelValues(name)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_metrics.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_metrics.go
@@ -58,6 +58,8 @@ type reflectorMetrics struct {
 	numberOfItemsInWatch SummaryMetric
 
 	lastResourceVersion GaugeMetric
+
+	listWatchError GaugeMetric
 }
 
 // MetricsProvider generates various metrics used by the reflector.
@@ -72,6 +74,8 @@ type MetricsProvider interface {
 	NewItemsInWatchMetric(name string) SummaryMetric
 
 	NewLastResourceVersionMetric(name string) GaugeMetric
+
+	NewListWatchErrorMetric(name string) GaugeMetric
 }
 
 type noopMetricsProvider struct{}
@@ -86,6 +90,7 @@ func (noopMetricsProvider) NewItemsInWatchMetric(name string) SummaryMetric  { r
 func (noopMetricsProvider) NewLastResourceVersionMetric(name string) GaugeMetric {
 	return noopMetric{}
 }
+func (noopMetricsProvider) NewListWatchErrorMetric(name string) GaugeMetric { return noopMetric{} }
 
 var metricsFactory = struct {
 	metricsProvider MetricsProvider
@@ -108,6 +113,7 @@ func newReflectorMetrics(name string) *reflectorMetrics {
 		watchDuration:        metricsFactory.metricsProvider.NewWatchDurationMetric(name),
 		numberOfItemsInWatch: metricsFactory.metricsProvider.NewItemsInWatchMetric(name),
 		lastResourceVersion:  metricsFactory.metricsProvider.NewLastResourceVersionMetric(name),
+		listWatchError:       metricsFactory.metricsProvider.NewListWatchErrorMetric(name),
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Reflector records whether its last list or watch attempt resulted in
an error talking to the API server. If it does hit an error, it sets a
metric guage to 1. Once a successful list or watch occurs the Reflector
will reset the gauge back to 0.

The goal for the metrics is to be able to trigger monitoring when a
user of a Reflector e.g. a kubelet, can't reach its API server. The goal
of the `ListWatchError` method on the Reflector is so that other users
of the Reflector can take programmatic action when their conncetion to
the API server is interrupted, e.g. try to restablish the connection.

For context on why this metric is necessary, I work with a cluster that        
recently suffered a split-brain where the API servers weren't reporting        
accurate information, which triggered error logs from the kubelet's reflectors.
However, since there were no kubelet metrics exposing the issue, or failing    
health checks, none of our alerting exposed the problem to us. The API server's
node statuses were all reporting healthy as well. Adding this reflector error  
metric gives us a way to see whether or not the Kubelet thinks it is in a fully
operational state.

**Which issue this PR fixes**: Address issues raised by #50928

**Special notes for your reviewer**:

This is my second attempt to expose API server connectivity errors, background discussion can be seen at https://github.com/kubernetes/kubernetes/pull/53306.

**Release note**:

```release-note
Expose API server connectivity errors as a Reflector metric
```
