### PR TITLE
kubeadm: fix the DNS addon bind address

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -57,7 +57,7 @@ func EnsureDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interf
 	}
 
 	var dnsBindAddr string
-	if dnsip.To16() != nil {
+	if dnsip.To4() == nil {
 		dnsBindAddr = "::1"
 	} else {
 		dnsBindAddr = "127.0.0.1"


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a small bug introduced in #54437 
The net package's definition of `To16` is as follows:
```
// To16 converts the IP address ip to a 16-byte representation.
// If ip is not an IP address (it is the wrong length), To16 returns nil.
func (ip IP) To16() IP {
	if len(ip) == IPv4len {
		return IPv4(ip[0], ip[1], ip[2], ip[3])
	}
	if len(ip) == IPv6len {
		return ip
	}
	return nil
}
```
We can see that the `To16 ` function returns a non nil value when passed in an IPv4 address. This PR switches the check to use `To4()` instead, which will return `nil` when passed an IPv6 address.