### PR TITLE
 Optimizing the implementation of the error check for PriorityClass

### DIFF
--- a/plugin/pkg/admission/priority/admission.go
+++ b/plugin/pkg/admission/priority/admission.go
@@ -162,12 +162,15 @@ func (p *PriorityPlugin) admitPod(a admission.Attributes) error {
 			if !ok {
 				// Now that we didn't find any system priority, try resolving by user defined priority classes.
 				pc, err := p.lister.Get(pod.Spec.PriorityClassName)
+
 				if err != nil {
-					return fmt.Errorf("failed to get default priority class %s: %v", pod.Spec.PriorityClassName, err)
+					if errors.IsNotFound(err) {
+						return admission.NewForbidden(a, fmt.Errorf("no PriorityClass with name %v was found", pod.Spec.PriorityClassName))
+					}
+
+					return fmt.Errorf("failed to get PriorityClass with name %s: %v", pod.Spec.PriorityClassName, err)
 				}
-				if pc == nil {
-					return admission.NewForbidden(a, fmt.Errorf("no PriorityClass with name %v was found", pod.Spec.PriorityClassName))
-				}
+
 				priority = pc.Value
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

When i create pod(on the bottom) with not exist PriorityClass, the output will be shown as follow:
```
# kubectl apply -f priorityclassname-pod.yaml 
Error from server: error when creating "priorityclassname-pod.yaml": failed to get default priority class not-exist-priorityclassname: priorityclass.scheduling.k8s.io "not-exist-priorityclassname" not found
```

In my eyes, "get default priority class" is not the correct description, so i changed it. The new output will be shown like this:
```
# kubectl apply -f priorityclassname-pod.yaml 
Error from server (NotFound): error when creating "priorityclassname-pod.yaml": priorityclass.scheduling.k8s.io "not-exist-priorityclassname" not found
```

In addition, the 'pc' will never be nil when err is nil, i think this check is not neccessary, so i removed it.

thank you!

Pod template:
```
apiVersion: v1
kind: Pod
metadata:
  name: priorityclassname-pod           
  labels:
    env: priorityclassname-pod    
spec:
  containers:
  - name: was
    image: gcr.io/google_containers/busybox:v1.0
    imagePullPolicy: IfNotPresent
  priorityClassName: not-exist-priorityclassname
```