### PR TITLE
auth: allow nodes to create tokens for svcaccts of pods

### DIFF
--- a/plugin/pkg/admission/noderestriction/BUILD
+++ b/plugin/pkg/admission/noderestriction/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kubernetes/plugin/pkg/admission/noderestriction",
     deps = [
         "//pkg/api/pod:go_default_library",
+        "//pkg/apis/authentication:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/policy:go_default_library",
         "//pkg/auth/nodeidentifier:go_default_library",
@@ -33,14 +34,18 @@ go_test(
     srcs = ["admission_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/apis/authentication:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/policy:go_default_library",
         "//pkg/auth/nodeidentifier:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/client/clientset_generated/internalclientset/typed/core/internalversion:go_default_library",
+        "//pkg/features:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/plugin/pkg/admission/noderestriction/admission_test.go
+++ b/plugin/pkg/admission/noderestriction/admission_test.go
@@ -21,18 +21,37 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	authenticationapi "k8s.io/kubernetes/pkg/apis/authentication"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/auth/nodeidentifier"
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	coreinternalversion "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
+	"k8s.io/kubernetes/pkg/features"
 )
+
+var (
+	trEnabledFeature  = utilfeature.NewFeatureGate()
+	trDisabledFeature = utilfeature.NewFeatureGate()
+)
+
+func init() {
+	if err := trEnabledFeature.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TokenRequest: {Default: true}}); err != nil {
+		panic(err)
+	}
+	if err := trDisabledFeature.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TokenRequest: {Default: false}}); err != nil {
+		panic(err)
+	}
+}
 
 func makeTestPod(namespace, name, node string, mirror bool) *api.Pod {
 	pod := &api.Pod{}
 	pod.Namespace = namespace
+	pod.UID = types.UID("pod-uid")
 	pod.Name = name
 	pod.Spec.NodeName = node
 	if mirror {
@@ -45,6 +64,23 @@ func makeTestPodEviction(name string) *policy.Eviction {
 	eviction := &policy.Eviction{}
 	eviction.Name = name
 	return eviction
+}
+
+func makeTokenRequest(podname string, poduid types.UID) *authenticationapi.TokenRequest {
+	tr := &authenticationapi.TokenRequest{
+		Spec: authenticationapi.TokenRequestSpec{
+			Audiences: []string{"foo"},
+		},
+	}
+	if podname != "" {
+		tr.Spec.BoundObjectRef = &authenticationapi.BoundObjectReference{
+			Kind:       "Pod",
+			APIVersion: "v1",
+			Name:       podname,
+			UID:        poduid,
+		}
+	}
+	return tr
 }
 
 func Test_nodePlugin_Admit(t *testing.T) {
@@ -86,6 +122,9 @@ func Test_nodePlugin_Admit(t *testing.T) {
 		nodeResource = api.Resource("nodes").WithVersion("v1")
 		nodeKind     = api.Kind("Node").WithVersion("v1")
 
+		svcacctResource  = api.Resource("serviceaccounts").WithVersion("v1")
+		tokenrequestKind = api.Kind("TokenRequest").WithVersion("v1")
+
 		noExistingPods = fake.NewSimpleClientset().Core()
 		existingPods   = fake.NewSimpleClientset(mymirrorpod, othermirrorpod, unboundmirrorpod, mypod, otherpod, unboundpod).Core()
 	)
@@ -106,6 +145,7 @@ func Test_nodePlugin_Admit(t *testing.T) {
 		name       string
 		podsGetter coreinternalversion.PodsGetter
 		attributes admission.Attributes
+		features   utilfeature.FeatureGate
 		err        string
 	}{
 		// Mirror pods bound to us
@@ -653,6 +693,42 @@ func Test_nodePlugin_Admit(t *testing.T) {
 			err:        "cannot modify node",
 		},
 
+		// Service accounts
+		{
+			name:       "forbid create of unbound token",
+			podsGetter: noExistingPods,
+			features:   trEnabledFeature,
+			attributes: admission.NewAttributesRecord(makeTokenRequest("", ""), nil, tokenrequestKind, "ns", "mysa", svcacctResource, "token", admission.Create, mynode),
+			err:        "not bound to a pod",
+		},
+		{
+			name:       "forbid create of token bound to nonexistant pod",
+			podsGetter: noExistingPods,
+			features:   trEnabledFeature,
+			attributes: admission.NewAttributesRecord(makeTokenRequest("nopod", "someuid"), nil, tokenrequestKind, "ns", "mysa", svcacctResource, "token", admission.Create, mynode),
+			err:        "not found",
+		},
+		{
+			name:       "forbid create of token bound to pod without uid",
+			podsGetter: existingPods,
+			features:   trEnabledFeature,
+			attributes: admission.NewAttributesRecord(makeTokenRequest(mypod.Name, ""), nil, tokenrequestKind, "ns", "mysa", svcacctResource, "token", admission.Create, mynode),
+			err:        "pod binding without a uid",
+		},
+		{
+			name:       "forbid create of token bound to pod scheduled on another node",
+			podsGetter: existingPods,
+			features:   trEnabledFeature,
+			attributes: admission.NewAttributesRecord(makeTokenRequest(otherpod.Name, otherpod.UID), nil, tokenrequestKind, otherpod.Namespace, "mysa", svcacctResource, "token", admission.Create, mynode),
+			err:        "pod scheduled on a different node",
+		},
+		{
+			name:       "allow create of token bound to pod scheduled this node",
+			podsGetter: existingPods,
+			features:   trEnabledFeature,
+			attributes: admission.NewAttributesRecord(makeTokenRequest(mypod.Name, mypod.UID), nil, tokenrequestKind, mypod.Namespace, "mysa", svcacctResource, "token", admission.Create, mynode),
+		},
+
 		// Unrelated objects
 		{
 			name:       "allow create of unrelated object",
@@ -714,6 +790,9 @@ func Test_nodePlugin_Admit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := NewPlugin(nodeidentifier.NewDefaultNodeIdentifier())
+			if tt.features != nil {
+				c.features = tt.features
+			}
 			c.podsGetter = tt.podsGetter
 			err := c.Admit(tt.attributes)
 			if (err == nil) != (len(tt.err) == 0) {

--- a/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
+++ b/plugin/pkg/auth/authorizer/node/node_authorizer_test.go
@@ -38,6 +38,8 @@ import (
 var (
 	csiEnabledFeature  = utilfeature.NewFeatureGate()
 	csiDisabledFeature = utilfeature.NewFeatureGate()
+	trEnabledFeature   = utilfeature.NewFeatureGate()
+	trDisabledFeature  = utilfeature.NewFeatureGate()
 )
 
 func init() {
@@ -45,6 +47,12 @@ func init() {
 		panic(err)
 	}
 	if err := csiDisabledFeature.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.CSIPersistentVolume: {Default: false}}); err != nil {
+		panic(err)
+	}
+	if err := trEnabledFeature.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TokenRequest: {Default: true}}); err != nil {
+		panic(err)
+	}
+	if err := trDisabledFeature.Add(map[utilfeature.Feature]utilfeature.FeatureSpec{features.TokenRequest: {Default: false}}); err != nil {
 		panic(err)
 	}
 }
@@ -151,6 +159,36 @@ func TestAuthorizer(t *testing.T) {
 			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "get", Resource: "volumeattachments", APIGroup: "storage.k8s.io", Name: "attachment0-node0"},
 			features: csiEnabledFeature,
 			expect:   authorizer.DecisionAllow,
+		},
+		{
+			name:     "allowed svcacct token create - feature enabled",
+			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "create", Resource: "serviceaccounts", Subresource: "token", Name: "svcacct0-node0", Namespace: "ns0"},
+			features: trEnabledFeature,
+			expect:   authorizer.DecisionAllow,
+		},
+		{
+			name:     "disallowed svcacct token create - serviceaccount not attached to node",
+			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "create", Resource: "serviceaccounts", Subresource: "token", Name: "svcacct0-node1", Namespace: "ns0"},
+			features: trEnabledFeature,
+			expect:   authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "disallowed svcacct token create - feature disabled",
+			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "create", Resource: "serviceaccounts", Subresource: "token", Name: "svcacct0-node0", Namespace: "ns0"},
+			features: trDisabledFeature,
+			expect:   authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "disallowed svcacct token create - no subresource",
+			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "create", Resource: "serviceaccounts", Name: "svcacct0-node0", Namespace: "ns0"},
+			features: trEnabledFeature,
+			expect:   authorizer.DecisionNoOpinion,
+		},
+		{
+			name:     "disallowed svcacct token create - non create",
+			attrs:    authorizer.AttributesRecord{User: node0, ResourceRequest: true, Verb: "update", Resource: "serviceaccounts", Subresource: "token", Name: "svcacct0-node0", Namespace: "ns0"},
+			features: trEnabledFeature,
+			expect:   authorizer.DecisionNoOpinion,
 		},
 	}
 
