### PR TITLE
Close the file before renaming in FileStore

### DIFF
--- a/pkg/kubelet/util/store/BUILD
+++ b/pkg/kubelet/util/store/BUILD
@@ -23,6 +23,7 @@ go_test(
     deps = [
         "//pkg/util/filesystem:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Also change the unit test to use a real file system to detect errors
like this.


