### PR TITLE
kubectl explain: ignore trailing period

### DIFF
--- a/build/visible_to/BUILD
+++ b/build/visible_to/BUILD
@@ -197,6 +197,7 @@ package_group(
         "//pkg/kubectl/cmd/auth",
         "//pkg/kubectl/cmd/resource",
         "//pkg/kubectl/cmd/set",
+        "//pkg/kubectl/explain",
     ],
 )
 

--- a/pkg/kubectl/explain/BUILD
+++ b/pkg/kubectl/explain/BUILD
@@ -37,6 +37,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "explain_test.go",
         "field_lookup_test.go",
         "fields_printer_test.go",
         "formatter_test.go",
@@ -48,7 +49,9 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/kubectl/explain",
     library = ":go_default_library",
     deps = [
+        "//pkg/kubectl/cmd/testing:go_default_library",
         "//pkg/kubectl/cmd/util/openapi/testing:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],
 )

--- a/pkg/kubectl/explain/explain.go
+++ b/pkg/kubectl/explain/explain.go
@@ -30,6 +30,10 @@ type fieldsPrinter interface {
 
 func splitDotNotation(model string) (string, []string) {
 	var fieldsPath []string
+
+	// ignore trailing period
+	model = strings.TrimSuffix(model, ".")
+
 	dotModel := strings.Split(model, ".")
 	if len(dotModel) >= 1 {
 		fieldsPath = dotModel[1:]

--- a/pkg/kubectl/explain/explain_test.go
+++ b/pkg/kubectl/explain/explain_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package explain
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	cmdtesting "k8s.io/kubernetes/pkg/kubectl/cmd/testing"
+)
+
+func TestSplitAndParseResourceRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		inresource string
+
+		expectedInResource string
+		expectedFieldsPath []string
+		expectedErr        bool
+	}{
+		{
+			name:       "no trailing period",
+			inresource: "field1.field2.field3",
+
+			expectedInResource: "field1",
+			expectedFieldsPath: []string{"field2", "field3"},
+		},
+		{
+			name:       "trailing period with correct fieldsPath",
+			inresource: "field1.field2.field3.",
+
+			expectedInResource: "field1",
+			expectedFieldsPath: []string{"field2", "field3"},
+		},
+		{
+			name:       "trailing period with incorrect fieldsPath",
+			inresource: "field1.field2.field3.",
+
+			expectedInResource: "field1",
+			expectedFieldsPath: []string{"field2", "field3", ""},
+			expectedErr:        true,
+		},
+	}
+
+	mapper := getMapper()
+	for _, test := range tests {
+		gotInResource, gotFieldsPath, err := SplitAndParseResourceRequest(test.inresource, mapper)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		if !reflect.DeepEqual(test.expectedInResource, gotInResource) && !test.expectedErr {
+			t.Errorf("%s: expected inresource: %s, got: %s", test.name, test.expectedInResource, gotInResource)
+		}
+
+		if !reflect.DeepEqual(test.expectedFieldsPath, gotFieldsPath) && !test.expectedErr {
+			t.Errorf("%s: expected fieldsPath: %s, got: %s", test.name, test.expectedFieldsPath, gotFieldsPath)
+		}
+	}
+}
+
+func getMapper() meta.RESTMapper {
+	f, _, _, _ := cmdtesting.NewTestFactory()
+	mapper, _ := f.Object()
+	return mapper
+}

--- a/pkg/kubectl/explain/field_lookup_test.go
+++ b/pkg/kubectl/explain/field_lookup_test.go
@@ -54,6 +54,10 @@ func TestFindField(t *testing.T) {
 			path: []string{"field1", "what?"},
 			err:  `field "what?" does not exist`,
 		},
+		{
+			path: []string{"field1", ""},
+			err:  `field "" does not exist`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #54891 

Ignores trailing period for kubectl explain i.e. `kubectl explain ingress.spec.rules.http.paths.` is valid and defaults to `kubectl explain ingress.spec.rules.http.paths`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
