### PR TITLE
Switch kubectl convert back to use legacyscheme and add tests

### DIFF
--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -157,6 +157,7 @@ go_test(
         "attach_test.go",
         "clusterinfo_dump_test.go",
         "cmd_test.go",
+        "convert_test.go",
         "cp_test.go",
         "create_clusterrole_test.go",
         "create_clusterrolebinding_test.go",

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -24,10 +24,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubernetes/pkg/api"
+	scheme "k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/resource"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 	"k8s.io/kubernetes/pkg/printers"
 

--- a/pkg/kubectl/cmd/convert_test.go
+++ b/pkg/kubectl/cmd/convert_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+	"k8s.io/kubernetes/pkg/printers"
+)
+
+type testcase struct {
+	name          string
+	file          string
+	outputVersion string
+	fields        []checkField
+}
+
+type checkField struct {
+	template string
+	expected string
+}
+
+func TestConvertObject(t *testing.T) {
+	testcases := []testcase{
+		{
+			name:          "apps deployment to extensions deployment",
+			file:          "../../../test/fixtures/pkg/kubectl/cmd/convert/appsdeployment.yaml",
+			outputVersion: "extensions/v1beta1",
+			fields: []checkField{
+				{
+					template: "{{.apiVersion}}",
+					expected: "extensions/v1beta1",
+				},
+			},
+		},
+		{
+			name:          "extensions deployment to apps deployment",
+			file:          "../../../test/fixtures/pkg/kubectl/cmd/convert/extensionsdeployment.yaml",
+			outputVersion: "apps/v1beta2",
+			fields: []checkField{
+				{
+					template: "{{.apiVersion}}",
+					expected: "apps/v1beta2",
+				},
+			},
+		},
+		{
+			name:          "v1 HPA to v2beta1 HPA",
+			file:          "../../../test/fixtures/pkg/kubectl/cmd/convert/v1HPA.yaml",
+			outputVersion: "autoscaling/v2beta1",
+			fields: []checkField{
+				{
+					template: "{{.apiVersion}}",
+					expected: "autoscaling/v2beta1",
+				},
+				{
+					template: "{{(index .spec.metrics 0).resource.name}}",
+					expected: "cpu",
+				},
+				{
+					template: "{{(index .spec.metrics 0).resource.targetAverageUtilization}}",
+					expected: "50",
+				},
+			},
+		},
+		{
+			name:          "v2beta1 HPA to v1 HPA",
+			file:          "../../../test/fixtures/pkg/kubectl/cmd/convert/v2beta1HPA.yaml",
+			outputVersion: "autoscaling/v1",
+			fields: []checkField{
+				{
+					template: "{{.apiVersion}}",
+					expected: "autoscaling/v1",
+				},
+				{
+					template: "{{.spec.targetCPUUtilizationPercentage}}",
+					expected: "50",
+				},
+			},
+		},
+	}
+
+	f, tf, _, _ := cmdtesting.NewAPIFactory()
+	tf.UnstructuredClient = &fake.RESTClient{
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}),
+	}
+	tf.Namespace = "test"
+	buf := bytes.NewBuffer([]byte{})
+
+	for _, tc := range testcases {
+		cmd := NewCmdConvert(f, buf)
+		cmd.Flags().Set("filename", tc.file)
+		cmd.Flags().Set("output-version", tc.outputVersion)
+		cmd.Flags().Set("local", "true")
+		cmd.Flags().Set("output", "go-template")
+
+		for _, field := range tc.fields {
+			buf.Reset()
+			tf.Printer, _ = printers.NewTemplatePrinter([]byte(field.template))
+			cmd.Run(cmd, []string{})
+			if buf.String() != field.expected {
+				t.Errorf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputVersion, field.expected, buf.String())
+			}
+		}
+	}
+}

--- a/test/fixtures/pkg/kubectl/cmd/convert/appsdeployment.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/appsdeployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx

--- a/test/fixtures/pkg/kubectl/cmd/convert/extensionsdeployment.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/extensionsdeployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        name: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx

--- a/test/fixtures/pkg/kubectl/cmd/convert/v1HPA.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/v1HPA.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  targetCPUUtilizationPercentage: 50

--- a/test/fixtures/pkg/kubectl/cmd/convert/v2beta1HPA.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/convert/v2beta1HPA.yaml
@@ -1,0 +1,16 @@
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: php-apache
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1beta1
+    kind: Deployment
+    name: php-apache
+  minReplicas: 1
+  maxReplicas: 10
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: 50


### PR DESCRIPTION
Revert the change of `convert.go` in #54533.
Add tests for kubectl convert.

Fixes #54873 

```release-note
NONE
```

cc: @smarterclayton 