### PR TITLE
components only display its relevant feature flags

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 
 	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/features"
 
 	"github.com/spf13/pflag"
 )
@@ -100,5 +100,5 @@ func (s *CloudControllerManagerServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.ConcurrentServiceSyncs, "concurrent-service-syncs", s.ConcurrentServiceSyncs, "The number of services that are allowed to sync concurrently. Larger number = more responsive service management, but more CPU (and network) load")
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 
-	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	utilfeature.DefaultFeatureGate.AddFlag(fs, features.CloudControllerManager)
 }

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/master/ports"
 
 	// add the kubernetes feature gates
-	_ "k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/features"
 
 	"github.com/cloudflare/cfssl/helpers"
 	"github.com/spf13/pflag"
@@ -223,7 +223,7 @@ func (s *CMServer) AddFlags(fs *pflag.FlagSet, allControllers []string, disabled
 
 	leaderelectionconfig.BindFlags(&s.LeaderElection, fs)
 
-	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	utilfeature.DefaultFeatureGate.AddFlag(fs, features.KubeControllerManager)
 }
 
 // Validate is used to validate the options and config before launching the controller manager

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -49,6 +49,7 @@ import (
 	api "k8s.io/kubernetes/pkg/apis/core"
 	clientset "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
+	"k8s.io/kubernetes/pkg/features"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 	"k8s.io/kubernetes/pkg/master/ports"
@@ -163,7 +164,7 @@ func AddFlags(options *Options, fs *pflag.FlagSet) {
 		"NAT timeout for TCP connections in the CLOSE_WAIT state")
 	fs.BoolVar(&options.config.EnableProfiling, "profiling", options.config.EnableProfiling, "If true enables profiling via web interface on /debug/pprof handler.")
 	fs.StringVar(&options.config.IPVS.Scheduler, "ipvs-scheduler", options.config.IPVS.Scheduler, "The ipvs scheduler type when proxy mode is ipvs")
-	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	utilfeature.DefaultFeatureGate.AddFlag(fs, features.KubeProxy)
 }
 
 func NewOptions() *Options {

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -402,7 +402,7 @@ func AddKubeletConfigFlags(fs *pflag.FlagSet, c *kubeletconfig.KubeletConfigurat
 	fs.DurationVar(&c.VolumeStatsAggPeriod.Duration, "volume-stats-agg-period", c.VolumeStatsAggPeriod.Duration, "Specifies interval for kubelet to calculate and cache the volume disk usage for all pods and volumes.  To disable volume calculations, set to 0.")
 	fs.StringVar(&c.VolumePluginDir, "volume-plugin-dir", c.VolumePluginDir, "<Warning: Alpha feature> The full path of the directory in which to search for additional third party volume plugins")
 	fs.Var(flag.MapStringBool(c.FeatureGates), "feature-gates", "A set of key=value pairs that describe feature gates for alpha/experimental features. "+
-		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(), "\n"))
+		"Options are:\n"+strings.Join(utilfeature.DefaultFeatureGate.KnownFeatures(features.Kubelet), "\n"))
 	fs.StringVar(&c.KubeletCgroups, "kubelet-cgroups", c.KubeletCgroups, "Optional absolute name of cgroups to create and run the Kubelet in.")
 	fs.StringVar(&c.SystemCgroups, "system-cgroups", c.SystemCgroups, "Optional absolute name of cgroups in which to place all non-kernel processes that are not already inside a cgroup under `/`. Empty for no container. Rolling back the flag requires a reboot.")
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -175,50 +175,60 @@ const (
 	//
 	// Enable running mount utilities in containers.
 	MountContainers utilfeature.Feature = "MountContainers"
+
+	// All components that requires feature gate should be listed here to prevent
+	// accidental naming mismatches
+	KubeAPIServer          utilfeature.Component = "kube-apiserver"
+	KubeControllerManager  utilfeature.Component = "kube-controller-manager"
+	KubeScheduler          utilfeature.Component = "kube-scheduler"
+	KubeProxy              utilfeature.Component = "kube-proxy"
+	Kubelet                utilfeature.Component = "kubelet"
+	CloudControllerManager utilfeature.Component = "cloud-controller-manager"
 )
 
 func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	utilfeature.MustAddDefault(defaultKubernetesFeatureGates)
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
-// To add a new feature, define a key for it above and add it here. The features will be
-// available throughout Kubernetes binaries.
+// To add a new feature, define a key for it above and add it here, sorted alphabetically.
+// The features will be available throughout Kubernetes binaries, but will only be shown
+// in flag help text for its components.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	ExternalTrafficLocalOnly:                    {Default: true, PreRelease: utilfeature.GA},
-	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
-	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},
-	KubeletConfigFile:                           {Default: false, PreRelease: utilfeature.Alpha},
-	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta},
-	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha},
-	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha},
-	DevicePlugins:                               {Default: false, PreRelease: utilfeature.Alpha},
-	TaintBasedEvictions:                         {Default: false, PreRelease: utilfeature.Alpha},
-	RotateKubeletServerCertificate:              {Default: false, PreRelease: utilfeature.Alpha},
-	RotateKubeletClientCertificate:              {Default: true, PreRelease: utilfeature.Beta},
-	PersistentLocalVolumes:                      {Default: false, PreRelease: utilfeature.Alpha},
-	LocalStorageCapacityIsolation:               {Default: false, PreRelease: utilfeature.Alpha},
-	HugePages:                                   {Default: false, PreRelease: utilfeature.Alpha},
-	DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
-	PodPriority:                                 {Default: false, PreRelease: utilfeature.Alpha},
-	EnableEquivalenceClassCache:                 {Default: false, PreRelease: utilfeature.Alpha},
-	TaintNodesByCondition:                       {Default: false, PreRelease: utilfeature.Alpha},
-	MountPropagation:                            {Default: false, PreRelease: utilfeature.Alpha},
-	ExpandPersistentVolumes:                     {Default: false, PreRelease: utilfeature.Alpha},
-	CPUManager:                                  {Default: false, PreRelease: utilfeature.Alpha},
-	ServiceNodeExclusion:                        {Default: false, PreRelease: utilfeature.Alpha},
-	MountContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
+	Accelerators:                                {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet}},
+	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	CPUManager:                                  {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	DevicePlugins:                               {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet}},
+	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	EnableEquivalenceClassCache:                 {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeScheduler}},
+	ExpandPersistentVolumes:                     {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeControllerManager, KubeAPIServer}},
+	ExperimentalCriticalPodAnnotation:           {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeControllerManager}},
+	ExperimentalHostUserNamespaceDefaultingGate: {Default: false, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{Kubelet}},
+	ExternalTrafficLocalOnly:                    {Default: true, PreRelease: utilfeature.GA, Components: []utilfeature.Component{KubeProxy, KubeAPIServer}},
+	HugePages:                                   {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	KubeletConfigFile:                           {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet}},
+	LocalStorageCapacityIsolation:               {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	MountContainers:                             {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet}},
+	MountPropagation:                            {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeAPIServer}},
+	PersistentLocalVolumes:                      {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeScheduler, KubeAPIServer}},
+	PodPriority:                                 {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeScheduler, KubeAPIServer}},
+	RotateKubeletClientCertificate:              {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{Kubelet}},
+	RotateKubeletServerCertificate:              {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{Kubelet, KubeControllerManager, KubeAPIServer}},
+	ServiceNodeExclusion:                        {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeControllerManager, CloudControllerManager}},
+	SupportIPVSProxyMode:                        {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeProxy}},
+	TaintBasedEvictions:                         {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeControllerManager}},
+	TaintNodesByCondition:                       {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeControllerManager, KubeScheduler, KubeAPIServer}},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
-	genericfeatures.APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
-	genericfeatures.Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
-	genericfeatures.APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	genericfeatures.APIListChunking:         {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
+	genericfeatures.APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer}},
+	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
+	genericfeatures.Initializers:            {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer, KubeControllerManager}},
+	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	apiextensionsfeatures.CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha},
-	SupportIPVSProxyMode:                           {Default: false, PreRelease: utilfeature.Alpha},
+	apiextensionsfeatures.CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer}},
 }

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -133,7 +133,7 @@ func AddFlags(options *Options, fs *pflag.FlagSet) {
 	fs.StringVar(&options.config.FailureDomains, "failure-domains", options.config.FailureDomains, "Indicate the \"all topologies\" set for an empty topologyKey when it's used for PreferredDuringScheduling pod anti-affinity.")
 	fs.MarkDeprecated("failure-domains", "Doesn't have any effect. Will be removed in future version.")
 	leaderelectionconfig.BindFlags(&options.config.LeaderElection.LeaderElectionConfiguration, fs)
-	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	utilfeature.DefaultFeatureGate.AddFlag(fs, features.KubeScheduler)
 }
 
 func NewOptions() (*Options, error) {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/features/kube_features.go
@@ -32,15 +32,18 @@ const (
 	//
 	// CustomResourceValidation is a list of validation methods for CustomResources
 	CustomResourceValidation utilfeature.Feature = "CustomResourceValidation"
+
+	KubeAPIServer utilfeature.Component = "kube-apiserver"
 )
 
 func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	utilfeature.MustAddDefault(defaultKubernetesFeatureGates)
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
-// To add a new feature, define a key for it above and add it here. The features will be
-// available throughout Kubernetes binaries.
+// To add a new feature, define a key for it above and add it here, sorted alphabetically.
+// The features will be available throughout Kubernetes binaries, but will only be shown
+// in flag help text for its components.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha},
+	CustomResourceValidation: {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer}},
 }

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -63,19 +63,23 @@ const (
 	// Allow API clients to retrieve resource lists in chunks rather than
 	// all at once.
 	APIListChunking utilfeature.Feature = "APIListChunking"
+
+	KubeAPIServer         utilfeature.Component = "kube-apiserver"
+	KubeControllerManager utilfeature.Component = "kube-controller-manager"
 )
 
 func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	utilfeature.MustAddDefault(defaultKubernetesFeatureGates)
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
-// To add a new feature, define a key for it above and add it here. The features will be
-// available throughout Kubernetes binaries.
+// To add a new feature, define a key for it above and add it here, sorted alphabetically.
+// The features will be available throughout Kubernetes binaries, but will only be shown
+// in flag help text for its components.
 var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
