### PR TITLE
Added a test for proper `%s` handling when display last applied confi…

### DIFF
--- a/pkg/kubectl/cmd/apply_test.go
+++ b/pkg/kubectl/cmd/apply_test.go
@@ -63,15 +63,17 @@ func validateApplyArgs(cmd *cobra.Command, args []string) error {
 }
 
 const (
-	filenameRC             = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.yaml"
-	filenameRCNoAnnotation = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-no-annotation.yaml"
-	filenameRCLASTAPPLIED  = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-lastapplied.yaml"
-	filenameSVC            = "../../../test/fixtures/pkg/kubectl/cmd/apply/service.yaml"
-	filenameRCSVC          = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml"
-	filenameNoExistRC      = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-noexist.yaml"
-	filenameRCPatchTest    = "../../../test/fixtures/pkg/kubectl/cmd/apply/patch.json"
-	dirName                = "../../../test/fixtures/pkg/kubectl/cmd/apply/testdir"
-	filenameRCJSON         = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.json"
+	filenameRC                = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.yaml"
+	filenameRCArgs            = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-args.yaml"
+	filenameRCLastAppliedArgs = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-lastapplied-args.yaml"
+	filenameRCNoAnnotation    = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-no-annotation.yaml"
+	filenameRCLASTAPPLIED     = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-lastapplied.yaml"
+	filenameSVC               = "../../../test/fixtures/pkg/kubectl/cmd/apply/service.yaml"
+	filenameRCSVC             = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-service.yaml"
+	filenameNoExistRC         = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc-noexist.yaml"
+	filenameRCPatchTest       = "../../../test/fixtures/pkg/kubectl/cmd/apply/patch.json"
+	dirName                   = "../../../test/fixtures/pkg/kubectl/cmd/apply/testdir"
+	filenameRCJSON            = "../../../test/fixtures/pkg/kubectl/cmd/apply/rc.json"
 
 	filenameWidgetClientside = "../../../test/fixtures/pkg/kubectl/cmd/apply/widget-clientside.yaml"
 	filenameWidgetServerside = "../../../test/fixtures/pkg/kubectl/cmd/apply/widget-serverside.yaml"
@@ -229,6 +231,7 @@ func walkMapPath(t *testing.T, start map[string]interface{}, path []string) map[
 
 func TestRunApplyViewLastApplied(t *testing.T) {
 	_, rcBytesWithConfig := readReplicationController(t, filenameRCLASTAPPLIED)
+	_, rcBytesWithArgs := readReplicationController(t, filenameRCLastAppliedArgs)
 	nameRC, rcBytes := readReplicationController(t, filenameRC)
 	pathRC := "/namespaces/test/replicationcontrollers/" + nameRC
 
@@ -246,6 +249,16 @@ func TestRunApplyViewLastApplied(t *testing.T) {
 			selector:     "",
 			args:         []string{},
 			respBytes:    rcBytesWithConfig,
+		},
+		{
+			name:         "test with file include `%s` in arguments",
+			filePath:     filenameRCArgs,
+			outputFormat: "",
+			expectedErr:  "",
+			expectedOut:  "args: -random_flag=%s@domain.com\n",
+			selector:     "",
+			args:         []string{},
+			respBytes:    rcBytesWithArgs,
 		},
 		{
 			name:         "view with file json format",

--- a/test/fixtures/pkg/kubectl/cmd/apply/rc-args.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/rc-args.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: test-rc
+  labels:
+    name: test-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: test-rc
+    spec:
+      containers:
+        - name: test-rc
+          image: nginx
+          args:
+          - -random_flag=%s@domain.com
+          ports:
+          - containerPort: 80

--- a/test/fixtures/pkg/kubectl/cmd/apply/rc-lastapplied-args.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/apply/rc-lastapplied-args.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"args":"-random_flag=%s@domain.com"}
+  name: test-rc
+  labels:
+    name: test-rc
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: test-rc
+    spec:
+      containers:
+        - name: test-rc
+          image: nginx
+          args:
+          - -random_flag=%s@domain.com
+          ports:
+          - containerPort: 80


### PR DESCRIPTION
**What this PR does / why we need it**:
Added missing tests which checks proper handling of `%s` in arguments for command `kubectl apply view-last-applied`

**Which issue this PR fixes**
#54645

**Special notes for your reviewer**:
Added a test case to cover specific issue described. 
It fails on version `v1.7.3`..`v1.7.9` and passes since `v1.8.0`. 

P.S. Not sure if there is already a lower level test which covers this case in the k8s test suite. I would recommend to add this test, so the issue would not reoccur.

**Release note**:
```release-note
NONE
```