### PR TITLE
e2e test should get KUBECONFIG correctly.

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1917,7 +1917,6 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	//c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	// if you want to change override values or bind them to flags, there are methods to help you

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1917,15 +1917,22 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	//c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	c, err := kubeConfig.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading KubeConfig: %v", err.Error())
 	}
+
 	if kubeContext != "" {
 		Logf(">>> kubeContext: %s", kubeContext)
 		c.CurrentContext = kubeContext
 	}
-	return c, nil
+	return &c, nil
 }
 
 type ClientConfigGetter func() (*restclient.Config, error)


### PR DESCRIPTION
function (LoadFromFile) cannot deal with the relative path in $KUBECONFIG file,  always got error about cert file not found when execute "make test-e2e".

Due to command 
```cluster/kubectl.sh config set-credentials myself --client-key=/var/run/kubernetes/client-admin.key --client-certificate=/var/run/kubernetes/client-admin.crt```
 always set relative path in $KUBECONFIG , and use LoadFromFile always got error, change it according "client-go\tools\clientcmd\api\doc.go"  suggested.  "make test-e2e" command can run without "cert file not found".