-	StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta},
-	AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta},
-	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha},
-	Initializers:            {Default: false, PreRelease: utilfeature.Alpha},
-	APIListChunking:         {Default: true, PreRelease: utilfeature.Beta},
+	APIListChunking:         {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
+	APIResponseCompression:  {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer}},
+	AdvancedAuditing:        {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
+	Initializers:            {Default: false, PreRelease: utilfeature.Alpha, Components: []utilfeature.Component{KubeAPIServer, KubeControllerManager}},
+	StreamingProxyRedirects: {Default: true, PreRelease: utilfeature.Beta, Components: []utilfeature.Component{KubeAPIServer}},
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -27,7 +27,7 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 
 	// add the generic feature gates
-	_ "k8s.io/apiserver/pkg/features"
+	"k8s.io/apiserver/pkg/features"
 
 	"github.com/spf13/pflag"
 )
@@ -150,5 +150,5 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 		"handler, which picks a randomized value above this number as the connection timeout, "+
 		"to spread out load.")
 
-	utilfeature.DefaultFeatureGate.AddFlag(fs)
+	utilfeature.DefaultFeatureGate.AddFlag(fs, features.KubeAPIServer)
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/feature/feature_gate_test.go
@@ -18,11 +18,100 @@ package feature
 
 import (
 	"fmt"
+	"sort"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/spf13/pflag"
 )
