### PR TITLE
Add dns, configmap, and custom resource definition conformance

### DIFF
--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -33,6 +33,11 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 	f := framework.NewDefaultFramework("custom-resource-definition")
 
 	Context("Simple CustomResourceDefinition", func() {
+		/*
+			   	   Testname: crd-creation-test
+			   	   Description: Create a random Custom Resource Definition and make sure
+				   the API returns success.
+		*/
 		framework.ConformanceIt("creating/deleting custom resource definition objects works ", func() {
 
 			framework.SkipUnlessServerVersionGTE(crdVersion, f.ClientSet.Discovery())

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -29,6 +29,11 @@ import (
 var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
+	/*
+		    Testname: configmap-in-env-field
+		    Description: Make sure config map value can be used as an environment
+			variable in the container (on container.env field)
+	*/
 	framework.ConformanceIt("should be consumable via environment variable ", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
@@ -72,6 +77,11 @@ var _ = Describe("[sig-api-machinery] ConfigMap", func() {
 		})
 	})
 
+	/*
+		    Testname: configmap-envfrom-field
+		    Description: Make sure config map value can be used as an source for
+			environment variables in the container (on container.envFrom field)
+	*/
 	framework.ConformanceIt("should be consumable via the environment ", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newEnvFromConfigMap(f, name)

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -32,10 +32,20 @@ import (
 var _ = Describe("[sig-storage] ConfigMap", func() {
 	f := framework.NewDefaultFramework("configmap")
 
+	/*
+		    Testname: configmap-nomap-simple
+		    Description: Make sure config map without mappings works by mounting it
+			to a volume with a custom path (mapping) on the pod with no other settings.
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume ", func() {
 		doConfigMapE2EWithoutMappings(f, 0, 0, nil)
 	})
 
+	/*
+		    Testname: configmap-nomap-default-mode
+		    Description: Make sure config map without mappings works by mounting it
+			to a volume with a custom path (mapping) on the pod with defaultMode set
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume with defaultMode set ", func() {
 		defaultMode := int32(0400)
 		doConfigMapE2EWithoutMappings(f, 0, 0, &defaultMode)
@@ -46,6 +56,11 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, &defaultMode)
 	})
 
+	/*
+		    Testname: configmap-nomap-user
+		    Description: Make sure config map without mappings works by mounting it
+			to a volume with a custom path (mapping) on the pod as non-root.
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root ", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 0, nil)
 	})
@@ -54,15 +69,30 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, 1000, 1001, nil)
 	})
 
+	/*
+		    Testname: configmap-simple-mapped
+		    Description: Make sure config map works by mounting it to a volume with
+			a custom path (mapping) on the pod with no other settings and make sure
+			the pod actually consumes it.
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings ", func() {
 		doConfigMapE2EWithMappings(f, 0, 0, nil)
 	})
 
+	/*
+		    Testname: configmap-with-item-mode-mapped
+		    Description: Make sure config map works with an item mode (e.g. 0400)
+			for the config map item.
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings and Item mode set", func() {
 		mode := int32(0400)
 		doConfigMapE2EWithMappings(f, 0, 0, &mode)
 	})
 
+	/*
+	   Testname: configmap-simple-user-mapped
+	   Description: Make sure config map works when it is mounted as non-root.
+	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root ", func() {
 		doConfigMapE2EWithMappings(f, 1000, 0, nil)
 	})
@@ -71,6 +101,11 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithMappings(f, 1000, 1001, nil)
 	})
 
+	/*
+		    Testname: configmap-update-test
+		    Description: Make sure update operation is working on config map and
+			the result is observed on volumes mounted in containers.
+	*/
 	framework.ConformanceIt("updates should be reflected in volume ", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
@@ -149,6 +184,11 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Eventually(pollLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("value-2"))
 	})
 
+	/*
+		    Testname: configmap-CUD-test
+		    Description: Make sure Create, Update, Delete operations are all working
+			on config map and the result is observed on volumes mounted in containers.
+	*/
 	framework.ConformanceIt("optional updates should be reflected in volume ", func() {
 		podLogTimeout := framework.GetPodSecretUpdateTimeout(f.ClientSet)
 		containerTimeoutArg := fmt.Sprintf("--retry_time=%v", int(podLogTimeout.Seconds()))
@@ -327,6 +367,11 @@ var _ = Describe("[sig-storage] ConfigMap", func() {
 		Eventually(pollDeleteLogs, podLogTimeout, framework.Poll).Should(ContainSubstring("Error reading file /etc/configmap-volumes/delete/data-1"))
 	})
 
+	/*
+		    Testname: configmap-multiple-volumes
+		    Description: Make sure config map works when it mounted as two different
+			volumes on the same node.
+	*/
 	framework.ConformanceIt("should be consumable in multiple volumes in the same pod ", func() {
 		var (
 			name             = "configmap-test-volume-" + string(uuid.NewUUID())

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -284,6 +284,10 @@ func reverseArray(arr []string) []string {
 var _ = SIGDescribe("DNS", func() {
 	f := framework.NewDefaultFramework("dns")
 
+	/*
+	   Testname: dns-for-clusters
+	   Description: Make sure that DNS can resolve the names of clusters.
+	*/
 	framework.ConformanceIt("should provide DNS for the cluster ", func() {
 		// All the names we need to be able to resolve.
 		// TODO: Spin up a separate test service and test that dns works for that service.
@@ -310,6 +314,10 @@ var _ = SIGDescribe("DNS", func() {
 		validateDNSResults(f, pod, append(wheezyFileNames, jessieFileNames...))
 	})
 
+	/*
+	   Testname: dns-for-services
+	   Description: Make sure that DNS can resolve the names of services.
+	*/
 	framework.ConformanceIt("should provide DNS for services ", func() {
 		// Create a test headless service.
 		By("Creating a test headless service")


### PR DESCRIPTION
annotations.

Signed-off-by: Brad Topol <btopol@us.ibm.com>
Add dns, configmap, and custom resource definition related conformance annotations

/sig testing
/area conformance
@sig-testing-pr-reviews

This PR adds pod related conformance annotations to the e2e test suite.

The PR fixes a portion of #53822. It focuses on adding conformance annotations as defined by the Kubernetes Conformance Workgroup for a subset of the dns, configmap, and custom resource definition based e2e conformance tests.
Special notes for your reviewer:

Please see https://docs.google.com/spreadsheets/d/1WWSOqFaG35VmmPOYbwetapj1VPOVMqjZfR9ih5To5gk/edit#gid=62929400
for the list of SIG Arch approved test names and descriptions that I am using.




**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note NONE

```
