### PR TITLE
remove unused return value 

### DIFF
--- a/pkg/apis/extensions/helpers.go
+++ b/pkg/apis/extensions/helpers.go
@@ -23,12 +23,12 @@ import (
 // SysctlsFromPodSecurityPolicyAnnotation parses an annotation value of the key
 // SysctlsSecurityPolocyAnnotationKey into a slice of sysctls. An empty slice
 // is returned if annotation is the empty string.
-func SysctlsFromPodSecurityPolicyAnnotation(annotation string) ([]string, error) {
+func SysctlsFromPodSecurityPolicyAnnotation(annotation string) []string {
 	if len(annotation) == 0 {
-		return []string{}, nil
+		return []string{}
 	}
 
-	return strings.Split(annotation, ","), nil
+	return strings.Split(annotation, ",")
 }
 
 // PodAnnotationsFromSysctls creates an annotation value for a slice of Sysctls.

--- a/pkg/apis/extensions/helpers_test.go
+++ b/pkg/apis/extensions/helpers_test.go
@@ -51,10 +51,7 @@ func TestSysctlsFromPodSecurityPolicyAnnotation(t *testing.T) {
 		{annotation: "a.b,a.b", expectedValue: []string{"a.b", "a.b"}},
 		{annotation: "", expectedValue: []string{}},
 	} {
-		sysctls, err := SysctlsFromPodSecurityPolicyAnnotation(test.annotation)
-		if err != nil {
-			t.Errorf("error for %q: %v", test.annotation, err)
-		}
+		sysctls := SysctlsFromPodSecurityPolicyAnnotation(test.annotation)
 		if !reflect.DeepEqual(sysctls, test.expectedValue) {
 			t.Errorf("wrong value for %q: got=%v wanted=%v", test.annotation, sysctls, test.expectedValue)
 		}

--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -690,12 +690,8 @@ func ValidatePodSecurityPolicySpecificAnnotations(annotations map[string]string,
 
 	sysctlAnnotation := annotations[extensions.SysctlsPodSecurityPolicyAnnotationKey]
 	sysctlFldPath := fldPath.Key(extensions.SysctlsPodSecurityPolicyAnnotationKey)
-	sysctls, err := extensions.SysctlsFromPodSecurityPolicyAnnotation(sysctlAnnotation)
-	if err != nil {
-		allErrs = append(allErrs, field.Invalid(sysctlFldPath, sysctlAnnotation, err.Error()))
-	} else {
-		allErrs = append(allErrs, validatePodSecurityPolicySysctls(sysctlFldPath, sysctls)...)
-	}
+	sysctls := extensions.SysctlsFromPodSecurityPolicyAnnotation(sysctlAnnotation)
+	allErrs = append(allErrs, validatePodSecurityPolicySysctls(sysctlFldPath, sysctls)...)
 
 	if p := annotations[seccomp.DefaultProfileAnnotationKey]; p != "" {
 		allErrs = append(allErrs, apivalidation.ValidateSeccompProfile(p, fldPath.Key(seccomp.DefaultProfileAnnotationKey))...)

--- a/pkg/security/podsecuritypolicy/factory.go
+++ b/pkg/security/podsecuritypolicy/factory.go
@@ -79,11 +79,8 @@ func (f *simpleStrategyFactory) CreateStrategies(psp *extensions.PodSecurityPoli
 
 	var unsafeSysctls []string
 	if ann, found := psp.Annotations[extensions.SysctlsPodSecurityPolicyAnnotationKey]; found {
-		var err error
-		unsafeSysctls, err = extensions.SysctlsFromPodSecurityPolicyAnnotation(ann)
-		if err != nil {
-			errs = append(errs, err)
-		}
+		unsafeSysctls = extensions.SysctlsFromPodSecurityPolicyAnnotation(ann)
+
 	}
 	sysctlsStrat := createSysctlsStrategy(unsafeSysctls)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->



**What this PR does / why we need it**:
 `SysctlsFromPodSecurityPolicyAnnotation `  does not return  any error, so remove it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
