### PR TITLE
LoadFromFile  func got error "cert file not found"

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1917,15 +1917,21 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	c, err := kubeConfig.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading KubeConfig: %v", err.Error())
 	}
+
 	if kubeContext != "" {
 		Logf(">>> kubeContext: %s", kubeContext)
 		c.CurrentContext = kubeContext
 	}
-	return c, nil
+	return &c, nil
 }
 
 type ClientConfigGetter func() (*restclient.Config, error)

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1917,7 +1917,6 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	//c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 	configOverrides := &clientcmd.ConfigOverrides{}
 	// if you want to change override values or bind them to flags, there are methods to help you

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1917,15 +1917,22 @@ func RestclientConfig(kubeContext string) (*clientcmdapi.Config, error) {
 	if TestContext.KubeConfig == "" {
 		return nil, fmt.Errorf("KubeConfig must be specified to load client config")
 	}
-	c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	//c, err := clientcmd.LoadFromFile(TestContext.KubeConfig)
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	c, err := kubeConfig.RawConfig()
 	if err != nil {
 		return nil, fmt.Errorf("error loading KubeConfig: %v", err.Error())
 	}
+
 	if kubeContext != "" {
 		Logf(">>> kubeContext: %s", kubeContext)
 		c.CurrentContext = kubeContext
 	}
-	return c, nil
+	return &c, nil
 }
 
 type ClientConfigGetter func() (*restclient.Config, error)


### PR DESCRIPTION

**What this PR does / why we need it**:
 Fix the issue about "cert file not found" when execute "make test-e2e" ( export KUBERNETES_PROVIDER=local) . 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

if config file (/var/run/kubernetes/admin.kubeconfig) use relative path value in key client-certificate and client-key,  LoadFromFile function cannot work as expect.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
