### PR TITLE
trigger endpoint update on pod deletion

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -215,6 +215,10 @@ func podToEndpointAddress(pod *v1.Pod) *v1.EndpointAddress {
 }
 
 func podChanged(oldPod, newPod *v1.Pod) bool {
+	// If the pod's deletion timestamp is set, remove endpoint from ready address.
+	if newPod.DeletionTimestamp != oldPod.DeletionTimestamp {
+		return true
+	}
 	// If the pod's readiness has changed, the associated endpoint address
 	// will move from the unready endpoints set to the ready endpoints.
 	// So for the purposes of an endpoint, a readiness change on a pod

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1039,6 +1039,13 @@ func TestPodChanged(t *testing.T) {
 		t.Errorf("Expected pod to be changed with pod readiness change")
 	}
 	oldPod.Status.Conditions = saveConditions
+
+	now := metav1.NewTime(time.Now().UTC())
+	newPod.ObjectMeta.DeletionTimestamp = &now
+	if !podChanged(oldPod, newPod) {
+		t.Errorf("Expected pod to be changed with DeletionTimestamp change")
+	}
+	newPod.ObjectMeta.DeletionTimestamp = oldPod.ObjectMeta.DeletionTimestamp.DeepCopy()
 }
 
 func TestDetermineNeededServiceUpdates(t *testing.T) {


### PR DESCRIPTION
Fixes #54723

cc: @joelsmith 

```release-note
Fix a bug where pod address is not removed from endpoints object while pod is in graceful termination.
```
