### PR TITLE
add priorityclasses type when get hep info

### DIFF
--- a/pkg/kubectl/cmd/util/printing.go
+++ b/pkg/kubectl/cmd/util/printing.go
@@ -254,6 +254,7 @@ func ValidResourceTypeList(f ClientAccessFactory) string {
 			* pods (aka 'po')
 			* podsecuritypolicies (aka 'psp')
 			* podtemplates
+			* priorityclasses (aka 'pc')
 			* replicasets (aka 'rs')
 			* replicationcontrollers (aka 'rc')
 			* resourcequotas (aka 'quota')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

add priorityclasses type when get hep info

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:Fixes #

**Special notes for your reviewer**:
There is a TODO that:
```
TODO: This function implementation should be replaced with a real implementation from the discovery service
```
I want to fix it, but when kubectl do not connect api-server, how do we resolve it.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
