### PR TITLE
Change bucket info of volume operations

### DIFF
--- a/pkg/volume/util/metrics.go
+++ b/pkg/volume/util/metrics.go
@@ -24,8 +24,9 @@ import (
 
 var storageOperationMetric = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
-		Name: "storage_operation_duration_seconds",
-		Help: "Storage operation duration",
+		Name:    "storage_operation_duration_seconds",
+		Help:    "Storage operation duration",
+		Buckets: []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 25, 50},
 	},
 	[]string{"volume_plugin", "operation_name"},
 )


### PR DESCRIPTION
The default buckets for volume operations are mostly incorrect because most metric tend to cluster in >10s bucket. 

This fixes the problem with buckets.

cc @kubernetes/sig-storage-pr-reviews @jingxu97 