### PR TITLE
Add SyncProxyRulesCount as a metric

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -956,6 +956,7 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInMicroseconds(start))
+		metrics.SyncProxyRulesCount.Add(1)
 		glog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 	// don't sync rules till we've received services and endpoints

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -864,6 +864,7 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		metrics.SyncProxyRulesLatency.Observe(metrics.SinceInMicroseconds(start))
+		metrics.SyncProxyRulesCount.Add(1)
 		glog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 	// don't sync rules till we've received services and endpoints

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -35,14 +35,24 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
+
+	// SyncProxyRulesCount is the number of times kube-proxy has synced proxy rules.
+	SyncProxyRulesCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: kubeProxySubsystem,
+			Name:      "sync_proxy_rules_count"
+			Help:      "SyncProxyRules count"
+	        },
+	)
 )
 
 var registerMetricsOnce sync.Once
 
-// RegisterMetrics registers sync proxy rules latency metrics
+// RegisterMetrics registers sync proxy rules metrics
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
 		prometheus.MustRegister(SyncProxyRulesLatency)
+		prometheus.MustRegister(SyncProxyRulesCount)
 	})
 }
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -40,8 +40,8 @@ var (
 	SyncProxyRulesCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: kubeProxySubsystem,
-			Name:      "sync_proxy_rules_count"
-			Help:      "SyncProxyRules count"
+			Name:      "sync_proxy_rules_count",
+			Help:      "SyncProxyRules count",
 	        },
 	)
 )

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -42,7 +42,7 @@ var (
 			Subsystem: kubeProxySubsystem,
 			Name:      "sync_proxy_rules_count",
 			Help:      "SyncProxyRules count",
-	        },
+		},
 	)
 )
 

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -26,6 +26,7 @@ import (
 const kubeProxySubsystem = "kubeproxy"
 
 var (
+	// SyncProxyRulesLatency is the latency of one round of kube-proxy syncing proxy rules.
 	SyncProxyRulesLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Subsystem: kubeProxySubsystem,
@@ -34,6 +35,15 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1000, 2, 15),
 		},
 	)
+
+	// SyncProxyRulesCount is the number of times kube-proxy has synced proxy rules.
+	SyncProxyRulesCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Subsystem: kubeProxySubsystem,
+			Name:      "sync_proxy_rules_count"
+			Help:      "SyncProxyRules count"
+	        },
+	)
 )
 
 var registerMetricsOnce sync.Once
@@ -41,6 +51,7 @@ var registerMetricsOnce sync.Once
 func RegisterMetrics() {
 	registerMetricsOnce.Do(func() {
 		prometheus.MustRegister(SyncProxyRulesLatency)
+		prometheus.MustRegister(SyncProxyRulesCount)
 	})
 }
 

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -40,8 +40,8 @@ var (
 	SyncProxyRulesCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Subsystem: kubeProxySubsystem,
-			Name:      "sync_proxy_rules_count"
-			Help:      "SyncProxyRules count"
+			Name:      "sync_proxy_rules_count",
+			Help:      "SyncProxyRules count",
 	        },
 	)
 )

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -42,7 +42,7 @@ var (
 			Subsystem: kubeProxySubsystem,
 			Name:      "sync_proxy_rules_count",
 			Help:      "SyncProxyRules count",
-	        },
+		},
 	)
 )
 

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -940,6 +940,7 @@ func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
 		SyncProxyRulesLatency.Observe(sinceInMicroseconds(start))
+		SyncProxyRulesCount.Add(1)
 		glog.V(4).Infof("syncProxyRules took %v", time.Since(start))
 	}()
 	// don't sync rules till we've received services and endpoints


### PR DESCRIPTION
This PR adds a metric to kube proxy called SyncProxyRulesCount. This metric will allow us to identify situations in which kube proxy is failing to sync iptables rules. 

Release Note:
```release-note
None
```
