### PR TITLE
apimachinery: fix Unstructured deepcopy panic

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -490,6 +490,10 @@ func (u *Unstructured) GetDeletionGracePeriodSeconds() *int64 {
 }
 
 func (u *Unstructured) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds *int64) {
+	if deletionGracePeriodSeconds == nil {
+		u.setNestedField(nil, "metadata", "deletionGracePeriodSeconds")
+		return
+	}
 	u.setNestedField(deletionGracePeriodSeconds, "metadata", "deletionGracePeriodSeconds")
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_test.go
@@ -75,4 +75,34 @@ func TestNilDeletionTimestamp(t *testing.T) {
 	if deletionTimestamp != nil {
 		t.Errorf("unexpected deletion timestamp field: %q", deletionTimestamp)
 	}
+
+	u.SetDeletionTimestamp(nil)
+	clone := u.DeepCopy()
+	if got := clone.GetDeletionTimestamp(); got != nil {
+		t.Errorf("unexpected deletion timestamp in clone: %v, wanted %v", got, nil)
+	}
+}
+
+func TestNilDeletionGracePeriod(t *testing.T) {
+	var u Unstructured
+	del := u.GetDeletionGracePeriodSeconds()
+	if del != nil {
+		t.Errorf("unexpected non-nil deletion grace period: %v", del)
+	}
+	u.SetDeletionGracePeriodSeconds(u.GetDeletionGracePeriodSeconds())
+	del = u.GetDeletionGracePeriodSeconds()
+	if del != nil {
+		t.Errorf("unexpected non-nil deletion grace period: %v", del)
+	}
+	metadata := u.Object["metadata"].(map[string]interface{})
+	deleteGracePeriod := metadata["deletionGracePeriod"]
+	if deleteGracePeriod != nil {
+		t.Errorf("unexpected deletion grace period field: %q", deleteGracePeriod)
+	}
+
+	u.SetDeletionGracePeriodSeconds(nil)
+	clone := u.DeepCopy()
+	if got := clone.GetDeletionGracePeriodSeconds(); got != nil {
+		t.Errorf("unexpected deletion timestamp in clone: %v, wanted %v", got, nil)
+	}
 }


### PR DESCRIPTION
Fixes https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/pr-logs/pull/54484/pull-kubernetes-unit/61498/#k8siokubernetescmdkube-apiserverapptesting-testcrd