### PR TITLE
Whitelist net.core.somaxconn as a safe sysctl

### DIFF
--- a/pkg/kubelet/sysctl/whitelist.go
+++ b/pkg/kubelet/sysctl/whitelist.go
@@ -42,6 +42,7 @@ func SafeSysctlWhitelist() []string {
 		"kernel.shm_rmid_forced",
 		"net.ipv4.ip_local_port_range",
 		"net.ipv4.tcp_syncookies",
+		"net.core.somaxconn",
 	}
 }
 

--- a/pkg/kubelet/sysctl/whitelist_test.go
+++ b/pkg/kubelet/sysctl/whitelist_test.go
@@ -54,6 +54,7 @@ func TestWhitelist(t *testing.T) {
 		{sysctl: "net.ipv4.ip_local_port_range"},
 		{sysctl: "kernel.msgmax"},
 		{sysctl: "kernel.sem"},
+		{sysctl: "net.core.somaxconn"},
 	}
 	invalid := []Test{
 		{sysctl: "kernel.shm_rmid_forced", hostIPC: true},


### PR DESCRIPTION
net.core.somaxconn should be a safe sysctl as it gets initialized on netns
creation. This will allow users to configure the parameter with pod annotations.

Implement #54132

**What this PR does / why we need it**:

Pod developers/operators can configure the sysctl parameter net.core.somaxconn
with pod annotation as explained in https://kubernetes.io/docs/concepts/cluster-administration/sysctl-cluster/.

Pod developer/operator should have control over the parameter as it is isolated for network namespace. 
Without this patch, it requires cluster admin to run kubelet with --experimental-allowed-unsafe-sysctls flags, which is not scalable. 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54132

**Special notes for your reviewer**:
N/A

**Release note**:
```release-note
Sysctl parameter net.core.somaxconn is now whitelisted as a safe sysctl. You can now configure the parameter by pod annotation as explained in https://kubernetes.io/docs/concepts/cluster-administration/sysctl-cluster/.
```