### PR TITLE
Add kubeadm way in ipvs proxy README

### DIFF
--- a/pkg/proxy/ipvs/README.md
+++ b/pkg/proxy/ipvs/README.md
@@ -35,7 +35,17 @@ Kube-proxy will run in iptables mode by default in a [local-up cluster](https://
 
 Users should export the env `KUBEPROXY_MODE=ipvs` to specify the ipvs mode before deploying the cluster if want to run kube-proxy in ipvs mode.
 
-// TODO: Kubeadm
+#### Cluster Created by Kubeadm
+
+Kube-proxy will run in iptables mode by default in a cluster deployed by [kubeadm](https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/). 
+
+Since IPVS mode is still feature-gated, users should add the flag `--feature-gates=SupportIPVSProxyMode=true` in `kubeadm init` command
+
+```
+kubeadm init --feature-gates=SupportIPVSProxyMode=true
+```
+
+to specify the ipvs mode before deploying the cluster if want to run kube-proxy in ipvs mode.
 
 #### Test
 
@@ -51,4 +61,3 @@ TCP  10.0.0.1:443 rr persistent 10800
 TCP  10.0.0.10:53 rr      
 UDP  10.0.0.10:53 rr
 ```
-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

As #53962 which support specify proxy mode for kubeadm is already in, we should add ipvs proxy kubeadm way in README.md.

**Which issue(s) this PR fixes**:
Fixes #54978

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
