### PR TITLE
Improve api validation unit test coverage

### DIFF
--- a/pkg/apis/core/v1/validation/BUILD
+++ b/pkg/apis/core/v1/validation/BUILD
@@ -23,6 +23,8 @@ go_test(
     deps = [
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/apis/core/v1/validation/validation_test.go
+++ b/pkg/apis/core/v1/validation/validation_test.go
@@ -21,6 +21,8 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -174,6 +176,229 @@ func TestValidateResourceRequirements(t *testing.T) {
 	for _, tc := range errorCase {
 		if errs := ValidateResourceRequirements(&tc.requirements, field.NewPath("resources")); len(errs) == 0 {
 			t.Errorf("%q expected error", tc.Name)
+		}
+	}
+}
+
+func TestValidatePodLogOptions(t *testing.T) {
+
+	var (
+		positiveLine             = int64(8)
+		negativeLine             = int64(-8)
+		limitBytesGreaterThan1   = int64(12)
+		limitBytesLessThan1      = int64(0)
+		sinceSecondsGreaterThan1 = int64(10)
+		sinceSecondsLessThan1    = int64(0)
+		timestamp                = metav1.Now()
+	)
+
+	successCase := []struct {
+		Name          string
+		podLogOptions v1.PodLogOptions
+	}{
+		{
+			Name:          "Empty PodLogOptions",
+			podLogOptions: v1.PodLogOptions{},
+		},
+		{
+			Name: "PodLogOptions with TailLines",
+			podLogOptions: v1.PodLogOptions{
+				TailLines: &positiveLine,
+			},
+		},
+		{
+			Name: "PodLogOptions with LimitBytes",
+			podLogOptions: v1.PodLogOptions{
+				LimitBytes: &limitBytesGreaterThan1,
+			},
+		},
+		{
+			Name: "PodLogOptions with only sinceSeconds",
+			podLogOptions: v1.PodLogOptions{
+				SinceSeconds: &sinceSecondsGreaterThan1,
+			},
+		},
+		{
+			Name: "PodLogOptions with LimitBytes with TailLines",
+			podLogOptions: v1.PodLogOptions{
+				LimitBytes: &limitBytesGreaterThan1,
+				TailLines:  &positiveLine,
+			},
+		},
+		{
+			Name: "PodLogOptions with LimitBytes with TailLines with SinceSeconds",
+			podLogOptions: v1.PodLogOptions{
+				LimitBytes:   &limitBytesGreaterThan1,
+				TailLines:    &positiveLine,
+				SinceSeconds: &sinceSecondsGreaterThan1,
+			},
+		},
+	}
+	for _, tc := range successCase {
+		if errs := ValidatePodLogOptions(&tc.podLogOptions); len(errs) != 0 {
+			t.Errorf("%q unexpected error: %v", tc.Name, errs)
+		}
+	}
+
+	errorCase := []struct {
+		Name          string
+		podLogOptions v1.PodLogOptions
+	}{
+		{
+			Name: "Invalid podLogOptions with Negative TailLines",
+			podLogOptions: v1.PodLogOptions{
+				TailLines:    &negativeLine,
+				LimitBytes:   &limitBytesGreaterThan1,
+				SinceSeconds: &sinceSecondsGreaterThan1,
+			},
+		},
+		{
+			Name: "Invalid podLogOptions with zero or negative LimitBytes",
+			podLogOptions: v1.PodLogOptions{
+				TailLines:    &positiveLine,
+				LimitBytes:   &limitBytesLessThan1,
+				SinceSeconds: &sinceSecondsGreaterThan1,
+			},
+		},
+		{
+			Name: "Invalid podLogOptions with zero or negative SinceSeconds",
+			podLogOptions: v1.PodLogOptions{
+				TailLines:    &negativeLine,
+				LimitBytes:   &limitBytesGreaterThan1,
+				SinceSeconds: &sinceSecondsLessThan1,
+			},
+		}, {
+			Name: "Invalid podLogOptions with both SinceSeconds and SinceTime set",
+			podLogOptions: v1.PodLogOptions{
+				TailLines:    &negativeLine,
+				LimitBytes:   &limitBytesGreaterThan1,
+				SinceSeconds: &sinceSecondsGreaterThan1,
+				SinceTime:    &timestamp,
+			},
+		},
+	}
+	for _, tc := range errorCase {
+		if errs := ValidatePodLogOptions(&tc.podLogOptions); len(errs) == 0 {
+			t.Errorf("%q expected error", tc.Name)
+		}
+	}
+}
+
+func TestAccumulateUniqueHostPorts(t *testing.T) {
+	successCase := []struct {
+		containers  []v1.Container
+		accumulator *sets.String
+		fldPath     *field.Path
+		result      string
+	}{
+		{
+			containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolTCP,
+						},
+					},
+				},
+			},
+			accumulator: &sets.String{},
+			fldPath:     field.NewPath("spec", "containers"),
+			result:      "HostPort is not allocated",
+		},
+		{
+			containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8081,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+			},
+			accumulator: &sets.String{},
+			fldPath:     field.NewPath("spec", "containers"),
+			result:      "HostPort is not allocated",
+		},
+	}
+	for index, tc := range successCase {
+		if errs := AccumulateUniqueHostPorts(tc.containers, tc.accumulator, tc.fldPath); len(errs) != 0 {
+			t.Errorf("unexpected error for test case %v: %v", index, errs)
+		}
+	}
+	errorCase := []struct {
+		containers  []v1.Container
+		accumulator *sets.String
+		fldPath     *field.Path
+		result      string
+	}{
+		{
+			containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+			},
+			accumulator: &sets.String{},
+			fldPath:     field.NewPath("spec", "containers"),
+			result:      "HostPort is already allocated",
+		},
+		{
+			containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8080,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+				{
+					Ports: []v1.ContainerPort{
+						{
+							HostPort: 8081,
+							Protocol: v1.ProtocolUDP,
+						},
+					},
+				},
+			},
+			accumulator: &sets.String{"8080/UDP": sets.Empty{}},
+			fldPath:     field.NewPath("spec", "containers"),
+			result:      "HostPort is already allocated",
+		},
+	}
+	for index, tc := range errorCase {
+		if errs := AccumulateUniqueHostPorts(tc.containers, tc.accumulator, tc.fldPath); len(errs) == 0 {
+			t.Errorf("test case %v: expected error %v, but get nil", index, tc.result)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add UT for ValidatePodLogOptions and AccumulateUniqueHostPorts

Before

```
coverage: 60.0% of statements
ok  	k8s.io/kubernetes/pkg/api/v1/validation	0.058s
```

After:
```
coverage: 92.9% of statements
ok  	k8s.io/kubernetes/pkg/api/v1/validation	0.057s
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
