### PR TITLE
ensure PrinterForCommand is consumed through cmdutil.Factory

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -336,7 +336,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 	}
 
 	cmds.AddCommand(alpha)
-	cmds.AddCommand(cmdconfig.NewCmdConfig(clientcmd.NewDefaultPathOptions(), out, err))
+	cmds.AddCommand(cmdconfig.NewCmdConfig(f, clientcmd.NewDefaultPathOptions(), out, err))
 	cmds.AddCommand(NewCmdPlugin(f, in, out, err))
 	cmds.AddCommand(NewCmdVersion(f, out))
 	cmds.AddCommand(NewCmdApiVersions(f, out))

--- a/pkg/kubectl/cmd/config/BUILD
+++ b/pkg/kubectl/cmd/config/BUILD
@@ -33,8 +33,6 @@ go_library(
         "//pkg/kubectl/util/i18n:go_default_library",
         "//pkg/printers:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",

--- a/pkg/kubectl/cmd/config/config.go
+++ b/pkg/kubectl/cmd/config/config.go
@@ -31,7 +31,7 @@ import (
 )
 
 // NewCmdConfig creates a command object for the "config" action, and adds all child commands to it.
-func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
+func NewCmdConfig(f cmdutil.Factory, pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *cobra.Command {
 	if len(pathOptions.ExplicitFileFlag) == 0 {
 		pathOptions.ExplicitFileFlag = clientcmd.RecommendedConfigPathFlag
 	}
@@ -53,7 +53,7 @@ func NewCmdConfig(pathOptions *clientcmd.PathOptions, out, errOut io.Writer) *co
 	// file paths are common to all sub commands
 	cmd.PersistentFlags().StringVar(&pathOptions.LoadingRules.ExplicitPath, pathOptions.ExplicitFileFlag, pathOptions.LoadingRules.ExplicitPath, "use a particular kubeconfig file")
 
-	cmd.AddCommand(NewCmdConfigView(out, errOut, pathOptions))
+	cmd.AddCommand(NewCmdConfigView(f, out, errOut, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetCluster(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetAuthInfo(out, pathOptions))
 	cmd.AddCommand(NewCmdConfigSetContext(out, pathOptions))

--- a/pkg/kubectl/cmd/config/config_test.go
+++ b/pkg/kubectl/cmd/config/config_test.go
@@ -865,7 +865,7 @@ func testConfigCommand(args []string, startingConfig clientcmdapi.Config, t *tes
 
 	buf := bytes.NewBuffer([]byte{})
 
-	cmd := NewCmdConfig(clientcmd.NewDefaultPathOptions(), buf, buf)
+	cmd := NewCmdConfig(cmdutil.NewFactory(nil), clientcmd.NewDefaultPathOptions(), buf, buf)
 	cmd.SetArgs(argsToUse)
 	cmd.Execute()
 

--- a/pkg/kubectl/cmd/config/view.go
+++ b/pkg/kubectl/cmd/config/view.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -57,7 +55,7 @@ var (
 		kubectl config view -o jsonpath='{.users[?(@.name == "e2e")].user.password}'`)
 )
 
-func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
+func NewCmdConfigView(f cmdutil.Factory, out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &ViewOptions{ConfigAccess: ConfigAccess}
 	// Default to yaml
 	defaultOutputFormat := "yaml"
@@ -82,7 +80,7 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 			}
 
 			printOpts := cmdutil.ExtractCmdPrintOptions(cmd, false)
-			printer, err := cmdutil.PrinterForOptions(meta.NewDefaultRESTMapper(nil, nil), latest.Scheme, nil, []runtime.Decoder{latest.Codec}, printOpts)
+			printer, err := f.PrinterForOptions(printOpts)
 			cmdutil.CheckErr(err)
 			printer = printers.NewVersionedPrinter(printer, latest.Scheme, latest.ExternalVersion)
 
@@ -94,8 +92,8 @@ func NewCmdConfigView(out, errOut io.Writer, ConfigAccess clientcmd.ConfigAccess
 	cmd.Flags().Set("output", defaultOutputFormat)
 
 	options.Merge.Default(true)
-	f := cmd.Flags().VarPF(&options.Merge, "merge", "", "Merge the full hierarchy of kubeconfig files")
-	f.NoOptDefVal = "true"
+	mergeFlag := cmd.Flags().VarPF(&options.Merge, "merge", "", "Merge the full hierarchy of kubeconfig files")
+	mergeFlag.NoOptDefVal = "true"
 	cmd.Flags().BoolVar(&options.RawByteData, "raw", false, "Display raw byte data")
 	cmd.Flags().BoolVar(&options.Flatten, "flatten", false, "Flatten the resulting kubeconfig file into self-contained output (useful for creating portable kubeconfig files)")
 	cmd.Flags().BoolVar(&options.Minify, "minify", false, "Remove all information not used by current-context from the output")

--- a/pkg/kubectl/cmd/config/view_test.go
+++ b/pkg/kubectl/cmd/config/view_test.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 )
 
 type viewClusterTest struct {
@@ -142,7 +143,7 @@ func (test viewClusterTest) run(t *testing.T) {
 	pathOptions.EnvVar = ""
 	buf := bytes.NewBuffer([]byte{})
 	errBuf := bytes.NewBuffer([]byte{})
-	cmd := NewCmdConfigView(buf, errBuf, pathOptions)
+	cmd := NewCmdConfigView(cmdutil.NewFactory(nil), buf, errBuf, pathOptions)
 	cmd.Flags().Parse(test.flags)
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v,kubectl config view flags: %v", err, test.flags)

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -56,7 +56,7 @@ func (f *ring2Factory) PrinterForOptions(options *printers.PrintOptions) (printe
 	// TODO: used by the custom column implementation and the name implementation, break this dependency
 	decoders := []runtime.Decoder{f.clientAccessFactory.Decoder(true), unstructured.UnstructuredJSONScheme}
 	encoder := f.clientAccessFactory.JSONEncoder()
-	return PrinterForOptions(mapper, typer, encoder, decoders, options)
+	return printerForOptions(mapper, typer, encoder, decoders, options)
 }
 
 func (f *ring2Factory) PrinterForMapping(options *printers.PrintOptions, mapping *meta.RESTMapping) (printers.ResourcePrinter, error) {

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -81,10 +81,10 @@ func ValidateOutputArgs(cmd *cobra.Command) error {
 	return nil
 }
 
-// PrinterForOptions returns the printer for the outputOptions (if given) or
+// printerForOptions returns the printer for the outputOptions (if given) or
 // returns the default printer for the command. Requires that printer flags have
 // been added to cmd (see AddPrinterFlags).
-func PrinterForOptions(mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options *printers.PrintOptions) (printers.ResourcePrinter, error) {
+func printerForOptions(mapper meta.RESTMapper, typer runtime.ObjectTyper, encoder runtime.Encoder, decoders []runtime.Decoder, options *printers.PrintOptions) (printers.ResourcePrinter, error) {
 	printer, err := printers.GetStandardPrinter(mapper, typer, encoder, decoders, *options)
 	if err != nil {
 		return nil, err

--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -93,7 +93,7 @@ func printerForOptions(mapper meta.RESTMapper, typer runtime.ObjectTyper, encode
 	// we try to convert to HumanReadablePrinter, if return ok, it must be no generic
 	// we execute AddHandlers() here before maybeWrapSortingPrinter so that we don't
 	// need to convert to delegatePrinter again then invoke AddHandlers()
-	if humanReadablePrinter, ok := printer.(*printers.HumanReadablePrinter); ok {
+	if humanReadablePrinter, ok := printer.(printers.PrintHandler); ok {
 		printersinternal.AddHandlers(humanReadablePrinter)
 	}
 


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

This patch is one in a series of patches that aims to move all
printing functions to the `cmdutil.Factory` in order to make
the factory the one-stop shop for accessing printers in the client.

This PR is related to https://github.com/kubernetes/kubernetes/pull/50113 and aims to break the set of changes
introduced in this commit in order to make them easier to review.

@fabianofranz @mengqiy @shiywang