### PR TITLE
kube-dns: tolerate being scheduled on master node

### DIFF
--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -96,4 +96,6 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
       serviceAccountName: kube-dns-autoscaler

--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -87,6 +87,8 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
       volumes:
       - name: kube-dns-config
         configMap:

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -87,6 +87,8 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
       volumes:
       - name: kube-dns-config
         configMap:

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -87,6 +87,8 @@ spec:
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"
+      - key: "node-role.kubernetes.io/master"
+        effect: NoSchedule
       volumes:
       - name: kube-dns-config
         configMap:


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows kube-dns to tolerate being scheduled on master nodes. 

When kube-dns addon pod is scheduled on worker nodes, but cluster autoscaler is schedule on a master node, we have seen several problems: 

+ In highly dynamic clusters where worker nodes are being autoscaled up and down, our clusters have gotten unhealthy and required manual intervention. Part of this was because kube-dns replicas were all scheduled to the same node (see kubernetes/kubernetes#52193 ).
+ master nodes often have more expansive permissions than the worker nodes (as @7chenko mentioned in the footnote to kubernetes/autoscaler#113 ). 

I did not change the nodeSelector to exclusively pick master nodes at present, but I am open to that.

**Which issue this PR fixes**



**Release note**:

<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve resiliency by annotating kube-dns addon to tolerate being scheduled on master nodes.
```