### PR TITLE
Refactoring to isolate pruning functionality

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -194,6 +194,7 @@ package_group(
     name = "pkg_kubectl_cmd_testing_CONSUMERS",
     packages = [
         "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/apply/prune",
         "//pkg/kubectl/cmd/auth",
         "//pkg/kubectl/cmd/resource",
         "//pkg/kubectl/cmd/set",
@@ -293,6 +294,7 @@ package_group(
         "//cmd/kubectl/app",
         "//pkg/kubectl",
         "//pkg/kubectl/cmd",
+        "//pkg/kubectl/cmd/apply/prune",
         "//pkg/kubectl/cmd/auth",
         "//pkg/kubectl/cmd/config",
         "//pkg/kubectl/cmd/resource",

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -943,7 +943,7 @@ run_create_secret_tests() {
     set +o errexit
 }
 
-# Runs all pod related tests.
+# Runs all "kubectl apply --prune" tests
 run_kubectl_apply_prune_tests() {
   set -o nounset
   set -o errexit

--- a/hack/testdata/pod-2.yaml
+++ b/hack/testdata/pod-2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-2
+  labels:
+    name: test-pod-label-2
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: gcr.io/google-containers/pause:2.0

--- a/hack/testdata/pv-2.yaml
+++ b/hack/testdata/pv-2.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-test-2
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: slow
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+  nfs:
+    path: /tmp
+    server: 172.17.0.2

--- a/hack/testdata/pv.yaml
+++ b/hack/testdata/pv.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: pv-test
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Recycle
+  storageClassName: slow
+  mountOptions:
+    - hard
+    - nfsvers=4.1
+  nfs:
+    path: /tmp
+    server: 172.17.0.2

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -78,6 +78,7 @@ go_library(
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/apply/parse:go_default_library",
         "//pkg/kubectl/apply/strategy:go_default_library",
+        "//pkg/kubectl/cmd/apply/prune:go_default_library",
         "//pkg/kubectl/cmd/auth:go_default_library",
         "//pkg/kubectl/cmd/config:go_default_library",
         "//pkg/kubectl/cmd/resource:go_default_library",
@@ -265,6 +266,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/kubectl/cmd/apply/prune:all-srcs",
         "//pkg/kubectl/cmd/auth:all-srcs",
         "//pkg/kubectl/cmd/config:all-srcs",
         "//pkg/kubectl/cmd/resource:all-srcs",

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -345,7 +345,9 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 			Out:                  out,
 			ShortOutput:          shortOutput,
 		}
-		pruner.Prune(visitedNamespaces, visitedUids)
+		if err := pruner.Prune(visitedNamespaces, visitedUids); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/kubectl/cmd/apply/prune/BUILD
+++ b/pkg/kubectl/cmd/apply/prune/BUILD
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["prune.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/apply/prune",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//pkg/client/clientset_generated/internalclientset:go_default_library",
+        "//pkg/kubectl:go_default_library",
+        "//pkg/kubectl/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["prune_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/apply/prune",
+    library = ":go_default_library",
+    deps = ["//pkg/kubectl/cmd/testing:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubectl/cmd/apply/prune/prune.go
+++ b/pkg/kubectl/cmd/apply/prune/prune.go
@@ -32,6 +32,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/resource"
 )
 
+// Pruner enscapsulates items necessary to delete resources which should be
+// removed during apply with the "--prune" flag
 type Pruner struct {
 	Mapper               meta.RESTMapper
 	GroupVersionKinds    []*meta.RESTMapping
@@ -46,7 +48,9 @@ type Pruner struct {
 	ShortOutput          bool
 }
 
-// Param: gvks array of groupVersionKind passed in --prune-whitelist or empty array if no flag.
+// ParseGvks returns an array of RestMappings for the GVK's to prune.
+// param: mapper to create RESTMappings.
+// param: gvks array of groupVersionKind passed in --prune-whitelist or empty array if no flag.
 // Returns default groupVersionKind mappings to prune, unless overriden by --prune-whitelist flag.
 func ParseGvks(mapper meta.RESTMapper, gvks []string) ([]*meta.RESTMapping, error) {
 
@@ -218,10 +222,8 @@ func (p *Pruner) delete(namespace, name string, mapping *meta.RESTMapping) error
 		options = metav1.NewDeleteOptions(int64(p.GracePeriod))
 	}
 	stopTimeout := 2 * time.Minute
-	if err := r.Stop(namespace, name, stopTimeout, options); err != nil {
-		return err
-	}
-	return nil
+	err = r.Stop(namespace, name, stopTimeout, options)
+	return err
 }
 
 func (p *Pruner) printSuccess(resource, name string, operation string) {

--- a/pkg/kubectl/cmd/apply/prune/prune.go
+++ b/pkg/kubectl/cmd/apply/prune/prune.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prune
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
+	"k8s.io/kubernetes/pkg/kubectl"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+)
+
+type Pruner struct {
+	Mapper               meta.RESTMapper
+	GroupVersionKinds    []*meta.RESTMapping
+	ClientFunc           resource.ClientMapperFunc
+	ClientsetFunc        func() (internalclientset.Interface, error)
+	Selector             string
+	IncludeUninitialized bool
+	Cascade              bool
+	GracePeriod          int
+	DryRun               bool
+	Out                  io.Writer
+	ShortOutput          bool
+}
+
+func defaultPruneGvks(mapper meta.RESTMapper) ([]*meta.RESTMapping, error) {
+
+	var defaultPruneGvks = [][]string{
+		{"", "v1", "ConfigMap"},
+		{"", "v1", "Endpoints"},
+		{"", "v1", "Namespace"},
+		{"", "v1", "PersistentVolumeClaim"},
+		{"", "v1", "PersistentVolume"},
+		{"", "v1", "Pod"},
+		{"", "v1", "ReplicationController"},
+		{"", "v1", "Secret"},
+		{"", "v1", "Service"},
+		{"batch", "v1", "Job"},
+		{"extensions", "v1beta1", "DaemonSet"},
+		{"extensions", "v1beta1", "Deployment"},
+		{"extensions", "v1beta1", "Ingress"},
+		{"extensions", "v1beta1", "ReplicaSet"},
+		{"apps", "v1beta1", "StatefulSet"},
+		{"apps", "v1beta1", "Deployment"},
+	}
+
+	var defaultPruneResources []*meta.RESTMapping
+	for _, gvk := range defaultPruneGvks {
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
+		if err != nil {
+			return nil, err
+		}
+		defaultPruneResources = append(defaultPruneResources, mapping)
+	}
+	return defaultPruneResources, nil
+}
+
+// Returns default groupVersionKind mappings to prune, unless overriden by --prune-whitelist flag.
+func ParseGvks(mapper meta.RESTMapper, gvks []string) ([]*meta.RESTMapping, error) {
+
+	// If no group/version/kind specified in "prune-whitelist" flag, then return default.
+	if len(gvks) == 0 {
+		return defaultPruneGvks(mapper)
+	}
+
+	// Parse groupVersionKind from passed prune-whitelist flag values
+	var groupVersionKinds []*meta.RESTMapping
+	for _, groupVersionKind := range gvks {
+		gvk := strings.Split(groupVersionKind, "/")
+		if len(gvk) != 3 {
+			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
+		}
+		if gvk[0] == "core" {
+			gvk[0] = ""
+		}
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
+		if err != nil {
+			return nil, err
+		}
+		groupVersionKinds = append(groupVersionKinds, mapping)
+	}
+
+	return groupVersionKinds, nil
+}
+
+// Prune resources not previously visited.
+func (p *Pruner) Prune(visitedNamespaces sets.String, visitedUids sets.String) error {
+	// Prune namespaced resources
+	for n := range visitedNamespaces {
+		for _, m := range p.GroupVersionKinds {
+			if m.Scope.Name() == meta.RESTScopeNameNamespace {
+				if err := p.pruneMapping(n, m, visitedUids); err != nil {
+					return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
+				}
+			}
+		}
+	}
+	// Prune non-namespaced resources
+	for _, m := range p.GroupVersionKinds {
+		if m.Scope.Name() == meta.RESTScopeNameRoot {
+			if err := p.pruneMapping(metav1.NamespaceNone, m, visitedUids); err != nil {
+				return fmt.Errorf("error pruning non-namespaced object %v: %v", m.GroupVersionKind, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (p *Pruner) pruneMapping(namespace string, mapping *meta.RESTMapping, visitedUids sets.String) error {
+	c, err := p.ClientFunc(mapping)
+	if err != nil {
+		return err
+	}
+
+	export := false
+	apiVersion := mapping.GroupVersionKind.Version
+	objList, err := resource.NewHelper(c, mapping).List(
+		namespace,
+		apiVersion,
+		export,
+		&metav1.ListOptions{
+			LabelSelector:        p.Selector,
+			IncludeUninitialized: p.IncludeUninitialized,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	objs, err := meta.ExtractList(objList)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		annots, err := mapping.MetadataAccessor.Annotations(obj)
+		if err != nil {
+			return err
+		}
+		if _, ok := annots[api.LastAppliedConfigAnnotation]; !ok {
+			// don't prune resources not created with apply
+			continue
+		}
+		uid, err := mapping.UID(obj)
+		if err != nil {
+			return err
+		}
+		if visitedUids.Has(string(uid)) {
+			continue
+		}
+
+		name, err := mapping.Name(obj)
+		if err != nil {
+			return err
+		}
+		if !p.DryRun {
+			if err := p.delete(namespace, name, mapping); err != nil {
+				return err
+			}
+		}
+		//cmdutil.Factory.PrintSuccess(p.Mapper, p.ShortOutput, p.Out, mapping.Resource, name, p.DryRun, "pruned")
+	}
+	return nil
+}
+
+func (p *Pruner) delete(namespace, name string, mapping *meta.RESTMapping) error {
+
+	c, err := p.ClientFunc(mapping)
+	if err != nil {
+		return err
+	}
+
+	helper := resource.NewHelper(c, mapping)
+	if !p.Cascade {
+		return helper.Delete(namespace, name)
+	}
+
+	cs, err := p.ClientsetFunc()
+	if err != nil {
+		return err
+	}
+	r, err := kubectl.ReaperFor(mapping.GroupVersionKind.GroupKind(), cs)
+	if err != nil {
+		if _, ok := err.(*kubectl.NoSuchReaperError); !ok {
+			return err
+		}
+		return helper.Delete(namespace, name)
+	}
+	var options *metav1.DeleteOptions
+	if p.GracePeriod >= 0 {
+		options = metav1.NewDeleteOptions(int64(p.GracePeriod))
+	}
+	stopTimeout := 2 * time.Minute
+	if err := r.Stop(namespace, name, stopTimeout, options); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/kubectl/cmd/apply/prune/prune.go
+++ b/pkg/kubectl/cmd/apply/prune/prune.go
@@ -185,7 +185,7 @@ func (p *Pruner) pruneMapping(namespace string, mapping *meta.RESTMapping, visit
 				return err
 			}
 		}
-		//cmdutil.Factory.PrintSuccess(p.Mapper, p.ShortOutput, p.Out, mapping.Resource, name, p.DryRun, "pruned")
+		p.printSuccess(mapping.Resource, name, "pruned")
 	}
 	return nil
 }
@@ -222,4 +222,27 @@ func (p *Pruner) delete(namespace, name string, mapping *meta.RESTMapping) error
 		return err
 	}
 	return nil
+}
+
+func (p *Pruner) printSuccess(resource, name string, operation string) {
+	resource, _ = p.Mapper.ResourceSingularizer(resource)
+	dryRunMsg := ""
+	if p.DryRun {
+		dryRunMsg = " (dry run)"
+	}
+	if p.ShortOutput {
+		// -o name: prints resource/name
+		if len(resource) > 0 {
+			fmt.Fprintf(p.Out, "%s/%s\n", resource, name)
+		} else {
+			fmt.Fprintf(p.Out, "%s\n", name)
+		}
+	} else {
+		// understandable output by default
+		if len(resource) > 0 {
+			fmt.Fprintf(p.Out, "%s \"%s\" %s%s\n", resource, name, operation, dryRunMsg)
+		} else {
+			fmt.Fprintf(p.Out, "\"%s\" %s%s\n", name, operation, dryRunMsg)
+		}
+	}
 }

--- a/pkg/kubectl/cmd/apply/prune/prune_test.go
+++ b/pkg/kubectl/cmd/apply/prune/prune_test.go
@@ -26,7 +26,7 @@ func TestParseGvks(t *testing.T) {
 
 	// Create the fake RESTMapper from the fake factory.
 	f, _, _, _ := cmdtesting.NewAPIFactory()
-	mapper, _, _ := f.UnstructuredObject()
+	mapper, _ := f.Object()
 
 	tests := []struct {
 		gvks     []string

--- a/pkg/kubectl/cmd/apply/prune/prune_test.go
+++ b/pkg/kubectl/cmd/apply/prune/prune_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package prune
+
+import (
+	"testing"
+
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+)
+
+func TestParseGvks(t *testing.T) {
+
+	// Create the fake RESTMapper from the fake factory.
+	f, _, _, _ := cmdtesting.NewAPIFactory()
+	mapper, _, _ := f.UnstructuredObject()
+
+	tests := []struct {
+		gvks     []string
+		group    []string
+		version  []string
+		kind     []string
+		resource []string
+	}{
+		{
+			gvks:     []string{"core/v1/ConfigMap", "extensions/v1beta1/Deployment"},
+			group:    []string{"", "extensions"},
+			version:  []string{"v1", "v1beta1"},
+			kind:     []string{"ConfigMap", "Deployment"},
+			resource: []string{"configmaps", "deployments"},
+		},
+	}
+	for _, test := range tests {
+		mappings, err := ParseGvks(mapper, test.gvks)
+		if err != nil {
+			t.Errorf("Error--TestParseGvks: %v", err)
+		}
+		if len(test.gvks) != len(mappings) {
+			t.Error("Error--TestParseGvks")
+		}
+		for i, mapping := range mappings {
+			if mapping.GroupVersionKind.Group != test.group[i] {
+				t.Errorf("Error--ParseGvks: %v", mapping.GroupVersionKind.Group)
+			}
+			if mapping.GroupVersionKind.Version != test.version[i] {
+				t.Errorf("Error--ParseGvks: %v", mapping.GroupVersionKind.Version)
+			}
+			if mapping.GroupVersionKind.Kind != test.kind[i] {
+				t.Errorf("Error--ParseGvks: %v", mapping.GroupVersionKind.Kind)
+			}
+			if mapping.Resource != test.resource[i] {
+				t.Errorf("Error--ParseGvks: %v", mapping.Resource)
+			}
+		}
+	}
+
+	// Unknown group/version/kind should throw an error.
+	_, err := ParseGvks(mapper, []string{"foo/bar/baz"})
+	if err == nil {
+		t.Error("Error: parsePruneWhitelst should return error when passed nil")
+	}
+}
+
+func TestParsePruneWhitelist(t *testing.T) {
+
+	tests := []struct {
+		gvk    []string
+		parsed [][]string
+	}{
+		{
+			gvk:    []string{},
+			parsed: [][]string{{}},
+		},
+		{
+			gvk:    nil,
+			parsed: [][]string{{}},
+		},
+		{
+			gvk:    []string{"core/v1/ConfigMap"},
+			parsed: [][]string{{"", "v1", "ConfigMap"}},
+		},
+		{
+			gvk:    []string{"batch/v1beta1/Job"},
+			parsed: [][]string{{"batch", "v1beta1", "Job"}},
+		},
+		{
+			gvk: []string{
+				"batch/v1beta1/Job",
+				"core/v1/Pod",
+				"extensions/v1beta1/Deployment",
+			},
+			parsed: [][]string{
+				{"batch", "v1beta1", "Job"},
+				{"", "v1", "Pod"},
+				{"extensions", "v1beta1", "Deployment"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		parsedPruneWhitelist, err := parsePruneWhitelist(test.gvk)
+		if err != nil {
+			t.Errorf("Error: parsePruneWhitelist: %v", err)
+		}
+		for i, parsedGvk := range parsedPruneWhitelist {
+			for j, parsedField := range parsedGvk {
+				if test.parsed[i][j] != parsedField {
+					t.Errorf("Error: parsePruneWhitelist [expected/parsed]: [%v/%v]",
+						test.parsed[i][j], parsedField)
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR refactors the pruning code in apply.go into its own package. By decoupling this functionality, pruning can be easily composed in the new kubectl repo, and it makes further clean-up easier. Additionally, it allows better testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # 

**Special notes for your reviewer**:

**Release note**: 
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
