### PR TITLE
Automated cherry pick of #54438 upstream release-1.8

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -555,7 +555,7 @@ func (vs *VSphere) DiskIsAttached(volPath string, nodeName k8stypes.NodeName) (b
 			glog.Errorf("Failed to get VM object for node: %q. err: +%v", vSphereInstance, err)
 			return false, err
 		}
-
+		volPath = vclib.RemoveClusterFromVDiskPath(volPath)
 		attached, err := vm.IsDiskAttached(ctx, volPath)
 		if err != nil {
 			glog.Errorf("DiskIsAttached failed to determine whether disk %q is still attached on node %q",
@@ -593,6 +593,7 @@ func (vs *VSphere) DisksAreAttached(nodeVolumes map[k8stypes.NodeName][]string) 
 		vmVolumes := make(map[string][]string)
 		for nodeName, volPaths := range nodeVolumes {
 			for i, volPath := range volPaths {
+				volPath = vclib.RemoveClusterFromVDiskPath(volPath)
 				// Get the canonical volume path for volPath.
 				canonicalVolumePath, err := getcanonicalVolumePath(ctx, dc, volPath)
 				if err != nil {


### PR DESCRIPTION
Cherry pick of #54438 on release-1.8
#54438: Fixing usage of clustered datastore name to be absolute datastore name

Without this Fix, Clustered Datastore or Datastore within storage folder can not be used with Release 1.8 of Kubernetes.

@pshahzeb 

Release note:
```
Fix clustered datastore name to be absolute.
```