+
+func TestFeatureGateKnownFeatures(t *testing.T) {
+	knownValue := &atomic.Value{}
+	knownValue.Store(map[Feature]FeatureSpec{})
+
+	enabled := map[Feature]bool{}
+	enabledValue := &atomic.Value{}
+	enabledValue.Store(enabled)
+
+	f := &featureGate{known: knownValue, enabled: enabledValue}
+	var (
+		test1 Feature = "test1"
+		test2 Feature = "test2"
+		test3 Feature = "test3"
+
+		hello Component = "hello"
+		world Component = "world"
+	)
+	if err := f.Add(map[Feature]FeatureSpec{
+		// test1 only available for component hello, world
+		test1: {Components: []Component{"hello", "world"}},
+		// test2 only available for component hello
+		test2: {Components: []Component{"hello"}},
+		// test3 available for all components
+		test3: {},
+	}); err != nil {
+		t.Errorf("failed to add feature: %v", err)
+	}
+	known := f.KnownFeatures(hello)
+	sort.Strings(known)
+	if len(known) != 3 ||
+		!strings.HasPrefix(known[0], "test1") ||
+		!strings.HasPrefix(known[1], "test2") ||
+		!strings.HasPrefix(known[2], "test3") {
+		t.Errorf("unexpected features %#v", known)
+	}
+	known = f.KnownFeatures(world)
+	sort.Strings(known)
+	if len(known) != 2 ||
+		!strings.HasPrefix(known[0], "test1") ||
+		!strings.HasPrefix(known[1], "test3") {
+		t.Errorf("unexpected features %#v", known)
+	}
+	known = f.KnownFeatures("")
+	sort.Strings(known)
+	if len(known) != 1 || !strings.HasPrefix(known[0], "test3") {
+		t.Errorf("unexpected features %#v", known)
+	}
+}
+
+func TestFeatureSpecEquals(t *testing.T) {
+	for _, test := range []struct {
+		a        FeatureSpec
+		b        FeatureSpec
+		expected bool
+	}{
+		{
+			a:        FeatureSpec{Default: false, PreRelease: Alpha},
+			b:        FeatureSpec{Default: false, PreRelease: Alpha},
+			expected: true,
+		},
+		{
+			a:        FeatureSpec{Default: false, PreRelease: Alpha},
+			b:        FeatureSpec{Default: true, PreRelease: Alpha},
+			expected: false,
+		},
+		{
+			a:        FeatureSpec{Default: false, PreRelease: Alpha},
+			b:        FeatureSpec{Default: false, PreRelease: Beta},
+			expected: false,
+		},
+		{
+			a:        FeatureSpec{Default: false, PreRelease: Alpha},
+			b:        FeatureSpec{Default: false, PreRelease: Alpha, Components: []Component{"test"}},
+			expected: false,
+		},
+		{
+			a:        FeatureSpec{Default: false, PreRelease: Alpha, Components: []Component{"hello", "world"}},
+			b:        FeatureSpec{Default: false, PreRelease: Alpha, Components: []Component{"world", "hello"}},
+			expected: true,
+		},
+	} {
+		if test.a.Equals(test.b) != test.expected {
+			t.Errorf("comparison of %v == %v failed, expect %v", test.a, test.b, test.expected)
+		}
+	}
+}
 
 func TestFeatureGateFlag(t *testing.T) {
 	// gates for testing
@@ -124,7 +213,7 @@ func TestFeatureGateFlag(t *testing.T) {
 			testAlphaGate: {Default: false, PreRelease: Alpha},
 			testBetaGate:  {Default: false, PreRelease: Beta},
 		})
