### PR TITLE
Do not clobber KUBERNETES_PROVIDER - fix kubeadm/gce log collection

### DIFF
--- a/cluster/kube-util.sh
+++ b/cluster/kube-util.sh
@@ -22,10 +22,12 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${KUBE_ROOT}/cluster/skeleton/util.sh"
 
-if [[ -n "${KUBERNETES_CONFORMANCE_TEST:-}" ]]; then
-    KUBERNETES_PROVIDER=""
-else
-    KUBERNETES_PROVIDER="${KUBERNETES_PROVIDER:-gce}"
+if [[ "${KUBERNETES_PROVIDER:-}" != "kubernetes-anywhere" ]]; then
+    if [[ -n "${KUBERNETES_CONFORMANCE_TEST:-}" ]]; then
+        KUBERNETES_PROVIDER=""
+    else
+        KUBERNETES_PROVIDER="${KUBERNETES_PROVIDER:-gce}"
+    fi
 fi
 
 # PROVIDER_VARS is a list of cloud provider specific variables. Note:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

This gets in the way of correct log collection for at least
the kubeadm/gce jobs. Not sure if this piece of code is needed
any more.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
