### PR TITLE
kubectl/config/rename: fix wording

### DIFF
--- a/pkg/kubectl/cmd/config/rename_context.go
+++ b/pkg/kubectl/cmd/config/rename_context.go
@@ -130,6 +130,6 @@ func (o RenameContextOptions) RunRenameContext(out io.Writer) error {
 		return err
 	}
 
-	fmt.Fprintf(out, "Context %q was renamed to %q.\n", o.contextName, o.newName)
+	fmt.Fprintf(out, "Context %q renamed to %q.\n", o.contextName, o.newName)
 	return nil
 }

--- a/pkg/kubectl/cmd/config/rename_context_test.go
+++ b/pkg/kubectl/cmd/config/rename_context_test.go
@@ -62,7 +62,7 @@ func TestRenameContext(t *testing.T) {
 		initialConfig:  initialConfig,
 		expectedConfig: expectedConfig,
 		args:           []string{currentContext, newContext},
-		expectedOut:    fmt.Sprintf("Context %q was renamed to %q.\n", currentContext, newContext),
+		expectedOut:    fmt.Sprintf("Context %q renamed to %q.\n", currentContext, newContext),
 		expectedErr:    "",
 	}
 	test.run(t)


### PR DESCRIPTION
Using `Context %q renamed to %q.` in rename-context to be consistent with other
commands like delete-context, set-context, use-context.

/sig cli
/release-note none