### PR TITLE
kubectl: 'apply view-last-applied' must not use printf()

### DIFF
--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -142,13 +142,13 @@ func (o *ViewLastAppliedOptions) RunApplyViewLastApplied() error {
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(jsonBuffer.Bytes()))
+			fmt.Fprint(o.Out, string(jsonBuffer.Bytes()))
 		case "yaml":
 			yamlOutput, err := yaml.JSONToYAML([]byte(str))
 			if err != nil {
 				return err
 			}
-			fmt.Fprintf(o.Out, string(yamlOutput))
+			fmt.Fprint(o.Out, string(yamlOutput))
 		}
 	}
 


### PR DESCRIPTION

**Which issue(s) this PR fixes** 
#54645

**Special notes for your reviewer**:
This is cherry-picked commit for branch `release-1.7` as suggested in the #54645 discussion  by @shiywang

**Release note**:
```release-note
NONE
```
