### PR TITLE
Fix Makefile doc for quick-release

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -389,7 +389,7 @@ define RELEASE_SKIP_TESTS_HELP_INFO
 #
 # Args:
 #   KUBE_RELEASE_RUN_TESTS: Whether to run tests. Set to 'y' to run tests anyways.
-#   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'true' to do so.
+#   KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'false' to do so.
 #
 # Example:
 #   make release-skip-tests


### PR DESCRIPTION
**What this PR does / why we need it**:  Fix Makefile doc for quick-release
In the Makefile doc for quick-release target, it says:
KUBE_FASTBUILD: Whether to cross-compile for other architectures. Set to 'true' to do so.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
