### PR TITLE
Automated cherry pick of #54175

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,3 +1,12 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-gcp
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
@@ -23,6 +32,7 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
+      serviceAccountName: fluentd-gcp
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
@@ -123,6 +133,3 @@ spec:
       - name: config-volume
         configMap:
           name: fluentd-gcp-config-v1.2.2
-      - name: ssl-certs
-        hostPath:
-          path: /etc/ssl/certs


### PR DESCRIPTION
Cherry pick of #54175 on release-1.8.

#54175: Update fluentd-gcp DaemonSet

Justification: Low-risk, add a service account to fluentd daemonset. Also cleans up an artifact left by https://github.com/kubernetes/kubernetes/pull/54784 (unused ssl cert volume).

This is required to unblock https://github.com/kubernetes/kubernetes/pull/55025

```release-note
- fluentd-gcp runs with a dedicated fluentd-gcp service account
- Stop mounting the host certificates into fluentd pod
```