### PR TITLE
Automated cherry pick of #54413

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -110,7 +110,7 @@ func (s *SpdyRoundTripper) Dial(req *http.Request) (net.Conn, error) {
 func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 	proxier := s.proxier
 	if proxier == nil {
-		proxier = http.ProxyFromEnvironment
+		proxier = utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
 	}
 	proxyURL, err := proxier(req)
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #54413 on release-1.8.

#54413: Use CIDR-aware proxy resolver for SPDY RoundTripper

**Release note**:
```release-note
- API machinery's httpstream/spdy calls now support CIDR notation for NO_PROXY
```