### PR TITLE
Fix bazel visibility of controller cert path for vendoring

### DIFF
--- a/build/openapi.bzl
+++ b/build/openapi.bzl
@@ -1,9 +1,0 @@
-# A project wanting to generate openapi code for vendored
-# k8s.io/kubernetes will need to set the following variables in
-# //build/openapi.bzl in their project and customize the go prefix:
-#
-# openapi_go_prefix = "k8s.io/myproject/"
-# openapi_vendor_prefix = "vendor/k8s.io/kubernetes/"
-
-openapi_go_prefix = "k8s.io/kubernetes/"
-openapi_vendor_prefix = ""

--- a/build/vendored.bzl
+++ b/build/vendored.bzl
@@ -1,0 +1,9 @@
+# A project wanting to use bazel to build vendored k8s.io/kubernetes
+# will need to set the following variables in //build/vendored.bzl in
+# their project and customize the go prefix:
+#
+# vendored_go_prefix = "k8s.io/myproject/"
+# vendored_path_prefix = "vendor/k8s.io/kubernetes/"
+
+vendored_go_prefix = "k8s.io/kubernetes/"
+vendored_path_prefix = ""

--- a/pkg/controller/certificates/BUILD
+++ b/pkg/controller/certificates/BUILD
@@ -3,6 +3,7 @@ load(
     "go_library",
     "go_test",
 )
+load("//build:vendored.bzl", "vendored_path_prefix")
 
 go_library(
     name = "go_default_library",
@@ -46,7 +47,7 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = [
-        "//pkg/controller:__pkg__",
+        "//" + vendored_path_prefix + "pkg/controller:__pkg__",
     ],
 )
 

--- a/pkg/generated/openapi/BUILD
+++ b/pkg/generated/openapi/BUILD
@@ -4,12 +4,12 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//pkg/generated/openapi:def.bzl", "openapi_library")
-load("//build:openapi.bzl", "openapi_go_prefix", "openapi_vendor_prefix")
+load("//build:vendored.bzl", "vendored_go_prefix", "vendored_path_prefix")
 
 openapi_library(
     name = "go_default_library",
     srcs = ["doc.go"],
-    go_prefix = openapi_go_prefix,
+    go_prefix = vendored_go_prefix,
     openapi_targets = [
         "pkg/apis/abac/v0",
         "pkg/apis/abac/v1beta1",
@@ -18,7 +18,7 @@ openapi_library(
         "pkg/version",
     ],
     tags = ["automanaged"],
-    vendor_prefix = openapi_vendor_prefix,
+    vendor_prefix = vendored_path_prefix,
     vendor_targets = [
         "k8s.io/api/admission/v1alpha1",
         "k8s.io/api/admissionregistration/v1alpha1",


### PR DESCRIPTION
This is intended to allow venderors like k8s.io/federation to avoid having to manually rewrite the BUILD file when updating to a new version of k8s.io/kubernetes.

```release-note
NONE
```

/sig multicluster testing
/area federation
/cc ixdy