### PR TITLE
Allow HPA to get custom metrics

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -162,7 +162,7 @@ func buildControllerRoles() ([]rbac.ClusterRole, []rbac.ClusterRoleBinding) {
 			rbac.NewRule("get").Groups(legacyGroup).Resources("services/proxy").Names("https:heapster:", "http:heapster:").RuleOrDie(),
 			// allow listing resource metrics and custom metrics
 			rbac.NewRule("list").Groups(resMetricsGroup).Resources("pods").RuleOrDie(),
-			rbac.NewRule("list").Groups(customMetricsGroup).Resources("*").RuleOrDie(),
+			rbac.NewRule("get", "list").Groups(customMetricsGroup).Resources("*").RuleOrDie(),
 			eventsRule(),
 		},
 	})

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -479,6 +479,7 @@ items:
     resources:
     - '*'
     verbs:
+    - get
     - list
   - apiGroups:
     - ""


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows HPA to read custom metrics.

**Release note**:
```release-note
Allow HPA to read custom metrics.
```
