### PR TITLE
[WIP] Fix inter-scope relationship GC bug

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -374,6 +374,7 @@ func TestProcessEvent(t *testing.T) {
 			},
 			attemptToDelete:  workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter()),
 			absentOwnerCache: NewUIDCache(2),
+			restMapper:       legacyscheme.Registry.RESTMapper(),
 		}
 		for i := 0; i < len(scenario.events); i++ {
 			dependencyGraphBuilder.graphChanges.Add(&scenario.events[i])


### PR DESCRIPTION
When creating virtual nodes, use the RESTMapper to determine the scope
of the node; if the node is cluster scoped, don't inherit the namespace
of the dependent.

Previously, if a namespaced resource is owned by a cluster scoped
resource, and the namespaced dependent is processed before the cluster
scoped owner has ever been observed by the garbage collector, the
dependent was erroneously deleted.

Fixes https://github.com/kubernetes/kubernetes/issues/54940.

```release-note
NONE
```
