### PR TITLE
kubeadm: use the CRI for preflights checks

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/phases/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/preflight.go
@@ -22,6 +22,7 @@ import (
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
+	utilsexec "k8s.io/utils/exec"
 )
 
 // NewCmdPreFlight calls cobra.Command for preflight checks
@@ -44,7 +45,8 @@ func NewCmdPreFlightMaster() *cobra.Command {
 		Short: "Run master pre-flight checks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := &kubeadmapi.MasterConfiguration{}
-			return preflight.RunInitMasterChecks(cfg)
+			criSocket := ""
+			return preflight.RunInitMasterChecks(utilsexec.New(), cfg, criSocket)
 		},
 	}
 
@@ -58,7 +60,8 @@ func NewCmdPreFlightNode() *cobra.Command {
 		Short: "Run node pre-flight checks",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg := &kubeadmapi.NodeConfiguration{}
-			return preflight.RunJoinNodeChecks(cfg)
+			criSocket := ""
+			return preflight.RunJoinNodeChecks(utilsexec.New(), cfg, criSocket)
 		},
 	}
 

--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 
@@ -50,6 +51,7 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",
+        "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -26,7 +26,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -54,6 +53,7 @@ import (
 	kubeadmversion "k8s.io/kubernetes/pkg/version"
 	schedulerapp "k8s.io/kubernetes/plugin/cmd/kube-scheduler/app"
 	"k8s.io/kubernetes/test/e2e_node/system"
