### PR TITLE
Fix StatefulSet API doc

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -69551,11 +69551,11 @@
     "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "rollingUpdate": {
-      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
+      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdate.",
       "$ref": "#/definitions/io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy"
      },
      "type": {
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy.",
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision.",
       "type": "string"
      }
     }
@@ -70493,11 +70493,11 @@
     "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
     "properties": {
      "rollingUpdate": {
-      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
+      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdate.",
       "$ref": "#/definitions/io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy"
      },
      "type": {
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision.",
       "type": "string"
      }
     }

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -6649,11 +6649,11 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy."
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision."
      },
      "rollingUpdate": {
       "$ref": "v1beta1.RollingUpdateStatefulSetStrategy",
-      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
+      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdate."
      }
     }
    },

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -9339,11 +9339,11 @@
     "properties": {
      "type": {
       "type": "string",
-      "description": "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate."
+      "description": "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision."
      },
      "rollingUpdate": {
       "$ref": "v1beta2.RollingUpdateStatefulSetStrategy",
-      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType."
+      "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdate."
      }
     }
    },

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -6867,14 +6867,14 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is <code>RollingUpdate</code>, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet&#8217;s updateRevision. The alternative strategy is <code>OnDelete</code> that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet&#8217;s currentRevision.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rollingUpdate</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RollingUpdate is used to communicate parameters when Type is RollingUpdate.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta1_rollingupdatestatefulsetstrategy">v1beta1.RollingUpdateStatefulSetStrategy</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -7623,14 +7623,14 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">type</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is <code>RollingUpdate</code>, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet&#8217;s updateRevision. The alternative strategy is <code>OnDelete</code> that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet&#8217;s currentRevision.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">rollingUpdate</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">RollingUpdate is used to communicate parameters when Type is RollingUpdate.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1beta2_rollingupdatestatefulsetstrategy">v1beta2.RollingUpdateStatefulSetStrategy</a></p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/pkg/apis/apps/types.go
+++ b/pkg/apis/apps/types.go
@@ -68,8 +68,17 @@ const (
 // necessary to perform the update for the indicated strategy.
 type StatefulSetUpdateStrategy struct {
 	// Type indicates the type of the StatefulSetUpdateStrategy.
+	// The default strategy is `RollingUpdate`, where an update will be
+	// applied to all Pods by following the StatefulSet ordering constraints.
+	// When the StatefulSet is scaled, new Pods are created from the
+	// specification version indicated by the StatefulSet's updateRevision.
+	// The alternative strategy is `OnDelete` that triggers the legacy
+	// behavior. Pods are recreated when they are manually deleted. When a
+	// scale operation is performed, new Pods are created from the
+	// specification version indicated by the StatefulSet's currentRevision.
+	// +optional
 	Type StatefulSetUpdateStrategyType
-	// RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+	// RollingUpdate is used to communicate parameters when Type is RollingUpdate.
 	RollingUpdate *RollingUpdateStatefulSetStrategy
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta1/generated.proto
@@ -476,9 +476,18 @@ message StatefulSetStatus {
 // necessary to perform the update for the indicated strategy.
 message StatefulSetUpdateStrategy {
   // Type indicates the type of the StatefulSetUpdateStrategy.
+  // The default strategy is `RollingUpdate`, where an update will be
+  // applied to all Pods by following the StatefulSet ordering constraints.
+  // When the StatefulSet is scaled, new Pods are created from the
+  // specification version indicated by the StatefulSet's updateRevision.
+  // The alternative strategy is `OnDelete` that triggers the legacy
+  // behavior. Pods are recreated when they are manually deleted. When a
+  // scale operation is performed, new Pods are created from the
+  // specification version indicated by the StatefulSet's currentRevision.
+  // +optional
   optional string type = 1;
 
-  // RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+  // RollingUpdate is used to communicate parameters when Type is RollingUpdate.
   optional RollingUpdateStatefulSetStrategy rollingUpdate = 2;
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -120,8 +120,17 @@ const (
 // necessary to perform the update for the indicated strategy.
 type StatefulSetUpdateStrategy struct {
 	// Type indicates the type of the StatefulSetUpdateStrategy.
+	// The default strategy is `RollingUpdate`, where an update will be
+	// applied to all Pods by following the StatefulSet ordering constraints.
+	// When the StatefulSet is scaled, new Pods are created from the
+	// specification version indicated by the StatefulSet's updateRevision.
+	// The alternative strategy is `OnDelete` that triggers the legacy
+	// behavior. Pods are recreated when they are manually deleted. When a
+	// scale operation is performed, new Pods are created from the
+	// specification version indicated by the StatefulSet's currentRevision.
+	// +optional
 	Type StatefulSetUpdateStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=StatefulSetStrategyType"`
-	// RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+	// RollingUpdate is used to communicate parameters when Type is RollingUpdate.
 	RollingUpdate *RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty" protobuf:"bytes,2,opt,name=rollingUpdate"`
 }
 

--- a/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types_swagger_doc_generated.go
@@ -262,8 +262,8 @@ func (StatefulSetStatus) SwaggerDoc() map[string]string {
 
 var map_StatefulSetUpdateStrategy = map[string]string{
 	"":              "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
-	"type":          "Type indicates the type of the StatefulSetUpdateStrategy.",
-	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
+	"type":          "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision.",
+	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdate.",
 }
 
 func (StatefulSetUpdateStrategy) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/apps/v1beta2/generated.proto
+++ b/staging/src/k8s.io/api/apps/v1beta2/generated.proto
@@ -734,11 +734,18 @@ message StatefulSetStatus {
 // necessary to perform the update for the indicated strategy.
 message StatefulSetUpdateStrategy {
   // Type indicates the type of the StatefulSetUpdateStrategy.
-  // Default is RollingUpdate.
+  // The default strategy is `RollingUpdate`, where an update will be
+  // applied to all Pods by following the StatefulSet ordering constraints.
+  // When the StatefulSet is scaled, new Pods are created from the
+  // specification version indicated by the StatefulSet's updateRevision.
+  // The alternative strategy is `OnDelete` that triggers the legacy
+  // behavior. Pods are recreated when they are manually deleted. When a
+  // scale operation is performed, new Pods are created from the
+  // specification version indicated by the StatefulSet's currentRevision.
   // +optional
   optional string type = 1;
 
-  // RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+  // RollingUpdate is used to communicate parameters when Type is RollingUpdate.
   // +optional
   optional RollingUpdateStatefulSetStrategy rollingUpdate = 2;
 }

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -122,10 +122,17 @@ const (
 // necessary to perform the update for the indicated strategy.
 type StatefulSetUpdateStrategy struct {
 	// Type indicates the type of the StatefulSetUpdateStrategy.
-	// Default is RollingUpdate.
+	// The default strategy is `RollingUpdate`, where an update will be
+	// applied to all Pods by following the StatefulSet ordering constraints.
+	// When the StatefulSet is scaled, new Pods are created from the
+	// specification version indicated by the StatefulSet's updateRevision.
+	// The alternative strategy is `OnDelete` that triggers the legacy
+	// behavior. Pods are recreated when they are manually deleted. When a
+	// scale operation is performed, new Pods are created from the
+	// specification version indicated by the StatefulSet's currentRevision.
 	// +optional
 	Type StatefulSetUpdateStrategyType `json:"type,omitempty" protobuf:"bytes,1,opt,name=type,casttype=StatefulSetStrategyType"`
-	// RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.
+	// RollingUpdate is used to communicate parameters when Type is RollingUpdate.
 	// +optional
 	RollingUpdate *RollingUpdateStatefulSetStrategy `json:"rollingUpdate,omitempty" protobuf:"bytes,2,opt,name=rollingUpdate"`
 }

--- a/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types_swagger_doc_generated.go
@@ -385,8 +385,8 @@ func (StatefulSetStatus) SwaggerDoc() map[string]string {
 
 var map_StatefulSetUpdateStrategy = map[string]string{
 	"":              "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
-	"type":          "Type indicates the type of the StatefulSetUpdateStrategy. Default is RollingUpdate.",
-	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
+	"type":          "Type indicates the type of the StatefulSetUpdateStrategy. The default strategy is `RollingUpdate`, where an update will be applied to all Pods by following the StatefulSet ordering constraints. When the StatefulSet is scaled, new Pods are created from the specification version indicated by the StatefulSet's updateRevision. The alternative strategy is `OnDelete` that triggers the legacy behavior. Pods are recreated when they are manually deleted. When a scale operation is performed, new Pods are created from the specification version indicated by the StatefulSet's currentRevision.",
+	"rollingUpdate": "RollingUpdate is used to communicate parameters when Type is RollingUpdate.",
 }
 
 func (StatefulSetUpdateStrategy) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the API documentation generated for `updateStrategy` of StatefulSet.
The current documentation failed to describe available choices. It only mentioned the default value.
  
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
