### PR TITLE
Automated cherry pick of #54635

### DIFF
--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -64,16 +64,13 @@ spec:
               mountPath: /usr/share/ca-certificates
               readOnly: true
         - name: prom-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
+          image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
           command:
             - /monitor
             - --source=heapster:http://localhost:8082?whitelisted=stackdriver_requests_count,stackdriver_timeseries_count
             - --stackdriver-prefix=container.googleapis.com/internal/addons
             - --pod-id=$(POD_NAME)
             - --namespace-id=$(POD_NAMESPACE)
-          volumeMounts:
-          - name: ssl-certs
-            mountPath: /etc/ssl/certs
           env:
             - name: POD_NAME
               valueFrom:

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -50,16 +50,26 @@ spec:
         image: gcr.io/google-containers/event-exporter:v0.1.7
         command:
         - '/event-exporter'
+      # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.1
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --component=event_exporter
-          - --stackdriver-prefix=container.googleapis.com/internal/addons
-          - --whitelisted-metrics=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
-        volumeMounts:
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
+          - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
+          - --api-override={{ prometheus_to_sd_endpoint }}
+          - --source=event_exported:http://localhost:80?whitelisted=stackdriver_sink_received_entry_count,stackdriver_sink_request_count,stackdriver_sink_successfully_sent_entry_count
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      # END_PROMETHEUS_TO_SD
       terminationGracePeriodSeconds: 30
       volumes:
       - name: ssl-certs

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -79,17 +79,26 @@ spec:
               then
                 exit 1;
               fi;
+      # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.1.3
+        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
         command:
           - /monitor
-          - --component=fluentd
-          - --target-port=31337
-          - --stackdriver-prefix=container.googleapis.com/internal/addons
-          - --whitelisted-metrics=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
-        volumeMounts:
-        - name: ssl-certs
-          mountPath: /etc/ssl/certs
+          - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
+          - --api-override={{ prometheus_to_sd_endpoint }}
+          - --source=fluentd:http://localhost:31337?whitelisted=stackdriver_successful_requests_count,stackdriver_failed_requests_count,stackdriver_ingested_entries_count,stackdriver_dropped_entries_count
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/fluentd-ds-ready: "true"
       tolerations:


### PR DESCRIPTION
Cherry pick of #54635 on release-1.7.

#54635: Bump version of prometheus-to-sd to 0.2.2.

```release-note
NONE
```