### PR TITLE
Remove val and ok in Storageos

### DIFF
--- a/pkg/volume/storageos/storageos_util_test.go
+++ b/pkg/volume/storageos/storageos_util_test.go
@@ -181,9 +181,9 @@ func TestCreateVolume(t *testing.T) {
 	if len(vol.Labels) == 0 {
 		t.Error("CreateVolume() Labels are empty")
 	} else {
+		var val string
+		var ok bool
 		for k, v := range labels {
-			var val string
-			var ok bool
 			if val, ok = vol.Labels[k]; !ok {
 				t.Errorf("CreateVolume() Label %s not set", k)
 			}
@@ -191,8 +191,6 @@ func TestCreateVolume(t *testing.T) {
 				t.Errorf("CreateVolume() returned unexpected Label value %s", val)
 			}
 		}
-		var val string
-		var ok bool
 		if val, ok = vol.Labels["labelfromapi"]; !ok {
 			t.Error("CreateVolume() Label from api not set")
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
in for loop has define the two para 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
