### PR TITLE
[Test Fix] Mock docker network dependencies and fix filtering bug

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -410,7 +410,7 @@ func (f *FakeDockerClient) ListContainers(options dockertypes.ContainerListOptio
 		var filtered []dockertypes.Container
 		for _, container := range containerList {
 			for _, statusFilter := range statusFilters {
-				if container.Status == statusFilter {
+				if toDockerContainerStatus(container.Status) == statusFilter {
 					filtered = append(filtered, container)
 					break
 				}
@@ -441,6 +441,19 @@ func (f *FakeDockerClient) ListContainers(options dockertypes.ContainerListOptio
 		containerList = filtered
 	}
 	return containerList, err
+}
+
+func toDockerContainerStatus(state string) string {
+	switch {
+	case strings.HasPrefix(state, StatusCreatedPrefix):
+		return "created"
+	case strings.HasPrefix(state, StatusRunningPrefix):
+		return "running"
+	case strings.HasPrefix(state, StatusExitedPrefix):
+		return "exited"
+	default:
+		return "unknown"
+	}
 }
 
 // InspectContainer is a test-spy implementation of Interface.InspectContainer.
@@ -565,6 +578,18 @@ func (f *FakeDockerClient) StartContainer(id string) error {
 	}
 	f.appendContainerTrace("Started", id)
 	container, ok := f.ContainerMap[id]
+	if container.HostConfig.NetworkMode.IsContainer() {
+		hostContainerID := container.HostConfig.NetworkMode.ConnectedContainer()
+		found := false
+		for _, container := range f.RunningContainerList {
+			if container.ID == hostContainerID {
+				found = true
+			}
+		}
+		if !found {
+			return fmt.Errorf("failed to start container \"%s\": Error response from daemon: cannot join network of a non running container: %s", id, hostContainerID)
+		}
+	}
 	timestamp := f.Clock.Now()
 	if !ok {
 		container = convertFakeContainer(&FakeContainer{ID: id, Name: id, CreatedAt: timestamp})


### PR DESCRIPTION
This PR only affects the mocked docker runtime, and has no impact on the kubelet.

Issue #53327 

When kubernetes creates a pod using the docker shim, it creates a container which contains the pod's network namespace, and then creates containers which specify that namespace.
The current mocked docker does not mock this interaction, and thus allows a container to be created even when the container whose network it is joining does not exist.
This allows the mocked kubelet to end up in a state where the pod does not exist, but a container in the pod does, and this breaks pod deletion.

This fixes the above by only allowing containers to be started if the container whose network it is trying to join is running.

Additionally, this PR fixes a filtering bug where we were incorrectly comparing docker container statuses.

/assign @shyamjvs 
can you test this to see if it fixes the issue?
/assign @Random-Liu 
for approval after @shyamjvs confirms this works.