### PR TITLE
discovery client not depend on pkg/api/legacyscheme

### DIFF
--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//pkg/kubectl/cmd/util/openapi/validation:go_default_library",
         "//pkg/kubectl/plugins:go_default_library",
         "//pkg/kubectl/resource:go_default_library",
+        "//pkg/kubectl/scheme:go_default_library",
         "//pkg/kubectl/validation:go_default_library",
         "//pkg/printers:go_default_library",
         "//pkg/printers/internalversion:go_default_library",

--- a/pkg/kubectl/cmd/util/cached_discovery.go
+++ b/pkg/kubectl/cmd/util/cached_discovery.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/kubectl/scheme"
 )
 
 // CachedDiscoveryClient implements the functions that discovery server-supported API groups,
@@ -66,7 +66,7 @@ func (d *CachedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion stri
 	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
 	if err == nil {
 		cachedResources := &metav1.APIResourceList{}
-		if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
+		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), cachedBytes, cachedResources); err == nil {
 			glog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedResources, nil
 		}
@@ -113,7 +113,7 @@ func (d *CachedDiscoveryClient) ServerGroups() (*metav1.APIGroupList, error) {
 	// don't fail on errors, we either don't have a file or won't be able to run the cached check. Either way we can fallback.
 	if err == nil {
 		cachedGroups := &metav1.APIGroupList{}
-		if err := runtime.DecodeInto(legacyscheme.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
+		if err := runtime.DecodeInto(scheme.Codecs.UniversalDecoder(), cachedBytes, cachedGroups); err == nil {
 			glog.V(10).Infof("returning cached discovery info from %v", filename)
 			return cachedGroups, nil
 		}
@@ -179,7 +179,7 @@ func (d *CachedDiscoveryClient) writeCachedFile(filename string, obj runtime.Obj
 		return err
 	}
 
-	bytes, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(), obj)
+	bytes, err := runtime.Encode(scheme.Codecs.LegacyCodec(), obj)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Switch kubectl's cached discovery client to use kubect's scheme (pkg/kubectl/scheme) which only registered with external version types.

The encoding and decoding here uses only `k8s.io/apimachinery/pkg/apis/meta/v1.APIGroupList` and `k8s.io/apimachinery/pkg/apis/meta/v1.APIResourceList` which are not internal version. So it should be safe.

```release-note
NONE
```

/assign @monopole 