+	utilsexec "k8s.io/utils/exec"
 )
 
 const (
@@ -81,6 +81,21 @@ func (e *Error) Error() string {
 // successful as often as possilble.
 type Checker interface {
 	Check() (warnings, errors []error)
+}
+
+// CRICheck verifies the container runtime through the CRI.
+type CRICheck struct {
+	socket string
+	exec   utilsexec.Interface
+}
+
+// Check validates the container runtime through the CRI.
+func (criCheck CRICheck) Check() (warnings, errors []error) {
+	if err := criCheck.exec.Command("sh", "-c", fmt.Sprintf("crictl -r %s info", criCheck.socket)).Run(); err != nil {
+		errors = append(errors, fmt.Errorf("unable to check if the container runtime at %q is running: %s", criCheck.socket, err))
+		return warnings, errors
+	}
+	return warnings, errors
 }
 
 // ServiceCheck verifies that the given service is enabled and active. If we do not
@@ -259,11 +274,12 @@ func (fcc FileContentCheck) Check() (warnings, errors []error) {
 type InPathCheck struct {
 	executable string
 	mandatory  bool
+	exec       utilsexec.Interface
 }
 
 // Check validates if the given executable is present in the path.
 func (ipc InPathCheck) Check() (warnings, errors []error) {
-	_, err := exec.LookPath(ipc.executable)
+	_, err := ipc.exec.LookPath(ipc.executable)
 	if err != nil {
 		if ipc.mandatory {
 			// Return as an error:
@@ -418,7 +434,9 @@ func (eac ExtraArgsCheck) Check() (warnings, errors []error) {
 }
 
 // SystemVerificationCheck defines struct used for for running the system verification node check in test/e2e_node/system
-type SystemVerificationCheck struct{}
+type SystemVerificationCheck struct {
+	CRISocket string
+}
 
 // Check runs all individual checks
 func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
@@ -431,8 +449,13 @@ func (sysver SystemVerificationCheck) Check() (warnings, errors []error) {
 	var warns []error
 	// All the common validators we'd like to run:
 	var validators = []system.Validator{
-		&system.KernelValidator{Reporter: reporter},
-		&system.DockerValidator{Reporter: reporter}}
+		&system.KernelValidator{Reporter: reporter}}
+
+	// run the docker validator only with dockershim
+	if sysver.CRISocket == "/var/run/dockershim.sock" {
+		// https://github.com/kubernetes/kubeadm/issues/533
+		validators = append(validators, &system.DockerValidator{Reporter: reporter})
+	}
 
 	if runtime.GOOS == "linux" {
 		//add linux validators
@@ -677,20 +700,24 @@ func getEtcdVersionResponse(client *http.Client, url string, target interface{})
 }
 
 // RunInitMasterChecks executes all individual, applicable to Master node checks.
-func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
+func RunInitMasterChecks(execer utilsexec.Interface, cfg *kubeadmapi.MasterConfiguration, criSocket string) error {
 	// First, check if we're root separately from the other preflight checks and fail fast
 	if err := RunRootCheckOnly(); err != nil {
 		return err
 	}
 
+	// check if we can use crictl to perform checks via the CRI
+	criCtlChecker := InPathCheck{executable: "crictl", mandatory: false, exec: execer}
+	warns, _ := criCtlChecker.Check()
+	useCRI := len(warns) == 0
+
 	checks := []Checker{
 		KubernetesVersionCheck{KubernetesVersion: cfg.KubernetesVersion, KubeadmVersion: kubeadmversion.Get().GitVersion},
-		SystemVerificationCheck{},
+		SystemVerificationCheck{CRISocket: criSocket},
 		IsPrivilegedUserCheck{},
 		HostnameCheck{nodeName: cfg.NodeName},
 		KubeletVersionCheck{},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
-		ServiceCheck{Service: "docker", CheckIfActive: true},
 		FirewalldCheck{ports: []int{int(cfg.API.BindPort), 10250}},
 		PortOpenCheck{port: int(cfg.API.BindPort)},
 		PortOpenCheck{port: 10250},
@@ -699,15 +726,16 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		DirAvailableCheck{Path: filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName)},
 		FileContentCheck{Path: bridgenf, Content: []byte{'1'}},
 		SwapCheck{},
-		InPathCheck{executable: "ip", mandatory: true},
-		InPathCheck{executable: "iptables", mandatory: true},
-		InPathCheck{executable: "mount", mandatory: true},
-		InPathCheck{executable: "nsenter", mandatory: true},
-		InPathCheck{executable: "ebtables", mandatory: false},
-		InPathCheck{executable: "ethtool", mandatory: false},
-		InPathCheck{executable: "socat", mandatory: false},
-		InPathCheck{executable: "tc", mandatory: false},
-		InPathCheck{executable: "touch", mandatory: false},
+		InPathCheck{executable: "ip", mandatory: true, exec: execer},
+		InPathCheck{executable: "iptables", mandatory: true, exec: execer},
+		InPathCheck{executable: "mount", mandatory: true, exec: execer},
+		InPathCheck{executable: "nsenter", mandatory: true, exec: execer},
+		InPathCheck{executable: "ebtables", mandatory: false, exec: execer},
+		InPathCheck{executable: "ethtool", mandatory: false, exec: execer},
+		InPathCheck{executable: "socat", mandatory: false, exec: execer},
+		InPathCheck{executable: "tc", mandatory: false, exec: execer},
+		InPathCheck{executable: "touch", mandatory: false, exec: execer},
+		criCtlChecker,
 		ExtraArgsCheck{
 			APIServerExtraArgs:         cfg.APIServerExtraArgs,
 			ControllerManagerExtraArgs: cfg.ControllerManagerExtraArgs,
@@ -716,6 +744,13 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 		HTTPProxyCheck{Proto: "https", Host: cfg.API.AdvertiseAddress, Port: int(cfg.API.BindPort)},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.ServiceSubnet},
 		HTTPProxyCIDRCheck{Proto: "https", CIDR: cfg.Networking.PodSubnet},
+	}
+
+	if useCRI {
+		checks = append(checks, CRICheck{socket: criSocket, exec: execer})
+	} else {
+		// assume docker
+		checks = append(checks, ServiceCheck{Service: "docker", CheckIfActive: true})
 	}
 
 	if len(cfg.Etcd.Endpoints) == 0 {
@@ -761,38 +796,49 @@ func RunInitMasterChecks(cfg *kubeadmapi.MasterConfiguration) error {
 }
 
 // RunJoinNodeChecks executes all individual, applicable to node checks.
-func RunJoinNodeChecks(cfg *kubeadmapi.NodeConfiguration) error {
+func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.NodeConfiguration, criSocket string) error {
 	// First, check if we're root separately from the other preflight checks and fail fast
 	if err := RunRootCheckOnly(); err != nil {
 		return err
 	}
 
+	// check if we can use crictl to perform checks via the CRI
+	criCtlChecker := InPathCheck{executable: "crictl", mandatory: false, exec: execer}
+	warns, _ := criCtlChecker.Check()
+	useCRI := len(warns) == 0
+
 	checks := []Checker{
-		SystemVerificationCheck{},
+		SystemVerificationCheck{CRISocket: criSocket},
 		IsPrivilegedUserCheck{},
 		HostnameCheck{cfg.NodeName},
 		KubeletVersionCheck{},
 		ServiceCheck{Service: "kubelet", CheckIfActive: false},
-		ServiceCheck{Service: "docker", CheckIfActive: true},
 		PortOpenCheck{port: 10250},
 		DirAvailableCheck{Path: filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.ManifestsSubDirName)},
 		FileAvailableCheck{Path: cfg.CACertPath},
 		FileAvailableCheck{Path: filepath.Join(kubeadmconstants.KubernetesDir, kubeadmconstants.KubeletKubeConfigFileName)},
+	}
+	if useCRI {
+		checks = append(checks, CRICheck{socket: criSocket, exec: execer})
+	} else {
+		// assume docker
+		checks = append(checks, ServiceCheck{Service: "docker", CheckIfActive: true})
 	}
 	//non-windows checks
 	if runtime.GOOS == "linux" {
 		checks = append(checks,
 			FileContentCheck{Path: bridgenf, Content: []byte{'1'}},
 			SwapCheck{},
-			InPathCheck{executable: "ip", mandatory: true},
-			InPathCheck{executable: "iptables", mandatory: true},
-			InPathCheck{executable: "mount", mandatory: true},
-			InPathCheck{executable: "nsenter", mandatory: true},
-			InPathCheck{executable: "ebtables", mandatory: false},
-			InPathCheck{executable: "ethtool", mandatory: false},
-			InPathCheck{executable: "socat", mandatory: false},
-			InPathCheck{executable: "tc", mandatory: false},
-			InPathCheck{executable: "touch", mandatory: false})
+			InPathCheck{executable: "ip", mandatory: true, exec: execer},
+			InPathCheck{executable: "iptables", mandatory: true, exec: execer},
+			InPathCheck{executable: "mount", mandatory: true, exec: execer},
+			InPathCheck{executable: "nsenter", mandatory: true, exec: execer},
+			InPathCheck{executable: "ebtables", mandatory: false, exec: execer},
+			InPathCheck{executable: "ethtool", mandatory: false, exec: execer},
+			InPathCheck{executable: "socat", mandatory: false, exec: execer},
+			InPathCheck{executable: "tc", mandatory: false, exec: execer},
+			InPathCheck{executable: "touch", mandatory: false, exec: execer},
+			criCtlChecker)
 	}
 
 	if len(cfg.DiscoveryTokenAPIServers) > 0 {

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -29,6 +29,7 @@ import (
 	"os"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/utils/exec"
 )
 
 var (
@@ -216,7 +217,7 @@ func TestRunInitMasterChecks(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := RunInitMasterChecks(rt.cfg)
+		actual := RunInitMasterChecks(exec.New(), rt.cfg, "")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed RunInitMasterChecks:\n\texpected: %t\n\t  actual: %t\n\t error: %v",
@@ -252,7 +253,7 @@ func TestRunJoinNodeChecks(t *testing.T) {
 	}
 
 	for _, rt := range tests {
-		actual := RunJoinNodeChecks(rt.cfg)
+		actual := RunJoinNodeChecks(exec.New(), rt.cfg, "")
 		if (actual == nil) != rt.expected {
 			t.Errorf(
 				"failed RunJoinNodeChecks:\n\texpected: %t\n\t  actual: %t",
@@ -279,8 +280,8 @@ func TestRunChecks(t *testing.T) {
 		{[]Checker{FileContentCheck{Path: "/does/not/exist"}}, false, ""},
 		{[]Checker{FileContentCheck{Path: "/"}}, true, ""},
 		{[]Checker{FileContentCheck{Path: "/", Content: []byte("does not exist")}}, false, ""},
-		{[]Checker{InPathCheck{executable: "foobarbaz"}}, true, "[preflight] WARNING: foobarbaz not found in system path\n"},
-		{[]Checker{InPathCheck{executable: "foobarbaz", mandatory: true}}, false, ""},
+		{[]Checker{InPathCheck{executable: "foobarbaz", exec: exec.New()}}, true, "[preflight] WARNING: foobarbaz not found in system path\n"},
+		{[]Checker{InPathCheck{executable: "foobarbaz", mandatory: true, exec: exec.New()}}, false, ""},
 		{[]Checker{ExtraArgsCheck{
 			APIServerExtraArgs:         map[string]string{"secure-port": "1234"},
 			ControllerManagerExtraArgs: map[string]string{"use-service-account-credentials": "true"},


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add preflights checks to be performed using `crictl` and the kubernetes CRI instead of relying on docker.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/285

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubeadm: use the CRI for preflights checks
```

@luxas PTAL