### PR TITLE
Update scheduler tests to use require statements per issue #43788

### DIFF
--- a/plugin/pkg/scheduler/BUILD
+++ b/plugin/pkg/scheduler/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//plugin/pkg/scheduler/testing:go_default_library",
         "//plugin/pkg/scheduler/util:go_default_library",
         "//plugin/pkg/scheduler/volumebinder:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/plugin/pkg/scheduler/algorithm/BUILD
+++ b/plugin/pkg/scheduler/algorithm/BUILD
@@ -35,6 +35,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],

--- a/plugin/pkg/scheduler/algorithm/predicates/BUILD
+++ b/plugin/pkg/scheduler/algorithm/predicates/BUILD
@@ -57,6 +57,7 @@ go_test(
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//plugin/pkg/scheduler/testing:go_default_library",
         "//plugin/pkg/scheduler/util:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/plugin/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
@@ -338,21 +339,18 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 		existingPodsMeta1, nodeInfoMap := getMeta(schedulertesting.FakePodLister(test.existingPods))
 		// Add test.addedPod to existingPodsMeta1 and make sure meta is equal to allPodsMeta
 		nodeInfo := nodeInfoMap[test.addedPod.Spec.NodeName]
-		if err := existingPodsMeta1.AddPod(test.addedPod, nodeInfo); err != nil {
-			t.Errorf("test [%v]: error adding pod to meta: %v", test.description, err)
-		}
-		if err := predicateMetadataEquivalent(allPodsMeta, existingPodsMeta1); err != nil {
-			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
-		}
+		err := existingPodsMeta1.AddPod(test.addedPod, nodeInfo)
+		require.NoError(t, err, "test [%v]: error adding pod to meta: %v", test.description, err)
+		err = predicateMetadataEquivalent(allPodsMeta, existingPodsMeta1)
+		require.NoError(t, err, "test [%v]: meta data are not equivalent: %v", test.description, err)
+
 		// Remove the added pod and from existingPodsMeta1 an make sure it is equal
 		// to meta generated for existing pods.
 		existingPodsMeta2, _ := getMeta(schedulertesting.FakePodLister(test.existingPods))
-		if err := existingPodsMeta1.RemovePod(test.addedPod); err != nil {
-			t.Errorf("test [%v]: error removing pod from meta: %v", test.description, err)
-		}
-		if err := predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2); err != nil {
-			t.Errorf("test [%v]: meta data are not equivalent: %v", test.description, err)
-		}
+		err = existingPodsMeta1.RemovePod(test.addedPod)
+		require.NoError(t, err, "test [%v]: error removing pod from meta: %v", test.description, err)
+		err = predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2)
+		require.NoError(t, err, "test [%v]: meta data are not equivalent: %v", test.description, err)
 	}
 }
 
@@ -394,7 +392,5 @@ func TestPredicateMetadata_ShallowCopy(t *testing.T) {
 		},
 	}
 
-	if !reflect.DeepEqual(source.ShallowCopy().(*predicateMetadata), &source) {
-		t.Errorf("Copy is not equal to source!")
-	}
+	require.True(t, reflect.DeepEqual(source.ShallowCopy().(*predicateMetadata), &source), "Copy is not equal to source!")
 }

