### PR TITLE
Block volumes Support: iSCSI plugin update

### DIFF
--- a/pkg/volume/iscsi/BUILD
+++ b/pkg/volume/iscsi/BUILD
@@ -17,14 +17,17 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/volume/iscsi",
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/util/mount:go_default_library",
         "//pkg/util/strings:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
+        "//pkg/volume/util/volumehelper:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/volume/iscsi/disk_manager.go
+++ b/pkg/volume/iscsi/disk_manager.go
@@ -27,15 +27,19 @@ import (
 // Abstract interface to disk operations.
 type diskManager interface {
 	MakeGlobalPDName(disk iscsiDisk) string
+	MakeGlobalVDPDName(disk iscsiDisk) string
 	// Attaches the disk to the kubelet's host machine.
 	AttachDisk(b iscsiDiskMounter) (string, error)
 	// Detaches the disk from the kubelet's host machine.
 	DetachDisk(disk iscsiDiskUnmounter, mntPath string) error
+	// Detaches the block disk from the kubelet's host machine.
+	DetachBlockISCSIDisk(disk iscsiDiskUnmapper, mntPath string) error
 }
 
 // utility to mount a disk based filesystem
+// globalPDPath: global mount path like, /var/lib/kubelet/plugins/kubernetes.io/iscsi/{ifaceName}/{portal-some_iqn-lun-lun_id}
+// volPath: pod volume dir path like, /var/lib/kubelet/pods/{podUID}/volumes/kubernetes.io~iscsi/{volumeName}
 func diskSetUp(manager diskManager, b iscsiDiskMounter, volPath string, mounter mount.Interface, fsGroup *int64) error {
-	// TODO: handle failed mounts here.
 	notMnt, err := mounter.IsLikelyNotMountPoint(volPath)
 	if err != nil && !os.IsNotExist(err) {
 		glog.Errorf("cannot validate mountpoint: %s", volPath)

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -19,6 +19,7 @@ package iscsi
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"k8s.io/api/core/v1"
@@ -80,7 +81,7 @@ type fakeDiskManager struct {
 
 func NewFakeDiskManager() *fakeDiskManager {
 	return &fakeDiskManager{
-		tmpDir: utiltesting.MkTmpdirOrDie("fc_test"),
+		tmpDir: utiltesting.MkTmpdirOrDie("iscsi_test"),
 	}
 }
 
@@ -91,6 +92,11 @@ func (fake *fakeDiskManager) Cleanup() {
 func (fake *fakeDiskManager) MakeGlobalPDName(disk iscsiDisk) string {
 	return fake.tmpDir
 }
+
+func (fake *fakeDiskManager) MakeGlobalVDPDName(disk iscsiDisk) string {
+	return fake.tmpDir
+}
+
 func (fake *fakeDiskManager) AttachDisk(b iscsiDiskMounter) (string, error) {
 	globalPath := b.manager.MakeGlobalPDName(*b.iscsiDisk)
 	err := os.MkdirAll(globalPath, 0750)
@@ -106,6 +112,15 @@ func (fake *fakeDiskManager) AttachDisk(b iscsiDiskMounter) (string, error) {
 
 func (fake *fakeDiskManager) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 	globalPath := c.manager.MakeGlobalPDName(*c.iscsiDisk)
+	err := os.RemoveAll(globalPath)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (fake *fakeDiskManager) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mntPath string) error {
+	globalPath := c.manager.MakeGlobalVDPDName(*c.iscsiDisk)
 	err := os.RemoveAll(globalPath)
 	if err != nil {
 		return err
@@ -289,10 +304,12 @@ type testcase struct {
 	defaultNs string
 	spec      *volume.Spec
 	// Expected return of the test
-	expectedName  string
-	expectedNs    string
-	expectedIface string
-	expectedError error
+	expectedName          string
+	expectedNs            string
+	expectedIface         string
+	expectedError         error
+	expectedDiscoveryCHAP bool
+	expectedSessionCHAP   bool
 }
 
 func TestGetSecretNameAndNamespaceForPV(t *testing.T) {
@@ -424,5 +441,105 @@ func TestGetISCSIInitiatorInfo(t *testing.T) {
 				err, resultIface)
 		}
 	}
+}
 
+func TestGetISCSICHAP(t *testing.T) {
+	tests := []testcase{
+		{
+			name: "persistent volume source",
+			spec: &volume.Spec{
+				PersistentVolume: &v1.PersistentVolume{
+					Spec: v1.PersistentVolumeSpec{
+						PersistentVolumeSource: v1.PersistentVolumeSource{
+							ISCSI: &v1.ISCSIPersistentVolumeSource{
+								DiscoveryCHAPAuth: true,
+								SessionCHAPAuth:   true,
+							},
+						},
+					},
+				},
+			},
+			expectedDiscoveryCHAP: true,
+			expectedSessionCHAP:   true,
+			expectedError:         nil,
+		},
+		{
+			name: "pod volume source",
+			spec: &volume.Spec{
+				Volume: &v1.Volume{
+					VolumeSource: v1.VolumeSource{
+						ISCSI: &v1.ISCSIVolumeSource{
+							DiscoveryCHAPAuth: true,
+							SessionCHAPAuth:   true,
+						},
+					},
+				},
+			},
+			expectedDiscoveryCHAP: true,
+			expectedSessionCHAP:   true,
+			expectedError:         nil,
+		},
+		{
+			name: "no volume",
+			spec: &volume.Spec{},
+			expectedDiscoveryCHAP: false,
+			expectedSessionCHAP:   false,
+			expectedError:         fmt.Errorf("Spec does not reference an ISCSI volume type"),
+		},
+	}
+	for _, testcase := range tests {
+		resultDiscoveryCHAP, err := getISCSIDiscoveryCHAPInfo(testcase.spec)
+		resultSessionCHAP, err := getISCSISessionCHAPInfo(testcase.spec)
+		switch testcase.name {
+		case "no volume":
+			if err.Error() != testcase.expectedError.Error() || resultDiscoveryCHAP != testcase.expectedDiscoveryCHAP || resultSessionCHAP != testcase.expectedSessionCHAP {
+				t.Errorf("%s failed: expected err=%v DiscoveryCHAP=%v SessionCHAP=%v, got %v/%v/%v",
+					testcase.name, testcase.expectedError, testcase.expectedDiscoveryCHAP, testcase.expectedSessionCHAP,
+					err, resultDiscoveryCHAP, resultSessionCHAP)
+			}
+		default:
+			if err != testcase.expectedError || resultDiscoveryCHAP != testcase.expectedDiscoveryCHAP || resultSessionCHAP != testcase.expectedSessionCHAP {
+				t.Errorf("%s failed: expected err=%v DiscoveryCHAP=%v SessionCHAP=%v, got %v/%v/%v", testcase.name, testcase.expectedError, testcase.expectedDiscoveryCHAP, testcase.expectedSessionCHAP,
+					err, resultDiscoveryCHAP, resultSessionCHAP)
+			}
+		}
+	}
+}
+
+func TestGetVolumeSpec(t *testing.T) {
+	path := "plugins/kubernetes.io/iscsi/volumeDevices/iface-default/127.0.0.1:3260-iqn.2014-12.server:storage.target01-lun-0"
+	spec, _ := getVolumeSpecFromGlobalMapPath("test", path)
+
+	portal := spec.PersistentVolume.Spec.PersistentVolumeSource.ISCSI.TargetPortal
+	if portal != "127.0.0.1:3260" {
+		t.Errorf("wrong portal: %v", portal)
+	}
+	iqn := spec.PersistentVolume.Spec.PersistentVolumeSource.ISCSI.IQN
+	if iqn != "iqn.2014-12.server:storage.target01" {
+		t.Errorf("wrong iqn: %v", iqn)
+	}
+	lun := spec.PersistentVolume.Spec.PersistentVolumeSource.ISCSI.Lun
+	if lun != 0 {
+		t.Errorf("wrong lun: %v", lun)
+	}
+	iface := spec.PersistentVolume.Spec.PersistentVolumeSource.ISCSI.ISCSIInterface
+	if iface != "default" {
+		t.Errorf("wrong ISCSIInterface: %v", iface)
+	}
+}
+
+func TestGetVolumeSpec_no_lun(t *testing.T) {
+	path := "plugins/kubernetes.io/iscsi/volumeDevices/iface-default/127.0.0.1:3260-iqn.2014-12.server:storage.target01"
+	_, err := getVolumeSpecFromGlobalMapPath("test", path)
+	if !strings.Contains(err.Error(), "malformatted mnt path") {
+		t.Errorf("should get error: malformatted mnt path")
+	}
+}
+
+func TestGetVolumeSpec_no_iface(t *testing.T) {
+	path := "plugins/kubernetes.io/iscsi/volumeDevices/default/127.0.0.1:3260-iqn.2014-12.server:storage.target01-lun-0"
+	_, err := getVolumeSpecFromGlobalMapPath("test", path)
+	if !strings.Contains(err.Error(), "failed to retreive iface") {
+		t.Errorf("should get error: failed to retreive iface")
+	}
 }

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -27,6 +27,9 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -163,10 +166,21 @@ func makePDNameInternal(host volume.VolumeHost, portal string, iqn string, lun s
 	return path.Join(host.GetPluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
 }
 
+// make a directory like /var/lib/kubelet/plugins/kubernetes.io/iscsi/volumeDevices/iface_name/portal-some_iqn-lun-lun_id
+func makeVDPDNameInternal(host volume.VolumeHost, portal string, iqn string, lun string, iface string) string {
+	return path.Join(host.GetVolumeDevicePluginDir(iscsiPluginName), "iface-"+iface, portal+"-"+iqn+"-lun-"+lun)
+}
+
 type ISCSIUtil struct{}
 
+// MakeGlobalPDName returns path of global plugin dir
 func (util *ISCSIUtil) MakeGlobalPDName(iscsi iscsiDisk) string {
-	return makePDNameInternal(iscsi.plugin.host, iscsi.Portals[0], iscsi.Iqn, iscsi.lun, iscsi.Iface)
+	return makePDNameInternal(iscsi.plugin.host, iscsi.Portals[0], iscsi.Iqn, iscsi.Lun, iscsi.Iface)
+}
+
+// MakeGlobalVDPDName returns path of global volume device plugin dir
+func (util *ISCSIUtil) MakeGlobalVDPDName(iscsi iscsiDisk) string {
+	return makeVDPDNameInternal(iscsi.plugin.host, iscsi.Portals[0], iscsi.Iqn, iscsi.Lun, iscsi.Iface)
 }
 
 func (util *ISCSIUtil) persistISCSI(conf iscsiDisk, mnt string) error {
@@ -184,7 +198,6 @@ func (util *ISCSIUtil) persistISCSI(conf iscsiDisk, mnt string) error {
 }
 
 func (util *ISCSIUtil) loadISCSI(conf *iscsiDisk, mnt string) error {
-	// NOTE: The iscsi config json is not deleted after logging out from target portals.
 	file := path.Join(mnt, "iscsi.json")
 	fp, err := os.Open(file)
 	if err != nil {
@@ -198,6 +211,7 @@ func (util *ISCSIUtil) loadISCSI(conf *iscsiDisk, mnt string) error {
 	return nil
 }
 
+// AttachDisk returns devicePath of volume if attach succeeded otherwise returns error
 func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	var devicePath string
 	var devicePaths []string
@@ -240,9 +254,9 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			return "", fmt.Errorf("Could not parse iface file for %s", b.Iface)
 		}
 		if iscsiTransport == "tcp" {
-			devicePath = strings.Join([]string{"/dev/disk/by-path/ip", tp, "iscsi", b.Iqn, "lun", b.lun}, "-")
+			devicePath = strings.Join([]string{"/dev/disk/by-path/ip", tp, "iscsi", b.Iqn, "lun", b.Lun}, "-")
 		} else {
-			devicePath = strings.Join([]string{"/dev/disk/by-path/pci", "*", "ip", tp, "iscsi", b.Iqn, "lun", b.lun}, "-")
+			devicePath = strings.Join([]string{"/dev/disk/by-path/pci", "*", "ip", tp, "iscsi", b.Iqn, "lun", b.Lun}, "-")
 		}
 
 		if exist := waitForPathToExist(&devicePath, 1, iscsiTransport); exist {
@@ -307,26 +321,6 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 
 	//Make sure we use a valid devicepath to find mpio device.
 	devicePath = devicePaths[0]
-
-	// mount it
-	globalPDPath := b.manager.MakeGlobalPDName(*b.iscsiDisk)
-	notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
-	if err != nil && !os.IsNotExist(err) {
-		return "", fmt.Errorf("Heuristic determination of mount point failed:%v", err)
-	}
-	if !notMnt {
-		glog.Infof("iscsi: %s already mounted", globalPDPath)
-		return "", nil
-	}
-
-	if err := os.MkdirAll(globalPDPath, 0750); err != nil {
-		glog.Errorf("iscsi: failed to mkdir %s, error", globalPDPath)
-		return "", err
-	}
-
-	// Persist iscsi disk config to json file for DetachDisk path
-	util.persistISCSI(*(b.iscsiDisk), globalPDPath)
-
 	for _, path := range devicePaths {
 		// There shouldnt be any empty device paths. However adding this check
 		// for safer side to avoid the possibility of an empty entry.
@@ -339,14 +333,67 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			break
 		}
 	}
-	err = b.mounter.FormatAndMount(devicePath, globalPDPath, b.fsType, nil)
-	if err != nil {
-		glog.Errorf("iscsi: failed to mount iscsi volume %s [%s] to %s, error %v", devicePath, b.fsType, globalPDPath, err)
-	}
-
-	return devicePath, err
+	glog.V(5).Infof("iscsi: AttachDisk devicePath: %s", devicePath)
+	// run global mount path related operations based on volumeMode
+	return globalPDPathOperation(b)(b, devicePath, util)
 }
 
+// globalPDPathOperation returns global mount path related operations based on volumeMode.
+// If the volumeMode is 'Filesystem' or not defined, plugin needs to create a dir, persist
+// iscsi configrations, and then format/mount the volume.
+// If the volumeMode is 'Block', plugin creates a dir and persists iscsi configrations.
+// Since volume type is block, plugin doesn't need to format/mount the volume.
+func globalPDPathOperation(b iscsiDiskMounter) func(iscsiDiskMounter, string, *ISCSIUtil) (string, error) {
+	// TODO: remove feature gate check after no longer needed
+	if utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) {
+		glog.V(5).Infof("iscsi: AttachDisk volumeMode: %s", b.volumeMode)
+		if b.volumeMode == v1.PersistentVolumeBlock {
+			// If the volumeMode is 'Block', plugin don't need to format the volume.
+			return func(b iscsiDiskMounter, devicePath string, util *ISCSIUtil) (string, error) {
+				globalPDPath := b.manager.MakeGlobalVDPDName(*b.iscsiDisk)
+				// Create dir like /var/lib/kubelet/plugins/kubernetes.io/iscsi/volumeDevices/{ifaceName}/{portal-some_iqn-lun-lun_id}
+				if err := os.MkdirAll(globalPDPath, 0750); err != nil {
+					glog.Errorf("iscsi: failed to mkdir %s, error", globalPDPath)
+					return "", err
+				}
+				// Persist iscsi disk config to json file for DetachDisk path
+				util.persistISCSI(*(b.iscsiDisk), globalPDPath)
+
+				return devicePath, nil
+			}
+		}
+	}
+	// If the volumeMode is 'Filesystem', plugin needs to format the volume
+	// and mount it to globalPDPath.
+	return func(b iscsiDiskMounter, devicePath string, util *ISCSIUtil) (string, error) {
+		globalPDPath := b.manager.MakeGlobalPDName(*b.iscsiDisk)
+		notMnt, err := b.mounter.IsLikelyNotMountPoint(globalPDPath)
+		if err != nil && !os.IsNotExist(err) {
+			return "", fmt.Errorf("Heuristic determination of mount point failed:%v", err)
+		}
+		// Return confirmed devicePath to caller
+		if !notMnt {
+			glog.Infof("iscsi: %s already mounted", globalPDPath)
+			return devicePath, nil
+		}
+		// Create dir like /var/lib/kubelet/plugins/kubernetes.io/iscsi/{ifaceName}/{portal-some_iqn-lun-lun_id}
+		if err := os.MkdirAll(globalPDPath, 0750); err != nil {
+			glog.Errorf("iscsi: failed to mkdir %s, error", globalPDPath)
+			return "", err
+		}
+		// Persist iscsi disk config to json file for DetachDisk path
+		util.persistISCSI(*(b.iscsiDisk), globalPDPath)
+
+		err = b.mounter.FormatAndMount(devicePath, globalPDPath, b.fsType, nil)
+		if err != nil {
+			glog.Errorf("iscsi: failed to mount iscsi volume %s [%s] to %s, error %v", devicePath, b.fsType, globalPDPath, err)
+		}
+
+		return devicePath, nil
+	}
+}
+
+// DetachDisk unmounts and detaches a volume from node
 func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 	_, cnt, err := mount.GetDeviceNameFromMount(c.mounter, mntPath)
 	if err != nil {
@@ -401,9 +448,91 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 	}
 	portals := removeDuplicate(bkpPortal)
 	if len(portals) == 0 {
-		return fmt.Errorf("iscsi detach disk: failed to detach iscsi disk. Couldn't get connected portals from configurations.")
+		return fmt.Errorf("iscsi detach disk: failed to detach iscsi disk. Couldn't get connected portals from configurations")
 	}
 
+	err = util.detachISCSIDisk(c.exec, portals, iqn, iface, volName, initiatorName, found)
+	if err != nil {
+		return fmt.Errorf("failed to finish detachISCSIDisk, err: %v", err)
+	}
+	return nil
+}
+
+// DetachBlockISCSIDisk removes loopback device for a volume and detaches a volume from node
+func (util *ISCSIUtil) DetachBlockISCSIDisk(c iscsiDiskUnmapper, mapPath string) error {
+	if pathExists, pathErr := volumeutil.PathExists(mapPath); pathErr != nil {
+		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+	} else if !pathExists {
+		glog.Warningf("Warning: Unmap skipped because path does not exist: %v", mapPath)
+		return nil
+	}
+	// If we arrive here, device is no longer used, see if need to logout the target
+	// device: 192.168.0.10:3260-iqn.2017-05.com.example:test-lun-0
+	device, _, err := extractDeviceAndPrefix(mapPath)
+	if err != nil {
+		return err
+	}
+	var bkpPortal []string
+	var volName, iqn, lun, iface, initiatorName string
+	found := true
+	// load iscsi disk config from json file
+	if err := util.loadISCSI(c.iscsiDisk, mapPath); err == nil {
+		bkpPortal, iqn, lun, iface, volName = c.iscsiDisk.Portals, c.iscsiDisk.Iqn, c.iscsiDisk.Lun, c.iscsiDisk.Iface, c.iscsiDisk.VolName
+		initiatorName = c.iscsiDisk.InitiatorName
+	} else {
+		// If the iscsi disk config is not found, fall back to the original behavior.
+		// This portal/iqn/iface is no longer referenced, log out.
+		// Extract the portal and iqn from device path.
+		bkpPortal = make([]string, 1)
+		bkpPortal[0], iqn, err = extractPortalAndIqn(device)
+		if err != nil {
+			return err
+		}
+		arr := strings.Split(device, "-lun-")
+		if len(arr) < 2 {
+			return fmt.Errorf("failed to retreive lun from mapPath: %v", mapPath)
+		}
+		lun = arr[1]
+		// Extract the iface from the mountPath and use it to log out. If the iface
+		// is not found, maintain the previous behavior to facilitate kubelet upgrade.
+		// Logout may fail as no session may exist for the portal/IQN on the specified interface.
+		iface, found = extractIface(mapPath)
+	}
+	portals := removeDuplicate(bkpPortal)
+	if len(portals) == 0 {
+		return fmt.Errorf("iscsi detach disk: failed to detach iscsi disk. Couldn't get connected portals from configurations")
+	}
+
+	devicePath := getDevByPath(portals[0], iqn, lun)
+	glog.V(5).Infof("iscsi: devicePath: %s", devicePath)
+	if _, err = os.Stat(devicePath); err != nil {
+		return fmt.Errorf("failed to validate devicePath: %s", devicePath)
+	}
+	// check if the dev is using mpio and if so mount it via the dm-XX device
+	if mappedDevicePath := c.deviceUtil.FindMultipathDeviceForDevice(devicePath); mappedDevicePath != "" {
+		devicePath = mappedDevicePath
+	}
+	// Get loopback device which takes fd lock for devicePath before
+	// detaching a volume from node.
+	blkUtil := volumeutil.NewBlockVolumePathHandler()
+	loop, err := volumeutil.BlockVolumePathHandler.GetLoopDevice(blkUtil, devicePath)
+	if err != nil {
+		return fmt.Errorf("failed to get loopback for device: %v, err: %v", devicePath, err)
+	}
+	// Detach a volume from kubelet node
+	err = util.detachISCSIDisk(c.exec, portals, iqn, iface, volName, initiatorName, found)
+	if err != nil {
+		return fmt.Errorf("failed to finish detachISCSIDisk, err: %v", err)
+	}
+	// The volume was successfully detached from node. We can safely remove the loopback.
+	err = volumeutil.BlockVolumePathHandler.RemoveLoopDevice(blkUtil, loop)
+	if err != nil {
+		return fmt.Errorf("failed to remove loopback :%v, err: %v", loop, err)
+	}
+	return nil
+}
+
+func (util *ISCSIUtil) detachISCSIDisk(exec mount.Exec, portals []string, iqn, iface, volName, initiatorName string, found bool) error {
 	for _, portal := range portals {
 		logoutArgs := []string{"-m", "node", "-p", portal, "-T", iqn, "--logout"}
 		deleteArgs := []string{"-m", "node", "-p", portal, "-T", iqn, "-o", "delete"}
@@ -412,13 +541,13 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 			deleteArgs = append(deleteArgs, []string{"-I", iface}...)
 		}
 		glog.Infof("iscsi: log out target %s iqn %s iface %s", portal, iqn, iface)
-		out, err := c.exec.Run("iscsiadm", logoutArgs...)
+		out, err := exec.Run("iscsiadm", logoutArgs...)
 		if err != nil {
 			glog.Errorf("iscsi: failed to detach disk Error: %s", string(out))
 		}
 		// Delete the node record
 		glog.Infof("iscsi: delete node record target %s iqn %s", portal, iqn)
-		out, err = c.exec.Run("iscsiadm", deleteArgs...)
+		out, err = exec.Run("iscsiadm", deleteArgs...)
 		if err != nil {
 			glog.Errorf("iscsi: failed to delete node record Error: %s", string(out))
 		}
@@ -427,13 +556,17 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, mntPath string) error {
 	// If the iface is not created via iscsi plugin, skip to delete
 	if initiatorName != "" && found && iface == (portals[0]+":"+volName) {
 		deleteArgs := []string{"-m", "iface", "-I", iface, "-o", "delete"}
-		out, err := c.exec.Run("iscsiadm", deleteArgs...)
+		out, err := exec.Run("iscsiadm", deleteArgs...)
 		if err != nil {
 			glog.Errorf("iscsi: failed to delete iface Error: %s", string(out))
 		}
 	}
 
 	return nil
+}
+
+func getDevByPath(portal, iqn, lun string) string {
+	return "/dev/disk/by-path/ip-" + portal + "-iscsi-" + iqn + "-lun-" + lun
 }
 
 func extractTransportname(ifaceOutput string) (iscsiTransport string) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Add interface changes to iSCSI volume plugin to enable block volumes support feature.

**Which issue this PR fixes**: 
Based on this proposal (kubernetes/community#805 & kubernetes/community#1265) and this feature issue: kubernetes/features#351

**Special notes for your reviewer**:

This PR temporarily includes following changes except iSCSI plugin change for reviewing purpose.
These changes will be removed from the PR once they are merged.
- (#50457) API Change 
- (#51494) Container runtime interface change, volumemanager changes, operationexecutor changes

There are another PRs related to this functionality.
(#50457) API Change
(#53385) VolumeMode PV-PVC Binding change
(#51494) Container runtime interface change, volumemanager changes, operationexecutor changes
(#55112) Block volume: Command line printer update
Plugins
(#51493) Block volumes Support: FC plugin update
(#54752) Block volumes Support: iSCSI plugin update

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```