@@ -459,6 +497,7 @@ func generate(opts sampleDataOpts) ([]*api.Pod, []*api.PersistentVolume, []*stor
 			pod.Namespace = fmt.Sprintf("ns%d", p%opts.namespaces)
 			pod.Name = fmt.Sprintf("pod%d-%s", p, nodeName)
 			pod.Spec.NodeName = nodeName
+			pod.Spec.ServiceAccountName = fmt.Sprintf("svcacct%d-%s", p, nodeName)
 
 			for i := 0; i < opts.uniqueSecretsPerPod; i++ {
 				pod.Spec.Volumes = append(pod.Spec.Volumes, api.Volume{VolumeSource: api.VolumeSource{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -146,6 +146,13 @@ func NodeRules() []rbac.PolicyRule {
 		nodePolicyRules = append(nodePolicyRules, pvcStatusPolicyRule)
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(features.TokenRequest) {
+		// Use the Node authorization to limit a node to create tokens for service accounts running on that node
+		// Use the NodeRestriction admission plugin to limit a node to create tokens bound to pods on that node
+		tokenRequestRule := rbac.NewRule("create").Groups(legacyGroup).Resources("serviceaccounts/token").RuleOrDie()
+		nodePolicyRules = append(nodePolicyRules, tokenRequestRule)
+	}
+
 	// CSI
 	if utilfeature.DefaultFeatureGate.Enabled(features.CSIPersistentVolume) {
 		volAttachRule := rbac.NewRule("get").Groups(storageGroup).Resources("volumeattachments").RuleOrDie()

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -448,6 +448,8 @@ func TestNodeAuthorizer(t *testing.T) {
 	defer utilfeaturetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIPersistentVolume, true)()
 	expectForbidden(t, getVolumeAttachment(node1ClientExternal))
 	expectAllowed(t, getVolumeAttachment(node2ClientExternal))
+
+	//TODO(mikedanese): integration test node restriction of TokenRequest
 }
 
 // expect executes a function a set number of times until it either returns the


### PR DESCRIPTION
ref https://github.com/kubernetes/kubernetes/issues/58790

running on them. nodes essentially have the power to do this today
but not explicitly. this allows agents using the node identity to
take actions on behalf of local pods.

@kubernetes/sig-auth-pr-reviews @smarterclayton 

```release-note
The node authorizer now allows nodes to request service account tokens for the service accounts of pods running on them.
```