### PR TITLE
rename metric reflector_xx_last_resource_version

### DIFF
--- a/pkg/util/reflector/prometheus/prometheus.go
+++ b/pkg/util/reflector/prometheus/prometheus.go
@@ -68,6 +68,12 @@ var (
 		Name:      "items_per_watch",
 		Help:      "How many items an API watch returns to the reflectors",
 	}, []string{"name"})
+
+	lastResourceVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Subsystem: reflectorSubsystem,
+		Name:      "last_resource_version",
+		Help:      "Last resource version seen for the reflectors",
+	}, []string{"name"})
 )
 
 func init() {
@@ -78,6 +84,7 @@ func init() {
 	prometheus.MustRegister(shortWatchesTotal)
 	prometheus.MustRegister(watchDuration)
 	prometheus.MustRegister(itemsPerWatch)
+	prometheus.MustRegister(lastResourceVersion)
 
 	cache.SetReflectorMetricsProvider(prometheusMetricsProvider{})
 }
@@ -117,11 +124,5 @@ func (prometheusMetricsProvider) NewItemsInWatchMetric(name string) cache.Summar
 }
 
 func (prometheusMetricsProvider) NewLastResourceVersionMetric(name string) cache.GaugeMetric {
-	rv := prometheus.NewGauge(prometheus.GaugeOpts{
-		Subsystem: name,
-		Name:      "last_resource_version",
-		Help:      "last resource version seen for the reflectors",
-	})
-	prometheus.MustRegister(rv)
-	return rv
+	return lastResourceVersion.WithLabelValues(name)
 }

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -109,7 +109,7 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	r := &Reflector{
 		name: name,
 		// we need this to be unique per process (some names are still the same)but obvious who it belongs to
-		metrics:       newReflectorMetrics(makeValidPromethusMetricName(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
+		metrics:       newReflectorMetrics(makeValidPromethusMetricLabel(fmt.Sprintf("reflector_"+name+"_%d", reflectorSuffix))),
 		listerWatcher: lw,
 		store:         store,
 		expectedType:  reflect.TypeOf(expectedType),
@@ -120,9 +120,9 @@ func NewNamedReflector(name string, lw ListerWatcher, expectedType interface{}, 
 	return r
 }
 
-func makeValidPromethusMetricName(in string) string {
+func makeValidPromethusMetricLabel(in string) string {
 	// this isn't perfect, but it removes our common characters
-	return strings.NewReplacer("/", "_", ".", "_", "-", "_").Replace(in)
+	return strings.NewReplacer("/", "_", ".", "_", "-", "_", ":", "_").Replace(in)
 }
 
 // internalPackages are packages that ignored when creating a default reflector name. These packages are in the common


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

mv reflector name from metric name to metric label

before:

```
reflector_k8s_io_kubernetes_pkg_client_informers_informers_generated_internalversion_factory_go:73_8664_last_resource_version{instance="104.154.20.21:443",job="kubernetes-apiservers"}
```

after

```
reflector_last_resource_version{instance="10.0.2.15:6443",job="kubernetes-apiservers",name="k8s_io_kubernetes_pkg_client_informers_informers_generated_internalversion_factory_go_73_8664"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52121 

**Special notes for your reviewer**:

None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```