### PR TITLE
GCE cloud should delete return NotFound error

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_targetproxy.go
+++ b/pkg/cloudprovider/providers/gce/gce_targetproxy.go
@@ -17,8 +17,6 @@ limitations under the License.
 package gce
 
 import (
-	"net/http"
-
 	compute "google.golang.org/api/compute/v1"
 )
 
@@ -59,9 +57,6 @@ func (gce *GCECloud) DeleteTargetHttpProxy(name string) error {
 	mc := newTargetProxyMetricContext("delete")
 	op, err := gce.service.TargetHttpProxies.Delete(gce.projectID, name).Do()
 	if err != nil {
-		if isHTTPErrorCode(err, http.StatusNotFound) {
-			return nil
-		}
 		return mc.Observe(err)
 	}
 	return gce.waitForGlobalOp(op, mc)
@@ -121,9 +116,6 @@ func (gce *GCECloud) DeleteTargetHttpsProxy(name string) error {
 	mc := newTargetProxyMetricContext("delete")
 	op, err := gce.service.TargetHttpsProxies.Delete(gce.projectID, name).Do()
 	if err != nil {
-		if isHTTPErrorCode(err, http.StatusNotFound) {
-			return nil
-		}
 		return mc.Observe(err)
 	}
 	return gce.waitForGlobalOp(op, mc)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
consistent it with kubernetes/pkg/cloudprovider/providers/gce/gce_healthchecks.go
should delete return NotFound
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #54717 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
