### PR TITLE
close the channel

### DIFF
--- a/test/e2e_node/services/util.go
+++ b/test/e2e_node/services/util.go
@@ -30,5 +30,9 @@ var terminationSignals = []os.Signal{syscall.SIGHUP, syscall.SIGINT, syscall.SIG
 func waitForTerminationSignal() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, terminationSignals...)
+	defer func() {
+		signal.Stop(sig)
+		close(sig)
+	}()
 	<-sig
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

stop and close the channel of os.Signal after using it
