### PR TITLE
Update cadvisor godeps to v0.27.2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,32 +30,32 @@
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/compute",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/containerregistry",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/disk",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/network",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/arm/storage",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
 			"ImportPath": "github.com/Azure/azure-sdk-for-go/storage",
-			"Comment": "v10.0.4-beta-1-g786cc84",
+			"Comment": "v10.0.4-beta-1-g786cc841",
 			"Rev": "786cc84138518bf7fd6d60e92fad1ac9d1a117ad"
 		},
 		{
@@ -424,7 +424,7 @@
 		},
 		{
 			"ImportPath": "github.com/codegangsta/negroni",
-			"Comment": "v0.1-62-g8d75e11",
+			"Comment": "v0.1.0-62-g8d75e11",
 			"Rev": "8d75e11374a1928608c906fe745b538483e7aeb2"
 		},
 		{
@@ -1060,17 +1060,17 @@
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/nat",
-			"Comment": "v0.2.1-30-g3ede32e",
+			"Comment": "v0.3.0",
 			"Rev": "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/sockets",
-			"Comment": "v0.2.1-30-g3ede32e",
+			"Comment": "v0.3.0",
 			"Rev": "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
 		},
 		{
 			"ImportPath": "github.com/docker/go-connections/tlsconfig",
-			"Comment": "v0.2.1-30-g3ede32e",
+			"Comment": "v0.3.0",
 			"Rev": "3ede32e2033de7505e6500d6c868c2b9ed9f169d"
 		},
 		{
@@ -1372,208 +1372,208 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/crio",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.27.1",
-			"Rev": "cda62a43857256fbc95dd31e7c810888f00f8ec7"
+			"Comment": "v0.27.2",
+			"Rev": "4957b7a942b01fe044a9ca8ba2dc9f5ca997431c"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",
@@ -1830,6 +1830,7 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{

--- a/vendor/github.com/google/cadvisor/container/crio/handler.go
+++ b/vendor/github.com/google/cadvisor/container/crio/handler.go
@@ -18,6 +18,7 @@ package crio
 import (
 	"fmt"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -142,6 +143,12 @@ func newCrioContainerHandler(
 	// get device ID from root, otherwise, it's going to error out as overlay
 	// mounts doesn't have fixed dev ids.
 	rootfsStorageDir = strings.TrimSuffix(rootfsStorageDir, "/merged")
+	switch storageDriver {
+	case overlayStorageDriver, overlay2StorageDriver:
+		// overlay and overlay2 driver are the same "overlay2" driver so treat
+		// them the same.
+		rootfsStorageDir = filepath.Join(rootfsStorageDir, "diff")
+	}
 
 	// TODO: extract object mother method
 	handler := &crioContainerHandler{

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -43,7 +43,8 @@ import (
 
 const (
 	// The read write layers exist here.
-	aufsRWLayer = "diff"
+	aufsRWLayer     = "diff"
+	overlay2RWLayer = "diff"
 
 	// Path to the directory where docker stores log files if the json logging driver is enabled.
 	pathToContainersDir = "containers"
@@ -195,8 +196,10 @@ func newDockerContainerHandler(
 	switch storageDriver {
 	case aufsStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
-	case overlayStorageDriver, overlay2StorageDriver:
+	case overlayStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID)
+	case overlay2StorageDriver:
+		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID, overlay2RWLayer)
 	case zfsStorageDriver:
 		status, err := Status()
 		if err != nil {


### PR DESCRIPTION
This fixes an issue with overlay2 support for Docker and CRI-O, which was introduced in 1.8.

We should cherrypick this to the 1.8 branch.

cc @kubernetes/sig-node-pr-reviews 
@derekwaynecarr @dchen1107 

```release-note
Fix overlay2 container disk metrics for Docker and CRI-O
```