### PR TITLE
should check and return err when err of r is not empty

### DIFF
--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -175,6 +175,10 @@ func (options *CertificateOptions) modifyCertificateCondition(f cmdutil.Factory,
 		Flatten().
 		Latest().
 		Do()
+	err = r.Err()
+	if err != nil {
+		return err
+	}
 	err = r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -359,6 +359,10 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 					ResourceNames(obj.Mapping.Resource, name).
 					Flatten().
 					Do()
+				err = r.Err()
+				if err != nil {
+					return err
+				}
 				// Note: we pass in "true" for the "quiet" parameter because
 				// ReadResult will only print one thing based on the "quiet"
 				// flag, and that's the "pod xxx deleted" message. If they


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

should check and return err when err of r is not empty


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
