### PR TITLE
diff: Propragate errors when diffing

### DIFF
--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -446,9 +446,8 @@ func RunDiff(f cmdutil.Factory, diff *DiffProgram, options *DiffOptions, from, t
 			Parser:  parser,
 			Encoder: f.JSONEncoder(),
 		}
-		differ.Diff(obj, printer)
 
-		return nil
+		return differ.Diff(obj, printer)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Because of that, errors while diffing would potentially not do anything,
leaving the user clueless of what was going on.

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
