### PR TITLE
Add support for configmap resource lock type to CCM

### DIFF
--- a/cmd/cloud-controller-manager/app/BUILD
+++ b/cmd/cloud-controller-manager/app/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: 

Adds support for configmap resource locks which can be specified currently via CLI args to the CCM. Currently the `--leader-elect-resource-lock=configmaps` is ignored. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #55124

```release-note
Fix support for configmap resource lock type in CCM
```

/cc @wlan0 @luxas @andrewsykim 

@prydie 


Output after running with this flag. 
```
$ kubectl -n kube-system get cm cloud-controller-manager -oyaml
apiVersion: v1
kind: ConfigMap
metadata:
  annotations:
    control-plane.alpha.kubernetes.io/leader: '{"holderIdentity":"<host>-external-cloud-controller","leaseDurationSeconds":15,"acquireTime":"2017-11-06T00:14:41Z","renewTime":"2017-11-06T00:17:54Z","leaderTransitions":0}'
  creationTimestamp: 2017-11-06T00:14:41Z
  name: cloud-controller-manager
  namespace: kube-system
  resourceVersion: "2548197"
  selfLink: /api/v1/namespaces/kube-system/configmaps/cloud-controller-manager
  uid: 7c4cfe24-c287-11e7-99e4-0000170192f0
```

