### PR TITLE
Fixing 'targetport' to service 'port' mapping

### DIFF
--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1043,8 +1043,8 @@ func (proxier *Proxier) syncProxyRules() {
 			false,
 			svcInfo.clusterIP.String(),
 			Enum(svcInfo.protocol),
-			uint16(svcInfo.port),
 			uint16(svcInfo.targetPort),
+			uint16(svcInfo.port),			
 		)
 		if err != nil {
 			glog.Errorf("Policy creation failed: %v", err)
@@ -1081,8 +1081,8 @@ func (proxier *Proxier) syncProxyRules() {
 				false,
 				externalIp.ip,
 				Enum(svcInfo.protocol),
-				uint16(svcInfo.port),
 				uint16(svcInfo.targetPort),
+				uint16(svcInfo.port),
 			)
 			if err != nil {
 				glog.Errorf("Policy creation failed: %v", err)
@@ -1099,8 +1099,8 @@ func (proxier *Proxier) syncProxyRules() {
 				false,
 				lbIngressIp.ip,
 				Enum(svcInfo.protocol),
-				uint16(svcInfo.port),
 				uint16(svcInfo.targetPort),
+				uint16(svcInfo.port),
 			)
 			if err != nil {
 				glog.Errorf("Policy creation failed: %v", err)

--- a/pkg/proxy/winkernel/proxier.go
+++ b/pkg/proxy/winkernel/proxier.go
@@ -1044,7 +1044,7 @@ func (proxier *Proxier) syncProxyRules() {
 			svcInfo.clusterIP.String(),
 			Enum(svcInfo.protocol),
 			uint16(svcInfo.targetPort),
-			uint16(svcInfo.port),			
+			uint16(svcInfo.port),
 		)
 		if err != nil {
 			glog.Errorf("Policy creation failed: %v", err)


### PR DESCRIPTION
Looks like the order should be reversed for this to work.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54968 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
