### PR TITLE
[WIP]OpenStack cloud provider should support project instead of tenant

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -124,8 +124,8 @@ type Config struct {
 		Username   string
 		UserId     string `gcfg:"user-id"`
 		Password   string
-		TenantId   string `gcfg:"tenant-id"`
-		TenantName string `gcfg:"tenant-name"`
+		ProjectId   string `gcfg:"project-id"`
+		ProjectName string `gcfg:"project-name"`
 		TrustId    string `gcfg:"trust-id"`
 		DomainId   string `gcfg:"domain-id"`
 		DomainName string `gcfg:"domain-name"`
@@ -156,8 +156,8 @@ func (cfg Config) toAuthOptions() gophercloud.AuthOptions {
 		Username:         cfg.Global.Username,
 		UserID:           cfg.Global.UserId,
 		Password:         cfg.Global.Password,
-		TenantID:         cfg.Global.TenantId,
-		TenantName:       cfg.Global.TenantName,
+		ProjectID:         cfg.Global.ProjectId,
+		ProjectName:       cfg.Global.ProjectName,
 		DomainID:         cfg.Global.DomainId,
 		DomainName:       cfg.Global.DomainName,
 

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -393,14 +393,14 @@ func configFromEnv() (cfg Config, ok bool) {
 	cfg.Global.Password = os.Getenv("OS_PASSWORD")
 	cfg.Global.Region = os.Getenv("OS_REGION_NAME")
 
-	cfg.Global.TenantName = os.Getenv("OS_TENANT_NAME")
-	if cfg.Global.TenantName == "" {
-		cfg.Global.TenantName = os.Getenv("OS_PROJECT_NAME")
+	cfg.Global.ProjectName = os.Getenv("OS_PROJECT_NAME")
+	if cfg.Global.ProjectName == "" {
+		cfg.Global.ProjectName = os.Getenv("OS_PROJECT_NAME")
 	}
 
-	cfg.Global.TenantId = os.Getenv("OS_TENANT_ID")
-	if cfg.Global.TenantId == "" {
-		cfg.Global.TenantId = os.Getenv("OS_PROJECT_ID")
+	cfg.Global.ProjectId = os.Getenv("OS_PROJECT_ID")
+	if cfg.Global.ProjectId == "" {
+		cfg.Global.ProjectId = os.Getenv("OS_PROJECT_ID")
 	}
 
 	cfg.Global.DomainId = os.Getenv("OS_DOMAIN_ID")
@@ -416,7 +416,7 @@ func configFromEnv() (cfg Config, ok bool) {
 	ok = (cfg.Global.AuthUrl != "" &&
 		cfg.Global.Username != "" &&
 		cfg.Global.Password != "" &&
-		(cfg.Global.TenantId != "" || cfg.Global.TenantName != "" ||
+		(cfg.Global.ProjectId != "" || cfg.Global.TProjectName != "" ||
 			cfg.Global.DomainId != "" || cfg.Global.DomainName != ""))
 
 	cfg.Metadata.SearchOrder = fmt.Sprintf("%s,%s", configDriveID, metadataID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Since the Keystone V2 APIs are deprecated, this PR replaces the use of tenant_id and tenant_name with project_id and project_name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #52563 

**Special notes for your reviewer**:

Gophercloud supports the use of project_id and project_name.

**Release note**:

we can discuss and I build on.

