### PR TITLE
Adjust resources for Metrics Server

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -62,7 +62,7 @@ spec:
                 fieldPath: metadata.namespace
         command:
           - /pod_nanny
-          - --cpu=80m
+          - --cpu=40m
           - --extra-cpu=0.5m
           - --memory=140Mi
           - --extra-memory=4Mi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adjusts resources set for Metrics Server by Pod Nanny to reduce resources usage by core Kubernetes components when enabling Metrics Server. In Kubernetes 1.8 Metrics Server is used only by HPAv2, other use-cases are covered by Heapster.

**Release note**:
```release-note
NONE
```
