### PR TITLE
update cadvisor godeps to v0.26.2

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,6 +1,6 @@
 {
 	"ImportPath": "k8s.io/kubernetes",
-	"GoVersion": "go1.8",
+	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Packages": [
 		"github.com/ugorji/go/codec/codecgen",
@@ -1251,208 +1251,208 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/api",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/cache/memory",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/client/v2",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/collector",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/common",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/docker",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/libcontainer",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/raw",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/rkt",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/container/systemd",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/devicemapper",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/events",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/fs",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/healthz",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/http/mux",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v2",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/machine",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/raw",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/manager/watcher/rkt",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/metrics",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/pages/static",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/storage",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/summary",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cloudinfo",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/cpuload/netlink",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/docker",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/oomparser",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysfs",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/sysinfo",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/utils/tail",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/validate",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/version",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/zfs",
-			"Comment": "v0.26.1",
-			"Rev": "d19cc94b760cd8f150a0a5d95b404dec39a121a1"
+			"Comment": "v0.26.2",
+			"Rev": "1216a6fa2367fcf9de05fd6347e3c4e0376d4e91"
 		},
 		{
 			"ImportPath": "github.com/google/certificate-transparency/go",
@@ -1717,6 +1717,7 @@
 		},
 		{
 			"ImportPath": "github.com/inconshreveable/mousetrap",
+			"Comment": "v1.0",
 			"Rev": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
 		},
 		{
@@ -2171,6 +2172,7 @@
 		},
 		{
 			"ImportPath": "github.com/pelletier/go-buffruneio",
+			"Comment": "v0.1.0",
 			"Rev": "df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d"
 		},
 		{
@@ -2583,6 +2585,7 @@
 		},
 		{
 			"ImportPath": "github.com/xiang90/probing",
+			"Comment": "0.0.1",
 			"Rev": "07dd2e8dfe18522e9c447ba95f2fe95262f63bb2"
 		},
 		{
@@ -2905,6 +2908,7 @@
 		},
 		{
 			"ImportPath": "gopkg.in/inf.v0",
+			"Comment": "v0.9.0",
 			"Rev": "3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4"
 		},
 		{

--- a/vendor/github.com/google/cadvisor/container/docker/handler.go
+++ b/vendor/github.com/google/cadvisor/container/docker/handler.go
@@ -43,7 +43,8 @@ import (
 
 const (
 	// The read write layers exist here.
-	aufsRWLayer = "diff"
+	aufsRWLayer     = "diff"
+	overlay2RWLayer = "diff"
 
 	// Path to the directory where docker stores log files if the json logging driver is enabled.
 	pathToContainersDir = "containers"
@@ -195,8 +196,10 @@ func newDockerContainerHandler(
 	switch storageDriver {
 	case aufsStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(aufsStorageDriver), aufsRWLayer, rwLayerID)
-	case overlayStorageDriver, overlay2StorageDriver:
+	case overlayStorageDriver:
 		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID)
+	case overlay2StorageDriver:
+		rootfsStorageDir = path.Join(storageDir, string(storageDriver), rwLayerID, overlay2RWLayer)
 	case zfsStorageDriver:
 		status, err := Status()
 		if err != nil {


### PR DESCRIPTION
Issue: #52336
This is to cherrypick https://github.com/google/cadvisor/pull/1770 to the 1.7 branch.
First, I cherrypicked it to the cadvisor v0.26 branch, which is the cadvisor release tied to k8s v1.7.
Now, I need to update the vendored version in 1.7 from 0.26.1 to 0.26.2.

```release-note
Fix overlay2 container disk metrics for Docker
```

/assign @wojtek-t @dchen1107 