### PR TITLE
fix Errorf() to follow golang style

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -123,8 +123,8 @@ func CreatesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) 
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 3 {
-		t.Error("Failed to scale statefulset to 3 replicas")
+	if e, a := int32(3), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -145,8 +145,8 @@ func ScalesUp(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) {
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 4 {
-		t.Error("Failed to scale statefulset to 4 replicas")
+	if e, a := int32(4), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -162,8 +162,8 @@ func ScalesDown(t *testing.T, set *apps.StatefulSet, invariants invariantFunc) {
 	if err := scaleDownStatefulSetControl(set, ssc, spc, invariants); err != nil {
 		t.Errorf("Failed to scale StatefulSet : %s", err)
 	}
-	if set.Status.Replicas != 0 {
-		t.Error("Failed to scale statefulset to 0 replicas")
+	if e, a := int32(0), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -180,8 +180,8 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 5 {
-		t.Error("Failed to scale statefulset to 5 replicas")
+	if e, a := int32(5), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
@@ -233,7 +233,7 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
 	if e, a := int32(5), set.Status.Replicas; e != a {
-		t.Errorf("Expected to scale to %d, got %d", e, a)
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -293,8 +293,8 @@ func CreatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantF
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 3 {
-		t.Error("Failed to scale StatefulSet to 3 replicas")
+	if e, a := int32(3), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -313,10 +313,9 @@ func UpdatePodFailure(t *testing.T, set *apps.StatefulSet, invariants invariantF
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 3 {
-		t.Error("Failed to scale StatefulSet to 3 replicas")
+	if e, a := int32(3), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
-
 	// now mutate a pod's identity
 	pods, err := spc.podsLister.List(labels.Everything())
 	if err != nil {
@@ -352,8 +351,8 @@ func UpdateSetStatusFailure(t *testing.T, set *apps.StatefulSet, invariants inva
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 3 {
-		t.Error("Failed to scale StatefulSet to 3 replicas")
+	if e, a := int32(3), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 
@@ -431,8 +430,8 @@ func TestStatefulSetControlScaleDownDeleteError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error getting updated StatefulSet: %v", err)
 	}
-	if set.Status.Replicas != 0 {
-		t.Error("Failed to scale statefulset to 0 replicas")
+	if e, a := int32(0), set.Status.Replicas; e != a {
+		t.Errorf("Expected to scale Statefulset to %d, got %d", e, a)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @enisoc 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
