### PR TITLE
Extends deviceplugin to gracefully handle full device plugin lifecycle.

### DIFF
--- a/pkg/kubelet/cm/BUILD
+++ b/pkg/kubelet/cm/BUILD
@@ -34,6 +34,7 @@ go_library(
         "//pkg/kubelet/apis/cri:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/cm/cpumanager:go_default_library",
+        "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/eviction/api:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",

--- a/pkg/kubelet/cm/container_manager.go
+++ b/pkg/kubelet/cm/container_manager.go
@@ -23,6 +23,7 @@ import (
 	// TODO: Migrate kubelet to either use its own internal objects or client library.
 	"k8s.io/api/core/v1"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	evictionapi "k8s.io/kubernetes/pkg/kubelet/eviction/api"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
@@ -41,7 +42,7 @@ type ContainerManager interface {
 	// Runs the container manager's housekeeping.
 	// - Ensures that the Docker daemon is in a container.
 	// - Creates the system container where all non-containerized processes run.
-	Start(*v1.Node, ActivePodsFunc, status.PodStatusProvider, internalapi.RuntimeService) error
+	Start(*v1.Node, ActivePodsFunc, config.SourcesReady, status.PodStatusProvider, internalapi.RuntimeService) error
 
 	// SystemCgroupsLimit returns resources allocated to system cgroups in the machine.
 	// These cgroups include the system and Kubernetes services.
@@ -68,6 +69,10 @@ type ContainerManager interface {
 
 	// GetCapacity returns the amount of compute resources tracked by container manager available on the node.
 	GetCapacity() v1.ResourceList
+
+	// GetDevicePluginResourceCapacity returns the amount of device plugin resources available on the node
+	// and inactive device plugin resources previously registered on the node.
+	GetDevicePluginResourceCapacity() (v1.ResourceList, []string)
 
 	// UpdateQOSCgroups performs housekeeping updates to ensure that the top
 	// level QoS containers have their desired state in a thread-safe way

--- a/pkg/kubelet/cm/container_manager_stub.go
+++ b/pkg/kubelet/cm/container_manager_stub.go
@@ -22,6 +22,7 @@ import (
 
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -32,7 +33,7 @@ type containerManagerStub struct{}
 
 var _ ContainerManager = &containerManagerStub{}
 
-func (cm *containerManagerStub) Start(_ *v1.Node, _ ActivePodsFunc, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
+func (cm *containerManagerStub) Start(_ *v1.Node, _ ActivePodsFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
 	glog.V(2).Infof("Starting stub container manager")
 	return nil
 }
@@ -67,6 +68,10 @@ func (cm *containerManagerStub) GetNodeAllocatableReservation() v1.ResourceList 
 
 func (cm *containerManagerStub) GetCapacity() v1.ResourceList {
 	return nil
+}
+
+func (cm *containerManagerStub) GetDevicePluginResourceCapacity() (v1.ResourceList, []string) {
+	return nil, []string{}
 }
 
 func (cm *containerManagerStub) NewPodContainerManager() PodContainerManager {

--- a/pkg/kubelet/cm/container_manager_unsupported.go
+++ b/pkg/kubelet/cm/container_manager_unsupported.go
@@ -26,6 +26,7 @@ import (
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/pkg/kubelet/status"
@@ -38,7 +39,7 @@ type unsupportedContainerManager struct {
 
 var _ ContainerManager = &unsupportedContainerManager{}
 
-func (unsupportedContainerManager) Start(_ *v1.Node, _ ActivePodsFunc, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
+func (unsupportedContainerManager) Start(_ *v1.Node, _ ActivePodsFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
 	return fmt.Errorf("Container Manager is unsupported in this build")
 }
 
@@ -72,6 +73,10 @@ func (cm *unsupportedContainerManager) GetNodeAllocatableReservation() v1.Resour
 
 func (cm *unsupportedContainerManager) GetCapacity() v1.ResourceList {
 	return nil
+}
+
+func (cm *unsupportedContainerManager) GetDevicePluginResourceCapacity() (v1.ResourceList, []string) {
+	return nil, []string{}
 }
 
 func (cm *unsupportedContainerManager) NewPodContainerManager() PodContainerManager {

--- a/pkg/kubelet/cm/container_manager_windows.go
+++ b/pkg/kubelet/cm/container_manager_windows.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	internalapi "k8s.io/kubernetes/pkg/kubelet/apis/cri"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	"k8s.io/kubernetes/pkg/util/mount"
 )
@@ -35,7 +36,7 @@ type containerManagerImpl struct {
 
 var _ ContainerManager = &containerManagerImpl{}
 
-func (cm *containerManagerImpl) Start(_ *v1.Node, _ ActivePodsFunc, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
+func (cm *containerManagerImpl) Start(_ *v1.Node, _ ActivePodsFunc, _ config.SourcesReady, _ status.PodStatusProvider, _ internalapi.RuntimeService) error {
 	glog.V(2).Infof("Starting Windows stub container manager")
 	return nil
 }

--- a/pkg/kubelet/cm/deviceplugin/BUILD
+++ b/pkg/kubelet/cm/deviceplugin/BUILD
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/kubelet/apis/deviceplugin/v1alpha:go_default_library",
+        "//pkg/kubelet/config:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/lifecycle:go_default_library",
         "//plugin/pkg/scheduler/schedulercache:go_default_library",

--- a/pkg/kubelet/cm/deviceplugin/manager.go
+++ b/pkg/kubelet/cm/deviceplugin/manager.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
@@ -61,6 +62,10 @@ type ManagerImpl struct {
 	// could be counted when updating allocated devices
 	activePods ActivePodsFunc
 
+	// sourcesReady provides the readiness of kubelet configuration sources such as apiserver update readiness.
+	// We use it to determine when we can purge inactive pods from checkpointed state.
+	sourcesReady config.SourcesReady
+
 	// callback is used for updating devices' states in one time call.
 	// e.g. a new device is advertised, two old devices are deleted and a running device fails.
 	callback monitorCallback
@@ -75,13 +80,17 @@ type ManagerImpl struct {
 	podDevices podDevices
 }
 
-// NewManagerImpl creates a new manager. updateCapacityFunc is called to
-// update ContainerManager capacity when device capacity changes.
-func NewManagerImpl(updateCapacityFunc func(v1.ResourceList)) (*ManagerImpl, error) {
-	return newManagerImpl(updateCapacityFunc, pluginapi.KubeletSocket)
+type sourcesReadyStub struct{}
+
+func (s *sourcesReadyStub) AddSource(source string) {}
+func (s *sourcesReadyStub) AllReady() bool          { return true }
+
+// NewManagerImpl creates a new manager.
+func NewManagerImpl() (*ManagerImpl, error) {
+	return newManagerImpl(pluginapi.KubeletSocket)
 }
 
-func newManagerImpl(updateCapacityFunc func(v1.ResourceList), socketPath string) (*ManagerImpl, error) {
+func newManagerImpl(socketPath string) (*ManagerImpl, error) {
 	glog.V(2).Infof("Creating Device Plugin manager at %s", socketPath)
 
 	if socketPath == "" || !filepath.IsAbs(socketPath) {
@@ -97,34 +106,36 @@ func newManagerImpl(updateCapacityFunc func(v1.ResourceList), socketPath string)
 		allocatedDevices: make(map[string]sets.String),
 		podDevices:       make(podDevices),
 	}
+	manager.callback = manager.genericDeviceUpdateCallback
 
-	manager.callback = func(resourceName string, added, updated, deleted []pluginapi.Device) {
-		var capacity = v1.ResourceList{}
-		kept := append(updated, added...)
-
-		manager.mutex.Lock()
-		defer manager.mutex.Unlock()
-
-		if _, ok := manager.allDevices[resourceName]; !ok {
-			manager.allDevices[resourceName] = sets.NewString()
-		}
-		// For now, Manager only keeps track of healthy devices.
-		// We can revisit this later when the need comes to track unhealthy devices here.
-		for _, dev := range kept {
-			if dev.Health == pluginapi.Healthy {
-				manager.allDevices[resourceName].Insert(dev.ID)
-			} else {
-				manager.allDevices[resourceName].Delete(dev.ID)
-			}
-		}
-		for _, dev := range deleted {
-			manager.allDevices[resourceName].Delete(dev.ID)
-		}
-		capacity[v1.ResourceName(resourceName)] = *resource.NewQuantity(int64(manager.allDevices[resourceName].Len()), resource.DecimalSI)
-		updateCapacityFunc(capacity)
-	}
+	// The following structs are populated with real implementations in manager.Start()
+	// Before that, initializes them to perform no-op operations.
+	manager.activePods = func() []*v1.Pod { return []*v1.Pod{} }
+	manager.sourcesReady = &sourcesReadyStub{}
 
 	return manager, nil
+}
+
+func (m *ManagerImpl) genericDeviceUpdateCallback(resourceName string, added, updated, deleted []pluginapi.Device) {
+	kept := append(updated, added...)
+	m.mutex.Lock()
+	if _, ok := m.allDevices[resourceName]; !ok {
+		m.allDevices[resourceName] = sets.NewString()
+	}
+	// For now, Manager only keeps track of healthy devices.
+	// TODO: adds support to track unhealthy devices.
+	for _, dev := range kept {
+		if dev.Health == pluginapi.Healthy {
+			m.allDevices[resourceName].Insert(dev.ID)
+		} else {
+			m.allDevices[resourceName].Delete(dev.ID)
+		}
+	}
+	for _, dev := range deleted {
+		m.allDevices[resourceName].Delete(dev.ID)
+	}
+	m.mutex.Unlock()
+	m.writeCheckpoint()
 }
 
 func (m *ManagerImpl) removeContents(dir string) error {
@@ -171,10 +182,11 @@ func (m *ManagerImpl) checkpointFile() string {
 // Start starts the Device Plugin Manager amd start initialization of
 // podDevices and allocatedDevices information from checkpoint-ed state and
 // starts device plugin registration service.
-func (m *ManagerImpl) Start(activePods ActivePodsFunc) error {
+func (m *ManagerImpl) Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady) error {
 	glog.V(2).Infof("Starting Device Plugin manager")
 
 	m.activePods = activePods
+	m.sourcesReady = sourcesReady
 
 	// Loads in allocatedDevices information from disk.
 	err := m.readCheckpoint()
@@ -237,6 +249,9 @@ func (m *ManagerImpl) Allocate(node *schedulercache.NodeInfo, attrs *lifecycle.P
 			return err
 		}
 	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
 
 	// quick return if no pluginResources requested
 	if _, podRequireDevicePluginResource := m.podDevices[string(pod.UID)]; !podRequireDevicePluginResource {
@@ -334,8 +349,6 @@ func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
 		if old, ok := m.endpoints[r.ResourceName]; ok && old == e {
 			glog.V(2).Infof("Delete resource for endpoint %v", e)
 			delete(m.endpoints, r.ResourceName)
-			// Issues callback to delete all of devices.
-			e.callback(e.resourceName, []pluginapi.Device{}, []pluginapi.Device{}, e.getDevices())
 		}
 
 		glog.V(2).Infof("Unregistered endpoint %v", e)
@@ -343,10 +356,56 @@ func (m *ManagerImpl) addEndpoint(r *pluginapi.RegisterRequest) {
 	}()
 }
 
+// GetCapacity is expected to be called when Kubelet updates its node status.
+// The first returned variable contains the registered device plugin resource capacity.
+// The second returned variable contains previously registered resources that are no longer active.
+// Kubelet uses this information to update resource capacity/allocatable in its node status.
+// After the call, device plugin can remove the inactive resources from its internal list as the
+// change is already reflected in Kubelet node status.
+// Note in the special case after Kubelet restarts, device plugin resource capacities can
+// temporarily drop to zero till corresponding device plugins re-register. This is OK because
+// cm.UpdatePluginResource() run during predicate Admit guarantees we adjust nodeinfo
+// capacity for already allocated pods so that they can continue to run. However, new pods
+// requiring device plugin resources will not be scheduled till device plugin re-registers.
+func (m *ManagerImpl) GetCapacity() (v1.ResourceList, []string) {
+	needsUpdateCheckpoint := false
+	var capacity = v1.ResourceList{}
+	var deletedResources []string
+	m.mutex.Lock()
+	for resourceName, devices := range m.allDevices {
+		if _, ok := m.endpoints[resourceName]; !ok {
+			delete(m.allDevices, resourceName)
+			deletedResources = append(deletedResources, resourceName)
+			needsUpdateCheckpoint = true
+		} else {
+			capacity[v1.ResourceName(resourceName)] = *resource.NewQuantity(int64(devices.Len()), resource.DecimalSI)
+		}
+	}
+	m.mutex.Unlock()
+	if needsUpdateCheckpoint {
+		m.writeCheckpoint()
+	}
+	return capacity, deletedResources
+}
+
+// checkpointData struct is used to store pod to device allocation information
+// and registered device information in a checkpoint file.
+// TODO: add version control when we need to change checkpoint format.
+type checkpointData struct {
+	PodDeviceEntries  []podDevicesCheckpointEntry
+	RegisteredDevices map[string][]string
+}
+
 // Checkpoints device to container allocation information to disk.
 func (m *ManagerImpl) writeCheckpoint() error {
 	m.mutex.Lock()
-	data := m.podDevices.toCheckpointData()
+	data := checkpointData{
+		PodDeviceEntries:  m.podDevices.toCheckpointData(),
+		RegisteredDevices: make(map[string][]string),
+	}
+	for resource, devices := range m.allDevices {
+		data.RegisteredDevices[resource] = devices.UnsortedList()
+	}
 	m.mutex.Unlock()
 
 	dataJSON, err := json.Marshal(data)
@@ -373,14 +432,23 @@ func (m *ManagerImpl) readCheckpoint() error {
 
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-	m.podDevices.fromCheckpointData(data)
+	m.podDevices.fromCheckpointData(data.PodDeviceEntries)
 	m.allocatedDevices = m.podDevices.devices()
+	for resource, devices := range data.RegisteredDevices {
+		m.allDevices[resource] = sets.NewString()
+		for _, dev := range devices {
+			m.allDevices[resource].Insert(dev)
+		}
+	}
 	return nil
 }
 
 // updateAllocatedDevices gets a list of active pods and then frees any Devices that are bound to
 // terminated pods. Returns error on failure.
 func (m *ManagerImpl) updateAllocatedDevices(activePods []*v1.Pod) {
+	if !m.sourcesReady.AllReady() {
+		return
+	}
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 	activePodUids := sets.NewString()
@@ -392,7 +460,7 @@ func (m *ManagerImpl) updateAllocatedDevices(activePods []*v1.Pod) {
 	if len(podsToBeRemoved) <= 0 {
 		return
 	}
-	glog.V(5).Infof("pods to be removed: %v", podsToBeRemoved.List())
+	glog.V(3).Infof("pods to be removed: %v", podsToBeRemoved.List())
 	m.podDevices.delete(podsToBeRemoved.List())
 	// Regenerated allocatedDevices after we update pod allocation information.
 	m.allocatedDevices = m.podDevices.devices()
@@ -419,6 +487,11 @@ func (m *ManagerImpl) devicesToAllocate(podUID, contName, resource string, requi
 	if needed == 0 {
 		// No change, no work.
 		return nil, nil
+	}
+	glog.V(3).Infof("Needs to allocate %v %v for pod %q container %q", needed, resource, podUID, contName)
+	// Needs to allocate additional devices.
+	if _, ok := m.allDevices[resource]; !ok {
+		return nil, fmt.Errorf("can't allocate unregistered device %v", resource)
 	}
 	devices = sets.NewString()
 	// Needs to allocate additional devices.
@@ -455,7 +528,11 @@ func (m *ManagerImpl) allocateContainerResources(pod *v1.Pod, container *v1.Cont
 		resource := string(k)
 		needed := int(v.Value())
 		glog.V(3).Infof("needs %d %s", needed, resource)
-		if _, registeredResource := m.allDevices[resource]; !registeredResource {
+		_, registeredResource := m.allDevices[resource]
+		_, allocatedResource := m.allocatedDevices[resource]
+		// Continues if this is neither an active device plugin resource nor
+		// a resource we have previously allocated.
+		if !registeredResource && !allocatedResource {
 			continue
 		}
 		// Updates allocatedDevices to garbage collect any stranded resources

--- a/pkg/kubelet/cm/deviceplugin/manager_stub.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_stub.go
@@ -19,6 +19,7 @@ package deviceplugin
 import (
 	"k8s.io/api/core/v1"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
@@ -32,7 +33,7 @@ func NewManagerStub() (*ManagerStub, error) {
 }
 
 // Start simply returns nil.
-func (h *ManagerStub) Start(activePods ActivePodsFunc) error {
+func (h *ManagerStub) Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady) error {
 	return nil
 }
 
@@ -54,4 +55,9 @@ func (h *ManagerStub) Allocate(node *schedulercache.NodeInfo, attrs *lifecycle.P
 // GetDeviceRunContainerOptions simply returns nil.
 func (h *ManagerStub) GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Container) *DeviceRunContainerOptions {
 	return nil
+}
+
+// GetCapacity simply returns nil capacity and empty removed resource list.
+func (h *ManagerStub) GetCapacity() (v1.ResourceList, []string) {
+	return nil, []string{}
 }

--- a/pkg/kubelet/cm/deviceplugin/types.go
+++ b/pkg/kubelet/cm/deviceplugin/types.go
@@ -19,6 +19,7 @@ package deviceplugin
 import (
 	"k8s.io/api/core/v1"
 	pluginapi "k8s.io/kubernetes/pkg/kubelet/apis/deviceplugin/v1alpha"
+	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
@@ -27,7 +28,7 @@ import (
 // Manager manages all the Device Plugins running on a node.
 type Manager interface {
 	// Start starts device plugin registration service.
-	Start(activePods ActivePodsFunc) error
+	Start(activePods ActivePodsFunc, sourcesReady config.SourcesReady) error
 
 	// Devices is the map of devices that have registered themselves
 	// against the manager.
@@ -51,6 +52,10 @@ type Manager interface {
 	// for the passed-in <pod, container> and returns its DeviceRunContainerOptions
 	// for the found one. An empty struct is returned in case no cached state is found.
 	GetDeviceRunContainerOptions(pod *v1.Pod, container *v1.Container) *DeviceRunContainerOptions
+
+	// GetCapacity returns the amount of available device plugin resource capacity
+	// and inactive device plugin resources previously registered on the node.
+	GetCapacity() (v1.ResourceList, []string)
 }
 
 // DeviceRunContainerOptions contains the combined container runtime settings to consume its allocated devices.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1304,7 +1304,7 @@ func (kl *Kubelet) initializeModules() error {
 		return fmt.Errorf("Kubelet failed to get node info: %v", err)
 	}
 
-	if err := kl.containerManager.Start(node, kl.GetActivePods, kl.statusManager, kl.runtimeService); err != nil {
+	if err := kl.containerManager.Start(node, kl.GetActivePods, kl.sourcesReady, kl.statusManager, kl.runtimeService); err != nil {
 		return fmt.Errorf("Failed to start ContainerManager %v", err)
 	}
 

--- a/test/e2e_node/gpu_device_plugin.go
+++ b/test/e2e_node/gpu_device_plugin.go
@@ -18,7 +18,6 @@ package e2e_node
 
 import (
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"time"
 
@@ -49,6 +48,7 @@ var _ = framework.KubeDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugi
 			initialConfig.FeatureGates[string(features.DevicePlugins)] = true
 		})
 
+		var devicePluginPod *v1.Pod
 		BeforeEach(func() {
 			By("Ensuring that Nvidia GPUs exists on the node")
 			if !checkIfNvidiaGPUsExistOnNode() {
@@ -56,7 +56,7 @@ var _ = framework.KubeDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugi
 			}
 
 			By("Creating the Google Device Plugin pod for NVIDIA GPU in GKE")
-			f.PodClient().CreateSync(framework.NVIDIADevicePlugin(f.Namespace.Name))
+			devicePluginPod = f.PodClient().CreateSync(framework.NVIDIADevicePlugin(f.Namespace.Name))
 
 			By("Waiting for GPUs to become available on the local node")
 			Eventually(func() bool {
@@ -84,7 +84,7 @@ var _ = framework.KubeDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugi
 		It("checks that when Kubelet restarts exclusive GPU assignation to pods is kept.", func() {
 			By("Creating one GPU pod on a node with at least two GPUs")
 			p1 := f.PodClient().CreateSync(makeCudaPauseImage())
-			devId1 := getDeviceId(f, p1.Name, p1.Name, 1)
+			count1, devId1 := getDeviceId(f, p1.Name, p1.Name, 1)
 			p1, err := f.PodClient().Get(p1.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 
@@ -92,16 +92,35 @@ var _ = framework.KubeDescribe("NVIDIA GPU Device Plugin [Feature:GPUDevicePlugi
 			restartKubelet(f)
 
 			By("Confirming that after a kubelet and pod restart, GPU assignement is kept")
-			devIdRestart := getDeviceId(f, p1.Name, p1.Name, 2)
-			Expect(devIdRestart).To(Equal(devId1))
+			count1, devIdRestart1 := getDeviceId(f, p1.Name, p1.Name, count1+1)
+			Expect(devIdRestart1).To(Equal(devId1))
 
 			By("Restarting Kubelet and creating another pod")
 			restartKubelet(f)
 			p2 := f.PodClient().CreateSync(makeCudaPauseImage())
 
 			By("Checking that pods got a different GPU")
-			devId2 := getDeviceId(f, p2.Name, p2.Name, 1)
+			count2, devId2 := getDeviceId(f, p2.Name, p2.Name, 1)
 			Expect(devId1).To(Not(Equal(devId2)))
+
+			By("Deleting device plugin.")
+			f.PodClient().Delete(devicePluginPod.Name, &metav1.DeleteOptions{})
+			By("Waiting for GPUs to become unavailable on the local node")
+			Eventually(func() bool {
+				return framework.NumberOfNVIDIAGPUs(getLocalNode(f)) <= 0
+			}, 10*time.Minute, framework.Poll).Should(BeTrue())
+			By("Checking that scheduled pods can continue to run even after we delete device plugin.")
+			count1, devIdRestart1 = getDeviceId(f, p1.Name, p1.Name, count1+1)
+			Expect(devIdRestart1).To(Equal(devId1))
+			count2, devIdRestart2 := getDeviceId(f, p2.Name, p2.Name, count2+1)
+			Expect(devIdRestart2).To(Equal(devId2))
+			By("Restarting Kubelet.")
+			restartKubelet(f)
+			By("Checking that scheduled pods can continue to run even after we delete device plugin and restart Kubelet.")
+			count1, devIdRestart1 = getDeviceId(f, p1.Name, p1.Name, count1+2)
+			Expect(devIdRestart1).To(Equal(devId1))
+			count2, devIdRestart2 = getDeviceId(f, p2.Name, p2.Name, count2+2)
+			Expect(devIdRestart2).To(Equal(devId2))
 
 			// Cleanup
 			f.PodClient().DeleteSync(p1.Name, &metav1.DeleteOptions{}, framework.DefaultPodDeletionTimeout)
@@ -140,9 +159,6 @@ func newDecimalResourceList(name v1.ResourceName, quantity int64) v1.ResourceLis
 
 // TODO: Find a uniform way to deal with systemctl/initctl/service operations. #34494
 func restartKubelet(f *framework.Framework) {
-	beforeSocks, err := filepath.Glob("/var/lib/kubelet/device-plugins/nvidiaGPU*.sock")
-	framework.ExpectNoError(err)
-	Expect(len(beforeSocks)).NotTo(BeZero())
 	stdout, err := exec.Command("sudo", "systemctl", "list-units", "kubelet*", "--state=running").CombinedOutput()
 	framework.ExpectNoError(err)
 	regex := regexp.MustCompile("(kubelet-[0-9]+)")
@@ -152,19 +168,18 @@ func restartKubelet(f *framework.Framework) {
 	framework.Logf("Get running kubelet with systemctl: %v, %v", string(stdout), kube)
 	stdout, err = exec.Command("sudo", "systemctl", "restart", kube).CombinedOutput()
 	framework.ExpectNoError(err, "Failed to restart kubelet with systemctl: %v, %v", err, stdout)
-	Eventually(func() ([]string, error) {
-		return filepath.Glob("/var/lib/kubelet/device-plugins/nvidiaGPU*.sock")
-	}, 5*time.Minute, framework.Poll).ShouldNot(ConsistOf(beforeSocks))
 }
 
-func getDeviceId(f *framework.Framework, podName string, contName string, restartCount int32) string {
+func getDeviceId(f *framework.Framework, podName string, contName string, restartCount int32) (int32, string) {
+	var count int32
 	// Wait till pod has been restarted at least restartCount times.
 	Eventually(func() bool {
 		p, err := f.PodClient().Get(podName, metav1.GetOptions{})
 		if err != nil || len(p.Status.ContainerStatuses) < 1 {
 			return false
 		}
-		return p.Status.ContainerStatuses[0].RestartCount >= restartCount
+		count = p.Status.ContainerStatuses[0].RestartCount
+		return count >= restartCount
 	}, 5*time.Minute, framework.Poll).Should(BeTrue())
 	logs, err := framework.GetPodLogs(f.ClientSet, f.Namespace.Name, podName, contName)
 	if err != nil {
@@ -174,7 +189,7 @@ func getDeviceId(f *framework.Framework, podName string, contName string, restar
 	regex := regexp.MustCompile("gpu devices: (nvidia[0-9]+)")
 	matches := regex.FindStringSubmatch(logs)
 	if len(matches) < 2 {
-		return ""
+		return count, ""
 	}
-	return matches[1]
+	return count, matches[1]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- Instead of using cm.capacity field to communicate device plugin resource capacity,
this PR changes to use an explicit cm.GetDevicePluginResourceCapacity() function
that returns device plugin resource capacity as well as any inactive device plugin resource.
Kubelet syncNodeStatus call this function during its periodic run to update node status
capacity and allocatable. After this call, device plugin can remove the inactive device
plugin resource from its allDevices field as the update is already pushed to API server.
- Extends device plugin checkpoint data to record registered resources
so that we can finish resource removing even upon kubelet restarts.
- Passes sourcesReady from kubelet to device plugin to avoid removing
inactive pods during grace period of kubelet restart.
- Extends gpu_device_plugin e2e_node test to verify that scheduled pods
can continue to run even after device plugin deletion and kubelet
restarts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Together with https://github.com/kubernetes/kubernetes/pull/54488, fixes https://github.com/kubernetes/kubernetes/issues/53395

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Extends deviceplugin to gracefully handle full device plugin lifecycle.
```
