### PR TITLE
Automated cherry pick of #53034

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -419,6 +419,12 @@ function kube::release::package_kube_manifests_tarball() {
   local objects
   objects=$(cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)
   tar c -C "${KUBE_ROOT}/cluster/addons" ${objects} | tar x -C "${gci_dst_dir}"
+  # Merge GCE-specific addons with general purpose addons.
+  local gce_objects
+  gce_objects=$(cd "${KUBE_ROOT}/cluster/gce/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) \( -not -name \*demo\* \))
+  if [[ -n "${gce_objects}" ]]; then
+    tar c -C "${KUBE_ROOT}/cluster/gce/addons" ${gce_objects} | tar x -C "${gci_dst_dir}"
+  fi
 
   kube::release::clean_cruft
 

--- a/cluster/BUILD
+++ b/cluster/BUILD
@@ -33,6 +33,7 @@ pkg_tar(
     deps = [
         "//cluster/addons",
         "//cluster/gce:gci-trusty-manifests",
+        "//cluster/gce/addons",
         "//cluster/saltbase:gci-trusty-salt-manifests",
     ],
 )

--- a/cluster/gce/BUILD
+++ b/cluster/gce/BUILD
@@ -34,6 +34,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//cluster/gce/addons:all-srcs",
         "//cluster/gce/gci/mounter:all-srcs",
     ],
     tags = ["automanaged"],

--- a/cluster/gce/addons/BUILD
+++ b/cluster/gce/addons/BUILD
@@ -1,0 +1,38 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+filegroup(
+    name = "addon-srcs",
+    srcs = glob(
+        [
+            "**/*.json",
+            "**/*.yaml",
+            "**/*.yaml.in",
+        ],
+        exclude = ["**/*demo*/**"],
+    ),
+)
+
+pkg_tar(
+    name = "addons",
+    extension = "tar.gz",
+    files = [
+        ":addon-srcs",
+    ],
+    mode = "0644",
+    strip_prefix = ".",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/cluster/gce/addons/README.md
+++ b/cluster/gce/addons/README.md
@@ -1,0 +1,7 @@
+# GCE Cluster addons
+
+These cluster add-ons are specific to GCE and GKE clusters. The GCE-specific addon directory is
+merged with the general cluster addon directory at release, so addon paths (relative to the addon
+directory) must be unique across the 2 directory structures.
+
+More details on addons in general can be found [here](../../addons/README.md).


### PR DESCRIPTION
Cherry pick of #53034 on release-1.8.

#53034: Introduce GCE-specific addons directory

Justification: configuration only changes, required by https://github.com/kubernetes/kubernetes/pull/55025

I think this should be a trivial cherry pick. It adds the configuration machinery to build a new directory into the release, but doesn't actually put anything in that directory (i.e. it should be a no-op as far as release is concerned)

```release-note
NONE
```

