### PR TITLE
Reduce metadata-proxy cpu requests to 30m

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -36,10 +36,10 @@ spec:
         resources:
           requests:
             memory: "32Mi"
-            cpu: "50m"
+            cpu: "30m"
           limits:
             memory: "32Mi"
-            cpu: "50m"
+            cpu: "30m"
         volumeMounts:
           - name: config-volume
             mountPath: /etc/nginx/


### PR DESCRIPTION
After the recent change enabling metadata-proxy in tests (https://github.com/kubernetes/kubernetes/pull/54150) we started seeing problems with scheduling cluster autoscaler on master. Metadata-proxy eats all of the available space leaving nothing for CA to run on. 

This PR reduces the cpu requests for metadata-proxy allowing other components to fit in.

cc: @kubernetes/sig-autoscaling-bugs 