### PR TITLE
Rename Detach() parameter.

### DIFF
--- a/pkg/volume/aws_ebs/attacher.go
+++ b/pkg/volume/aws_ebs/attacher.go
@@ -253,8 +253,8 @@ func (plugin *awsElasticBlockStorePlugin) NewDetacher() (volume.Detacher, error)
 	}, nil
 }
 
-func (detacher *awsElasticBlockStoreDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
-	volumeID := aws.KubernetesVolumeID(path.Base(deviceMountPath))
+func (detacher *awsElasticBlockStoreDetacher) Detach(volumeName string, nodeName types.NodeName) error {
+	volumeID := aws.KubernetesVolumeID(path.Base(volumeName))
 
 	attached, err := detacher.awsVolumes.DiskIsAttached(volumeID, nodeName)
 	if err != nil {

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -374,8 +374,8 @@ func (detacher *cinderDiskDetacher) waitDiskDetached(instanceID, volumeID string
 	return err
 }
 
-func (detacher *cinderDiskDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
-	volumeID := path.Base(deviceMountPath)
+func (detacher *cinderDiskDetacher) Detach(volumeName string, nodeName types.NodeName) error {
+	volumeID := path.Base(volumeName)
 	instances, res := detacher.cinderProvider.Instances()
 	if !res {
 		return fmt.Errorf("failed to list openstack instances")

--- a/pkg/volume/fc/attacher.go
+++ b/pkg/volume/fc/attacher.go
@@ -135,7 +135,7 @@ func (plugin *fcPlugin) NewDetacher() (volume.Detacher, error) {
 	}, nil
 }
 
-func (detacher *fcDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *fcDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }
 

--- a/pkg/volume/flexvolume/detacher-defaults.go
+++ b/pkg/volume/flexvolume/detacher-defaults.go
@@ -27,8 +27,8 @@ import (
 type detacherDefaults flexVolumeDetacher
 
 // Detach is part of the volume.Detacher interface.
-func (d *detacherDefaults) Detach(deviceName string, hostName types.NodeName) error {
-	glog.Warning(logPrefix(d.plugin.flexVolumePlugin), "using default Detach for device ", deviceName, ", host ", hostName)
+func (d *detacherDefaults) Detach(volumeName string, hostName types.NodeName) error {
+	glog.Warning(logPrefix(d.plugin.flexVolumePlugin), "using default Detach for volume ", volumeName, ", host ", hostName)
 	return nil
 }
 

--- a/pkg/volume/flexvolume/detacher.go
+++ b/pkg/volume/flexvolume/detacher.go
@@ -34,15 +34,15 @@ type flexVolumeDetacher struct {
 var _ volume.Detacher = &flexVolumeDetacher{}
 
 // Detach is part of the volume.Detacher interface.
-func (d *flexVolumeDetacher) Detach(pvOrVolumeName string, hostName types.NodeName) error {
+func (d *flexVolumeDetacher) Detach(volumeName string, hostName types.NodeName) error {
 
 	call := d.plugin.NewDriverCall(detachCmd)
-	call.Append(pvOrVolumeName)
+	call.Append(volumeName)
 	call.Append(string(hostName))
 
 	_, err := call.Run()
 	if isCmdNotSupportedErr(err) {
-		return (*detacherDefaults)(d).Detach(pvOrVolumeName, hostName)
+		return (*detacherDefaults)(d).Detach(volumeName, hostName)
 	}
 	return err
 }

--- a/pkg/volume/gce_pd/attacher.go
+++ b/pkg/volume/gce_pd/attacher.go
@@ -247,8 +247,8 @@ func (plugin *gcePersistentDiskPlugin) NewDetacher() (volume.Detacher, error) {
 // Callers are responsible for retrying on failure.
 // Callers are responsible for thread safety between concurrent attach and detach
 // operations.
-func (detacher *gcePersistentDiskDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
-	pdName := path.Base(deviceMountPath)
+func (detacher *gcePersistentDiskDetacher) Detach(volumeName string, nodeName types.NodeName) error {
+	pdName := path.Base(volumeName)
 
 	attached, err := detacher.gceDisks.DiskIsAttached(pdName, nodeName)
 	if err != nil {

--- a/pkg/volume/iscsi/attacher.go
+++ b/pkg/volume/iscsi/attacher.go
@@ -137,7 +137,7 @@ func (plugin *iscsiPlugin) NewDetacher() (volume.Detacher, error) {
 	}, nil
 }
 
-func (detacher *iscsiDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *iscsiDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }
 

--- a/pkg/volume/photon_pd/attacher.go
+++ b/pkg/volume/photon_pd/attacher.go
@@ -243,10 +243,10 @@ func (plugin *photonPersistentDiskPlugin) NewDetacher() (volume.Detacher, error)
 }
 
 // Detach the given device from the given host.
-func (detacher *photonPersistentDiskDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *photonPersistentDiskDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 
 	hostName := string(nodeName)
-	pdID := deviceMountPath
+	pdID := volumeName
 	attached, err := detacher.photonDisks.DiskIsAttached(pdID, nodeName)
 	if err != nil {
 		// Log error and continue with detach

--- a/pkg/volume/rbd/attacher.go
+++ b/pkg/volume/rbd/attacher.go
@@ -220,6 +220,6 @@ func (detacher *rbdDetacher) UnmountDevice(deviceMountPath string) error {
 }
 
 // Detach implements Detacher.Detach.
-func (detacher *rbdDetacher) Detach(deviceName string, nodeName types.NodeName) error {
+func (detacher *rbdDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 	return nil
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -468,7 +468,7 @@ func (fv *FakeVolume) GetMountDeviceCallCount() int {
 	return fv.MountDeviceCallCount
 }
 
-func (fv *FakeVolume) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (fv *FakeVolume) Detach(volumeName string, nodeName types.NodeName) error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.DetachCallCount++

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -195,8 +195,10 @@ type BulkVolumeVerifier interface {
 
 // Detacher can detach a volume from a node.
 type Detacher interface {
-	// Detach the given device from the node with the given Name.
-	Detach(deviceName string, nodeName types.NodeName) error
+	// Detach the given volume from the node with the given Name.
+	// volumeName is name of the volume as returned from plugin's
+	// GetVolumeName().
+	Detach(volumeName string, nodeName types.NodeName) error
 
 	// UnmountDevice unmounts the global mount of the disk. This
 	// should only be called once all bind mounts have been

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -251,9 +251,9 @@ func (plugin *vsphereVolumePlugin) NewDetacher() (volume.Detacher, error) {
 }
 
 // Detach the given device from the given node.
-func (detacher *vsphereVMDKDetacher) Detach(deviceMountPath string, nodeName types.NodeName) error {
+func (detacher *vsphereVMDKDetacher) Detach(volumeName string, nodeName types.NodeName) error {
 
-	volPath := getVolPathfromDeviceMountPath(deviceMountPath)
+	volPath := getVolPathfromVolumeName(volumeName)
 	attached, err := detacher.vsphereVolumes.DiskIsAttached(volPath, nodeName)
 	if err != nil {
 		// Log error and continue with detach

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -170,7 +170,7 @@ func (util *VsphereDiskUtil) DeleteVolume(vd *vsphereVolumeDeleter) error {
 	return nil
 }
 
-func getVolPathfromDeviceMountPath(deviceMountPath string) string {
+func getVolPathfromVolumeName(deviceMountPath string) string {
 	// Assumption: No file or folder is named starting with '[' in datastore
 	volPath := deviceMountPath[strings.LastIndex(deviceMountPath, "["):]
 	// space between datastore and vmdk name in volumePath is encoded as '\040' when returned by GetMountRefs().


### PR DESCRIPTION
`Detach()` does not get device name, it gets volume name. Parameters named `deviceMountPath` or `deviceName` just confuses developers.

Note that this PR  just renames parameters here and there, there should be no behavior change.

@kubernetes/sig-storage-pr-reviews 

/assign @gnufied @jingxu97 

**Release note**:
```release-note
NONE
```
