### PR TITLE
Fix the test TestTarUntar in pkg/kubectl/cmd/cp_test.go on macOS

### DIFF
--- a/pkg/kubectl/cmd/cp_test.go
+++ b/pkg/kubectl/cmd/cp_test.go
@@ -199,7 +199,7 @@ func TestTarUntar(t *testing.T) {
 	}
 
 	for _, file := range files {
-		absPath := dir2 + strings.TrimPrefix(dir, os.TempDir())
+		absPath := path.Join(dir2, strings.TrimPrefix(dir, os.TempDir()))
 		filepath := path.Join(absPath, file.name)
 
 		if file.fileType == RegularFile {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The test `TestTarUntar` was failing in `pkg/kubectl/cmd/cp_test.go` on macOS, because of a path concatenation issue:
```
--- FAIL: TestTarUntar (0.01s)
    cp_test.go:208: unexpected error: open /var/folders/31/qqrw38t57s3d298k_945nr_40000gn/T/output362095636input870771017/foo: no such file or directory
...
```
As can be seen above, there is a missing path separator between `output362095636` and  `input870771017`. This PR make that test pass again on macOS. I have also confirmed that it is still passing on Linux.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
