### PR TITLE
make iptables wait flag generic and tune it to 5 seconds

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -118,9 +118,11 @@ const NoFlushTables FlushFlag = false
 // (test whether a rule exists).
 const MinCheckVersion = "1.4.11"
 
-// Minimum iptables versions supporting the -w and -w2 flags
-const MinWaitVersion = "1.4.20"
-const MinWait2Version = "1.4.22"
+// Minimum iptables versions supporting the -w and -w<seconds> flags
+const WaitMinVersion = "1.4.20"
+const WaitSecondsMinVersion = "1.4.22"
+const WaitString = "-w"
+const WaitSecondsString = "-w5"
 
 const LockfilePath16x = "/run/xtables.lock"
 
@@ -537,24 +539,24 @@ func getIPTablesWaitFlag(vstring string) []string {
 		return nil
 	}
 
-	minVersion, err := utilversion.ParseGeneric(MinWaitVersion)
+	minVersion, err := utilversion.ParseGeneric(WaitMinVersion)
 	if err != nil {
-		glog.Errorf("MinWaitVersion (%s) is not a valid version string: %v", MinWaitVersion, err)
+		glog.Errorf("WaitMinVersion (%s) is not a valid version string: %v", WaitMinVersion, err)
 		return nil
 	}
 	if version.LessThan(minVersion) {
 		return nil
 	}
 
-	minVersion, err = utilversion.ParseGeneric(MinWait2Version)
+	minVersion, err = utilversion.ParseGeneric(WaitSecondsMinVersion)
 	if err != nil {
-		glog.Errorf("MinWait2Version (%s) is not a valid version string: %v", MinWait2Version, err)
+		glog.Errorf("WaitSecondsMinVersion (%s) is not a valid version string: %v", WaitSecondsMinVersion, err)
 		return nil
 	}
 	if version.LessThan(minVersion) {
-		return []string{"-w"}
+		return []string{WaitString}
 	} else {
-		return []string{"-w2"}
+		return []string{WaitSecondsString}
 	}
 }
 

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -686,11 +686,11 @@ func TestIPTablesWaitFlag(t *testing.T) {
 		{"0.55.55", ""},
 		{"1.0.55", ""},
 		{"1.4.19", ""},
-		{"1.4.20", "-w"},
-		{"1.4.21", "-w"},
-		{"1.4.22", "-w2"},
-		{"1.5.0", "-w2"},
-		{"2.0.0", "-w2"},
+		{"1.4.20", WaitString},
+		{"1.4.21", WaitString},
+		{"1.4.22", WaitSecondsString},
+		{"1.5.0", WaitSecondsString},
+		{"2.0.0", WaitSecondsString},
 	}
 
 	for _, testCase := range testCases {
@@ -730,7 +730,7 @@ func TestWaitFlagUnavailable(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 3 {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny("-w", "-w2") {
+	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny(WaitString, WaitSecondsString) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }
@@ -762,10 +762,10 @@ func TestWaitFlagOld(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 3 {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-w") {
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", WaitString) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
-	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny("-w2") {
+	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny(WaitSecondsString) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }
@@ -797,10 +797,10 @@ func TestWaitFlagNew(t *testing.T) {
 	if fcmd.CombinedOutputCalls != 3 {
 		t.Errorf("expected 3 CombinedOutput() calls, got %d", fcmd.CombinedOutputCalls)
 	}
-	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", "-w2") {
+	if !sets.NewString(fcmd.CombinedOutputLog[2]...).HasAll("iptables", WaitSecondsString) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
-	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny("-w") {
+	if sets.NewString(fcmd.CombinedOutputLog[2]...).HasAny(WaitString) {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 }


### PR DESCRIPTION
Excerpt from [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1506396) opened by @eparis 

> iptables-restore has a 2s wait timeout. Data collected today shows that even with a much faster kernel we can reasonably expect iptables-restore to take upwards of 2.4 seconds. (with unpatched/released RHEL kernel this can easily take 7-8 second)

> longest runs I saw over about 30 minutes were:
> 2.267244
> 2.284707
> 2.291535
> 2.376457

> If we get 2 iptables restores going at the same time, with a 2s timeout it is very likely the second will fail.

> I'd like to suggest a 5s timeout. It should still bound the number of thread we may be waiting on and increases the reliability that a common situation will be automatically resolved without failing up the stack.
