### PR TITLE
StopPodSandbox should not log when container is already removed

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -239,9 +239,9 @@ func (ds *dockerService) StopPodSandbox(podSandboxID string) error {
 		}
 	}
 	if err := ds.client.StopContainer(podSandboxID, defaultSandboxGracePeriod); err != nil {
-		glog.Errorf("Failed to stop sandbox %q: %v", podSandboxID, err)
 		// Do not return error if the container does not exist
 		if !libdocker.IsContainerNotFoundError(err) {
+			glog.Errorf("Failed to stop sandbox %q: %v", podSandboxID, err)
 			errList = append(errList, err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
StopPodSandbox should not log when a container is already gone.  It should only log if it could not stop and the container was still present.

Fixes https://github.com/kubernetes/kubernetes/issues/55021

**Special notes for your reviewer**:
This was seen in our production logs, need to eliminate spam.

**Release note**:
```release-note
NONE
```
