### PR TITLE
Add downward api and docker container conformance annotations

### DIFF
--- a/test/e2e/common/docker_containers.go
+++ b/test/e2e/common/docker_containers.go
@@ -27,12 +27,24 @@ import (
 var _ = framework.KubeDescribe("Docker Containers", func() {
 	f := framework.NewDefaultFramework("containers")
 
+	/*
+		    Testname: container-without-command-args
+		    Description: When a Pod is created neither 'command' nor 'args' are
+			provided for a Container, ensure that the docker image's default
+			command and args are used.
+	*/
 	framework.ConformanceIt("should use the image defaults if command and args are blank ", func() {
 		f.TestContainerOutput("use defaults", entrypointTestPod(), 0, []string{
 			"[/ep default arguments]",
 		})
 	})
 
+	/*
+		    Testname: container-with-args
+		    Description: When a Pod is created and 'args' are provided for a
+			Container, ensure that they take precedent to the docker image's
+			default arguments, but that the default command is used.
+	*/
 	framework.ConformanceIt("should be able to override the image's default arguments (docker cmd) ", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Args = []string{"override", "arguments"}
@@ -44,6 +56,12 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 
 	// Note: when you override the entrypoint, the image's arguments (docker cmd)
 	// are ignored.
+	/*
+		    Testname: container-with-command
+		    Description: When a Pod is created and 'command' is provided for a
+			Container, ensure that it takes precedent to the docker image's default
+			command.
+	*/
 	framework.ConformanceIt("should be able to override the image's default commmand (docker entrypoint) ", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}
@@ -53,6 +71,12 @@ var _ = framework.KubeDescribe("Docker Containers", func() {
 		})
 	})
 
+	/*
+		    Testname: container-with-command-args
+		    Description: When a Pod is created and 'command' and 'args' are
+			provided for a Container, ensure that they take precedent to the docker
+			image's default command and arguments.
+	*/
 	framework.ConformanceIt("should be able to override the image's default command and arguments ", func() {
 		pod := entrypointTestPod()
 		pod.Spec.Containers[0].Command = []string{"/ep-2"}

--- a/test/e2e/common/downward_api.go
+++ b/test/e2e/common/downward_api.go
@@ -37,6 +37,11 @@ var (
 var _ = Describe("[sig-api-machinery] Downward API", func() {
 	f := framework.NewDefaultFramework("downward-api")
 
+	/*
+		    Testname: downwardapi-env-name-namespace
+		    Description: Ensure that downward API can provide pod's name and
+			namespaces as environment variables.
+	*/
 	framework.ConformanceIt("should provide pod name and namespace as env vars ", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
@@ -68,6 +73,11 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		testDownwardAPI(f, podName, env, expectations)
 	})
 
+	/*
+		    Testname: downwardapi-env-pod-ip
+		    Description: Ensure that downward API can provide an IP address for
+			pod as an environment variable.
+	*/
 	framework.ConformanceIt("should provide pod IP as an env var ", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
@@ -89,6 +99,11 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		testDownwardAPI(f, podName, env, expectations)
 	})
 
+	/*
+		    Testname: downwardapi-env-host-ip
+		    Description: Ensure that downward API can provide an IP address for
+			host node as an environment variable.
+	*/
 	framework.ConformanceIt("should provide host IP as an env var ", func() {
 		framework.SkipUnlessServerVersionGTE(hostIPVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())
@@ -111,6 +126,11 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		testDownwardAPI(f, podName, env, expectations)
 	})
 
+	/*
+		    Testname: downwardapi-env-limits-requests
+		    Description: Ensure that downward API can provide CPU/memory limit
+			and CPU/memory request as environment variables.
+	*/
 	framework.ConformanceIt("should provide container's limits.cpu/memory and requests.cpu/memory as env vars ", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
@@ -157,6 +177,12 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		testDownwardAPI(f, podName, env, expectations)
 	})
 
+	/*
+		    Testname: downwardapi-env-default-allocatable
+		    Description: Ensure that downward API can provide default node
+			allocatable values for CPU and memory as environment variables if CPU
+			and memory limits are not specified for a container.
+	*/
 	framework.ConformanceIt("should provide default limits.cpu/memory from node allocatable ", func() {
 		podName := "downward-api-" + string(uuid.NewUUID())
 		env := []v1.EnvVar{
@@ -202,6 +228,11 @@ var _ = Describe("[sig-api-machinery] Downward API", func() {
 		testDownwardAPIUsingPod(f, pod, env, expectations)
 	})
 
+	/*
+		    Testname: downwardapi-env-pod-uid
+		    Description: Ensure that downward API can provide pod UID as an
+			environment variable.
+	*/
 	framework.ConformanceIt("should provide pod UID as env vars ", func() {
 		framework.SkipUnlessServerVersionGTE(podUIDVersion, f.ClientSet.Discovery())
 		podName := "downward-api-" + string(uuid.NewUUID())

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -39,6 +39,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		podClient = f.PodClient()
 	})
 
+	/*
+		    Testname: downwardapi-volume-podname
+		    Description: Ensure that downward API can provide pod's name through
+			DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should provide podname only ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumePodForSimpleTest(podName, "/etc/podname")
@@ -48,6 +53,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-set-default-mode
+		    Description: Ensure that downward API can set default file premission
+			mode for DownwardAPIVolumeFiles if no mode is specified.
+	*/
 	framework.ConformanceIt("should set DefaultMode on files ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		defaultMode := int32(0400)
@@ -58,6 +68,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-set-mode
+		    Description: Ensure that downward API can set file premission mode for
+			DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should set mode on item file ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		mode := int32(0400)
@@ -97,6 +112,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-update-label
+		    Description: Ensure that downward API updates labels in
+			DownwardAPIVolumeFiles when pod's labels get modified.
+	*/
 	framework.ConformanceIt("should update labels on modification ", func() {
 		labels := map[string]string{}
 		labels["key1"] = "value1"
@@ -124,6 +144,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("key3=\"value3\"\n"))
 	})
 
+	/*
+		    Testname: downwardapi-volume-update-annotation
+		    Description: Ensure that downward API updates annotations in
+			DownwardAPIVolumeFiles when pod's annotations get modified.
+	*/
 	framework.ConformanceIt("should update annotations on modification ", func() {
 		annotations := map[string]string{}
 		annotations["builder"] = "bar"
@@ -153,6 +178,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 			podLogTimeout, framework.Poll).Should(ContainSubstring("builder=\"foo\"\n"))
 	})
 
+	/*
+		    Testname: downwardapi-volume-cpu-limit
+		    Description: Ensure that downward API can provide container's CPU limit
+			through DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should provide container's cpu limit ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_limit")
@@ -162,6 +192,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-memory-limit
+		    Description: Ensure that downward API can provide container's memory
+			limit through DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should provide container's memory limit ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_limit")
@@ -171,6 +206,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-cpu-request
+		    Description: Ensure that downward API can provide container's CPU
+			request through DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should provide container's cpu request ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/cpu_request")
@@ -180,6 +220,11 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-memory-request
+		    Description: Ensure that downward API can provide container's memory
+			request through DownwardAPIVolumeFiles.
+	*/
 	framework.ConformanceIt("should provide container's memory request ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForContainerResources(podName, "/etc/memory_request")
@@ -189,6 +234,12 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		})
 	})
 
+	/*
+		    Testname: downwardapi-volume-default-cpu
+		    Description: Ensure that downward API can provide default node
+			allocatable value for CPU through DownwardAPIVolumeFiles if CPU
+			limit is not specified for a container.
+	*/
 	framework.ConformanceIt("should provide node allocatable (cpu) as default cpu limit if the limit is not set ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/cpu_limit")
@@ -196,6 +247,12 @@ var _ = Describe("[sig-storage] Downward API volume", func() {
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
 
+	/*
+		    Testname: downwardapi-volume-default-memory
+		    Description: Ensure that downward API can provide default node
+			allocatable value for memory through DownwardAPIVolumeFiles if memory
+			limit is not specified for a container.
+	*/
 	framework.ConformanceIt("should provide node allocatable (memory) as default memory limit if the limit is not set ", func() {
 		podName := "downwardapi-volume-" + string(uuid.NewUUID())
 		pod := downwardAPIVolumeForDefaultContainerResources(podName, "/etc/memory_limit")


### PR DESCRIPTION
Signed-off-by: Brad Topol <btopol@us.ibm.com>
Add downward api and docker container conformance annotations

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds downward api and docker container related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the downward api and docker container based e2e conformance tests.

Special notes for your reviewer:
Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note NONE
```
