### PR TITLE
Updates the expected default Quobyte plugin mount path

### DIFF
--- a/pkg/volume/quobyte/quobyte_test.go
+++ b/pkg/volume/quobyte/quobyte_test.go
@@ -98,8 +98,9 @@ func doTestPlugin(t *testing.T, spec *volume.Spec) {
 		t.Error("Got a nil Mounter")
 	}
 
-	if volumePath != fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/root#root@vol", tmpDir) {
-		t.Errorf("Got unexpected path: %s expected: %s", volumePath, fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/root#root@vol", tmpDir))
+	expectedPath := fmt.Sprintf("%s/plugins/kubernetes.io~quobyte/%s/root#root@vol", tmpDir, qbMountPointName)
+	if volumePath != expectedPath {
+		t.Errorf("Got unexpected path: %s expected: %s", volumePath, expectedPath)
 	}
 	if err := mounter.SetUp(nil); err != nil {
 		t.Errorf("Expected success, got: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Up to now the Quobyte volume plugin expects the Quobyte mount to reside at
"k8s_plugins_dir/kubernetes.io\~quobyte". This change updates this to a
subdir "<plugins_dir>/kubernetes.io\~quobyte/mnt" in order
to prevent mount locking issues. With the old setup the plugins dir itself is mounted
into containers when using the Quobyte volume plugin which we no longer want to do.
This is now handled by using a subdir name variable (default value "mnt").

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
No open issue ticket.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
For Quobyte volume mounts this moves the default mount point from "k8s_plugins_dir/kubernetes.io~quobyte" to "k8s_plugins_dir/kubernetes.io~quobyte/mnt" in order to prevent the requirement to mount the "k8s_plugins_dir" itself into a container.

action required: Update the volume mount point in existing Quobyte configurations to the new "/mnt" subdir, e.g. as described in the [Quobyte Kubernetes deployment setup guide](https://github.com/quobyte/kubernetes/tree/master/deploy).
```
