### PR TITLE
Remove version check in kubectl e2e test.

### DIFF
--- a/test/e2e/kubectl/BUILD
+++ b/test/e2e/kubectl/BUILD
@@ -16,7 +16,6 @@ go_library(
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/kubectl/cmd/util:go_default_library",
-        "//pkg/util/version:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/generated:go_default_library",
         "//test/e2e/scheduling:go_default_library",

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -59,7 +59,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/util"
-	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/generated"
 	"k8s.io/kubernetes/test/e2e/scheduling"
@@ -119,44 +118,6 @@ var testImages = struct {
 }
 var (
 	proxyRegexp = regexp.MustCompile("Starting to serve on 127.0.0.1:([0-9]+)")
-
-	// Extended pod logging options were introduced in #13780 (v1.1.0) so we don't expect tests
-	// that rely on extended pod logging options to work on clusters before that.
-	//
-	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
-	extendedPodLogFilterVersion = utilversion.MustParseSemantic("v1.1.0")
-
-	// NodePorts were made optional in #12831 (v1.1.0) so we don't expect tests that used to
-	// require NodePorts but no longer include them to work on clusters before that.
-	//
-	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
-	nodePortsOptionalVersion = utilversion.MustParseSemantic("v1.1.0")
-
-	// Jobs were introduced in v1.1, so we don't expect tests that rely on jobs to work on
-	// clusters before that.
-	//
-	// TODO(ihmccreery): remove once we don't care about v1.0 anymore, (tentatively in v1.3).
-	jobsVersion = utilversion.MustParseSemantic("v1.1.0")
-
-	// Deployments were introduced by default in v1.2, so we don't expect tests that rely on
-	// deployments to work on clusters before that.
-	//
-	// TODO(ihmccreery): remove once we don't care about v1.1 anymore, (tentatively in v1.4).
-	deploymentsVersion = utilversion.MustParseSemantic("v1.2.0-alpha.7.726")
-
-	// Pod probe parameters were introduced in #15967 (v1.2) so we don't expect tests that use
-	// these probe parameters to work on clusters before that.
-	//
-	// TODO(ihmccreery): remove once we don't care about v1.1 anymore, (tentatively in v1.4).
-	podProbeParametersVersion = utilversion.MustParseSemantic("v1.2.0-alpha.4")
-
-	// 'kubectl create quota' was introduced in #28351 (v1.4) so we don't expect tests that use
-	// 'kubectl create quota' to work on kubectl clients before that.
-	kubectlCreateQuotaVersion = utilversion.MustParseSemantic("v1.4.0-alpha.2")
-
-	// Returning container command exit codes in kubectl run/exec was introduced in #26541 (v1.4)
-	// so we don't expect tests that verifies return code to work on kubectl clients before that.
-	kubectlContainerExitCodeVersion = utilversion.MustParseSemantic("v1.4.0-alpha.3")
 
 	CronJobGroupVersionResourceAlpha = schema.GroupVersionResource{Group: "batch", Version: "v2alpha1", Resource: "cronjobs"}
 	CronJobGroupVersionResourceBeta  = schema.GroupVersionResource{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}
@@ -355,8 +316,6 @@ var _ = SIGDescribe("Kubectl client", func() {
 		}
 
 		framework.ConformanceIt("should create and stop a working application ", func() {
-			framework.SkipUnlessServerVersionGTE(deploymentsVersion, c.Discovery())
-
 			defer forEachGBFile(func(contents string) {
 				cleanupKubectlInputs(contents, ns)
 			})
@@ -483,7 +442,6 @@ var _ = SIGDescribe("Kubectl client", func() {
 		})
 
 		It("should return command exit codes", func() {
-			framework.SkipUnlessKubectlVersionGTE(kubectlContainerExitCodeVersion)
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
 			By("execing into a container with a successful command")
@@ -528,7 +486,6 @@ var _ = SIGDescribe("Kubectl client", func() {
 
 		It("should support inline execution and attach", func() {
 			framework.SkipIfContainerRuntimeIs("rkt") // #23335
-			framework.SkipUnlessServerVersionGTE(jobsVersion, c.Discovery())
 
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 
@@ -831,7 +788,6 @@ metadata:
 
 	framework.KubeDescribe("Kubectl describe", func() {
 		framework.ConformanceIt("should check if kubectl describe prints relevant information for rc and pods ", func() {
-			framework.SkipUnlessServerVersionGTE(nodePortsOptionalVersion, c.Discovery())
 			kv, err := framework.KubectlVersion()
 			Expect(err).NotTo(HaveOccurred())
 			framework.SkipUnlessServerVersionGTE(kv, c.Discovery())
@@ -1061,8 +1017,6 @@ metadata:
 		})
 
 		framework.ConformanceIt("should be able to retrieve and filter logs ", func() {
-			framework.SkipUnlessServerVersionGTE(extendedPodLogFilterVersion, c.Discovery())
-
 			// Split("something\n", "\n") returns ["something", ""], so
 			// strip trailing newline first
 			lines := func(out string) []string {
@@ -1161,17 +1115,8 @@ metadata:
 
 		BeforeEach(func() {
 			nsFlag = fmt.Sprintf("--namespace=%v", ns)
-			gte, err := framework.ServerVersionGTE(deploymentsVersion, c.Discovery())
-			if err != nil {
-				framework.Failf("Failed to get server version: %v", err)
-			}
-			if gte {
-				name = "e2e-test-nginx-deployment"
-				cleanUp = func() { framework.RunKubectlOrDie("delete", "deployment", name, nsFlag) }
-			} else {
-				name = "e2e-test-nginx-rc"
-				cleanUp = func() { framework.RunKubectlOrDie("delete", "rc", name, nsFlag) }
-			}
+			name = "e2e-test-nginx-deployment"
+			cleanUp = func() { framework.RunKubectlOrDie("delete", "deployment", name, nsFlag) }
 		})
 
 		AfterEach(func() {
@@ -1309,8 +1254,6 @@ metadata:
 		})
 
 		framework.ConformanceIt("should create a deployment from an image ", func() {
-			framework.SkipUnlessServerVersionGTE(deploymentsVersion, c.Discovery())
-
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", dName, "--image="+nginxImage, "--generator=deployment/v1beta1", nsFlag)
 			By("verifying the deployment " + dName + " was created")
@@ -1351,8 +1294,6 @@ metadata:
 		})
 
 		framework.ConformanceIt("should create a job from an image when restart is OnFailure ", func() {
-			framework.SkipUnlessServerVersionGTE(jobsVersion, c.Discovery())
-
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", jobName, "--restart=OnFailure", "--generator=job/v1", "--image="+nginxImage, nsFlag)
 			By("verifying the job " + jobName + " was created")
@@ -1421,8 +1362,6 @@ metadata:
 		})
 
 		framework.ConformanceIt("should create a pod from an image when restart is Never ", func() {
-			framework.SkipUnlessServerVersionGTE(jobsVersion, c.Discovery())
-
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", podName, "--restart=Never", "--generator=run-pod/v1", "--image="+nginxImage, nsFlag)
 			By("verifying the pod " + podName + " was created")
@@ -1454,8 +1393,6 @@ metadata:
 		})
 
 		framework.ConformanceIt("should update a single-container pod's image ", func() {
-			framework.SkipUnlessServerVersionGTE(jobsVersion, c.Discovery())
-
 			By("running the image " + nginxImage)
 			framework.RunKubectlOrDie("run", podName, "--generator=run-pod/v1", "--image="+nginxImage, "--labels=run="+podName, nsFlag)
 
@@ -1496,7 +1433,6 @@ metadata:
 
 			// The rkt runtime doesn't support attach, see #23335
 			framework.SkipIfContainerRuntimeIs("rkt")
-			framework.SkipUnlessServerVersionGTE(jobsVersion, c.Discovery())
 
 			By("executing a command with run --rm and attach with stdin")
 			t := time.NewTimer(runJobTimeout)
@@ -1670,7 +1606,6 @@ metadata:
 
 	framework.KubeDescribe("Kubectl create quota", func() {
 		It("should create a quota without scopes", func() {
-			framework.SkipUnlessKubectlVersionGTE(kubectlCreateQuotaVersion)
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			quotaName := "million"
 
@@ -1700,7 +1635,6 @@ metadata:
 		})
 
 		It("should create a quota with scopes", func() {
-			framework.SkipUnlessKubectlVersionGTE(kubectlCreateQuotaVersion)
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			quotaName := "scopes"
 
@@ -1729,7 +1663,6 @@ metadata:
 		})
 
 		It("should reject quota with invalid scopes", func() {
-			framework.SkipUnlessKubectlVersionGTE(kubectlCreateQuotaVersion)
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)
 			quotaName := "scopes"
 

--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"net"
 	"os/exec"
@@ -36,7 +35,6 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -51,8 +49,7 @@ const (
 
 // TODO support other ports besides 80
 var (
-	portForwardRegexp        = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
-	portForwardPortToStdOutV = utilversion.MustParseSemantic("v1.3.0-alpha.4")
+	portForwardRegexp = regexp.MustCompile("Forwarding from 127.0.0.1:([0-9]+) -> 80")
 )
 
 func pfPod(expectedClientData, chunks, chunkSize, chunkIntervalMillis string, bindAddress string) *v1.Pod {
@@ -167,24 +164,12 @@ func runPortForward(ns, podName string, port int) *portForwardCommand {
 	// by the port-forward command. We don't want to hard code the port as we have no
 	// way of guaranteeing we can pick one that isn't in use, particularly on Jenkins.
 	framework.Logf("starting port-forward command and streaming output")
-	stdout, stderr, err := framework.StartCmdAndStreamOutput(cmd)
+	portOutput, _, err := framework.StartCmdAndStreamOutput(cmd)
 	if err != nil {
 		framework.Failf("Failed to start port-forward command: %v", err)
 	}
 
 	buf := make([]byte, 128)
-
-	// After v1.3.0-alpha.4 (#17030), kubectl port-forward outputs port
-	// info to stdout, not stderr, so for version-skewed tests, look there
-	// instead.
-	var portOutput io.ReadCloser
-	if useStdOut, err := framework.KubectlVersionGTE(portForwardPortToStdOutV); err != nil {
-		framework.Failf("Failed to get kubectl version: %v", err)
-	} else if useStdOut {
-		portOutput = stdout
-	} else {
-		portOutput = stderr
-	}
 
 	var n int
 	framework.Logf("reading from `kubectl port-forward` command's stdout")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We don't need to check these versions for kubectl e2e tests in current cycle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref: #55053

**Special notes for your reviewer**:
/cc @liggitt 
since you're also from sig-cli-maintainers :)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
