### PR TITLE
Just use filepath.isAbs to validate mount paths.

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -1954,12 +1954,8 @@ func ValidateVolumeMounts(mounts []api.VolumeMount, volumes sets.String, contain
 		if mountpoints.Has(mnt.MountPath) {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must be unique"))
 		}
-		if !path.IsAbs(mnt.MountPath) {
-			// also allow windows absolute path
-			p := mnt.MountPath
-			if len(p) < 2 || ((p[0] < 'A' || p[0] > 'Z') && (p[0] < 'a' || p[0] > 'z')) || p[1] != ':' {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must be an absolute path"))
-			}
+		if !filepath.IsAbs(mnt.MountPath) {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must be an absolute path"))
 		}
 		mountpoints.Insert(mnt.MountPath)
 		if len(mnt.SubPath) > 0 {

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -3718,6 +3718,7 @@ func TestValidateVolumeMounts(t *testing.T) {
 		"name not found":                         {{Name: "", MountPath: "/foo"}},
 		"empty mountpath":                        {{Name: "abc", MountPath: ""}},
 		"relative mountpath":                     {{Name: "abc", MountPath: "bar"}},
+		"windows path on linux":                  {{Name: "abc", MountPath: "C:\\some\\path"}},
 		"mountpath collision":                    {{Name: "foo", MountPath: "/path/a"}, {Name: "bar", MountPath: "/path/a"}},
 		"absolute subpath":                       {{Name: "abc", MountPath: "/bar", SubPath: "/baz"}},
 		"subpath in ..":                          {{Name: "abc", MountPath: "/bar", SubPath: "../baz"}},


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/51240 introduced relaxed validation for Windows path, which as @thockin pointed out allows `C:` to be valid on a Linux machine.

The correct approach is to just use `path/filepath.isAbs` from the go standard library which is OS independent.

That's what this PR does.

@thockin @saad-ali @andyzhangx 