### PR TITLE
Whitelist net.ipv6.conf.all.disable_ipv6 as a safe sysctl

### DIFF
--- a/pkg/kubelet/sysctl/whitelist.go
+++ b/pkg/kubelet/sysctl/whitelist.go
@@ -42,6 +42,7 @@ func SafeSysctlWhitelist() []string {
 		"kernel.shm_rmid_forced",
 		"net.ipv4.ip_local_port_range",
 		"net.ipv4.tcp_syncookies",
+		"net.ipv6.conf.all.disable_ipv6",
 	}
 }
 

--- a/pkg/kubelet/sysctl/whitelist_test.go
+++ b/pkg/kubelet/sysctl/whitelist_test.go
@@ -54,6 +54,7 @@ func TestWhitelist(t *testing.T) {
 		{sysctl: "net.ipv4.ip_local_port_range"},
 		{sysctl: "kernel.msgmax"},
 		{sysctl: "kernel.sem"},
+		{sysctl: "net.ipv6.conf.all.disable_ipv6"},
 	}
 	invalid := []Test{
 		{sysctl: "kernel.shm_rmid_forced", hostIPC: true},


### PR DESCRIPTION
**What this PR does / why we need it**:
This can be used to disable ipv6 inside containers.

**Which issue(s) this PR fixes** 
Fixes #55006.

**Special notes for your reviewer**:
N/A

**Release note**:

```
Sysctl parameter net.ipv6.conf.all.disable_ipv6 is now whitelisted as a safe sysctl. You can now configure the parameter by pod annotation as explained in https://kubernetes.io/docs/concepts/cluster-administration/sysctl-cluster/.
```