--- a/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -381,15 +382,11 @@ func TestPodFitsResources(t *testing.T) {
 		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 0, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 0, 32, 5, 20, 5)}}
 		test.nodeInfo.SetNode(&node)
 		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, test.reasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 
 	notEnoughPodsTests := []struct {
@@ -436,15 +433,11 @@ func TestPodFitsResources(t *testing.T) {
 		node := v1.Node{Status: v1.NodeStatus{Capacity: v1.ResourceList{}, Allocatable: makeAllocatableResources(10, 20, 0, 1, 0, 0, 0)}}
 		test.nodeInfo.SetNode(&node)
 		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, test.reasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 
 	storagePodsTests := []struct {
@@ -494,15 +487,11 @@ func TestPodFitsResources(t *testing.T) {
 		node := v1.Node{Status: v1.NodeStatus{Capacity: makeResources(10, 20, 0, 32, 5, 20, 5).Capacity, Allocatable: makeAllocatableResources(10, 20, 0, 32, 5, 20, 5)}}
 		test.nodeInfo.SetNode(&node)
 		fits, reasons, err := PodFitsResources(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, test.reasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 
 }
@@ -555,15 +544,11 @@ func TestPodFitsHost(t *testing.T) {
 		nodeInfo := schedulercache.NewNodeInfo()
 		nodeInfo.SetNode(test.node)
 		fits, reasons, err := PodFitsHost(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: unexpected difference: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: unexpected difference: expected: %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -693,15 +678,12 @@ func TestPodFitsHostPorts(t *testing.T) {
 
 	for _, test := range tests {
 		fits, reasons, err := PodFitsHostPorts(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if test.fits != fits {
-			t.Errorf("%s: expected %v, saw %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected %v, saw %v", test.test, test.fits, fits)
 	}
 }
 
@@ -734,9 +716,7 @@ func TestGetUsedPorts(t *testing.T) {
 
 	for _, test := range tests {
 		ports := schedutil.GetUsedPorts(test.pods...)
-		if !reflect.DeepEqual(test.ports, ports) {
-			t.Errorf("%s: expected %v, got %v", "test get used ports", test.ports, ports)
-		}
+		require.True(t, reflect.DeepEqual(test.ports, ports), "%s: expected %v, got %v", "test get used ports", test.ports, ports)
 	}
 }
 
@@ -778,17 +758,15 @@ func TestGCEDiskConflicts(t *testing.T) {
 
 	for _, test := range tests {
 		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !ok {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
+		if test.isOk {
+			require.True(t, ok, "%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
+		if !test.isOk {
+			require.False(t, ok, "%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
 	}
 }
@@ -831,17 +809,15 @@ func TestAWSDiskConflicts(t *testing.T) {
 
 	for _, test := range tests {
 		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !ok {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
+		if test.isOk {
+			require.True(t, ok, "%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
+		if !test.isOk {
+			require.False(t, ok, "%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
 	}
 }
@@ -890,17 +866,15 @@ func TestRBDDiskConflicts(t *testing.T) {
 
 	for _, test := range tests {
 		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !ok {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
+		if test.isOk {
+			require.True(t, ok, "%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
+		if !test.isOk {
+			require.False(t, ok, "%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
 	}
 }
@@ -949,17 +923,15 @@ func TestISCSIDiskConflicts(t *testing.T) {
 
 	for _, test := range tests {
 		ok, reasons, err := NoDiskConflict(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !ok {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !ok && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
+		if test.isOk {
+			require.True(t, ok, "%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
-		if test.isOk && !ok {
-			t.Errorf("%s: expected ok, got none.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
-		}
-		if !test.isOk && ok {
-			t.Errorf("%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
+		if !test.isOk {
+			require.False(t, ok, "%s: expected no ok, got one.  %v %s %s", test.test, test.pod, test.nodeInfo, test.test)
 		}
 	}
 }
@@ -1424,15 +1396,11 @@ func TestPodFitsSelector(t *testing.T) {
 		nodeInfo.SetNode(&node)
 
 		fits, reasons, err := PodMatchNodeSelector(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -1491,15 +1459,11 @@ func TestNodeLabelPresence(t *testing.T) {
 
 		labelChecker := NodeLabelChecker{test.labels, test.presence}
 		fits, reasons, err := labelChecker.CheckNodeLabelPresence(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -1644,20 +1608,14 @@ func TestServiceAffinity(t *testing.T) {
 					precompute(pm)
 				}
 			})
-			if pmeta, ok := (PredicateMetadata(test.pod, nodeInfoMap)).(*predicateMetadata); ok {
-				fits, reasons, err := predicate(test.pod, pmeta, nodeInfo)
-				if err != nil {
-					t.Errorf("%s: unexpected error: %v", test.test, err)
-				}
-				if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-					t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-				}
-				if fits != test.fits {
-					t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-				}
-			} else {
-				t.Errorf("Error casting.")
+			pmeta, ok := (PredicateMetadata(test.pod, nodeInfoMap)).(*predicateMetadata)
+			require.True(t, ok, "Error casting.")
+			fits, reasons, err := predicate(test.pod, pmeta, nodeInfo)
+			require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+			if !fits {
+				require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 			}
+			require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 		}
 
 		testIt(false) // Confirm that the predicate works without precomputed data (resilience)
@@ -2072,15 +2030,11 @@ func TestEBSVolumeCountConflicts(t *testing.T) {
 		os.Setenv(KubeMaxPDVols, strconv.Itoa(test.maxVols))
 		pred := NewMaxPDVolumeCountPredicate(EBSVolumeFilterType, pvInfo, pvcInfo)
 		fits, reasons, err := pred(test.newPod, PredicateMetadata(test.newPod, nil), schedulercache.NewNodeInfo(test.existingPods...))
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v, got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected %v, got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -2198,15 +2152,11 @@ func TestRunGeneralPredicates(t *testing.T) {
 	for _, test := range resourceTests {
 		test.nodeInfo.SetNode(test.node)
 		fits, reasons, err := GeneralPredicates(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, test.reasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, test.reasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.reasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected: %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -2817,12 +2767,10 @@ func TestInterPodAffinity(t *testing.T) {
 		nodeInfo.SetNode(test.node)
 		nodeInfoMap := map[string]*schedulercache.NodeInfo{test.node.Name: nodeInfo}
 		fits, reasons, _ := fit.InterPodAffinityMatches(test.pod, PredicateMetadata(test.pod, nodeInfoMap), nodeInfo)
-		if !fits && !reflect.DeepEqual(reasons, test.expectFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.expectFailureReasons)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, test.expectFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, test.expectFailureReasons)
 		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -3239,8 +3187,9 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 			}
 
 			fits, reasons, _ := testFit.InterPodAffinityMatches(test.pod, meta, nodeInfo)
-			if !fits && !reflect.DeepEqual(reasons, test.nodesExpectAffinityFailureReasons[indexNode]) {
-				t.Errorf("index: %d test: %s unexpected failure reasons: %v expect: %v", indexTest, test.test, reasons, test.nodesExpectAffinityFailureReasons[indexNode])
+			if !fits {
+				require.True(t, reflect.DeepEqual(reasons, test.nodesExpectAffinityFailureReasons[indexNode]),
+					"index: %d test: %s unexpected failure reasons: %v expect: %v", indexTest, test.test, reasons, test.nodesExpectAffinityFailureReasons[indexNode])
 			}
 			affinity := test.pod.Spec.Affinity
 			if affinity != nil && affinity.NodeAffinity != nil {
@@ -3248,18 +3197,13 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 				nodeInfo.SetNode(&node)
 				nodeInfoMap := map[string]*schedulercache.NodeInfo{node.Name: nodeInfo}
 				fits2, reasons, err := PodMatchNodeSelector(test.pod, PredicateMetadata(test.pod, nodeInfoMap), nodeInfo)
-				if err != nil {
-					t.Errorf("%s: unexpected error: %v", test.test, err)
-				}
-				if !fits2 && !reflect.DeepEqual(reasons, selectorExpectedFailureReasons) {
-					t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.test, reasons, selectorExpectedFailureReasons)
+				require.NoError(t, err, "%s: unexpected error: %v", test.test, err)
+				if !fits2 {
+					require.True(t, reflect.DeepEqual(reasons, selectorExpectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.test, reasons, selectorExpectedFailureReasons)
 				}
 				fits = fits && fits2
 			}
-
-			if fits != test.fits[node.Name] {
-				t.Errorf("%s: expected %v for %s got %v", test.test, test.fits[node.Name], node.Name, fits)
-			}
+			require.Equal(t, test.fits[node.Name], fits, "%s: expected %v for %s got %v", test.test, test.fits[node.Name], node.Name, fits)
 		}
 	}
 }
@@ -3453,15 +3397,11 @@ func TestPodToleratesTaints(t *testing.T) {
 		nodeInfo := schedulercache.NewNodeInfo()
 		nodeInfo.SetNode(&test.node)
 		fits, reasons, err := PodToleratesNodeTaints(test.pod, PredicateMetadata(test.pod, nil), nodeInfo)
-		if err != nil {
-			t.Errorf("%s, unexpected error: %v", test.test, err)
+		require.NoError(t, err, "%s, unexpected error: %v", test.test, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s, unexpected failure reason: %v, want: %v", test.test, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s, unexpected failure reason: %v, want: %v", test.test, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s, expected: %v got %v", test.test, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s, expected: %v got %v", test.test, test.fits, fits)
 	}
 }
 
@@ -3563,15 +3503,11 @@ func TestPodSchedulesOnNodeWithMemoryPressureCondition(t *testing.T) {
 
 	for _, test := range tests {
 		fits, reasons, err := CheckNodeMemoryPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.name, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.name, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.name, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected %v got %v", test.name, test.fits, fits)
 	}
 }
 
@@ -3635,15 +3571,11 @@ func TestPodSchedulesOnNodeWithDiskPressureCondition(t *testing.T) {
 
 	for _, test := range tests {
 		fits, reasons, err := CheckNodeDiskPressurePredicate(test.pod, PredicateMetadata(test.pod, nil), test.nodeInfo)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.name, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.name, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.name, reasons, expectedFailureReasons)
-		}
-		if fits != test.fits {
-			t.Errorf("%s: expected %v got %v", test.name, test.fits, fits)
-		}
+		require.Equal(t, test.fits, fits, "%s: expected %v got %v", test.name, test.fits, fits)
 	}
 }
 
@@ -3712,10 +3644,9 @@ func TestNodeConditionPredicate(t *testing.T) {
 
 	for _, test := range tests {
 		nodeInfo := makeEmptyNodeInfo(test.node)
-		if fit, reasons, err := CheckNodeConditionPredicate(nil, nil, nodeInfo); fit != test.schedulable {
-			t.Errorf("%s: expected: %t, got %t; %+v, %v",
-				test.node.Name, test.schedulable, fit, reasons, err)
-		}
+		fit, reasons, err := CheckNodeConditionPredicate(nil, nil, nodeInfo)
+		require.Equal(t, test.schedulable, fit, "%s: expected: %t, got %t; %+v, %v",
+			test.node.Name, test.schedulable, fit, reasons, err)
 	}
 }
 
@@ -3852,16 +3783,11 @@ func TestVolumeZonePredicate(t *testing.T) {
 		node.SetNode(test.Node)
 
 		fits, reasons, err := fit(test.Pod, nil, node)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.Name, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.Name, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
-		}
-		if fits != test.Fits {
-			t.Errorf("%s: expected %v got %v", test.Name, test.Fits, fits)
-		}
-
+		require.Equal(t, test.Fits, fits, "%s: expected %v got %v", test.Name, test.Fits, fits)
 	}
 }
 
@@ -3945,16 +3871,11 @@ func TestVolumeZonePredicateMultiZone(t *testing.T) {
 		node.SetNode(test.Node)
 
 		fits, reasons, err := fit(test.Pod, nil, node)
-		if err != nil {
-			t.Errorf("%s: unexpected error: %v", test.Name, err)
+		require.NoError(t, err, "%s: unexpected error: %v", test.Name, err)
+		if !fits {
+			require.True(t, reflect.DeepEqual(reasons, expectedFailureReasons), "%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
 		}
-		if !fits && !reflect.DeepEqual(reasons, expectedFailureReasons) {
-			t.Errorf("%s: unexpected failure reasons: %v, want: %v", test.Name, reasons, expectedFailureReasons)
-		}
-		if fits != test.Fits {
-			t.Errorf("%s: expected %v got %v", test.Name, test.Fits, fits)
-		}
-
+		require.Equal(t, test.Fits, fits, "%s: expected %v got %v", test.Name, test.Fits, fits)
 	}
 }
 
@@ -4111,9 +4032,7 @@ func TestGetMaxVols(t *testing.T) {
 	for _, test := range tests {
 		os.Setenv(KubeMaxPDVols, test.rawMaxVols)
 		result := getMaxVols(defaultValue)
-		if result != test.expected {
-			t.Errorf("%s: expected %v got %v", test.test, test.expected, result)
-		}
+		require.Equal(t, test.expected, result, "%s: expected %v got %v", test.test, test.expected, result)
 	}
 
 	os.Unsetenv(KubeMaxPDVols)

--- a/plugin/pkg/scheduler/algorithm/predicates/utils_test.go
+++ b/plugin/pkg/scheduler/algorithm/predicates/utils_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -107,10 +108,8 @@ func Test_decode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		if got := decode(tt.args); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("test name = %v, decode() = %v, want %v", tt.name, got, tt.want)
-		}
-
+		got := decode(tt.args)
+		require.True(t, reflect.DeepEqual(got, tt.want), "test name = %v, decode() = %v, want %v", tt.name, got, tt.want)
 	}
 }
 
@@ -175,9 +174,8 @@ func Test_specialPortConflictCheck(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := specialPortConflictCheck(tt.args.specialHostPort, tt.args.otherHostPorts); got != tt.want {
-				t.Errorf("specialPortConflictCheck() = %v, want %v", got, tt.want)
-			}
+			got := specialPortConflictCheck(tt.args.specialHostPort, tt.args.otherHostPorts)
+			require.Equal(t, tt.want, got, "specialPortConflictCheck() = %v, want %v", got, tt.want)
 		})
 	}
 }
@@ -255,9 +253,8 @@ func Test_portsConflict(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := portsConflict(tt.args.existingPorts, tt.args.wantPorts); got != tt.want {
-				t.Errorf("portsConflict() = %v, want %v", got, tt.want)
-			}
+			got := portsConflict(tt.args.existingPorts, tt.args.wantPorts)
+			require.Equal(t, tt.want, got, "portsConflict() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/BUILD
+++ b/plugin/pkg/scheduler/algorithm/priorities/BUILD
@@ -65,6 +65,7 @@ go_test(
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//plugin/pkg/scheduler/testing:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/plugin/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -254,11 +255,7 @@ func TestBalancedResourceAllocation(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := priorityFunction(BalancedResourceAllocationMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/image_locality_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/image_locality_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -162,16 +163,12 @@ func TestImageLocalityPriority(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := priorityFunction(ImageLocalityPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
 
 		sort.Sort(test.expectedList)
 		sort.Sort(list)
 
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }
 

--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -517,12 +518,8 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			hardPodAffinityWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 		}
 		list, err := interPodAffinity.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
 	}
 }
 
@@ -605,11 +602,7 @@ func TestHardPodAffinitySymmetricWeight(t *testing.T) {
 			hardPodAffinityWeight: test.hardPodAffinityWeight,
 		}
 		list, err := ipa.CalculateInterPodAffinityPriority(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: \nexpected \n\t%#v, \ngot \n\t%#v\n", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/least_requested_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/least_requested_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -254,11 +255,7 @@ func TestLeastRequested(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := priorityFunction(LeastRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	apps "k8s.io/api/apps/v1beta1"
 	"k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
@@ -160,8 +161,6 @@ func TestPriorityMetadata(t *testing.T) {
 		schedulertesting.FakeStatefulSetLister([]*apps.StatefulSet{}))
 	for _, test := range tests {
 		ptData := mataDataProducer(test.pod, nil)
-		if !reflect.DeepEqual(test.expected, ptData) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expected, ptData)
-		}
+		require.True(t, reflect.DeepEqual(test.expected, ptData), "%s: expected %#v, got %#v", test.test, test.expected, ptData)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/most_requested_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/most_requested_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -211,11 +212,7 @@ func TestMostRequested(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(test.pods, test.nodes)
 		list, err := priorityFunction(MostRequestedPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/node_affinity_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_affinity_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -169,11 +170,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
 		nap := priorityFunction(CalculateNodeAffinityPriorityMap, CalculateNodeAffinityPriorityReduce, nil)
 		list, err := nap(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: \nexpected %#v, \ngot      %#v", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: \nexpected %#v, \ngot      %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/node_label_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_label_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -113,14 +114,10 @@ func TestNewNodeLabelPriority(t *testing.T) {
 			presence: test.presence,
 		}
 		list, err := priorityFunction(labelPrioritizer.CalculateNodeLabelPriorityMap, nil, nil)(nil, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
 		// sort the two lists to avoid failures on account of different ordering
 		sort.Sort(test.expectedList)
 		sort.Sort(list)
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -143,14 +144,10 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 	for _, test := range tests {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
 		list, err := priorityFunction(CalculateNodePreferAvoidPodsPriorityMap, nil, nil)(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
+		require.NoError(t, err, "unexpected error: %v", err)
 		// sort the two lists to avoid failures on account of different ordering
 		sort.Sort(test.expectedList)
 		sort.Sort(list)
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s: expected %#v, got %#v", test.test, test.expectedList, list)
-		}
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s: expected %#v, got %#v", test.test, test.expectedList, list)
 	}
 }

--- a/plugin/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -229,13 +230,8 @@ func TestTaintAndToleration(t *testing.T) {
 		nodeNameToInfo := schedulercache.CreateNodeNameToInfoMap(nil, test.nodes)
 		ttp := priorityFunction(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil)
 		list, err := ttp(test.pod, nodeNameToInfo, test.nodes)
-		if err != nil {
-			t.Errorf("%s, unexpected error: %v", test.test, err)
-		}
-
-		if !reflect.DeepEqual(test.expectedList, list) {
-			t.Errorf("%s,\nexpected:\n\t%+v,\ngot:\n\t%+v", test.test, test.expectedList, list)
-		}
+		require.NoError(t, err, "%s, unexpected error: %v", test.test, err)
+		require.True(t, reflect.DeepEqual(test.expectedList, list), "%s,\nexpected:\n\t%+v,\ngot:\n\t%+v", test.test, test.expectedList, list)
 	}
 
 }

--- a/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
+++ b/plugin/pkg/scheduler/algorithm/scheduler_interface_test.go
@@ -19,6 +19,7 @@ package algorithm
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 )
 
@@ -33,28 +34,18 @@ type schedulerTester struct {
 // Call if you know exactly where pod should get scheduled.
 func (st *schedulerTester) expectSchedule(pod *v1.Pod, expected string) {
 	actual, err := st.scheduler.Schedule(pod, st.nodeLister)
-	if err != nil {
-		st.t.Errorf("Unexpected error %v\nTried to schedule: %#v", err, pod)
-		return
-	}
-	if actual != expected {
-		st.t.Errorf("Unexpected scheduling value: %v, expected %v", actual, expected)
-	}
+	require.NoError(st.t, err, "Unexpected error %v\nTried to schedule: %#v", err, pod)
+	require.Equal(st.t, expected, actual, "Unexpected scheduling value: %v, expected %v", actual, expected)
 }
 
 // Call if you can't predict where pod will be scheduled.
 func (st *schedulerTester) expectSuccess(pod *v1.Pod) {
 	_, err := st.scheduler.Schedule(pod, st.nodeLister)
-	if err != nil {
-		st.t.Errorf("Unexpected error %v\nTried to schedule: %#v", err, pod)
-		return
-	}
+	require.NoError(st.t, err, "Unexpected error %v\nTried to schedule: %#v", err, pod)
 }
 
 // Call if pod should *not* schedule.
 func (st *schedulerTester) expectFailure(pod *v1.Pod) {
 	_, err := st.scheduler.Schedule(pod, st.nodeLister)
-	if err == nil {
-		st.t.Error("Unexpected non-error")
-	}
+	require.Error(st.t, err, "Unexpected non-error")
 }

--- a/plugin/pkg/scheduler/algorithm/types_test.go
+++ b/plugin/pkg/scheduler/algorithm/types_test.go
@@ -19,6 +19,7 @@ package algorithm
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
@@ -41,25 +42,23 @@ func TestEmptyMetadataProducer(t *testing.T) {
 	// Test EmptyControllerLister should return nill
 	controllerLister := EmptyControllerLister{}
 	nilController, nilError := controllerLister.List(fakeLabelSelector)
-	if nilController != nil || nilError != nil {
-		t.Errorf("failed to produce empty controller lister: got %v, expected nil", nilController)
-	}
+	require.Nil(t, nilController, "failed to produce empty controller lister: got %v, expected nil", nilController)
+	require.Nil(t, nilError, "failed to produce empty controller lister: got %v, expected nil", nilController)
+
 	// Test GetPodControllers on empty controller lister should return nill
 	nilController, nilError = controllerLister.GetPodControllers(fakePod)
-	if nilController != nil || nilError != nil {
-		t.Errorf("failed to produce empty controller lister: got %v, expected nil", nilController)
-	}
+	require.Nil(t, nilController, "failed to produce empty controller lister: got %v, expected nil", nilController)
+	require.Nil(t, nilError, "failed to produce empty controller lister: got %v, expected nil", nilController)
+
 	// Test GetPodReplicaSets on empty replica sets should return nill
 	replicaSetLister := EmptyReplicaSetLister{}
 	nilRss, nilErrRss := replicaSetLister.GetPodReplicaSets(fakePod)
-	if nilRss != nil || nilErrRss != nil {
-		t.Errorf("failed to produce empty replicaSetLister: got %v, expected nil", nilRss)
-	}
+	require.Nil(t, nilRss, "failed to produce empty replicaSetLister: got %v, expected nil", nilRss)
+	require.Nil(t, nilErrRss, "failed to produce empty replicaSetLister: got %v, expected nil", nilRss)
 
 	// Test GetPodStatefulSets on empty replica sets should return nill
 	statefulSetLister := EmptyStatefulSetLister{}
 	nilSSL, nilErrSSL := statefulSetLister.GetPodStatefulSets(fakePod)
-	if nilSSL != nil || nilErrSSL != nil {
-		t.Errorf("failed to produce empty statefulSetLister: got %v, expected nil", nilSSL)
-	}
+	require.Nil(t, nilSSL, "failed to produce empty statefulSetLister: got %v, expected nil", nilSSL)
+	require.Nil(t, nilErrSSL, "failed to produce empty statefulSetLister: got %v, expected nil", nilSSL)
 }

--- a/plugin/pkg/scheduler/algorithmprovider/BUILD
+++ b/plugin/pkg/scheduler/algorithmprovider/BUILD
@@ -20,6 +20,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//plugin/pkg/scheduler/factory:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -38,6 +38,7 @@ go_test(
         "//plugin/pkg/scheduler/api:go_default_library",
         "//plugin/pkg/scheduler/api/latest:go_default_library",
         "//plugin/pkg/scheduler/factory:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/plugin/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/plugin/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -19,6 +19,7 @@ package defaults
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/predicates"
 )
@@ -45,9 +46,7 @@ func TestCopyAndReplace(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
-		if !result.Equal(testCase.expected) {
-			t.Errorf("expected %v got %v", testCase.expected, result)
-		}
+		require.Equal(t, testCase.expected, result, "expected %v got %v", testCase.expected, result)
 	}
 }
 
@@ -60,9 +59,8 @@ func TestDefaultPriorities(t *testing.T) {
 		"NodePreferAvoidPodsPriority",
 		"NodeAffinityPriority",
 		"TaintTolerationPriority")
-	if expected := defaultPriorities(); !result.Equal(expected) {
-		t.Errorf("expected %v got %v", expected, result)
-	}
+	expected := defaultPriorities()
+	require.Equal(t, expected, result, "expected %v got %v", expected, result)
 }
 
 func TestDefaultPredicates(t *testing.T) {
@@ -81,7 +79,6 @@ func TestDefaultPredicates(t *testing.T) {
 		predicates.CheckVolumeBinding,
 	)
 
-	if expected := defaultPredicates(); !result.Equal(expected) {
-		t.Errorf("expected %v got %v", expected, result)
-	}
+	expected := defaultPredicates()
+	require.Equal(t, expected, result, "expected %v got %v", expected, result)
 }

--- a/plugin/pkg/scheduler/api/validation/BUILD
+++ b/plugin/pkg/scheduler/api/validation/BUILD
@@ -21,7 +21,10 @@ go_test(
     srcs = ["validation_test.go"],
     importpath = "k8s.io/kubernetes/plugin/pkg/scheduler/api/validation",
     library = ":go_default_library",
-    deps = ["//plugin/pkg/scheduler/api:go_default_library"],
+    deps = [
+        "//plugin/pkg/scheduler/api:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+    ],
 )
 
 filegroup(

--- a/plugin/pkg/scheduler/api/validation/validation_test.go
+++ b/plugin/pkg/scheduler/api/validation/validation_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
 
@@ -73,8 +74,6 @@ func TestValidatePolicy(t *testing.T) {
 
 	for _, test := range tests {
 		actual := ValidatePolicy(test.policy)
-		if fmt.Sprint(test.expected) != fmt.Sprint(actual) {
-			t.Errorf("expected: %s, actual: %s", test.expected, actual)
-		}
+		require.Equal(t, fmt.Sprint(test.expected), fmt.Sprint(actual), "expected: %s, actual: %s", test.expected, actual)
 	}
 }

--- a/plugin/pkg/scheduler/core/BUILD
+++ b/plugin/pkg/scheduler/core/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//plugin/pkg/scheduler/testing:go_default_library",
         "//plugin/pkg/scheduler/util:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/plugin/pkg/scheduler/core/extender_test.go
+++ b/plugin/pkg/scheduler/core/extender_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -321,17 +322,10 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		podIgnored := &v1.Pod{}
 		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {
-			if err == nil {
-				t.Errorf("Unexpected non-error for %s, machine %s", test.name, machine)
-			}
+			require.Errorf(t, err, "Unexpected non-error for %s, machine %s", test.name, machine)
 		} else {
-			if err != nil {
-				t.Errorf("Unexpected error: %v", err)
-				continue
-			}
-			if test.expectedHost != machine {
-				t.Errorf("Failed : %s, Expected: %s, Saw: %s", test.name, test.expectedHost, machine)
-			}
+			require.NoError(t, err, "Unexpected error: %v", err)
+			require.Equal(t, test.expectedHost, machine, "Failed : %s, Expected: %s, Saw: %s", test.name, test.expectedHost, machine)
 		}
 	}
 }

--- a/plugin/pkg/scheduler/factory/BUILD
+++ b/plugin/pkg/scheduler/factory/BUILD
@@ -74,6 +74,7 @@ go_test(
         "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//plugin/pkg/scheduler/testing:go_default_library",
         "//plugin/pkg/scheduler/util:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/plugin/pkg/scheduler/factory/plugins_test.go
+++ b/plugin/pkg/scheduler/factory/plugins_test.go
@@ -19,6 +19,7 @@ package factory
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/api"
 )
@@ -34,14 +35,10 @@ func TestAlgorithmNameValidation(t *testing.T) {
 		"Some,Alg:orithm",
 	}
 	for _, name := range algorithmNamesShouldValidate {
-		if !validName.MatchString(name) {
-			t.Errorf("%v should be a valid algorithm name but is not valid.", name)
-		}
+		require.True(t, validName.MatchString(name), "%v should be a valid algorithm name but is not valid.", name)
 	}
 	for _, name := range algorithmNamesShouldNotValidate {
-		if validName.MatchString(name) {
-			t.Errorf("%v should be an invalid algorithm name but is valid.", name)
-		}
+		require.False(t, validName.MatchString(name), "%v should be an invalid algorithm name but is valid.", name)
 	}
 }
 
@@ -70,13 +67,9 @@ func TestValidatePriorityConfigOverFlow(t *testing.T) {
 	for _, test := range tests {
 		err := validateSelectedConfigs(test.configs)
 		if test.expected {
-			if err == nil {
-				t.Errorf("Expected Overflow for %s", test.description)
-			}
+			require.Errorf(t, err, "Expected Overflow for %s", test.description)
 		} else {
-			if err != nil {
-				t.Errorf("Did not expect an overflow for %s", test.description)
-			}
+			require.NoError(t, err, "Did not expect an overflow for %s", test.description)
 		}
 	}
 }

--- a/plugin/pkg/scheduler/schedulercache/BUILD
+++ b/plugin/pkg/scheduler/schedulercache/BUILD
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//plugin/pkg/scheduler/algorithm/priorities/util:go_default_library",
         "//plugin/pkg/scheduler/util:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/plugin/pkg/scheduler/util/BUILD
+++ b/plugin/pkg/scheduler/util/BUILD
@@ -17,6 +17,7 @@ go_test(
     library = ":go_default_library",
     deps = [
         "//pkg/apis/scheduling:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/plugin/pkg/scheduler/util/testutil_test.go
+++ b/plugin/pkg/scheduler/util/testutil_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -40,9 +41,8 @@ func TestResourcePathWithPrefix(t *testing.T) {
 		{"", "resource", "mynamespace", "myresource", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testCases {
-		if actual := Test.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
-		}
+		actual := Test.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
 	}
 
 	TestGroup := Test
@@ -62,9 +62,8 @@ func TestResourcePathWithPrefix(t *testing.T) {
 		{"", "resource", "mynamespace", "myresource", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testGroupCases {
-		if actual := TestGroup.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
-		}
+		actual := TestGroup.ResourcePathWithPrefix(item.prefix, item.resource, item.namespace, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for prefix: %s, resource: %s, namespace: %s and name: %s", item.expected, actual, item.prefix, item.resource, item.namespace, item.name)
 	}
 
 }
@@ -82,9 +81,8 @@ func TestResourcePath(t *testing.T) {
 		{"resource", "", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
 	}
 	for _, item := range testCases {
-		if actual := Test.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
-		}
+		actual := Test.ResourcePath(item.resource, item.namespace, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
 	}
 
 	TestGroup := Test
@@ -102,9 +100,8 @@ func TestResourcePath(t *testing.T) {
 		{"resource", "", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource"},
 	}
 	for _, item := range testGroupCases {
-		if actual := TestGroup.ResourcePath(item.resource, item.namespace, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
-		}
+		actual := TestGroup.ResourcePath(item.resource, item.namespace, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s, namespace: %s and name: %s", item.expected, actual, item.resource, item.namespace, item.name)
 	}
 
 }
@@ -121,9 +118,8 @@ func TestSubResourcePath(t *testing.T) {
 		{"resource", "mynamespace", "myresource", "", "/api/" + Test.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testCases {
-		if actual := Test.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
-		}
+		actual := Test.SubResourcePath(item.resource, item.namespace, item.name, item.sub)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
 	}
 
 	TestGroup := Test
@@ -140,9 +136,8 @@ func TestSubResourcePath(t *testing.T) {
 		{"resource", "mynamespace", "myresource", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/namespaces/mynamespace/resource/myresource"},
 	}
 	for _, item := range testGroupCases {
-		if actual := TestGroup.SubResourcePath(item.resource, item.namespace, item.name, item.sub); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
-		}
+		actual := TestGroup.SubResourcePath(item.resource, item.namespace, item.name, item.sub)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s, namespace: %s, name: %s and sub: %s", item.expected, actual, item.resource, item.namespace, item.name, item.sub)
 	}
 
 }
@@ -157,9 +152,8 @@ func TestSelfLink(t *testing.T) {
 		{"resource", "", "/api/" + Test.externalGroupVersion.Version + "/resource"},
 	}
 	for _, item := range testCases {
-		if actual := Test.SelfLink(item.resource, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
-		}
+		actual := Test.SelfLink(item.resource, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
 	}
 
 	TestGroup := Test
@@ -174,9 +168,8 @@ func TestSelfLink(t *testing.T) {
 		{"resource", "", "/apis/" + TestGroup.externalGroupVersion.Group + "/" + TestGroup.externalGroupVersion.Version + "/resource"},
 	}
 	for _, item := range testGroupCases {
-		if actual := TestGroup.SelfLink(item.resource, item.name); actual != item.expected {
-			t.Errorf("Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
-		}
+		actual := TestGroup.SelfLink(item.resource, item.name)
+		require.Equal(t, actual, item.expected, "Expected: %s, got: %s for resource: %s and name: %s", item.expected, actual, item.resource, item.name)
 	}
 }
 
@@ -191,23 +184,16 @@ func TestV1EncodeDecodeStatus(t *testing.T) {
 	v1Codec := Test.Codec()
 
 	encoded, err := runtime.Encode(v1Codec, status)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
+
 	typeMeta := metav1.TypeMeta{}
-	if err := json.Unmarshal(encoded, &typeMeta); err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	if typeMeta.Kind != "Status" {
-		t.Errorf("Kind is not set to \"Status\". Got %v", string(encoded))
-	}
-	if typeMeta.APIVersion != "v1" {
-		t.Errorf("APIVersion is not set to \"v1\". Got %v", string(encoded))
-	}
+	err = json.Unmarshal(encoded, &typeMeta)
+	require.NoError(t, err, "unexpected error: %v", err)
+	require.Equal(t, typeMeta.Kind, "Status", "Kind is not set to \"Status\". Got %v", string(encoded))
+	require.Equal(t, typeMeta.APIVersion, "v1", "APIVersion is not set to \"v1\". Got %v", string(encoded))
+
 	decoded, err := runtime.Decode(v1Codec, encoded)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	require.NoError(t, err, "unexpected error: %v", err)
 	if !reflect.DeepEqual(status, decoded) {
 		t.Errorf("expected: %#v, got: %#v", status, decoded)
 	}

--- a/plugin/pkg/scheduler/util/utils_test.go
+++ b/plugin/pkg/scheduler/util/utils_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
@@ -52,10 +53,7 @@ func TestGetPodPriority(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if GetPodPriority(test.pod) != test.expectedPriority {
-			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
-		}
-
+		require.Equal(t, GetPodPriority(test.pod), test.expectedPriority, "expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
 	}
 }
 
@@ -83,13 +81,10 @@ func TestSortableList(t *testing.T) {
 		podList.Items = append(podList.Items, pod)
 	}
 	podList.Sort()
-	if len(podList.Items) != 10 {
-		t.Errorf("expected length of list was 10, got: %v", len(podList.Items))
-	}
+	require.Len(t, podList.Items, 10, "expected length of list was 10, got: %v", len(podList.Items))
+
 	var prevPriority = int32(10)
 	for _, p := range podList.Items {
-		if *p.(*v1.Pod).Spec.Priority >= prevPriority {
-			t.Errorf("Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
-		}
+		require.True(t, *p.(*v1.Pod).Spec.Priority < prevPriority, "Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to hopefully make unit tests a bit more readable in the scheduler package by using assert statements.

**Which issue(s) this PR fixes**:
Fixes #43788 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
