### PR TITLE
kubelet/get-pod-from-path: unused param should be removed

### DIFF
--- a/pkg/kubelet/config/file.go
+++ b/pkg/kubelet/config/file.go
@@ -48,12 +48,12 @@ func NewSourceFile(path string, nodeName types.NodeName, period time.Duration, u
 	// "golang.org/x/exp/inotify" requires a path without trailing "/"
 	path = strings.TrimRight(path, string(os.PathSeparator))
 
-	config := newSourceFile(path, nodeName, period, updates)
+	config := newSourceFile(path, nodeName, updates)
 	glog.V(1).Infof("Watching path %q", path)
 	go wait.Forever(config.run, period)
 }
 
-func newSourceFile(path string, nodeName types.NodeName, period time.Duration, updates chan<- interface{}) *sourceFile {
+func newSourceFile(path string, nodeName types.NodeName, updates chan<- interface{}) *sourceFile {
 	send := func(objs []interface{}) {
 		var pods []*v1.Pod
 		for _, o := range objs {

--- a/pkg/kubelet/config/file_linux_test.go
+++ b/pkg/kubelet/config/file_linux_test.go
@@ -46,7 +46,7 @@ import (
 
 func TestExtractFromNonExistentFile(t *testing.T) {
 	ch := make(chan interface{}, 1)
-	c := newSourceFile("/some/fake/file", "localhost", time.Millisecond, ch)
+	c := newSourceFile("/some/fake/file", "localhost", ch)
 	err := c.watch()
 	if err == nil {
 		t.Errorf("Expected error")
@@ -137,7 +137,7 @@ func TestExtractFromBadDataFile(t *testing.T) {
 	}
 
 	ch := make(chan interface{}, 1)
-	c := newSourceFile(fileName, "localhost", time.Millisecond, ch)
+	c := newSourceFile(fileName, "localhost", ch)
 	err = c.resetStoreFromPath()
 	if err == nil {
 		t.Fatalf("expected error, got nil")
@@ -153,7 +153,7 @@ func TestExtractFromEmptyDir(t *testing.T) {
 	defer os.RemoveAll(dirName)
 
 	ch := make(chan interface{}, 1)
-	c := newSourceFile(dirName, "localhost", time.Millisecond, ch)
+	c := newSourceFile(dirName, "localhost", ch)
 	err = c.resetStoreFromPath()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:

I'm sorry that i have not notice this PR has been closed because of the error of test. And, i found it can't reopen again,  so i open the other one, thank you!

https://github.com/kubernetes/kubernetes/pull/38184

I am so sorry for trouble with you, PTAL, thank you!
