### PR TITLE
Validate that PersistentVolumeSource is not changed during PV Update

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1554,6 +1554,12 @@ func ValidatePersistentVolume(pv *api.PersistentVolume) field.ErrorList {
 func ValidatePersistentVolumeUpdate(newPv, oldPv *api.PersistentVolume) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = ValidatePersistentVolume(newPv)
+
+	// PersistentVolumeSource should be immutable after creation.
+	if !apiequality.Semantic.DeepEqual(newPv.Spec.PersistentVolumeSource, oldPv.Spec.PersistentVolumeSource) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "persistentvolumesource"), "is immutable after creation"))
+	}
+
 	newPv.Status = oldPv.Status
 	return allErrs
 }


### PR DESCRIPTION

**What this PR does / why we need it**: An administrator might change `PV.Spec.PersistentVolumeSource`, but Kubernetes does not have the ability perform this type of update.

**Which issue this PR fixes** : fixes #54562

**Special notes for your reviewer**: N/A

**Release note**:
```
Prevent updates to PV.Spec.PersistentVolumeSource.
```
