### PR TITLE
Make github hide generated files in diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,10 @@
 hack/verify-flags/known-flags.txt merge=union
 test/test_owners.csv merge=union
 
-**/zz_generated.*.go -diff
-**/types.generated.go -diff
-**/generated.pb.go -diff
-**/generated.proto -diff
-**/types_swagger_doc_generated.go -diff
-docs/api-reference/** -diff
+**/zz_generated.*.go -diff linguist-generated=true
+**/types.generated.go -diff linguist-generated=true
+**/generated.pb.go -diff linguist-generated=true
+**/generated.proto -diff linguist-generated=true
+**/types_swagger_doc_generated.go -diff linguist-generated=true
+docs/api-reference/** -diff linguist-generated=true
+api/swagger-spec/*.json -diff linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,7 +4,7 @@ test/test_owners.csv merge=union
 **/zz_generated.*.go -diff linguist-generated=true
 **/types.generated.go -diff linguist-generated=true
 **/generated.pb.go -diff linguist-generated=true
-**/generated.proto -diff linguist-generated=true
+**/generated.proto -diff
 **/types_swagger_doc_generated.go -diff linguist-generated=true
 docs/api-reference/** -diff linguist-generated=true
 api/swagger-spec/*.json -diff linguist-generated=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
https://github.com/github/linguist#generated-code says to add `linguist-generated=true` to any files that you don't want to see diffs in. IMO this will make PRs a little easier to review.

e.g. the top half of https://github.com/kubernetes/kubernetes/pull/53988 should disappear

**Which issue this PR fixes** 

**Special notes for your reviewer**:

**Release note**: NONE
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