-		f.AddFlag(fs)
+		f.AddFlag(fs, "")
 
 		err := fs.Parse([]string{fmt.Sprintf("--%s=%s", flagName, test.arg)})
 		if test.parseError != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently kubernetes components display all features in `--help` text even if the
features do not apply to a specific component. This change adds
`Components` to `FeatureSpec` and use that to manipulate the `--help`
text to display only relevant feature flag to a component.

For example, kubelet features gate before:

```
--feature-gates mapStringBool                              A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
APIListChunking=true|false (BETA - default=true)
APIResponseCompression=true|false (ALPHA - default=false)
Accelerators=true|false (ALPHA - default=false)
AdvancedAuditing=true|false (BETA - default=true)
AllAlpha=true|false (ALPHA - default=false)
AllowExtTrafficLocalEndpoints=true|false (default=true)
AppArmor=true|false (BETA - default=true)
CPUManager=true|false (ALPHA - default=false)
CustomResourceValidation=true|false (ALPHA - default=false)
DebugContainers=true|false (ALPHA - default=false)
DevicePlugins=true|false (ALPHA - default=false)
DynamicKubeletConfig=true|false (ALPHA - default=false)
EnableEquivalenceClassCache=true|false (ALPHA - default=false)
ExpandPersistentVolumes=true|false (ALPHA - default=false)
ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)
ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)
HugePages=true|false (ALPHA - default=false)
Initializers=true|false (ALPHA - default=false)
KubeletConfigFile=true|false (ALPHA - default=false)
LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
MountPropagation=true|false (ALPHA - default=false)
PersistentLocalVolumes=true|false (ALPHA - default=false)
PodPriority=true|false (ALPHA - default=false)
RotateKubeletClientCertificate=true|false (BETA - default=true)
RotateKubeletServerCertificate=true|false (ALPHA - default=false)
ServiceNodeExclusion=true|false (ALPHA - default=false)
StreamingProxyRedirects=true|false (BETA - default=true)
SupportIPVSProxyMode=true|false (ALPHA - default=false)
TaintBasedEvictions=true|false (ALPHA - default=false)
TaintNodesByCondition=true|false (ALPHA - default=false)
```

kubelet features gate after this change:

```
--feature-gates mapStringBool                               A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
Accelerators=true|false (ALPHA - default=false)
AppArmor=true|false (BETA - default=true)
CPUManager=true|false (ALPHA - default=false)
DevicePlugins=true|false (ALPHA - default=false)
DynamicKubeletConfig=true|false (ALPHA - default=false)
ExperimentalCriticalPodAnnotation=true|false (ALPHA - default=false)
ExperimentalHostUserNamespaceDefaulting=true|false (BETA - default=false)
HugePages=true|false (ALPHA - default=false)
KubeletConfigFile=true|false (ALPHA - default=false)
LocalStorageCapacityIsolation=true|false (ALPHA - default=false)
MountPropagation=true|false (ALPHA - default=false)
PersistentLocalVolumes=true|false (ALPHA - default=false)
PodPriority=true|false (ALPHA - default=false)
RotateKubeletClientCertificate=true|false (BETA - default=true)
RotateKubeletServerCertificate=true|false (ALPHA - default=false)
```

Since this only changes `--help` text, any previous usage of invalid feature gate for a component
will still be accepted.

**Which issue(s) this PR fixes***:
Fix #46822

**Special notes for your reviewer**:
List of components for each features was derived manually from function usages, package imports etc. Its very much possible that they can be wrong.

cc @luxas @liggitt @xiangpengzhao 