### PR TITLE
Fix hook failure in kubernetes-worker charm due to iptables conflict

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -854,7 +854,7 @@ def fix_iptables_for_docker_1_13():
     https://github.com/kubernetes/kubernetes/issues/40182
     https://github.com/kubernetes/kubernetes/issues/39823
     """
-    cmd = ['iptables', '-P', 'FORWARD', 'ACCEPT']
+    cmd = ['iptables', '-w', '300', '-P', 'FORWARD', 'ACCEPT']
     check_call(cmd)
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This fixes a hook failure that can occur on the kubernetes-worker charm due to iptable conflicts:

```
Another app is currently holding the xtables lock. Perhaps you want to use the -w option?
...
subprocess.CalledProcessError: Command '['iptables', '-P', 'FORWARD', 'ACCEPT']' returned non-zero exit status 4
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Passing `-w 300` to iptables tells it to wait up to 5 minutes to acquire the xtables lock, rather than aborting immediately.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
