### PR TITLE
validation to GPU and hugepages in creating LimitRange

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -3853,6 +3853,11 @@ func ValidateLimitRange(limitRange *api.LimitRange) field.ErrorList {
 					allErrs = append(allErrs, field.Invalid(idxPath.Child("maxLimitRequestRatio").Key(string(k)), maxRatio, fmt.Sprintf("ratio %s is greater than max/min = %f", maxRatio.String(), maxRatioLimit)))
 				}
 			}
+
+			// for GPU and hugepages, the default value and defaultRequest value must match if both are specified
+			if !helper.IsOvercommitAllowed(api.ResourceName(k)) && defaultQuantityFound && defaultRequestQuantityFound && defaultQuantity.Cmp(defaultRequestQuantity) != 0 {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("defaultRequest").Key(string(k)), defaultRequestQuantity, fmt.Sprintf("default value %s must equal to defaultRequest value %s in %s", defaultQuantity.String(), defaultRequestQuantity.String(), k)))
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
validate if default and defaultRequest match when creating LimitRange for GPU and hugepages.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54917 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
validate if default and defaultRequest match when creating LimitRange for GPU and hugepages.
```
