### PR TITLE
gcr.io/google-containers -> k8s.gcr.io

### DIFF
--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -177,15 +177,15 @@ filename | sha256 hash
 ### Other notable changes
 
 * kube-apiserver now drops unneeded path information if an older version of Windows kubectl sends it. ([#44586](https://github.com/kubernetes/kubernetes/pull/44586), [@mml](https://github.com/mml))
-* Bump k8s.gcr.io/glbc from 0.8.0 to 0.9.2. Release notes: [0.9.0](https://github.com/kubernetes/ingress/releases/tag/0.9.0), [0.9.1](https://github.com/kubernetes/ingress/releases/tag/0.9.1), [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43098](https://github.com/kubernetes/kubernetes/pull/43098), [@timstclair](https://github.com/timstclair))
+* Bump gcr.io/google_containers/glbc from 0.8.0 to 0.9.2. Release notes: [0.9.0](https://github.com/kubernetes/ingress/releases/tag/0.9.0), [0.9.1](https://github.com/kubernetes/ingress/releases/tag/0.9.1), [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43098](https://github.com/kubernetes/kubernetes/pull/43098), [@timstclair](https://github.com/timstclair))
 * Patch CVE-2016-8859 in alpine based images: ([#42937](https://github.com/kubernetes/kubernetes/pull/42937), [@timstclair](https://github.com/timstclair))
-    * - k8s.gcr.io/etcd-empty-dir-cleanup
-    * - k8s.gcr.io/kube-dnsmasq-amd64
+    * - gcr.io/google-containers/etcd-empty-dir-cleanup
+    * - gcr.io/google-containers/kube-dnsmasq-amd64
 * Check if pathExists before performing Unmount ([#39311](https://github.com/kubernetes/kubernetes/pull/39311), [@rkouj](https://github.com/rkouj))
 * Unmount operation should not fail if volume is already unmounted ([#38547](https://github.com/kubernetes/kubernetes/pull/38547), [@rkouj](https://github.com/rkouj))
 * Updates base image used for `kube-addon-manager` to latest `python:2.7-slim` and embedded `kubectl` to `v1.3.10`. No functionality changes expected. ([#42842](https://github.com/kubernetes/kubernetes/pull/42842), [@ixdy](https://github.com/ixdy))
 * list-resources: don't fail if the grep fails to match any resources ([#41933](https://github.com/kubernetes/kubernetes/pull/41933), [@ixdy](https://github.com/ixdy))
-* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Backporting TPR fix to 1.4 ([#42380](https://github.com/kubernetes/kubernetes/pull/42380), [@foxish](https://github.com/foxish))
 * Fix AWS device allocator to only use valid device names ([#41455](https://github.com/kubernetes/kubernetes/pull/41455), [@gnufied](https://github.com/gnufied))
 * Reverts to looking up the current VM in vSphere using the machine's UUID, either obtained via sysfs or via the `vm-uuid` parameter in the cloud configuration file. ([#40892](https://github.com/kubernetes/kubernetes/pull/40892), [@robdaemon](https://github.com/robdaemon))

--- a/CHANGELOG-1.4.md
+++ b/CHANGELOG-1.4.md
@@ -177,15 +177,15 @@ filename | sha256 hash
 ### Other notable changes
 
 * kube-apiserver now drops unneeded path information if an older version of Windows kubectl sends it. ([#44586](https://github.com/kubernetes/kubernetes/pull/44586), [@mml](https://github.com/mml))
-* Bump gcr.io/google_containers/glbc from 0.8.0 to 0.9.2. Release notes: [0.9.0](https://github.com/kubernetes/ingress/releases/tag/0.9.0), [0.9.1](https://github.com/kubernetes/ingress/releases/tag/0.9.1), [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43098](https://github.com/kubernetes/kubernetes/pull/43098), [@timstclair](https://github.com/timstclair))
+* Bump k8s.gcr.io/glbc from 0.8.0 to 0.9.2. Release notes: [0.9.0](https://github.com/kubernetes/ingress/releases/tag/0.9.0), [0.9.1](https://github.com/kubernetes/ingress/releases/tag/0.9.1), [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43098](https://github.com/kubernetes/kubernetes/pull/43098), [@timstclair](https://github.com/timstclair))
 * Patch CVE-2016-8859 in alpine based images: ([#42937](https://github.com/kubernetes/kubernetes/pull/42937), [@timstclair](https://github.com/timstclair))
-    * - gcr.io/google-containers/etcd-empty-dir-cleanup
-    * - gcr.io/google-containers/kube-dnsmasq-amd64
+    * - k8s.gcr.io/etcd-empty-dir-cleanup
+    * - k8s.gcr.io/kube-dnsmasq-amd64
 * Check if pathExists before performing Unmount ([#39311](https://github.com/kubernetes/kubernetes/pull/39311), [@rkouj](https://github.com/rkouj))
 * Unmount operation should not fail if volume is already unmounted ([#38547](https://github.com/kubernetes/kubernetes/pull/38547), [@rkouj](https://github.com/rkouj))
 * Updates base image used for `kube-addon-manager` to latest `python:2.7-slim` and embedded `kubectl` to `v1.3.10`. No functionality changes expected. ([#42842](https://github.com/kubernetes/kubernetes/pull/42842), [@ixdy](https://github.com/ixdy))
 * list-resources: don't fail if the grep fails to match any resources ([#41933](https://github.com/kubernetes/kubernetes/pull/41933), [@ixdy](https://github.com/ixdy))
-* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Backporting TPR fix to 1.4 ([#42380](https://github.com/kubernetes/kubernetes/pull/42380), [@foxish](https://github.com/foxish))
 * Fix AWS device allocator to only use valid device names ([#41455](https://github.com/kubernetes/kubernetes/pull/41455), [@gnufied](https://github.com/gnufied))
 * Reverts to looking up the current VM in vSphere using the machine's UUID, either obtained via sysfs or via the `vm-uuid` parameter in the cloud configuration file. ([#40892](https://github.com/kubernetes/kubernetes/pull/40892), [@robdaemon](https://github.com/robdaemon))

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -249,18 +249,18 @@ filename | sha256 hash
 
 * kube-up (with gce/gci and gce/coreos providers) now ensures the authentication token file contains correct tokens for the control plane components, even if the file already exists (ensures upgrades and downgrades work successfully) ([#43676](https://github.com/kubernetes/kubernetes/pull/43676), [@liggitt](https://github.com/liggitt))
 * Patch CVE-2016-8859 in alpine based images: ([#42936](https://github.com/kubernetes/kubernetes/pull/42936), [@timstclair](https://github.com/timstclair))
-    * - k8s.gcr.io/cluster-proportional-autoscaler-amd64
-    * - k8s.gcr.io/dnsmasq-metrics-amd64
-    * - k8s.gcr.io/etcd-empty-dir-cleanup
-    * - k8s.gcr.io/kube-addon-manager
-    * - k8s.gcr.io/kube-dnsmasq-amd64
+    * - gcr.io/google-containers/cluster-proportional-autoscaler-amd64
+    * - gcr.io/google-containers/dnsmasq-metrics-amd64
+    * - gcr.io/google-containers/etcd-empty-dir-cleanup
+    * - gcr.io/google-containers/kube-addon-manager
+    * - gcr.io/google-containers/kube-dnsmasq-amd64
 * - Disable thin_ls due to excessive iops ([#43113](https://github.com/kubernetes/kubernetes/pull/43113), [@dashpole](https://github.com/dashpole))
     * - Ignore .mount cgroups, fixing dissappearing stats
     * - Fix wc goroutine leak
     * - Update aws-sdk-go dependency to 1.6.10
 * PodSecurityPolicy authorization is correctly enforced by the PodSecurityPolicy admission plugin. ([#43489](https://github.com/kubernetes/kubernetes/pull/43489), [@liggitt](https://github.com/liggitt))
-* Bump k8s.gcr.io/glbc from 0.9.1 to 0.9.2. Release notes: [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43097](https://github.com/kubernetes/kubernetes/pull/43097), [@timstclair](https://github.com/timstclair))
-* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Bump gcr.io/google_containers/glbc from 0.9.1 to 0.9.2. Release notes: [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43097](https://github.com/kubernetes/kubernetes/pull/43097), [@timstclair](https://github.com/timstclair))
+* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * restored normalization of custom `--etcd-prefix` when `--storage-backend` is set to etcd3 ([#42506](https://github.com/kubernetes/kubernetes/pull/42506), [@liggitt](https://github.com/liggitt))
 
 
@@ -655,7 +655,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
   - [alpha] Introducing the v1alpha1 CRI API to allow pluggable container runtimes; an experimental docker-CRI integration is ready for testing and feedback. ([docs](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md)) ([kubernetes/features#54](https://github.com/kubernetes/features/issues/54))
   - [alpha] Kubelet launches container in a per pod cgroup hierarchy based on quality of service tier ([kubernetes/features#126](https://github.com/kubernetes/features/issues/126))
   - [beta] Kubelet integrates with memcg notification API to detect when a hard eviction threshold is crossed ([kubernetes/features#125](https://github.com/kubernetes/features/issues/125))
-  - [beta] Introducing the beta version containerized node conformance test k8s.gcr.io/node-test:0.2 for users to verify node setup. ([docs](http://kubernetes.io/docs/admin/node-conformance/)) ([kubernetes/features#84](https://github.com/kubernetes/features/issues/84))
+  - [beta] Introducing the beta version containerized node conformance test gcr.io/google_containers/node-test:0.2 for users to verify node setup. ([docs](http://kubernetes.io/docs/admin/node-conformance/)) ([kubernetes/features#84](https://github.com/kubernetes/features/issues/84))
 - **Scheduling**
   - [alpha] Added support for accounting opaque integer resources. ([docs](http://kubernetes.io/docs/user-guide/compute-resources/#opaque-integer-resources-alpha-feature)) ([kubernetes/features#76](https://github.com/kubernetes/features/issues/76))
   - [beta] PodDisruptionBudget has been promoted to beta, can be used to safely drain nodes while respecting application SLO's ([docs](http://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)) ([kubernetes/features#85](https://github.com/kubernetes/features/issues/85))

--- a/CHANGELOG-1.5.md
+++ b/CHANGELOG-1.5.md
@@ -249,18 +249,18 @@ filename | sha256 hash
 
 * kube-up (with gce/gci and gce/coreos providers) now ensures the authentication token file contains correct tokens for the control plane components, even if the file already exists (ensures upgrades and downgrades work successfully) ([#43676](https://github.com/kubernetes/kubernetes/pull/43676), [@liggitt](https://github.com/liggitt))
 * Patch CVE-2016-8859 in alpine based images: ([#42936](https://github.com/kubernetes/kubernetes/pull/42936), [@timstclair](https://github.com/timstclair))
-    * - gcr.io/google-containers/cluster-proportional-autoscaler-amd64
-    * - gcr.io/google-containers/dnsmasq-metrics-amd64
-    * - gcr.io/google-containers/etcd-empty-dir-cleanup
-    * - gcr.io/google-containers/kube-addon-manager
-    * - gcr.io/google-containers/kube-dnsmasq-amd64
+    * - k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    * - k8s.gcr.io/dnsmasq-metrics-amd64
+    * - k8s.gcr.io/etcd-empty-dir-cleanup
+    * - k8s.gcr.io/kube-addon-manager
+    * - k8s.gcr.io/kube-dnsmasq-amd64
 * - Disable thin_ls due to excessive iops ([#43113](https://github.com/kubernetes/kubernetes/pull/43113), [@dashpole](https://github.com/dashpole))
     * - Ignore .mount cgroups, fixing dissappearing stats
     * - Fix wc goroutine leak
     * - Update aws-sdk-go dependency to 1.6.10
 * PodSecurityPolicy authorization is correctly enforced by the PodSecurityPolicy admission plugin. ([#43489](https://github.com/kubernetes/kubernetes/pull/43489), [@liggitt](https://github.com/liggitt))
-* Bump gcr.io/google_containers/glbc from 0.9.1 to 0.9.2. Release notes: [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43097](https://github.com/kubernetes/kubernetes/pull/43097), [@timstclair](https://github.com/timstclair))
-* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Bump k8s.gcr.io/glbc from 0.9.1 to 0.9.2. Release notes: [0.9.2](https://github.com/kubernetes/ingress/releases/tag/0.9.2) ([#43097](https://github.com/kubernetes/kubernetes/pull/43097), [@timstclair](https://github.com/timstclair))
+* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * restored normalization of custom `--etcd-prefix` when `--storage-backend` is set to etcd3 ([#42506](https://github.com/kubernetes/kubernetes/pull/42506), [@liggitt](https://github.com/liggitt))
 
 
@@ -655,7 +655,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
   - [alpha] Introducing the v1alpha1 CRI API to allow pluggable container runtimes; an experimental docker-CRI integration is ready for testing and feedback. ([docs](https://github.com/kubernetes/community/blob/master/contributors/devel/container-runtime-interface.md)) ([kubernetes/features#54](https://github.com/kubernetes/features/issues/54))
   - [alpha] Kubelet launches container in a per pod cgroup hierarchy based on quality of service tier ([kubernetes/features#126](https://github.com/kubernetes/features/issues/126))
   - [beta] Kubelet integrates with memcg notification API to detect when a hard eviction threshold is crossed ([kubernetes/features#125](https://github.com/kubernetes/features/issues/125))
-  - [beta] Introducing the beta version containerized node conformance test gcr.io/google_containers/node-test:0.2 for users to verify node setup. ([docs](http://kubernetes.io/docs/admin/node-conformance/)) ([kubernetes/features#84](https://github.com/kubernetes/features/issues/84))
+  - [beta] Introducing the beta version containerized node conformance test k8s.gcr.io/node-test:0.2 for users to verify node setup. ([docs](http://kubernetes.io/docs/admin/node-conformance/)) ([kubernetes/features#84](https://github.com/kubernetes/features/issues/84))
 - **Scheduling**
   - [alpha] Added support for accounting opaque integer resources. ([docs](http://kubernetes.io/docs/user-guide/compute-resources/#opaque-integer-resources-alpha-feature)) ([kubernetes/features#76](https://github.com/kubernetes/features/issues/76))
   - [beta] PodDisruptionBudget has been promoted to beta, can be used to safely drain nodes while respecting application SLO's ([docs](http://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/)) ([kubernetes/features#85](https://github.com/kubernetes/features/issues/85))

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1869,7 +1869,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
 * Fixes a bug in the OpenStack-Heat kubernetes provider, in the handling of differences between the Identity v2 and Identity v3 APIs ([#40105](https://github.com/kubernetes/kubernetes/pull/40105), [@sc68cal](https://github.com/sc68cal))
 
 ### Container Images
-* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Remove unnecessary metrics (http/process/go) from being exposed by etcd-version-monitor ([#41807](https://github.com/kubernetes/kubernetes/pull/41807), [@shyamjvs](https://github.com/shyamjvs))
 * Align the hyperkube image to support running binaries at /usr/local/bin/ like the other server images ([#41017](https://github.com/kubernetes/kubernetes/pull/41017), [@luxas](https://github.com/luxas))
 * Bump up GLBC version from 0.9.0-beta to 0.9.1 ([#41037](https://github.com/kubernetes/kubernetes/pull/41037), [@bprashanth](https://github.com/bprashanth))
@@ -1916,7 +1916,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
 * Use kube-dns:1.11.0 ([#39925](https://github.com/kubernetes/kubernetes/pull/39925), [@sadlil](https://github.com/sadlil))
 
 ### DNS Autoscaler
-* Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
+* Patch CVE-2016-8859 in k8s.gcr.io/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
 
 ### Cluster Autoscaler
 * Allow the Horizontal Pod Autoscaler controller to talk to the metrics API and custom metrics API as standard APIs. ([#41824](https://github.com/kubernetes/kubernetes/pull/41824), [@DirectXMan12](https://github.com/DirectXMan12))
@@ -2083,7 +2083,7 @@ filename | sha256 hash
 * Rescheduler uses taints in v1beta1 and will remove old ones (in version v1alpha1) right after its start. ([#43106](https://github.com/kubernetes/kubernetes/pull/43106), [@piosz](https://github.com/piosz))
 * kubeadm: `kubeadm reset` won't drain and remove the current node anymore ([#42713](https://github.com/kubernetes/kubernetes/pull/42713), [@luxas](https://github.com/luxas))
 * hack/godep-restore.sh: use godep v79 which works ([#42965](https://github.com/kubernetes/kubernetes/pull/42965), [@sttts](https://github.com/sttts))
-* Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
+* Patch CVE-2016-8859 in k8s.gcr.io/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
 * Disable devicemapper thin_ls due to excessive iops ([#42899](https://github.com/kubernetes/kubernetes/pull/42899), [@dashpole](https://github.com/dashpole))
 
 
@@ -2317,7 +2317,7 @@ filename | sha256 hash
 * Add configurable limits to CronJob resource to specify how many successful and failed jobs are preserved. ([#40932](https://github.com/kubernetes/kubernetes/pull/40932), [@peay](https://github.com/peay))
 * Deprecate outofdisk-transition-frequency and low-diskspace-threshold-mb flags ([#41941](https://github.com/kubernetes/kubernetes/pull/41941), [@dashpole](https://github.com/dashpole))
 * Add OWNERS for sample-apiserver in staging ([#42094](https://github.com/kubernetes/kubernetes/pull/42094), [@sttts](https://github.com/sttts))
-* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Add storage.k8s.io/v1 API ([#40088](https://github.com/kubernetes/kubernetes/pull/40088), [@jsafrane](https://github.com/jsafrane))
 * Juju - K8s master charm now properly keeps distributed master files in sync for an HA control plane. ([#41351](https://github.com/kubernetes/kubernetes/pull/41351), [@chuckbutler](https://github.com/chuckbutler))
 * Fix zsh completion: unknown file attribute error ([#38104](https://github.com/kubernetes/kubernetes/pull/38104), [@elipapa](https://github.com/elipapa))

--- a/CHANGELOG-1.6.md
+++ b/CHANGELOG-1.6.md
@@ -1869,7 +1869,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
 * Fixes a bug in the OpenStack-Heat kubernetes provider, in the handling of differences between the Identity v2 and Identity v3 APIs ([#40105](https://github.com/kubernetes/kubernetes/pull/40105), [@sc68cal](https://github.com/sc68cal))
 
 ### Container Images
-* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Remove unnecessary metrics (http/process/go) from being exposed by etcd-version-monitor ([#41807](https://github.com/kubernetes/kubernetes/pull/41807), [@shyamjvs](https://github.com/shyamjvs))
 * Align the hyperkube image to support running binaries at /usr/local/bin/ like the other server images ([#41017](https://github.com/kubernetes/kubernetes/pull/41017), [@luxas](https://github.com/luxas))
 * Bump up GLBC version from 0.9.0-beta to 0.9.1 ([#41037](https://github.com/kubernetes/kubernetes/pull/41037), [@bprashanth](https://github.com/bprashanth))
@@ -1916,7 +1916,7 @@ Features for this release were tracked via the use of the [kubernetes/features](
 * Use kube-dns:1.11.0 ([#39925](https://github.com/kubernetes/kubernetes/pull/39925), [@sadlil](https://github.com/sadlil))
 
 ### DNS Autoscaler
-* Patch CVE-2016-8859 in k8s.gcr.io/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
+* Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
 
 ### Cluster Autoscaler
 * Allow the Horizontal Pod Autoscaler controller to talk to the metrics API and custom metrics API as standard APIs. ([#41824](https://github.com/kubernetes/kubernetes/pull/41824), [@DirectXMan12](https://github.com/DirectXMan12))
@@ -2083,7 +2083,7 @@ filename | sha256 hash
 * Rescheduler uses taints in v1beta1 and will remove old ones (in version v1alpha1) right after its start. ([#43106](https://github.com/kubernetes/kubernetes/pull/43106), [@piosz](https://github.com/piosz))
 * kubeadm: `kubeadm reset` won't drain and remove the current node anymore ([#42713](https://github.com/kubernetes/kubernetes/pull/42713), [@luxas](https://github.com/luxas))
 * hack/godep-restore.sh: use godep v79 which works ([#42965](https://github.com/kubernetes/kubernetes/pull/42965), [@sttts](https://github.com/sttts))
-* Patch CVE-2016-8859 in k8s.gcr.io/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
+* Patch CVE-2016-8859 in gcr.io/google-containers/cluster-proportional-autoscaler-amd64 ([#42933](https://github.com/kubernetes/kubernetes/pull/42933), [@timstclair](https://github.com/timstclair))
 * Disable devicemapper thin_ls due to excessive iops ([#42899](https://github.com/kubernetes/kubernetes/pull/42899), [@dashpole](https://github.com/dashpole))
 
 
@@ -2317,7 +2317,7 @@ filename | sha256 hash
 * Add configurable limits to CronJob resource to specify how many successful and failed jobs are preserved. ([#40932](https://github.com/kubernetes/kubernetes/pull/40932), [@peay](https://github.com/peay))
 * Deprecate outofdisk-transition-frequency and low-diskspace-threshold-mb flags ([#41941](https://github.com/kubernetes/kubernetes/pull/41941), [@dashpole](https://github.com/dashpole))
 * Add OWNERS for sample-apiserver in staging ([#42094](https://github.com/kubernetes/kubernetes/pull/42094), [@sttts](https://github.com/sttts))
-* Update k8s.gcr.io/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
+* Update gcr.io/google-containers/rescheduler to v0.2.2, which uses busybox as a base image instead of ubuntu. ([#41911](https://github.com/kubernetes/kubernetes/pull/41911), [@ixdy](https://github.com/ixdy))
 * Add storage.k8s.io/v1 API ([#40088](https://github.com/kubernetes/kubernetes/pull/40088), [@jsafrane](https://github.com/jsafrane))
 * Juju - K8s master charm now properly keeps distributed master files in sync for an HA control plane. ([#41351](https://github.com/kubernetes/kubernetes/pull/41351), [@chuckbutler](https://github.com/chuckbutler))
 * Fix zsh completion: unknown file attribute error ([#38104](https://github.com/kubernetes/kubernetes/pull/38104), [@elipapa](https://github.com/elipapa))

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -71735,7 +71735,7 @@
     ],
     "properties": {
      "names": {
-      "description": "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+      "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
       "type": "array",
       "items": {
        "type": "string"

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -20212,7 +20212,7 @@
       "items": {
        "type": "string"
       },
-      "description": "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]"
+      "description": "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]"
      },
      "sizeBytes": {
       "type": "integer",

--- a/build/BUILD
+++ b/build/BUILD
@@ -62,7 +62,7 @@ DOCKERIZED_BINARIES = {
 
 [docker_bundle(
     name = binary,
-    images = {"gcr.io/google_containers/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal"},
+    images = {"k8s.gcr.io/%s:{STABLE_DOCKER_TAG}" % binary: binary + "-internal"},
     stamp = True,
 ) for binary in DOCKERIZED_BINARIES.keys()]
 

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file creates a standard build environment for building Kubernetes
-FROM gcr.io/google_containers/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
+FROM k8s.gcr.io/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
 
 # Mark this as a kube-build container
 RUN touch /kube-build-image

--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -21,7 +21,7 @@ TAG=$(shell cat VERSION)
 all: push
 
 build:
-	docker build --pull -t gcr.io/google_containers/$(IMAGE):$(TAG) .
+	docker build --pull -t k8s.gcr.io/$(IMAGE):$(TAG) .
 
 push: build
-	gcloud docker --server=gcr.io -- push gcr.io/google_containers/$(IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push k8s.gcr.io/$(IMAGE):$(TAG)

--- a/build/common.sh
+++ b/build/common.sh
@@ -96,7 +96,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,busybox
           kube-scheduler,busybox
           kube-aggregator,busybox
-          kube-proxy,gcr.io/google-containers/debian-iptables-amd64:${debian_iptables_version}
+          kube-proxy,k8s.gcr.io/debian-iptables-amd64:${debian_iptables_version}
         );;
     "arm")
         local targets=(
@@ -105,7 +105,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,arm32v7/busybox
           kube-scheduler,arm32v7/busybox
           kube-aggregator,arm32v7/busybox
-          kube-proxy,gcr.io/google-containers/debian-iptables-arm:${debian_iptables_version}
+          kube-proxy,k8s.gcr.io/debian-iptables-arm:${debian_iptables_version}
         );;
     "arm64")
         local targets=(
@@ -114,7 +114,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,arm64v8/busybox
           kube-scheduler,arm64v8/busybox
           kube-aggregator,arm64v8/busybox
-          kube-proxy,gcr.io/google-containers/debian-iptables-arm64:${debian_iptables_version}
+          kube-proxy,k8s.gcr.io/debian-iptables-arm64:${debian_iptables_version}
         );;
     "ppc64le")
         local targets=(
@@ -123,7 +123,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,ppc64le/busybox
           kube-scheduler,ppc64le/busybox
           kube-aggregator,ppc64le/busybox
-          kube-proxy,gcr.io/google-containers/debian-iptables-ppc64le:${debian_iptables_version}
+          kube-proxy,k8s.gcr.io/debian-iptables-ppc64le:${debian_iptables_version}
         );;
     "s390x")
         local targets=(
@@ -132,7 +132,7 @@ kube::build::get_docker_wrapped_binaries() {
           kube-controller-manager,s390x/busybox
           kube-scheduler,s390x/busybox
           kube-aggregator,s390x/busybox
-          kube-proxy,gcr.io/google-containers/debian-iptables-s390x:${debian_iptables_version}
+          kube-proxy,k8s.gcr.io/debian-iptables-s390x:${debian_iptables_version}
         );;
   esac
 

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -14,7 +14,7 @@
 
 all: build
 
-REGISTRY ?= gcr.io/google-containers
+REGISTRY ?= k8s.gcr.io
 IMAGE ?= debian-base
 BUILD_IMAGE ?= debian-build
 
@@ -71,7 +71,7 @@ endif
 	rm -rf $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
 
 clean:
 	docker rmi -f $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) || true

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -15,15 +15,15 @@
 # Build the hyperkube base image. This image is used to build the hyperkube image.
 #
 # Usage:
-#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push)
+#   [ARCH=amd64] [REGISTRY="k8s.gcr.io"] make (build|push)
 
-REGISTRY?=gcr.io/google-containers
+REGISTRY?=k8s.gcr.io
 IMAGE?=debian-hyperkube-base
 TAG=0.6
 ARCH?=amd64
 CACHEBUST?=1
 
-BASEIMAGE=gcr.io/google-containers/debian-base-$(ARCH):0.2
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.2
 CNI_VERSION=v0.6.0
 
 TEMP_DIR:=$(shell mktemp -d)
@@ -57,4 +57,4 @@ endif
 	rm -rf $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)

--- a/build/debian-hyperkube-base/README.md
+++ b/build/debian-hyperkube-base/README.md
@@ -1,6 +1,6 @@
 ### debian-hyperkube-base
 
-Serves as the base image for `gcr.io/google-containers/hyperkube-${ARCH}`
+Serves as the base image for `k8s.gcr.io/hyperkube-${ARCH}`
 images.
 
 This image is compiled for multiple architectures.
@@ -12,19 +12,19 @@ If you're editing the Dockerfile or some other thing, please bump the `TAG` in t
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> gcr.io/google-containers/debian-hyperkube-base-amd64:TAG
+# ---> k8s.gcr.io/debian-hyperkube-base-amd64:TAG
 
 $ make push ARCH=arm
-# ---> gcr.io/google-containers/debian-hyperkube-base-arm:TAG
+# ---> k8s.gcr.io/debian-hyperkube-base-arm:TAG
 
 $ make push ARCH=arm64
-# ---> gcr.io/google-containers/debian-hyperkube-base-arm64:TAG
+# ---> k8s.gcr.io/debian-hyperkube-base-arm64:TAG
 
 $ make push ARCH=ppc64le
-# ---> gcr.io/google-containers/debian-hyperkube-base-ppc64le:TAG
+# ---> k8s.gcr.io/debian-hyperkube-base-ppc64le:TAG
 
 $ make push ARCH=s390x
-# ---> gcr.io/google-containers/debian-hyperkube-base-s390x:TAG
+# ---> k8s.gcr.io/debian-hyperkube-base-s390x:TAG
 ```
 
 If you don't want to push the images, run `make build` instead

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	build push
 
-REGISTRY?="gcr.io/google-containers"
+REGISTRY?="k8s.gcr.io"
 IMAGE=debian-iptables
 TAG=v8
 ARCH?=amd64
@@ -34,7 +34,7 @@ ifeq ($(ARCH),s390x)
 	QEMUARCH=s390x
 endif
 
-BASEIMAGE=gcr.io/google-containers/debian-base-$(ARCH):0.2
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.2
 
 build:
 	cp ./* $(TEMP_DIR)
@@ -55,6 +55,6 @@ endif
 	docker build --pull -t $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/$(IMAGE)-$(ARCH):$(TAG)
 
 all: push

--- a/build/debian-iptables/README.md
+++ b/build/debian-iptables/README.md
@@ -1,6 +1,6 @@
 ### debian-iptables
 
-Serves as the base image for `gcr.io/google_containers/kube-proxy-${ARCH}` and multiarch (not `amd64`) `gcr.io/google_containers/flannel-${ARCH}` images.
+Serves as the base image for `k8s.gcr.io/kube-proxy-${ARCH}` and multiarch (not `amd64`) `k8s.gcr.io/flannel-${ARCH}` images.
 
 This image is compiled for multiple architectures.
 
@@ -11,19 +11,19 @@ If you're editing the Dockerfile or some other thing, please bump the `TAG` in t
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> gcr.io/google_containers/debian-iptables-amd64:TAG
+# ---> k8s.gcr.io/debian-iptables-amd64:TAG
 
 $ make push ARCH=arm
-# ---> gcr.io/google_containers/debian-iptables-arm:TAG
+# ---> k8s.gcr.io/debian-iptables-arm:TAG
 
 $ make push ARCH=arm64
-# ---> gcr.io/google_containers/debian-iptables-arm64:TAG
+# ---> k8s.gcr.io/debian-iptables-arm64:TAG
 
 $ make push ARCH=ppc64le
-# ---> gcr.io/google_containers/debian-iptables-ppc64le:TAG
+# ---> k8s.gcr.io/debian-iptables-ppc64le:TAG
 
 $ make push ARCH=s390x
-# ---> gcr.io/google_containers/debian-iptables-s390x:TAG
+# ---> k8s.gcr.io/debian-iptables-s390x:TAG
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -284,7 +284,7 @@ function kube::release::create_docker_images_for_server() {
     local images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
-    local -r docker_registry="gcr.io/google_containers"
+    local -r docker_registry="k8s.gcr.io"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
     if [[ -z "${docker_tag}" ]]; then

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY: all push push-legacy container clean orphan
 
-REGISTRY ?= gcr.io/google_containers
+REGISTRY ?= k8s.gcr.io
 IMAGE = $(REGISTRY)/pause-$(ARCH)
 LEGACY_AMD64_IMAGE = $(REGISTRY)/pause
 
@@ -26,7 +26,7 @@ ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 CFLAGS = -Os -Wall -Werror -static
-KUBE_CROSS_IMAGE ?= gcr.io/google_containers/kube-cross
+KUBE_CROSS_IMAGE ?= k8s.gcr.io/kube-cross
 KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
 
 BIN = pause
@@ -87,13 +87,13 @@ endif
 
 push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
-	gcloud docker -- push $(IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(IMAGE):$(TAG)
 	touch $@
 
 push-legacy: .push-legacy-$(ARCH)
 .push-legacy-$(ARCH): .container-$(ARCH)
 ifeq ($(ARCH),amd64)
-	gcloud docker -- push $(LEGACY_AMD64_IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(LEGACY_AMD64_IMAGE):$(TAG)
 endif
 	touch $@
 

--- a/cluster/addons/addon-manager/Makefile
+++ b/cluster/addons/addon-manager/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE=gcr.io/google-containers/kube-addon-manager
+IMAGE=k8s.gcr.io/kube-addon-manager
 ARCH?=amd64
 TEMP_DIR:=$(shell mktemp -d)
 VERSION=v6.4-beta.2
@@ -46,12 +46,12 @@ build:
 	docker build --pull -t $(IMAGE)-$(ARCH):$(VERSION) $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(IMAGE)-$(ARCH):$(VERSION)
+	gcloud docker --server=k8s.gcr.io -- push $(IMAGE)-$(ARCH):$(VERSION)
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag
 	docker rmi $(IMAGE):$(VERSION) 2>/dev/null || true
 	docker tag $(IMAGE)-$(ARCH):$(VERSION) $(IMAGE):$(VERSION)
-	gcloud docker -- push $(IMAGE):$(VERSION)
+	gcloud docker --server=k8s.gcr.io -- push $(IMAGE):$(VERSION)
 endif
 
 clean:

--- a/cluster/addons/addon-manager/README.md
+++ b/cluster/addons/addon-manager/README.md
@@ -39,20 +39,20 @@ The `addon-manager` is built for multiple architectures.
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> gcr.io/google-containers/kube-addon-manager-amd64:VERSION
-# ---> gcr.io/google-containers/kube-addon-manager:VERSION (image with backwards-compatible naming)
+# ---> k8s.gcr.io/kube-addon-manager-amd64:VERSION
+# ---> k8s.gcr.io/kube-addon-manager:VERSION (image with backwards-compatible naming)
 
 $ make push ARCH=arm
-# ---> gcr.io/google-containers/kube-addon-manager-arm:VERSION
+# ---> k8s.gcr.io/kube-addon-manager-arm:VERSION
 
 $ make push ARCH=arm64
-# ---> gcr.io/google-containers/kube-addon-manager-arm64:VERSION
+# ---> k8s.gcr.io/kube-addon-manager-arm64:VERSION
 
 $ make push ARCH=ppc64le
-# ---> gcr.io/google-containers/kube-addon-manager-ppc64le:VERSION
+# ---> k8s.gcr.io/kube-addon-manager-ppc64le:VERSION
 
 $ make push ARCH=s390x
-# ---> gcr.io/google-containers/kube-addon-manager-s390x:VERSION
+# ---> k8s.gcr.io/kube-addon-manager-s390x:VERSION
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/cpvpa-amd64:v0.6.0
+        - image: k8s.gcr.io/cpvpa-amd64:v0.6.0
           name: autoscaler
           command:
             - /cpvpa

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2
+        - image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2
           name: autoscaler
           command:
             - /cluster-proportional-autoscaler

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/cpvpa-amd64:v0.6.0
+        - image: k8s.gcr.io/cpvpa-amd64:v0.6.0
           name: autoscaler
           command:
             - /cpvpa

--- a/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
+++ b/cluster/addons/cluster-loadbalancing/glbc/default-svc-controller.yaml
@@ -24,7 +24,7 @@ spec:
         # Any image is permissible as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.3
+        image: k8s.gcr.io/defaultbackend:1.3
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -45,7 +45,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -65,7 +65,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: eventer
           command:
             - /eventer
@@ -78,7 +78,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -107,7 +107,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -45,7 +45,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -66,7 +66,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: eventer
           command:
             - /eventer
@@ -79,7 +79,7 @@ spec:
             - name: usr-ca-certs
               mountPath: /usr/share/ca-certificates
               readOnly: true
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -108,7 +108,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -45,7 +45,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,13 +58,13 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: eventer
           command:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:
@@ -93,7 +93,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/influxdb-grafana-controller.yaml
@@ -29,7 +29,7 @@ spec:
         operator: "Exists"
       containers:
         - name: influxdb
-          image: gcr.io/google_containers/heapster-influxdb-amd64:v1.3.3
+          image: k8s.gcr.io/heapster-influxdb-amd64:v1.3.3
           resources:
             limits:
               cpu: 100m
@@ -46,7 +46,7 @@ spec:
           - name: influxdb-persistent-storage
             mountPath: /data
         - name: grafana
-          image: gcr.io/google_containers/heapster-grafana-amd64:v4.4.3
+          image: k8s.gcr.io/heapster-grafana-amd64:v4.4.3
           env:
           resources:
             # keep request = limit to keep this container in guaranteed class

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -43,7 +43,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -65,7 +65,7 @@ spec:
               readOnly: true
         # BEGIN_PROMETHEUS_TO_SD
         - name: prom-to-sd
-          image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+          image: k8s.gcr.io/prometheus-to-sd:v0.2.2
           command:
             - /monitor
             - --source=heapster:http://localhost:8082?whitelisted=stackdriver_requests_count,stackdriver_timeseries_count
@@ -83,7 +83,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -43,7 +43,7 @@ spec:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.0
+        - image: k8s.gcr.io/heapster-amd64:v1.5.0-beta.0
           name: heapster
           livenessProbe:
             httpGet:
@@ -55,7 +55,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: k8s.gcr.io/addon-resizer:1.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: kubernetes-dashboard
-        image: gcr.io/google_containers/kubernetes-dashboard-amd64:v1.6.3
+        image: k8s.gcr.io/kubernetes-dashboard-amd64:v1.6.3
         resources:
           # keep request = limit to keep this container in guaranteed class
           limits:

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -77,7 +77,7 @@ spec:
     spec:
       containers:
       - name: autoscaler
-        image: gcr.io/google_containers/cluster-proportional-autoscaler-amd64:1.1.2-r2
+        image: k8s.gcr.io/cluster-proportional-autoscaler-amd64:1.1.2-r2
         resources:
             requests:
                 cpu: "20m"

--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -94,7 +94,7 @@ spec:
           optional: true
       containers:
       - name: kubedns
-        image: gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-kube-dns-amd64:1.14.7
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -145,7 +145,7 @@ spec:
         - name: kube-dns-config
           mountPath: /kube-dns-config
       - name: dnsmasq
-        image: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-dnsmasq-nanny-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -184,7 +184,7 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
-        image: gcr.io/google_containers/k8s-dns-sidecar-amd64:1.14.7
+        image: k8s.gcr.io/k8s-dns-sidecar-amd64:1.14.7
         livenessProbe:
           httpGet:
             path: /metrics

--- a/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
+++ b/cluster/addons/etcd-empty-dir-cleanup/etcd-empty-dir-cleanup.yaml
@@ -12,4 +12,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: gcr.io/google-containers/etcd-empty-dir-cleanup:3.0.14.0
+    image: k8s.gcr.io/etcd-empty-dir-cleanup:3.0.14.0

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	binary build push
 
-PREFIX = gcr.io/google-containers
+PREFIX = k8s.gcr.io
 IMAGE = elasticsearch
 TAG = v5.6.2
 
@@ -22,7 +22,7 @@ build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push:
-	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/$(IMAGE):$(TAG)
 
 binary:
 	CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-w" elasticsearch_logging_discovery.go

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -73,7 +73,7 @@ spec:
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: gcr.io/google-containers/elasticsearch:v5.6.2
+      - image: k8s.gcr.io/elasticsearch:v5.6.2
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -71,7 +71,7 @@ spec:
       serviceAccountName: fluentd-es
       containers:
       - name: fluentd-es
-        image: gcr.io/google-containers/fluentd-elasticsearch:v2.0.2
+        image: k8s.gcr.io/fluentd-elasticsearch:v2.0.2
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/Makefile
@@ -14,7 +14,7 @@
 
 .PHONY:	build push
 
-PREFIX = gcr.io/google-containers
+PREFIX = k8s.gcr.io
 IMAGE = fluentd-elasticsearch
 TAG = v2.0.2
 
@@ -22,4 +22,4 @@ build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push:
-	gcloud docker -- push $(PREFIX)/$(IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/$(IMAGE):$(TAG)

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/README.md
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/README.md
@@ -4,11 +4,11 @@ that collects Docker container log files using [Fluentd][fluentd]
 and sends them to an instance of [Elasticsearch][elasticsearch].
 This image is designed to be used as part of the [Kubernetes][kubernetes]
 cluster bring up process. The image resides at GCR under the name
-[gcr.io/google-containers/fluentd-elasticsearch][image].
+[k8s.gcr.io/fluentd-elasticsearch][image].
 
 [fluentd]: http://www.fluentd.org/
 [elasticsearch]: https://www.elastic.co/products/elasticsearch
 [kubernetes]: https://kubernetes.io
-[image]: https://gcr.io/google-containers/fluentd-elasticsearch
+[image]: https://k8s.gcr.io/fluentd-elasticsearch
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/cluster/addons/fluentd-elasticsearch/fluentd-es-image/README.md?pixel)]()

--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -47,12 +47,12 @@ spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: gcr.io/google-containers/event-exporter:v0.1.7
+        image: k8s.gcr.io/event-exporter:v0.1.7
         command:
         - '/event-exporter'
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+        image: k8s.gcr.io/prometheus-to-sd:v0.2.2
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -36,7 +36,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: fluentd-gcp
-        image: gcr.io/google-containers/fluentd-gcp:2.0.10
+        image: k8s.gcr.io/fluentd-gcp:2.0.10
         env:
         - name: FLUENTD_ARGS
           value: --no-supervisor -q
@@ -91,7 +91,7 @@ spec:
               fi;
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google-containers/prometheus-to-sd:v0.2.2
+        image: k8s.gcr.io/prometheus-to-sd:v0.2.2
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
+++ b/cluster/addons/ip-masq-agent/ip-masq-agent.yaml
@@ -17,7 +17,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ip-masq-agent
-        image: gcr.io/google-containers/ip-masq-agent-amd64:v2.0.2
+        image: k8s.gcr.io/ip-masq-agent-amd64:v2.0.2
         resources:
           requests:
             cpu: 10m

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -38,7 +38,7 @@ spec:
       dnsPolicy: Default
       containers:
       - name: metadata-proxy
-        image: gcr.io/google_containers/metadata-proxy:v0.1.4
+        image: k8s.gcr.io/metadata-proxy:v0.1.4
         securityContext:
           privileged: true
         resources:
@@ -50,7 +50,7 @@ spec:
             cpu: "15m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: gcr.io/google_containers/prometheus-to-sd:v0.2.2
+        image: k8s.gcr.io/prometheus-to-sd:v0.2.2
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.2.0
+        image: k8s.gcr.io/metrics-server-amd64:v0.2.0
         command:
         - /metrics-server
         - --source=kubernetes.summary_api:''
@@ -43,7 +43,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: gcr.io/google_containers/addon-resizer:1.7
+        image: k8s.gcr.io/addon-resizer:1.7
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/node-problem-detector/npd.yaml
+++ b/cluster/addons/node-problem-detector/npd.yaml
@@ -43,7 +43,7 @@ spec:
     spec:
       containers:
       - name: node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.4.1
+        image: k8s.gcr.io/node-problem-detector:v0.4.1
         command:
         - "/bin/sh"
         - "-c"

--- a/cluster/addons/python-image/Makefile
+++ b/cluster/addons/python-image/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMAGE=gcr.io/google_containers/python
+IMAGE=k8s.gcr.io/python
 VERSION=v1
 
 .PHONY: build push
@@ -21,5 +21,5 @@ build:
 	docker build --pull -t "$(IMAGE):$(VERSION)" .
 
 push:
-	gcloud docker -- push "$(IMAGE):$(VERSION)"
+	gcloud docker --server=k8s.gcr.io -- push "$(IMAGE):$(VERSION)"
 

--- a/cluster/addons/registry/README.md
+++ b/cluster/addons/registry/README.md
@@ -199,7 +199,7 @@ spec:
     spec:
       containers:
       - name: kube-registry-proxy
-        image: gcr.io/google_containers/kube-registry-proxy:0.4
+        image: k8s.gcr.io/kube-registry-proxy:0.4
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/registry/images/Makefile
+++ b/cluster/addons/registry/images/Makefile
@@ -15,10 +15,10 @@
 .PHONY: build push vet test clean
 
 TAG = 0.4
-REPO = gcr.io/google_containers/kube-registry-proxy
+REPO = k8s.gcr.io/kube-registry-proxy
 
 build:
 	docker build --pull -t $(REPO):$(TAG) .
 
 push:
-	gcloud docker -- push $(REPO):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REPO):$(TAG)

--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -493,7 +493,7 @@ function stage-images() {
     (
       "${docker_cmd[@]}" load -i "${temp_dir}/kubernetes/server/bin/${binary}.tar"
       "${docker_cmd[@]}" rmi "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}" 2>/dev/null || true
-      "${docker_cmd[@]}" tag "gcr.io/google_containers/${binary}:${docker_tag}" "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
+      "${docker_cmd[@]}" tag "k8s.gcr.io/${binary}:${docker_tag}" "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
       "${docker_push_cmd[@]}" push "${KUBE_DOCKER_REGISTRY}/${binary}:${KUBE_IMAGE_TAG}"
     ) &> "${temp_dir}/${binary}-push.log" &
   done

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -154,7 +154,7 @@ ENABLE_METRICS_SERVER="${KUBE_ENABLE_METRICS_SERVER:-true}"
 # Useful for scheduling heapster in large clusters with nodes of small size.
 HEAPSTER_MACHINE_TYPE="${HEAPSTER_MACHINE_TYPE:-}"
 
-# Set etcd image (e.g. gcr.io/google_containers/etcd) and version (e.g. 3.1.10) if you need
+# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.1.10) if you need
 # non-default version.
 ETCD_IMAGE="${TEST_ETCD_IMAGE:-}"
 ETCD_DOCKER_REPOSITORY="${TEST_ETCD_DOCKER_REPOSITORY:-}"

--- a/cluster/gce/container-linux/configure-helper.sh
+++ b/cluster/gce/container-linux/configure-helper.sh
@@ -662,7 +662,7 @@ function prepare-kube-proxy-manifest-variables {
   remove-salt-config-comments "${src_file}"
 
   local -r kubeconfig="--kubeconfig=/var/lib/kube-proxy/kubeconfig"
-  local kube_docker_registry="gcr.io/google_containers"
+  local kube_docker_registry="k8s.gcr.io"
   if [[ -n "${KUBE_DOCKER_REGISTRY:-}" ]]; then
     kube_docker_registry=${KUBE_DOCKER_REGISTRY}
   fi
@@ -844,7 +844,7 @@ function compute-master-manifest-variables {
     CLOUD_CONFIG_VOLUME="{\"name\": \"cloudconfigmount\",\"hostPath\": {\"path\": \"/etc/gce.conf\", \"type\": \"FileOrCreate\"}},"
     CLOUD_CONFIG_MOUNT="{\"name\": \"cloudconfigmount\",\"mountPath\": \"/etc/gce.conf\", \"readOnly\": true},"
   fi
-  DOCKER_REGISTRY="gcr.io/google_containers"
+  DOCKER_REGISTRY="k8s.gcr.io"
   if [[ -n "${KUBE_DOCKER_REGISTRY:-}" ]]; then
     DOCKER_REGISTRY="${KUBE_DOCKER_REGISTRY}"
   fi

--- a/cluster/gce/container-linux/configure.sh
+++ b/cluster/gce/container-linux/configure.sh
@@ -140,12 +140,12 @@ function install-kube-binary-config {
   echo "Downloading k8s manifests tar"
   download-or-bust "${manifests_tar_hash}" "${manifests_tar_urls[@]}"
   tar xzf "${KUBE_HOME}/${manifests_tar}" -C "${dst_dir}" --overwrite
-  local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-gcr.io/google_containers}"
-  if [[ "${kube_addon_registry}" != "gcr.io/google_containers" ]]; then
+  local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-k8s.gcr.io}"
+  if [[ "${kube_addon_registry}" != "k8s.gcr.io" ]]; then
     find "${dst_dir}" -name \*.yaml -or -name \*.yaml.in | \
-      xargs sed -ri "s@(image:\s.*)gcr.io/google_containers@\1${kube_addon_registry}@"
+      xargs sed -ri "s@(image:\s.*)k8s.gcr.io@\1${kube_addon_registry}@"
     find "${dst_dir}" -name \*.manifest -or -name \*.json | \
-      xargs sed -ri "s@(image\":\s+\")gcr.io/google_containers@\1${kube_addon_registry}@"
+      xargs sed -ri "s@(image\":\s+\")k8s.gcr.io@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/container-linux-configure-helper.sh" "${KUBE_HOME}/bin/configure-helper.sh"
   chmod -R 755 "${kube_bin}"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1088,7 +1088,7 @@ function prepare-kube-proxy-manifest-variables {
   remove-salt-config-comments "${src_file}"
 
   local -r kubeconfig="--kubeconfig=/var/lib/kube-proxy/kubeconfig"
-  local kube_docker_registry="gcr.io/google_containers"
+  local kube_docker_registry="k8s.gcr.io"
   if [[ -n "${KUBE_DOCKER_REGISTRY:-}" ]]; then
     kube_docker_registry=${KUBE_DOCKER_REGISTRY}
   fi
@@ -1260,7 +1260,7 @@ function compute-master-manifest-variables {
     CLOUD_CONFIG_VOLUME="{\"name\": \"cloudconfigmount\",\"hostPath\": {\"path\": \"/etc/gce.conf\", \"type\": \"FileOrCreate\"}},"
     CLOUD_CONFIG_MOUNT="{\"name\": \"cloudconfigmount\",\"mountPath\": \"/etc/gce.conf\", \"readOnly\": true},"
   fi
-  DOCKER_REGISTRY="gcr.io/google_containers"
+  DOCKER_REGISTRY="k8s.gcr.io"
   if [[ -n "${KUBE_DOCKER_REGISTRY:-}" ]]; then
     DOCKER_REGISTRY="${KUBE_DOCKER_REGISTRY}"
   fi

--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -217,12 +217,12 @@ function install-kube-manifests {
   echo "Downloading k8s manifests tar"
   download-or-bust "${manifests_tar_hash}" "${manifests_tar_urls[@]}"
   tar xzf "${KUBE_HOME}/${manifests_tar}" -C "${dst_dir}" --overwrite
-  local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-gcr.io/google_containers}"
-  if [[ "${kube_addon_registry}" != "gcr.io/google_containers" ]]; then
+  local -r kube_addon_registry="${KUBE_ADDON_REGISTRY:-k8s.gcr.io}"
+  if [[ "${kube_addon_registry}" != "k8s.gcr.io" ]]; then
     find "${dst_dir}" -name \*.yaml -or -name \*.yaml.in | \
-      xargs sed -ri "s@(image:\s.*)gcr.io/google_containers@\1${kube_addon_registry}@"
+      xargs sed -ri "s@(image:\s.*)k8s.gcr.io@\1${kube_addon_registry}@"
     find "${dst_dir}" -name \*.manifest -or -name \*.json | \
-      xargs sed -ri "s@(image\":\s+\")gcr.io/google_containers@\1${kube_addon_registry}@"
+      xargs sed -ri "s@(image\":\s+\")k8s.gcr.io@\1${kube_addon_registry}@"
   fi
   cp "${dst_dir}/kubernetes/gci-trusty/gci-configure-helper.sh" "${KUBE_BIN}/configure-helper.sh"
   cp "${dst_dir}/kubernetes/gci-trusty/health-monitor.sh" "${KUBE_BIN}/health-monitor.sh"

--- a/cluster/gce/gci/mounter/Makefile
+++ b/cluster/gce/gci/mounter/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG=v2
-REGISTRY=gcr.io/google_containers
+REGISTRY=k8s.gcr.io
 IMAGE=gci-mounter
 
 all: container
@@ -22,7 +22,7 @@ container:
 	docker build --pull -t ${REGISTRY}/${IMAGE}:${TAG} .
 
 push: 
-	gcloud docker -- push ${REGISTRY}/${IMAGE}:${TAG}
+	gcloud docker --server=k8s.gcr.io -- push ${REGISTRY}/${IMAGE}:${TAG}
 
 upload:
 	./stage-upload.sh ${TAG} ${REGISTRY}/${IMAGE}:${TAG}

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -229,12 +229,12 @@ function set-preferred-region() {
   fi
 
   # If we're using regional GCR, and we're outside the US, go to the
-  # regional registry. The gcr.io/google_containers registry is
+  # regional registry. The k8s.gcr.io registry is
   # appropriate for US (for now).
   if [[ "${REGIONAL_KUBE_ADDONS}" == "true" ]] && [[ "${preferred}" != "us" ]]; then
-    KUBE_ADDON_REGISTRY="${preferred}.gcr.io/google_containers"
+    KUBE_ADDON_REGISTRY="${preferred}.k8s.gcr.io"
   else
-    KUBE_ADDON_REGISTRY="gcr.io/google_containers"
+    KUBE_ADDON_REGISTRY="k8s.gcr.io"
   fi
 
   if [[ "${ENABLE_DOCKER_REGISTRY_CACHE:-}" == "true" ]]; then

--- a/cluster/get-kube-local.sh
+++ b/cluster/get-kube-local.sh
@@ -97,7 +97,7 @@ function create_cluster {
   --pid=host \
   --privileged=true \
   -d \
-  gcr.io/google_containers/hyperkube-${arch}:${release} \
+  k8s.gcr.io/hyperkube-${arch}:${release} \
     /hyperkube kubelet \
       --containerized \
       --hostname-override="127.0.0.1" \

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -15,7 +15,7 @@
 .PHONY:	build push
 
 ETCD_VERSION = 3.0.14
-IMAGE = gcr.io/google-containers/etcd-empty-dir-cleanup
+IMAGE = k8s.gcr.io/etcd-empty-dir-cleanup
 TAG = 3.0.14.0
 
 clean:
@@ -29,4 +29,4 @@ build: clean
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz
 
 push: build
-	gcloud docker -- push $(IMAGE):$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(IMAGE):$(TAG)

--- a/cluster/images/etcd-version-monitor/Makefile
+++ b/cluster/images/etcd-version-monitor/Makefile
@@ -15,11 +15,11 @@
 # Build the etcd-version-monitor image
 #
 # Usage:
-# 	[GOLANG_VERSION=1.8.3] [REGISTRY=gcr.io/google-containers] [TAG=test] make (build|push)
+# 	[GOLANG_VERSION=1.8.3] [REGISTRY=k8s.gcr.io] [TAG=test] make (build|push)
 # TODO(shyamjvs): Support architectures other than amd64 if needed.
 ARCH:=amd64
 GOLANG_VERSION?=1.8.3
-REGISTRY?=gcr.io/google-containers
+REGISTRY?=k8s.gcr.io
 TAG?=0.1.0
 IMAGE:=$(REGISTRY)/etcd-version-monitor:$(TAG)
 CURRENT_DIR:=$(pwd)
@@ -36,7 +36,7 @@ build:
 	docker build -t $(IMAGE) $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(IMAGE)
+	gcloud docker --server=k8s.gcr.io -- push $(IMAGE)
 
 all: build
 

--- a/cluster/images/etcd-version-monitor/README.md
+++ b/cluster/images/etcd-version-monitor/README.md
@@ -10,7 +10,7 @@ The metrics are exposed at the http://localhost:9101/metrics endpoint.
 
 To run this tool as a docker container:
 - make build
-- docker run --net=host -i -t gcr.io/google_containers/etcd-version-monitor:test /etcd-version-monitor --logtostderr
+- docker run --net=host -i -t k8s.gcr.io/etcd-version-monitor:test /etcd-version-monitor --logtostderr
 
 To run this as a pod on the kubernetes cluster:
 - Place the 'etcd-version-monitor.yaml' in the manifests directory of

--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
@@ -7,7 +7,7 @@ spec:
   hostNetwork: true
   containers:
   - name: etcd-version-monitor
-    image: gcr.io/google-containers/etcd-version-monitor:0.1.0
+    image: k8s.gcr.io/etcd-version-monitor:0.1.0
     command:
     - /etcd-version-monitor
     - --logtostderr

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[TAGS=2.2.1 2.3.7 3.0.17 3.1.10] [REGISTRY=gcr.io/google_containers] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[TAGS=2.2.1 2.3.7 3.0.17 3.1.10] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any tag from here.
@@ -29,7 +29,7 @@
 TAGS?=2.2.1 2.3.7 3.0.17 3.1.10
 REGISTRY_TAG?=3.1.10
 ARCH?=amd64
-REGISTRY?=gcr.io/google_containers
+REGISTRY?=k8s.gcr.io
 GOLANG_VERSION?=1.7.6
 GOARM=7
 TEMP_DIR:=$(shell mktemp -d)
@@ -105,12 +105,12 @@ endif
 	docker build --pull -t $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(TEMP_DIR)
 
 push: build
-	gcloud docker -- push $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG)
 
 ifeq ($(ARCH),amd64)
 	# Backward compatibility. TODO: deprecate this image tag
 	docker tag $(REGISTRY)/etcd-$(ARCH):$(REGISTRY_TAG) $(REGISTRY)/etcd:$(REGISTRY_TAG)
-	gcloud docker -- push $(REGISTRY)/etcd:$(REGISTRY_TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/etcd:$(REGISTRY_TAG)
 endif
 
 all: build

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -10,20 +10,20 @@ For other architectures, `etcd` is cross-compiled from source. Arch-specific `bu
 ```console
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> gcr.io/google_containers/etcd-amd64:TAG
-# ---> gcr.io/google_containers/etcd:TAG
+# ---> k8s.gcr.io/etcd-amd64:TAG
+# ---> k8s.gcr.io/etcd:TAG
 
 $ make push ARCH=arm
-# ---> gcr.io/google_containers/etcd-arm:TAG
+# ---> k8s.gcr.io/etcd-arm:TAG
 
 $ make push ARCH=arm64
-# ---> gcr.io/google_containers/etcd-arm64:TAG
+# ---> k8s.gcr.io/etcd-arm64:TAG
 
 $ make push ARCH=ppc64le
-# ---> gcr.io/google_containers/etcd-ppc64le:TAG
+# ---> k8s.gcr.io/etcd-ppc64le:TAG
 
 $ make push ARCH=s390x
-# ---> gcr.io/google_containers/etcd-s390x:TAG
+# ---> k8s.gcr.io/etcd-s390x:TAG
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/images/hyperkube/BUILD
+++ b/cluster/images/hyperkube/BUILD
@@ -27,7 +27,7 @@ docker_build(
 
 docker_bundle(
     name = "hyperkube",
-    images = {"gcr.io/google-containers/hyperkube-amd64:{STABLE_DOCKER_TAG}": "hyperkube-internal"},
+    images = {"k8s.gcr.io/hyperkube-amd64:{STABLE_DOCKER_TAG}": "hyperkube-internal"},
     stamp = True,
 )
 

--- a/cluster/images/hyperkube/Dockerfile
+++ b/cluster/images/hyperkube/Dockerfile
@@ -16,7 +16,7 @@ FROM BASEIMAGE
 
 # Create symlinks for each hyperkube server
 # Also create symlinks to /usr/local/bin/ where the server image binaries live, so the hyperkube image may be
-# used instead of gcr.io/google_containers/kube-* without any modifications.
+# used instead of k8s.gcr.io/kube-* without any modifications.
 # TODO: replace manual symlink creation with --make-symlink command once
 # cross-building with qemu supports go binaries. See #28702
 # RUN /hyperkube --make-symlinks

--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -15,13 +15,13 @@
 # Build the hyperkube image.
 #
 # Usage:
-#   [ARCH=amd64] [REGISTRY="gcr.io/google-containers"] make (build|push) VERSION={some_released_version_of_kubernetes}
+#   [ARCH=amd64] [REGISTRY="k8s.gcr.io"] make (build|push) VERSION={some_released_version_of_kubernetes}
 
-REGISTRY?=gcr.io/google-containers
+REGISTRY?=k8s.gcr.io
 ARCH?=amd64
 HYPERKUBE_BIN?=_output/dockerized/bin/linux/$(ARCH)/hyperkube
 
-BASEIMAGE=gcr.io/google-containers/debian-hyperkube-base-$(ARCH):0.6
+BASEIMAGE=k8s.gcr.io/debian-hyperkube-base-$(ARCH):0.6
 TEMP_DIR:=$(shell mktemp -d -t hyperkubeXXXXXX)
 
 all: build
@@ -44,11 +44,11 @@ endif
 	rm -rf "${TEMP_DIR}"
 
 push: build
-	gcloud docker -- push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${REGISTRY}/hyperkube-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
 	docker rmi ${REGISTRY}/hyperkube:${VERSION} 2>/dev/null || true
 	docker tag ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${REGISTRY}/hyperkube:${VERSION}
-	gcloud docker -- push ${REGISTRY}/hyperkube:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${REGISTRY}/hyperkube:${VERSION}
 endif
 
 .PHONY: build push all

--- a/cluster/images/hyperkube/README.md
+++ b/cluster/images/hyperkube/README.md
@@ -10,23 +10,23 @@
 $ build/run.sh make cross
 
 # Build for linux/amd64 (default)
-# export REGISTRY=$HOST/$ORG to switch from gcr.io/google_containers
+# export REGISTRY=$HOST/$ORG to switch from k8s.gcr.io
 
 $ make push VERSION={target_version} ARCH=amd64
-# ---> gcr.io/google_containers/hyperkube-amd64:VERSION
-# ---> gcr.io/google_containers/hyperkube:VERSION (image with backwards-compatible naming)
+# ---> k8s.gcr.io/hyperkube-amd64:VERSION
+# ---> k8s.gcr.io/hyperkube:VERSION (image with backwards-compatible naming)
 
 $ make push VERSION={target_version} ARCH=arm
-# ---> gcr.io/google_containers/hyperkube-arm:VERSION
+# ---> k8s.gcr.io/hyperkube-arm:VERSION
 
 $ make push VERSION={target_version} ARCH=arm64
-# ---> gcr.io/google_containers/hyperkube-arm64:VERSION
+# ---> k8s.gcr.io/hyperkube-arm64:VERSION
 
 $ make push VERSION={target_version} ARCH=ppc64le
-# ---> gcr.io/google_containers/hyperkube-ppc64le:VERSION
+# ---> k8s.gcr.io/hyperkube-ppc64le:VERSION
 
 $ make push VERSION={target_version} ARCH=s390x
-# ---> gcr.io/google_containers/hyperkube-s390x:VERSION
+# ---> k8s.gcr.io/hyperkube-s390x:VERSION
 ```
 
 If you don't want to push the images, run `make` or `make build` instead

--- a/cluster/images/kubemark/Makefile
+++ b/cluster/images/kubemark/Makefile
@@ -24,7 +24,7 @@ build:
 	docker build --pull -t $(REGISTRY)/$(PROJECT)/kubemark .
 
 gcloudpush: build
-	gcloud docker -- push $(REGISTRY)/$(PROJECT)/kubemark
+	gcloud docker --server=k8s.gcr.io -- push $(REGISTRY)/$(PROJECT)/kubemark
 
 push: build
 	docker -- push $(REGISTRY)/$(PROJECT)/kubemark

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -573,7 +573,7 @@ def launch_default_ingress_controller():
 
     # Render the ingress replication controller manifest
     context['ingress_image'] = \
-        "gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.13"
+        "k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.13"
     if arch() == 's390x':
         context['ingress_image'] = \
             "docker.io/cdkbot/nginx-ingress-controller-s390x:0.9.0-beta.13"

--- a/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
@@ -17,7 +17,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: k8s.gcr.io/defaultbackend:1.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cluster/kubemark/gce/config-default.sh
+++ b/cluster/kubemark/gce/config-default.sh
@@ -61,7 +61,7 @@ RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 TERMINATED_POD_GC_THRESHOLD=${TERMINATED_POD_GC_THRESHOLD:-100}
 KUBE_APISERVER_REQUEST_TIMEOUT=300
 
-# Set etcd image (e.g. gcr.io/google_containers/etcd) and version (e.g. 3.1.10) if you need
+# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.1.10) if you need
 # non-default version.
 ETCD_IMAGE="${TEST_ETCD_IMAGE:-}"
 ETCD_VERSION="${TEST_ETCD_VERSION:-}"

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/google-containers/logexporter:v0.1.1
+        image: k8s.gcr.io/logexporter:v0.1.1
         env:
         - name: NODE_NAME
           valueFrom:

--- a/cluster/restore-from-backup.sh
+++ b/cluster/restore-from-backup.sh
@@ -155,7 +155,7 @@ if [ "${ETCD_API}" == "etcd2" ]; then
   echo "Starting etcd ${ETCD_VERSION} to restore data"
   image=$(docker run -d -v ${BACKUP_DIR}:/var/etcd/data \
     --net=host -p ${etcd_port}:${etcd_port} \
-    "gcr.io/google_containers/etcd:${ETCD_VERSION}" /bin/sh -c \
+    "k8s.gcr.io/etcd:${ETCD_VERSION}" /bin/sh -c \
     "/usr/local/bin/etcd --data-dir /var/etcd/data --force-new-cluster")
   if [ "$?" -ne "0" ]; then
     echo "Docker container didn't started correctly"
@@ -187,7 +187,7 @@ elif [ "${ETCD_API}" == "etcd3" ]; then
   # setting with --name in the etcd manifest file and then it seems to work.
   # TODO(jsz): This command may not work in case of HA.
   image=$(docker run -d -v ${BACKUP_DIR}:/var/tmp/backup --env ETCDCTL_API=3 \
-    "gcr.io/google_containers/etcd:${ETCD_VERSION}" /bin/sh -c \
+    "k8s.gcr.io/etcd:${ETCD_VERSION}" /bin/sh -c \
     "/usr/local/bin/etcdctl snapshot restore ${BACKUP_DIR}/${snapshot} --name ${NAME} --initial-cluster ${NAME}=http://localhost:2380; mv /${NAME}.etcd/member /var/tmp/backup/")
   if [ "$?" -ne "0" ]; then
     echo "Docker container didn't started correctly"

--- a/cluster/saltbase/install.sh
+++ b/cluster/saltbase/install.sh
@@ -81,7 +81,7 @@ for docker_file in "${KUBE_DOCKER_WRAPPED_BINARIES[@]}"; do
 done
 
 cat <<EOF >>"${docker_images_sls_file}"
-kube_docker_registry: '$(echo ${KUBE_DOCKER_REGISTRY:-gcr.io/google_containers})'
+kube_docker_registry: '$(echo ${KUBE_DOCKER_REGISTRY:-k8s.gcr.io})'
 EOF
 
 # TODO(zmerlynn): Forgive me, this is really gross. But in order to
@@ -89,13 +89,13 @@ EOF
 # have to templatize a couple of the add-ons anyways, manually
 # templatize the addon registry for regional support. When we get
 # better templating, we can fix this.
-readonly kube_addon_registry="${KUBE_ADDON_REGISTRY:-gcr.io/google_containers}"
-if [[ "${kube_addon_registry}" != "gcr.io/google_containers" ]]; then
+readonly kube_addon_registry="${KUBE_ADDON_REGISTRY:-k8s.gcr.io}"
+if [[ "${kube_addon_registry}" != "k8s.gcr.io" ]]; then
   find /srv/salt-new -name \*.yaml -or -name \*.yaml.in | \
-    xargs sed -ri "s@(image:\s.*)gcr.io/google_containers@\1${kube_addon_registry}@"
+    xargs sed -ri "s@(image:\s.*)k8s.gcr.io@\1${kube_addon_registry}@"
   # All the legacy .manifest files with hardcoded gcr.io are JSON.
   find /srv/salt-new -name \*.manifest -or -name \*.json | \
-    xargs sed -ri "s@(image\":\s+\")gcr.io/google_containers@\1${kube_addon_registry}@"
+    xargs sed -ri "s@(image\":\s+\")k8s.gcr.io@\1${kube_addon_registry}@"
 fi
 
 echo "+++ Swapping in new configs"

--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.2-beta1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.0.2-beta1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",

--- a/cluster/saltbase/salt/e2e-image-puller/e2e-image-puller.manifest
+++ b/cluster/saltbase/salt/e2e-image-puller/e2e-image-puller.manifest
@@ -14,7 +14,7 @@ spec:
         cpu: 100m
       limits:
         cpu: 100m
-    image: gcr.io/google_containers/busybox:1.24
+    image: k8s.gcr.io/busybox:1.24
     # TODO: Replace this with a go script that pulls in parallel?
     # Currently it takes ~5m to pull all e2e images, so this is OK, and
     # fewer moving parts is always better.
@@ -29,52 +29,52 @@ spec:
     - -c
     - >
       for i in
-      gcr.io/google_containers/alpine-with-bash:1.0
-      gcr.io/google_containers/apparmor-loader:0.1
-      gcr.io/google_containers/busybox:1.24
-      gcr.io/google_containers/dnsutils:e2e
-      gcr.io/google_containers/e2e-net-amd64:1.0
-      gcr.io/google_containers/echoserver:1.6
-      gcr.io/google_containers/eptest:0.1
-      gcr.io/google_containers/fakegitserver:0.1
-      gcr.io/google_containers/galera-install:0.1
-      gcr.io/google_containers/hostexec:1.2
-      gcr.io/google_containers/invalid-image:invalid-tag
-      gcr.io/google_containers/iperf:e2e
-      gcr.io/google_containers/jessie-dnsutils:e2e
-      gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.14.5
-      gcr.io/google_containers/liveness:e2e
-      gcr.io/google_containers/logs-generator:v0.1.0
-      gcr.io/google_containers/mounttest:0.8
-      gcr.io/google_containers/mounttest-user:0.5
-      gcr.io/google_containers/mysql-galera:e2e
-      gcr.io/google_containers/mysql-healthz:1.0
-      gcr.io/google_containers/netexec:1.4
-      gcr.io/google_containers/netexec:1.5
-      gcr.io/google_containers/netexec:1.7
-      gcr.io/google_containers/nettest:1.7
-      gcr.io/google_containers/nginx:1.7.9
-      gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.1
-      gcr.io/google_containers/nginx-slim:0.7
-      gcr.io/google_containers/nginx-slim:0.8
-      gcr.io/google_containers/node-problem-detector:v0.3.0
-      gcr.io/google_containers/pause
-      gcr.io/google_containers/porter:4524579c0eb935c056c8e75563b4e1eda31587e0
-      gcr.io/google_containers/portforwardtester:1.2
-      gcr.io/google_containers/redis-install-3.2.0:e2e
-      gcr.io/google_containers/resource_consumer:beta4
-      gcr.io/google_containers/resource_consumer/controller:beta4
+      k8s.gcr.io/alpine-with-bash:1.0
+      k8s.gcr.io/apparmor-loader:0.1
+      k8s.gcr.io/busybox:1.24
+      k8s.gcr.io/dnsutils:e2e
+      k8s.gcr.io/e2e-net-amd64:1.0
+      k8s.gcr.io/echoserver:1.6
+      k8s.gcr.io/eptest:0.1
+      k8s.gcr.io/fakegitserver:0.1
+      k8s.gcr.io/galera-install:0.1
+      k8s.gcr.io/hostexec:1.2
+      k8s.gcr.io/invalid-image:invalid-tag
+      k8s.gcr.io/iperf:e2e
+      k8s.gcr.io/jessie-dnsutils:e2e
+      k8s.gcr.io/k8s-dns-dnsmasq-amd64:1.14.5
+      k8s.gcr.io/liveness:e2e
+      k8s.gcr.io/logs-generator:v0.1.0
+      k8s.gcr.io/mounttest:0.8
+      k8s.gcr.io/mounttest-user:0.5
+      k8s.gcr.io/mysql-galera:e2e
+      k8s.gcr.io/mysql-healthz:1.0
+      k8s.gcr.io/netexec:1.4
+      k8s.gcr.io/netexec:1.5
+      k8s.gcr.io/netexec:1.7
+      k8s.gcr.io/nettest:1.7
+      k8s.gcr.io/nginx:1.7.9
+      k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.1
+      k8s.gcr.io/nginx-slim:0.7
+      k8s.gcr.io/nginx-slim:0.8
+      k8s.gcr.io/node-problem-detector:v0.3.0
+      k8s.gcr.io/pause
+      k8s.gcr.io/porter:4524579c0eb935c056c8e75563b4e1eda31587e0
+      k8s.gcr.io/portforwardtester:1.2
+      k8s.gcr.io/redis-install-3.2.0:e2e
+      k8s.gcr.io/resource_consumer:beta4
+      k8s.gcr.io/resource_consumer/controller:beta4
       gcr.io/kubernetes-e2e-test-images/serve-hostname-amd64:1.1
-      gcr.io/google_containers/servicelb:0.1
-      gcr.io/google_containers/test-webserver:e2e
-      gcr.io/google_containers/update-demo:kitten
-      gcr.io/google_containers/update-demo:nautilus
-      gcr.io/google_containers/volume-ceph:0.1
-      gcr.io/google_containers/volume-gluster:0.2
-      gcr.io/google_containers/volume-iscsi:0.1
-      gcr.io/google_containers/volume-nfs:0.8
-      gcr.io/google_containers/volume-rbd:0.1
-      gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e
+      k8s.gcr.io/servicelb:0.1
+      k8s.gcr.io/test-webserver:e2e
+      k8s.gcr.io/update-demo:kitten
+      k8s.gcr.io/update-demo:nautilus
+      k8s.gcr.io/volume-ceph:0.1
+      k8s.gcr.io/volume-gluster:0.2
+      k8s.gcr.io/volume-iscsi:0.1
+      k8s.gcr.io/volume-nfs:0.8
+      k8s.gcr.io/volume-rbd:0.1
+      k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e
       gcr.io/google_samples/gb-redisslave:nonexistent
       ; do echo $(date '+%X') pulling $i; docker pull $i 1>/dev/null; done; exit 0;
     securityContext:
@@ -91,7 +91,7 @@ spec:
         cpu: 100m
       limits:
         cpu: 100m
-    image:  gcr.io/google_containers/kube-nethealth-amd64:1.0
+    image:  k8s.gcr.io/kube-nethealth-amd64:1.0
     command:
     - /bin/sh
     - -c

--- a/cluster/saltbase/salt/etcd/etcd.manifest
+++ b/cluster/saltbase/salt/etcd/etcd.manifest
@@ -39,7 +39,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "{{ pillar.get('etcd_docker_repository', 'gcr.io/google_containers/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.1.10') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.1.10') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}

--- a/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
+++ b/cluster/saltbase/salt/kube-addons/kube-addon-manager.yaml
@@ -13,7 +13,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: gcr.io/google-containers/kube-addon-manager:v6.4-beta.2
+    image: k8s.gcr.io/kube-addon-manager:v6.4-beta.2
     command:
     - /bin/bash
     - -c

--- a/cluster/saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml
+++ b/cluster/saltbase/salt/kube-registry-proxy/kube-registry-proxy.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: kube-registry-proxy
-        image: gcr.io/google_containers/kube-registry-proxy:0.4
+        image: k8s.gcr.io/kube-registry-proxy:0.4
         resources:
           limits:
             cpu: 100m

--- a/cluster/saltbase/salt/l7-gcp/glbc.manifest
+++ b/cluster/saltbase/salt/l7-gcp/glbc.manifest
@@ -13,7 +13,7 @@ spec:
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/glbc:0.9.7
+  - image: k8s.gcr.io/glbc:0.9.7
     livenessProbe:
       httpGet:
         path: /healthz

--- a/cluster/saltbase/salt/rescheduler/rescheduler.manifest
+++ b/cluster/saltbase/salt/rescheduler/rescheduler.manifest
@@ -13,7 +13,7 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google-containers/rescheduler:v0.3.1
+  - image: k8s.gcr.io/rescheduler:v0.3.1
     name: rescheduler
     volumeMounts:
     - mountPath: /var/log/rescheduler.log

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -39,7 +39,7 @@ const (
 	// DefaultCertificatesDir defines default certificate directory
 	DefaultCertificatesDir = "/etc/kubernetes/pki"
 	// DefaultImageRepository defines default image registry
-	DefaultImageRepository = "gcr.io/google_containers"
+	DefaultImageRepository = "k8s.gcr.io"
 
 	// DefaultEtcdDataDir defines default location of etcd where static pods will save data to
 	DefaultEtcdDataDir = "/var/lib/etcd"

--- a/cmd/kubeadm/app/images/images_test.go
+++ b/cmd/kubeadm/app/images/images_test.go
@@ -27,7 +27,7 @@ import (
 const (
 	testversion = "v10.1.2-alpha.1.100+0123456789abcdef+SOMETHING"
 	expected    = "v10.1.2-alpha.1.100_0123456789abcdef_SOMETHING"
-	gcrPrefix   = "gcr.io/google_containers"
+	gcrPrefix   = "k8s.gcr.io"
 )
 
 func TestGetCoreImage(t *testing.T) {

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -65,7 +65,7 @@ spec:
     - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
     - --authorization-mode=Node,RBAC
     - --etcd-servers=http://127.0.0.1:2379
-    image: gcr.io/google_containers/kube-apiserver-amd64:v1.7.4
+    image: k8s.gcr.io/kube-apiserver-amd64:v1.7.4
     livenessProbe:
       failureThreshold: 8
       httpGet:
@@ -144,7 +144,7 @@ spec:
         - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
         - --authorization-mode=Node,RBAC
         - --etcd-servers=http://127.0.0.1:2379
-        image: gcr.io/google_containers/kube-apiserver-amd64:v1.7.4
+        image: k8s.gcr.io/kube-apiserver-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -216,7 +216,7 @@ spec:
     - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
     - --address=127.0.0.1
     - --use-service-account-credentials=true
-    image: gcr.io/google_containers/kube-controller-manager-amd64:v1.7.4
+    image: k8s.gcr.io/kube-controller-manager-amd64:v1.7.4
     livenessProbe:
       failureThreshold: 8
       httpGet:
@@ -288,7 +288,7 @@ spec:
         - --cluster-signing-key-file=/etc/kubernetes/pki/ca.key
         - --address=127.0.0.1
         - --use-service-account-credentials=true
-        image: gcr.io/google_containers/kube-controller-manager-amd64:v1.7.4
+        image: k8s.gcr.io/kube-controller-manager-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -361,7 +361,7 @@ spec:
     - --leader-elect=true
     - --kubeconfig=/etc/kubernetes/scheduler.conf
     - --address=127.0.0.1
-    image: gcr.io/google_containers/kube-scheduler-amd64:v1.7.4
+    image: k8s.gcr.io/kube-scheduler-amd64:v1.7.4
     livenessProbe:
       failureThreshold: 8
       httpGet:
@@ -409,7 +409,7 @@ spec:
         - --leader-elect=true
         - --kubeconfig=/etc/kubernetes/scheduler.conf
         - --address=127.0.0.1
-        image: gcr.io/google_containers/kube-scheduler-amd64:v1.7.4
+        image: k8s.gcr.io/kube-scheduler-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8
           httpGet:
@@ -510,7 +510,7 @@ metadata:
   name: testpod
 spec:
   containers:
-    - image: gcr.io/google_containers/busybox
+    - image: k8s.gcr.io/busybox
 `,
 			expectError: false,
 		},
@@ -526,7 +526,7 @@ spec:
   "spec": {
     "containers": [
       {
-        "image": "gcr.io/google_containers/busybox"
+        "image": "k8s.gcr.io/busybox"
       }
     ]
   }
@@ -541,7 +541,7 @@ kind: Pod
 metadata:
   name: testpod
 spec:
-  - image: gcr.io/google_containers/busybox
+  - image: k8s.gcr.io/busybox
 `,
 			expectError: true,
 		},

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -60,7 +60,7 @@ etcd:
   image: ""
   keyFile: ""
 featureFlags: null
-imageRepository: gcr.io/google_containers
+imageRepository: k8s.gcr.io
 kubernetesVersion: %s
 networking:
   dnsDomain: cluster.local

--- a/cmd/kubeadm/app/util/template_test.go
+++ b/cmd/kubeadm/app/util/template_test.go
@@ -22,8 +22,8 @@ import (
 
 const (
 	validTmpl    = "image: {{ .ImageRepository }}/pause-{{ .Arch }}:3.0"
-	validTmplOut = "image: gcr.io/google_containers/pause-amd64:3.0"
-	doNothing    = "image: gcr.io/google_containers/pause-amd64:3.0"
+	validTmplOut = "image: k8s.gcr.io/pause-amd64:3.0"
+	doNothing    = "image: k8s.gcr.io/pause-amd64:3.0"
 	invalidTmpl1 = "{{ .baz }/d}"
 	invalidTmpl2 = "{{ !foobar }}"
 )
@@ -39,7 +39,7 @@ func TestParseTemplate(t *testing.T) {
 		{
 			template: validTmpl,
 			data: struct{ ImageRepository, Arch string }{
-				ImageRepository: "gcr.io/google_containers",
+				ImageRepository: "k8s.gcr.io",
 				Arch:            "amd64",
 			},
 			output:      validTmplOut,
@@ -49,7 +49,7 @@ func TestParseTemplate(t *testing.T) {
 		{
 			template: doNothing,
 			data: struct{ ImageRepository, Arch string }{
-				ImageRepository: "gcr.io/google_containers",
+				ImageRepository: "k8s.gcr.io",
 				Arch:            "amd64",
 			},
 			output:      doNothing,

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// When these values are updated, also update test/e2e/framework/util.go
-	defaultPodSandboxImageName    = "gcr.io/google_containers/pause"
+	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
 	defaultPodSandboxImageVersion = "3.0"
 	// From pkg/kubelet/rkt/rkt.go to avoid circular import
 	defaultRktAPIServiceEndpoint = "localhost:15441"

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -9009,7 +9009,7 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">names</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Names by which this image is known. e.g. ["gcr.io/google_containers/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Names by which this image is known. e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string array</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/examples/cluster-dns/dns-backend-rc.yaml
+++ b/examples/cluster-dns/dns-backend-rc.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: dns-backend
-          image: gcr.io/google_containers/example-dns-backend:v1
+          image: k8s.gcr.io/example-dns-backend:v1
           ports:
             - name: backend-port
               containerPort: 8000

--- a/examples/cluster-dns/dns-frontend-pod.yaml
+++ b/examples/cluster-dns/dns-frontend-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
     - name: dns-frontend
-      image: gcr.io/google_containers/example-dns-frontend:v1
+      image: k8s.gcr.io/example-dns-frontend:v1
       command:
         - python
         - client.py

--- a/examples/cluster-dns/images/backend/Makefile
+++ b/examples/cluster-dns/images/backend/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = v1
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 IMAGE = example-dns-backend
 
 all: push
@@ -22,6 +22,6 @@ image:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
-	gcloud docker -- push $(PREFIX)/$(IMAGE)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/$(IMAGE)
 
 clean:

--- a/examples/cluster-dns/images/frontend/Makefile
+++ b/examples/cluster-dns/images/frontend/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = v1
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 IMAGE = example-dns-frontend
 
 all: push
@@ -22,6 +22,6 @@ image:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .
 
 push: image
-	gcloud docker -- push $(PREFIX)/$(IMAGE)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/$(IMAGE)
 
 clean:

--- a/examples/explorer/Makefile
+++ b/examples/explorer/Makefile
@@ -21,10 +21,10 @@ explorer: explorer.go
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-w' ./explorer.go
 
 container: explorer
-	docker build --pull -t gcr.io/google_containers/explorer:$(TAG) .
+	docker build --pull -t k8s.gcr.io/explorer:$(TAG) .
 
 push: container
-	gcloud docker -- push gcr.io/google_containers/explorer:$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push k8s.gcr.io/explorer:$(TAG)
 
 clean:
 	rm -f explorer

--- a/examples/explorer/pod.yaml
+++ b/examples/explorer/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: explorer
-      image: gcr.io/google_containers/explorer:1.0
+      image: k8s.gcr.io/explorer:1.0
       args: ["-port=8080"]
       ports:
         - containerPort: 8080

--- a/examples/guestbook-go/Makefile
+++ b/examples/guestbook-go/Makefile
@@ -15,9 +15,9 @@
 # Build the guestbook-go example
 
 # Usage:
-#   [VERSION=v3] [REGISTRY="gcr.io/google_containers"] make build
+#   [VERSION=v3] [REGISTRY="k8s.gcr.io"] make build
 VERSION?=v3
-REGISTRY?=gcr.io/google_containers
+REGISTRY?=k8s.gcr.io
 
 release: clean build push clean
 
@@ -29,7 +29,7 @@ build:
 
 # push the image to an registry
 push:
-	gcloud docker -- push ${REGISTRY}/guestbook:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${REGISTRY}/guestbook:${VERSION}
 
 # remove previous images and containers
 clean:

--- a/examples/guestbook-go/guestbook-controller.json
+++ b/examples/guestbook-go/guestbook-controller.json
@@ -22,7 +22,7 @@
             "containers":[
                {
                   "name":"guestbook",
-                  "image":"gcr.io/google_containers/guestbook:v3",
+                  "image":"k8s.gcr.io/guestbook:v3",
                   "ports":[
                      {
                         "name":"http-server",

--- a/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
+++ b/examples/guestbook/all-in-one/guestbook-all-in-one.yaml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        image: k8s.gcr.io/redis:e2e  # or just image: redis
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook/legacy/redis-master-controller.yaml
+++ b/examples/guestbook/legacy/redis-master-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        image: k8s.gcr.io/redis:e2e  # or just image: redis
         resources:
           requests:
             cpu: 100m

--- a/examples/guestbook/redis-master-deployment.yaml
+++ b/examples/guestbook/redis-master-deployment.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: master
-        image: gcr.io/google_containers/redis:e2e  # or just image: redis
+        image: k8s.gcr.io/redis:e2e  # or just image: redis
         resources:
           requests:
             cpu: 100m

--- a/examples/kubectl-container/Makefile
+++ b/examples/kubectl-container/Makefile
@@ -37,11 +37,11 @@ tag: .tag
 
 container:
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	docker build --pull -t gcr.io/google_containers/kubectl:$(TAG) .
+	docker build --pull -t k8s.gcr.io/kubectl:$(TAG) .
 
 push: container
 	$(if $(TAG),,$(error TAG is not defined. Use 'make tag' to see a suggestion))
-	gcloud docker -- push gcr.io/google_containers/kubectl:$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push k8s.gcr.io/kubectl:$(TAG)
 
 clean:
 	rm -f kubectl

--- a/examples/kubectl-container/pod.json
+++ b/examples/kubectl-container/pod.json
@@ -8,7 +8,7 @@
     "containers": [
       {
         "name": "bb",
-        "image": "gcr.io/google_containers/busybox",
+        "image": "k8s.gcr.io/busybox",
         "command": [
           "sh", "-c", "sleep 5; wget -O - ${KUBERNETES_RO_SERVICE_HOST}:${KUBERNETES_RO_SERVICE_PORT}/api/v1/pods/; sleep 10000"
         ],
@@ -36,7 +36,7 @@
       },
       {
         "name": "kubectl",
-        "image": "gcr.io/google_containers/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty",
+        "image": "k8s.gcr.io/kubectl:v0.18.0-120-gaeb4ac55ad12b1-dirty",
         "imagePullPolicy": "Always",
         "args": [
           "proxy", "-p", "8001"

--- a/examples/spark/spark-gluster/spark-master-controller.yaml
+++ b/examples/spark/spark-gluster/spark-master-controller.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark:1.5.2_v1
+          image: k8s.gcr.io/spark:1.5.2_v1
           command: ["/start-master"]
           ports:
             - containerPort: 7077

--- a/examples/spark/spark-gluster/spark-worker-controller.yaml
+++ b/examples/spark/spark-gluster/spark-worker-controller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark:1.5.2_v1
+          image: k8s.gcr.io/spark:1.5.2_v1
           command: ["/start-worker"]
           ports:
             - containerPort: 8888

--- a/examples/spark/spark-master-controller.yaml
+++ b/examples/spark/spark-master-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-master
-          image: gcr.io/google_containers/spark:1.5.2_v1
+          image: k8s.gcr.io/spark:1.5.2_v1
           command: ["/start-master"]
           ports:
             - containerPort: 7077

--- a/examples/spark/spark-worker-controller.yaml
+++ b/examples/spark/spark-worker-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: spark-worker
-          image: gcr.io/google_containers/spark:1.5.2_v1
+          image: k8s.gcr.io/spark:1.5.2_v1
           command: ["/start-worker"]
           ports:
             - containerPort: 8081

--- a/examples/spark/zeppelin-controller.yaml
+++ b/examples/spark/zeppelin-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: zeppelin
-          image: gcr.io/google_containers/zeppelin:v0.5.6_v1
+          image: k8s.gcr.io/zeppelin:v0.5.6_v1
           ports:
             - containerPort: 8080
           resources:

--- a/examples/storage/cassandra/image/Dockerfile
+++ b/examples/storage/cassandra/image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/ubuntu-slim:0.9
+FROM k8s.gcr.io/ubuntu-slim:0.9
 
 ARG BUILD_DATE
 ARG VCS_REF

--- a/examples/storage/cassandra/image/Makefile
+++ b/examples/storage/cassandra/image/Makefile
@@ -35,7 +35,7 @@ container-dev:
 build: container container-dev
 
 push: build
-	gcloud docker -- push ${PROJECT}/cassandra:${VERSION}
-	gcloud docker -- push ${PROJECT}/cassandra:${VERSION}-dev
+	gcloud docker --server=k8s.gcr.io -- push ${PROJECT}/cassandra:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${PROJECT}/cassandra:${VERSION}-dev
 
 .PHONY: all build push

--- a/examples/storage/redis/redis-controller.yaml
+++ b/examples/storage/redis/redis-controller.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: gcr.io/google_containers/redis:v1
+        image: k8s.gcr.io/redis:v1
         ports:
         - containerPort: 6379
         resources:

--- a/examples/storage/redis/redis-master.yaml
+++ b/examples/storage/redis/redis-master.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   containers:
     - name: master
-      image: gcr.io/google_containers/redis:v1
+      image: k8s.gcr.io/redis:v1
       env:
         - name: MASTER
           value: "true"

--- a/examples/storage/redis/redis-sentinel-controller.yaml
+++ b/examples/storage/redis/redis-sentinel-controller.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: sentinel
-        image: gcr.io/google_containers/redis:v1
+        image: k8s.gcr.io/redis:v1
         env:
           - name: SENTINEL
             value: "true"

--- a/examples/storage/rethinkdb/admin-pod.yaml
+++ b/examples/storage/rethinkdb/admin-pod.yaml
@@ -7,7 +7,7 @@ metadata:
   name: rethinkdb-admin
 spec:
   containers:
-  - image: gcr.io/google_containers/rethinkdb:1.16.0_1
+  - image: k8s.gcr.io/rethinkdb:1.16.0_1
     name: rethinkdb
     env:
     - name: POD_NAMESPACE

--- a/examples/storage/rethinkdb/rc.yaml
+++ b/examples/storage/rethinkdb/rc.yaml
@@ -16,7 +16,7 @@ spec:
         role: replicas
     spec:
       containers:
-      - image: gcr.io/google_containers/rethinkdb:1.16.0_1
+      - image: k8s.gcr.io/rethinkdb:1.16.0_1
         name: rethinkdb
         env:
         - name: POD_NAMESPACE

--- a/examples/volumes/portworx/portworx-volume-pod.yaml
+++ b/examples/volumes/portworx/portworx-volume-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-portworx-volume-pod
 spec:
   containers:
-  - image: gcr.io/google_containers/test-webserver
+  - image: k8s.gcr.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-portworx-volume

--- a/examples/volumes/portworx/portworx-volume-pvcpod.yaml
+++ b/examples/volumes/portworx/portworx-volume-pvcpod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: gcr.io/google_containers/test-webserver
+    image: k8s.gcr.io/test-webserver
     volumeMounts:
     - name: test-volume
       mountPath: /test-portworx-volume

--- a/examples/volumes/portworx/portworx-volume-pvcscpod.yaml
+++ b/examples/volumes/portworx/portworx-volume-pvcscpod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: gcr.io/google_containers/test-webserver
+    image: k8s.gcr.io/test-webserver
     volumeMounts:
     - name: test-volume
       mountPath: /test-portworx-volume

--- a/examples/volumes/scaleio/pod-sc-pvc.yaml
+++ b/examples/volumes/scaleio/pod-sc-pvc.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: pod-sio-small-container
-      image: gcr.io/google_containers/test-webserver
+      image: k8s.gcr.io/test-webserver
       volumeMounts:
       - mountPath: /test
         name: test-data

--- a/examples/volumes/scaleio/pod.yaml
+++ b/examples/volumes/scaleio/pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-0
 spec:
   containers:
-  - image: gcr.io/google_containers/test-webserver
+  - image: k8s.gcr.io/test-webserver
     name: pod-0
     volumeMounts:
     - mountPath: /test-pd

--- a/examples/volumes/vsphere/simple-statefulset.yaml
+++ b/examples/volumes/vsphere/simple-statefulset.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/examples/volumes/vsphere/vsphere-volume-pod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pod.yaml
@@ -4,7 +4,7 @@ metadata:
   name: test-vmdk
 spec:
   containers:
-  - image: gcr.io/google_containers/test-webserver
+  - image: k8s.gcr.io/test-webserver
     name: test-container
     volumeMounts:
     - mountPath: /test-vmdk

--- a/examples/volumes/vsphere/vsphere-volume-pvcpod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcpod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: gcr.io/google_containers/test-webserver
+    image: k8s.gcr.io/test-webserver
     volumeMounts:
     - name: test-volume
       mountPath: /test-vmdk

--- a/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
+++ b/examples/volumes/vsphere/vsphere-volume-pvcscpod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: gcr.io/google_containers/test-webserver
+    image: k8s.gcr.io/test-webserver
     volumeMounts:
     - name: test-volume
       mountPath: /test-vmdk

--- a/hack/gen-swagger-doc/README.md
+++ b/hack/gen-swagger-doc/README.md
@@ -3,7 +3,7 @@ This folder contains the sources needed to build the gen-swagger-doc container.
 To build the container image, 
 
 ```
-$ sudo docker build -t gcr.io/google_containers/gen-swagger-docs:v1 .
+$ sudo docker build -t k8s.gcr.io/gen-swagger-docs:v1 .
 ```
 
 To generate the html docs,

--- a/hack/lib/swagger.sh
+++ b/hack/lib/swagger.sh
@@ -117,7 +117,7 @@ kube::swagger::gen_api_ref_docs() {
       -v "${swagger_spec_path}":/swagger-source:z \
       -v "${register_file}":/register.go:z \
       --net=host -e "https_proxy=${KUBERNETES_HTTPS_PROXY:-}" \
-      gcr.io/google_containers/gen-swagger-docs:v8 \
+      k8s.gcr.io/gen-swagger-docs:v8 \
       "${swagger_json_name}"
   done
 

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -728,7 +728,7 @@ function start_kubelet {
         --privileged=true \
         -i \
         --cidfile=$KUBELET_CIDFILE \
-        gcr.io/google_containers/kubelet \
+        k8s.gcr.io/kubelet \
         /kubelet --v=${LOG_LEVEL} --containerized ${priv_arg}--chaos-chance="${CHAOS_CHANCE}" --pod-manifest-path="${POD_MANIFEST_PATH}" --hostname-override="${HOSTNAME_OVERRIDE}" --cloud-provider="${CLOUD_PROVIDER}" --cloud-config="${CLOUD_CONFIG}" \ --address="127.0.0.1" --kubeconfig "$CERT_DIR"/kubelet.kubeconfig --port="$KUBELET_PORT"  --enable-controller-attach-detach="${ENABLE_CONTROLLER_ATTACH_DETACH}" &> $KUBELET_LOG &
     fi
 }

--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -37,15 +37,15 @@ KUBELET_HEALTHZ_PORT=${KUBELET_HEALTHZ_PORT:-10248}
 CTLRMGR_PORT=${CTLRMGR_PORT:-10252}
 PROXY_HOST=127.0.0.1 # kubectl only serves on localhost.
 
-IMAGE_NGINX="gcr.io/google-containers/nginx:1.7.9"
-IMAGE_DEPLOYMENT_R1="gcr.io/google-containers/nginx:test-cmd"  # deployment-revision1.yaml
+IMAGE_NGINX="k8s.gcr.io/nginx:1.7.9"
+IMAGE_DEPLOYMENT_R1="k8s.gcr.io/nginx:test-cmd"  # deployment-revision1.yaml
 IMAGE_DEPLOYMENT_R2="$IMAGE_NGINX"  # deployment-revision2.yaml
-IMAGE_PERL="gcr.io/google-containers/perl"
-IMAGE_PAUSE_V2="gcr.io/google-containers/pause:2.0"
-IMAGE_DAEMONSET_R2="gcr.io/google-containers/pause:latest"
-IMAGE_DAEMONSET_R2_2="gcr.io/google-containers/nginx:test-cmd"  # rollingupdate-daemonset-rv2.yaml
-IMAGE_STATEFULSET_R1="gcr.io/google_containers/nginx-slim:0.7"
-IMAGE_STATEFULSET_R2="gcr.io/google_containers/nginx-slim:0.8"
+IMAGE_PERL="k8s.gcr.io/perl"
+IMAGE_PAUSE_V2="k8s.gcr.io/pause:2.0"
+IMAGE_DAEMONSET_R2="k8s.gcr.io/pause:latest"
+IMAGE_DAEMONSET_R2_2="k8s.gcr.io/nginx:test-cmd"  # rollingupdate-daemonset-rv2.yaml
+IMAGE_STATEFULSET_R1="k8s.gcr.io/nginx-slim:0.7"
+IMAGE_STATEFULSET_R2="k8s.gcr.io/nginx-slim:0.8"
 
 # Expose kubectl directly for readability
 PATH="${KUBE_OUTPUT_HOSTBIN}":$PATH
@@ -712,9 +712,9 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'changed-with-yaml:'
   ## Patch pod from JSON can change image
   # Command
-  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "gcr.io/google_containers/pause-amd64:3.0"}]}}'
-  # Post-condition: valid-pod POD has image gcr.io/google_containers/pause-amd64:3.0
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'gcr.io/google_containers/pause-amd64:3.0:'
+  kubectl patch "${kube_flags[@]}" -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml -p='{"spec":{"containers":[{"name": "kubernetes-serve-hostname", "image": "k8s.gcr.io/pause-amd64:3.0"}]}}'
+  # Post-condition: valid-pod POD has image k8s.gcr.io/pause-amd64:3.0
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/pause-amd64:3.0:'
 
   ## If resourceVersion is specified in the patch, it will be treated as a precondition, i.e., if the resourceVersion is different from that is stored in the server, the Patch should be rejected
   ERROR_FILE="${KUBE_TEMP}/conflict-error"
@@ -800,8 +800,8 @@ __EOF__
   # Pre-condition: valid-pod POD has image nginx
   kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'nginx:'
   [[ "$(EDITOR=/tmp/tmp-editor.sh kubectl edit "${kube_flags[@]}" pods/valid-pod --output-patch=true | grep Patch:)" ]]
-  # Post-condition: valid-pod POD has image gcr.io/google_containers/serve_hostname
-  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'gcr.io/google_containers/serve_hostname:'
+  # Post-condition: valid-pod POD has image k8s.gcr.io/serve_hostname
+  kube::test::get_object_assert pods "{{range.items}}{{$image_field}}:{{end}}" 'k8s.gcr.io/serve_hostname:'
   # cleaning
   rm /tmp/tmp-editor.sh
 
@@ -2739,7 +2739,7 @@ run_deployment_tests() {
   create_and_use_new_namespace
   kube::log::status "Testing deployments"
   # Test kubectl create deployment (using default - old generator)
-  kubectl create deployment test-nginx-extensions --image=gcr.io/google-containers/nginx:test-cmd
+  kubectl create deployment test-nginx-extensions --image=k8s.gcr.io/nginx:test-cmd
   # Post-Condition: Deployment "nginx" is created.
   kube::test::get_object_assert 'deploy test-nginx-extensions' "{{$container_name_field}}" 'nginx'
   # and old generator was used, iow. old defaults are applied
@@ -2754,7 +2754,7 @@ run_deployment_tests() {
   kubectl delete deployment test-nginx-extensions "${kube_flags[@]}"
 
   # Test kubectl create deployment
-  kubectl create deployment test-nginx-apps --image=gcr.io/google-containers/nginx:test-cmd --generator=deployment-basic/apps.v1beta1
+  kubectl create deployment test-nginx-apps --image=k8s.gcr.io/nginx:test-cmd --generator=deployment-basic/apps.v1beta1
   # Post-Condition: Deployment "nginx" is created.
   kube::test::get_object_assert 'deploy test-nginx-apps' "{{$container_name_field}}" 'nginx'
   # and new generator was used, iow. new defaults are applied
@@ -2799,7 +2799,7 @@ run_deployment_tests() {
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   kube::test::get_object_assert rs "{{range.items}}{{$id_field}}:{{end}}" ''
   # Create deployment
-  kubectl create deployment nginx-deployment --image=gcr.io/google-containers/nginx:test-cmd
+  kubectl create deployment nginx-deployment --image=k8s.gcr.io/nginx:test-cmd
   # Wait for rs to come up.
   kube::test::wait_object_assert rs "{{range.items}}{{$rs_replicas_field}}{{end}}" '1'
   # Delete the deployment with cascade set to false.
@@ -3057,7 +3057,7 @@ run_rs_tests() {
   # Test set commands
   # Pre-condition: frontend replica set exists at generation 1
   kube::test::get_object_assert 'rs frontend' "{{${generation_field}}}" '1'
-  kubectl set image rs/frontend "${kube_flags[@]}" *=gcr.io/google-containers/pause:test-cmd
+  kubectl set image rs/frontend "${kube_flags[@]}" *=k8s.gcr.io/pause:test-cmd
   kube::test::get_object_assert 'rs frontend' "{{${generation_field}}}" '2'
   kubectl set env rs/frontend "${kube_flags[@]}" foo=bar
   kube::test::get_object_assert 'rs frontend' "{{${generation_field}}}" '3'
@@ -3144,7 +3144,7 @@ run_daemonset_tests() {
   # Template Generation should stay 1
   kube::test::get_object_assert 'daemonsets bind' "{{${template_generation_field}}}" '1'
   # Test set commands
-  kubectl set image daemonsets/bind "${kube_flags[@]}" *=gcr.io/google-containers/pause:test-cmd
+  kubectl set image daemonsets/bind "${kube_flags[@]}" *=k8s.gcr.io/pause:test-cmd
   kube::test::get_object_assert 'daemonsets bind' "{{${template_generation_field}}}" '2'
   kubectl set env daemonsets/bind "${kube_flags[@]}" foo=bar
   kube::test::get_object_assert 'daemonsets bind' "{{${template_generation_field}}}" '3'

--- a/hack/testdata/deployment-label-change1.yaml
+++ b/hack/testdata/deployment-label-change1.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80

--- a/hack/testdata/deployment-label-change2.yaml
+++ b/hack/testdata/deployment-label-change2.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80

--- a/hack/testdata/deployment-multicontainer-resources.yaml
+++ b/hack/testdata/deployment-multicontainer-resources.yaml
@@ -16,9 +16,9 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80
       - name: perl
-        image: gcr.io/google-containers/perl
+        image: k8s.gcr.io/perl
       terminationGracePeriodSeconds: 0

--- a/hack/testdata/deployment-multicontainer.yaml
+++ b/hack/testdata/deployment-multicontainer.yaml
@@ -16,8 +16,8 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80
       - name: perl
-        image: gcr.io/google-containers/perl
+        image: k8s.gcr.io/perl

--- a/hack/testdata/deployment-revision1.yaml
+++ b/hack/testdata/deployment-revision1.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd
         ports:
         - containerPort: 80

--- a/hack/testdata/deployment-revision2.yaml
+++ b/hack/testdata/deployment-revision2.yaml
@@ -16,6 +16,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9
         ports:
         - containerPort: 80

--- a/hack/testdata/filter/pod-apply-selector.yaml
+++ b/hack/testdata/filter/pod-apply-selector.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/filter/pod-dont-apply.yaml
+++ b/hack/testdata/filter/pod-dont-apply.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/multi-resource-json-modify.json
+++ b/hack/testdata/multi-resource-json-modify.json
@@ -43,7 +43,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "gcr.io/google-containers/pause:2.0",
+           "image": "k8s.gcr.io/pause:2.0",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-json.json
+++ b/hack/testdata/multi-resource-json.json
@@ -41,7 +41,7 @@
        "spec":{
          "containers":[{
            "name": "mock-container",
-           "image": "gcr.io/google-containers/pause:2.0",
+           "image": "k8s.gcr.io/pause:2.0",
            "ports":[{
              "containerPort":9949,
              "protocol":"TCP"

--- a/hack/testdata/multi-resource-list-modify.json
+++ b/hack/testdata/multi-resource-list-modify.json
@@ -47,7 +47,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "gcr.io/google-containers/pause:2.0",
+                    "image": "k8s.gcr.io/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-list.json
+++ b/hack/testdata/multi-resource-list.json
@@ -45,7 +45,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "gcr.io/google-containers/pause:2.0",
+                    "image": "k8s.gcr.io/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist-modify.json
+++ b/hack/testdata/multi-resource-rclist-modify.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "gcr.io/google-containers/pause:2.0",
+                    "image": "k8s.gcr.io/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "gcr.io/google-containers/pause:2.0",
+                "image": "k8s.gcr.io/pause:2.0",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-rclist.json
+++ b/hack/testdata/multi-resource-rclist.json
@@ -26,7 +26,7 @@
                "spec":{
                   "containers":[{
                     "name": "mock-container",
-                    "image": "gcr.io/google-containers/pause:2.0",
+                    "image": "k8s.gcr.io/pause:2.0",
                     "ports":[{
                         "containerPort":9949,
                         "protocol":"TCP"
@@ -60,7 +60,7 @@
             "spec":{
               "containers":[{
                 "name": "mock-container",
-                "image": "gcr.io/google-containers/pause:2.0",
+                "image": "k8s.gcr.io/pause:2.0",
                 "ports":[{
                   "containerPort":9949,
                   "protocol":"TCP"

--- a/hack/testdata/multi-resource-yaml-modify.yaml
+++ b/hack/testdata/multi-resource-yaml-modify.yaml
@@ -29,7 +29,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/multi-resource-yaml.yaml
+++ b/hack/testdata/multi-resource-yaml.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0
         ports:
         - containerPort: 9949
           protocol: TCP

--- a/hack/testdata/null-propagation/deployment-l1.yaml
+++ b/hack/testdata/null-propagation/deployment-l1.yaml
@@ -10,4 +10,4 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9

--- a/hack/testdata/null-propagation/deployment-l2.yaml
+++ b/hack/testdata/null-propagation/deployment-l2.yaml
@@ -14,5 +14,5 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9
         terminationMessagePolicy: null

--- a/hack/testdata/pod-apply.yaml
+++ b/hack/testdata/pod-apply.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/pod-with-api-env.yaml
+++ b/hack/testdata/pod-with-api-env.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: gcr.io/google_containers/busybox
+      image: k8s.gcr.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: TEST_CMD_1

--- a/hack/testdata/pod-with-precision.json
+++ b/hack/testdata/pod-with-precision.json
@@ -9,7 +9,7 @@
       "containers": [
         {
           "name": "kubernetes-pause",
-          "image": "gcr.io/google_containers/pause-amd64:3.0"
+          "image": "k8s.gcr.io/pause-amd64:3.0"
         }
       ],
       "restartPolicy": "Never",

--- a/hack/testdata/pod.yaml
+++ b/hack/testdata/pod.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/prune/a.yaml
+++ b/hack/testdata/prune/a.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/prune/b.yaml
+++ b/hack/testdata/prune/b.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/recursive/deployment/deployment/nginx-broken.yaml
+++ b/hack/testdata/recursive/deployment/deployment/nginx-broken.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9
         ports:
         - containerPort: 80

--- a/hack/testdata/recursive/deployment/deployment/nginx.yaml
+++ b/hack/testdata/recursive/deployment/deployment/nginx.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9
         ports:
         - containerPort: 80

--- a/hack/testdata/recursive/deployment/nginx.yaml
+++ b/hack/testdata/recursive/deployment/nginx.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google-containers/nginx:1.7.9
+        image: k8s.gcr.io/nginx:1.7.9
         ports:
         - containerPort: 80

--- a/hack/testdata/rollingupdate-daemonset-rv2.yaml
+++ b/hack/testdata/rollingupdate-daemonset-rv2.yaml
@@ -24,6 +24,6 @@ spec:
               namespaces: []
       containers:
       - name: kubernetes-pause
-        image: gcr.io/google-containers/pause:latest
+        image: k8s.gcr.io/pause:latest
       - name: app
-        image: gcr.io/google-containers/nginx:test-cmd
+        image: k8s.gcr.io/nginx:test-cmd

--- a/hack/testdata/rollingupdate-daemonset.yaml
+++ b/hack/testdata/rollingupdate-daemonset.yaml
@@ -24,4 +24,4 @@ spec:
               namespaces: []
       containers:
       - name: kubernetes-pause
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/rollingupdate-statefulset-rv2.yaml
+++ b/hack/testdata/rollingupdate-statefulset-rv2.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web
@@ -27,7 +27,7 @@ spec:
         - -c
         - 'while true; do sleep 1; done'
       - name: pause
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0
         ports:
         - containerPort: 81
           name: web-2

--- a/hack/testdata/rollingupdate-statefulset.yaml
+++ b/hack/testdata/rollingupdate-statefulset.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 5
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.7
+        image: k8s.gcr.io/nginx-slim:0.7
         ports:
         - containerPort: 80
           name: web

--- a/hack/testdata/sorted-pods/sorted-pod1.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod1.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/sorted-pods/sorted-pod2.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod2.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/hack/testdata/sorted-pods/sorted-pod3.yaml
+++ b/hack/testdata/sorted-pods/sorted-pod3.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   containers:
   - name: kubernetes-pause
-    image: gcr.io/google-containers/pause:2.0
+    image: k8s.gcr.io/pause:2.0

--- a/pkg/api/testing/deep_copy_test.go
+++ b/pkg/api/testing/deep_copy_test.go
@@ -64,7 +64,7 @@ var benchmarkPod api.Pod = api.Pod{
 		Containers: []api.Container{
 			{
 				Name:  "etcd-container",
-				Image: "gcr.io/google_containers/etcd:2.0.9",
+				Image: "k8s.gcr.io/etcd:2.0.9",
 				Command: []string{
 					"/usr/local/bin/etcd",
 					"--addr",
@@ -120,7 +120,7 @@ var benchmarkPod api.Pod = api.Pod{
 				},
 				Ready:        true,
 				RestartCount: 0,
-				Image:        "gcr.io/google_containers/etcd:2.0.9",
+				Image:        "k8s.gcr.io/etcd:2.0.9",
 				ImageID:      "docker://b6b9a86dc06aa1361357ca1b105feba961f6a4145adca6c54e142c0be0fe87b0",
 				ContainerID:  "docker://3cbbf818f1addfc252957b4504f56ef2907a313fe6afc47fc75373674255d46d",
 			},

--- a/pkg/api/testing/replication_controller_example.json
+++ b/pkg/api/testing/replication_controller_example.json
@@ -47,7 +47,7 @@
                 "containers": [
                     {
                         "name": "elasticsearch-logging",
-                        "image": "gcr.io/google_containers/elasticsearch:1.0",
+                        "image": "k8s.gcr.io/elasticsearch:1.0",
                         "ports": [
                             {
                                 "name": "db",

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	defaultSandboxImage = "gcr.io/google_containers/pause-amd64:3.0"
+	defaultSandboxImage = "k8s.gcr.io/pause-amd64:3.0"
 
 	// Various default sandbox resources requests/limits.
 	defaultSandboxCPUshares int64 = 2

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -96,7 +96,7 @@ func generateImageTags() []string {
 	// that kubelet report up to maxNamesPerImageInNodeStatus tags.
 	count := rand.IntnRange(maxNamesPerImageInNodeStatus+1, maxImageTagsForTest+1)
 	for ; count > 0; count-- {
-		tagList = append(tagList, "gcr.io/google_containers:v"+strconv.Itoa(count))
+		tagList = append(tagList, "k8s.gcr.io:v"+strconv.Itoa(count))
 	}
 	return tagList
 }
@@ -492,11 +492,11 @@ func TestUpdateExistingNodeStatus(t *testing.T) {
 			// images will be sorted from max to min in node status.
 			Images: []v1.ContainerImage{
 				{
-					Names:     []string{"gcr.io/google_containers:v3", "gcr.io/google_containers:v4"},
+					Names:     []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
 					SizeBytes: 456,
 				},
 				{
-					Names:     []string{"gcr.io/google_containers:v1", "gcr.io/google_containers:v2"},
+					Names:     []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
 					SizeBytes: 123,
 				},
 			},
@@ -680,11 +680,11 @@ func TestUpdateNodeStatusWithRuntimeStateError(t *testing.T) {
 			},
 			Images: []v1.ContainerImage{
 				{
-					Names:     []string{"gcr.io/google_containers:v3", "gcr.io/google_containers:v4"},
+					Names:     []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
 					SizeBytes: 456,
 				},
 				{
-					Names:     []string{"gcr.io/google_containers:v1", "gcr.io/google_containers:v2"},
+					Names:     []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
 					SizeBytes: 123,
 				},
 			},

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -127,12 +127,12 @@ func newTestKubelet(t *testing.T, controllerAttachDetachEnabled bool) *TestKubel
 	imageList := []kubecontainer.Image{
 		{
 			ID:       "abc",
-			RepoTags: []string{"gcr.io/google_containers:v1", "gcr.io/google_containers:v2"},
+			RepoTags: []string{"k8s.gcr.io:v1", "k8s.gcr.io:v2"},
 			Size:     123,
 		},
 		{
 			ID:       "efg",
-			RepoTags: []string{"gcr.io/google_containers:v3", "gcr.io/google_containers:v4"},
+			RepoTags: []string{"k8s.gcr.io:v3", "k8s.gcr.io:v4"},
 			Size:     456,
 		},
 	}

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -429,7 +429,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: gcr.io/google_containers/test-webserver
+	//     - image: k8s.gcr.io/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd
@@ -467,7 +467,7 @@ type MountedVolume struct {
 	//     name: test-pd
 	//   spec:
 	//     containers:
-	//     - image: gcr.io/google_containers/test-webserver
+	//     - image: k8s.gcr.io/test-webserver
 	//     	 name: test-container
 	//     	 volumeMounts:
 	//     	 - mountPath: /test-pd

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -326,7 +326,7 @@ func getTestPodWithSecret(podName, secretName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "secret-volume-test",
-					Image: "gcr.io/google_containers/mounttest:0.8",
+					Image: "k8s.gcr.io/mounttest:0.8",
 					Args: []string{
 						"--file_content=/etc/secret-volume/data-1",
 						"--file_mode=/etc/secret-volume/data-1"},
@@ -365,7 +365,7 @@ func getTestPodWithGCEPD(podName, pdName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "pd-volume-test",
-					Image: "gcr.io/google_containers/mounttest:0.8",
+					Image: "k8s.gcr.io/mounttest:0.8",
 					Args: []string{
 						"--file_content=/etc/pd-volume/data-1",
 					},

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -162,7 +162,7 @@ metadata:
   name: testpod
 spec:
   containers:
-    - image: gcr.io/google_containers/busybox
+    - image: k8s.gcr.io/busybox
 `,
 			false,
 		},
@@ -179,7 +179,7 @@ spec:
   "spec": {
     "containers": [
       {
-        "image": "gcr.io/google_containers/busybox"
+        "image": "k8s.gcr.io/busybox"
       }
     ]
   }
@@ -195,7 +195,7 @@ kind: Pod
 metadata:
   name: testpod
 spec:
-  - image: gcr.io/google_containers/busybox
+  - image: k8s.gcr.io/busybox
 `,
 			true,
 		},

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -94,8 +94,8 @@ func TestRecyclerPod(t *testing.T) {
 				// Pod gets Running and Succeeded
 				newPodEvent(watch.Added, "podRecyclerSuccess", v1.PodPending, ""),
 				newEvent(v1.EventTypeNormal, "Successfully assigned recycler-for-podRecyclerSuccess to 127.0.0.1"),
-				newEvent(v1.EventTypeNormal, "pulling image \"gcr.io/google_containers/busybox\""),
-				newEvent(v1.EventTypeNormal, "Successfully pulled image \"gcr.io/google_containers/busybox\""),
+				newEvent(v1.EventTypeNormal, "pulling image \"k8s.gcr.io/busybox\""),
+				newEvent(v1.EventTypeNormal, "Successfully pulled image \"k8s.gcr.io/busybox\""),
 				newEvent(v1.EventTypeNormal, "Created container with docker id 83d929aeac82"),
 				newEvent(v1.EventTypeNormal, "Started container with docker id 83d929aeac82"),
 				newPodEvent(watch.Modified, "podRecyclerSuccess", v1.PodRunning, ""),
@@ -103,8 +103,8 @@ func TestRecyclerPod(t *testing.T) {
 			},
 			expectedEvents: []mockEvent{
 				{v1.EventTypeNormal, "Successfully assigned recycler-for-podRecyclerSuccess to 127.0.0.1"},
-				{v1.EventTypeNormal, "pulling image \"gcr.io/google_containers/busybox\""},
-				{v1.EventTypeNormal, "Successfully pulled image \"gcr.io/google_containers/busybox\""},
+				{v1.EventTypeNormal, "pulling image \"k8s.gcr.io/busybox\""},
+				{v1.EventTypeNormal, "Successfully pulled image \"k8s.gcr.io/busybox\""},
 				{v1.EventTypeNormal, "Created container with docker id 83d929aeac82"},
 				{v1.EventTypeNormal, "Started container with docker id 83d929aeac82"},
 			},

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -594,7 +594,7 @@ message Container {
 // Describe a container image
 message ContainerImage {
   // Names by which this image is known.
-  // e.g. ["gcr.io/google_containers/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+  // e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
   repeated string names = 1;
 
   // The size of the image in bytes.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -3739,7 +3739,7 @@ type PodSignature struct {
 // Describe a container image
 type ContainerImage struct {
 	// Names by which this image is known.
-	// e.g. ["gcr.io/google_containers/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
+	// e.g. ["k8s.gcr.io/hyperkube:v1.0.7", "dockerhub.io/google_containers/hyperkube:v1.0.7"]
 	Names []string `json:"names" protobuf:"bytes,1,rep,name=names"`
 	// The size of the image in bytes.
 	// +optional

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -296,7 +296,7 @@ func (Container) SwaggerDoc() map[string]string {
 
 var map_ContainerImage = map[string]string{
 	"":          "Describe a container image",
-	"names":     "Names by which this image is known. e.g. [\"gcr.io/google_containers/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
+	"names":     "Names by which this image is known. e.g. [\"k8s.gcr.io/hyperkube:v1.0.7\", \"dockerhub.io/google_containers/hyperkube:v1.0.7\"]",
 	"sizeBytes": "The size of the image in bytes.",
 }
 

--- a/test/e2e/apimachinery/initializers.go
+++ b/test/e2e/apimachinery/initializers.go
@@ -315,7 +315,7 @@ func newReplicaset() *v1beta1.ReplicaSet {
 					Containers: []v1.Container{
 						{
 							Name:  name + "-container",
-							Image: "gcr.io/google_containers/porter:4524579c0eb935c056c8e75563b4e1eda31587e0",
+							Image: "k8s.gcr.io/porter:4524579c0eb935c056c8e75563b4e1eda31587e0",
 						},
 					},
 				},

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -257,7 +257,7 @@ func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 				Containers: []v1.Container{
 					{
 						Name:  "busybox",
-						Image: "gcr.io/google_containers/echoserver:1.6",
+						Image: "k8s.gcr.io/echoserver:1.6",
 					},
 				},
 				RestartPolicy: v1.RestartPolicyAlways,
@@ -301,7 +301,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
 		Name:  "busybox",
-		Image: "gcr.io/google_containers/echoserver:1.6",
+		Image: "k8s.gcr.io/echoserver:1.6",
 	}
 	if exclusive {
 		container.Ports = []v1.ContainerPort{

--- a/test/e2e/auth/metadata_concealment.go
+++ b/test/e2e/auth/metadata_concealment.go
@@ -45,7 +45,7 @@ var _ = SIGDescribe("Metadata Concealment", func() {
 						Containers: []v1.Container{
 							{
 								Name:  "check-metadata-concealment",
-								Image: "gcr.io/google_containers/check-metadata-concealment:v0.0.2",
+								Image: "k8s.gcr.io/check-metadata-concealment:v0.0.2",
 							},
 						},
 						RestartPolicy: v1.RestartPolicyOnFailure,

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -185,7 +185,7 @@ func createAppArmorProfileLoader(f *framework.Framework) {
 				Spec: api.PodSpec{
 					Containers: []api.Container{{
 						Name:  "apparmor-loader",
-						Image: "gcr.io/google_containers/apparmor-loader:0.1",
+						Image: "k8s.gcr.io/apparmor-loader:0.1",
 						Args:  []string{"-poll", "10s", "/profiles"},
 						SecurityContext: &api.SecurityContext{
 							Privileged: &True,

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -61,9 +61,9 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.TestWebserver),
 	imageutils.GetE2EImage(imageutils.Hostexec),
-	"gcr.io/google_containers/volume-nfs:0.8",
-	"gcr.io/google_containers/volume-gluster:0.2",
-	"gcr.io/google_containers/e2e-net-amd64:1.0",
+	"k8s.gcr.io/volume-nfs:0.8",
+	"k8s.gcr.io/volume-gluster:0.2",
+	"k8s.gcr.io/e2e-net-amd64:1.0",
 )
 
 func svcByName(name string, port int) *v1.Service {

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -862,7 +862,7 @@ func MakeSecPod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bo
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",
-					Image:   "gcr.io/google_containers/busybox:1.24",
+					Image:   "k8s.gcr.io/busybox:1.24",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", command},
 					SecurityContext: &v1.SecurityContext{

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -801,7 +801,7 @@ func newEchoServerPodSpec(podName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "echoserver",
-					Image: "gcr.io/google_containers/echoserver:1.6",
+					Image: "k8s.gcr.io/echoserver:1.6",
 					Ports: []v1.ContainerPort{{ContainerPort: int32(port)}},
 				},
 			},

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -152,7 +152,7 @@ const (
 	ClaimProvisionTimeout = 5 * time.Minute
 
 	// When these values are updated, also update cmd/kubelet/app/options/options.go
-	currentPodInfraContainerImageName    = "gcr.io/google_containers/pause"
+	currentPodInfraContainerImageName    = "k8s.gcr.io/pause"
 	currentPodInfraContainerImageVersion = "3.0"
 
 	// How long each node is given during a process that restarts all nodes

--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -56,11 +56,11 @@ import (
 
 // Current supported images for e2e volume testing to be assigned to VolumeTestConfig.serverImage
 const (
-	NfsServerImage       string = "gcr.io/google_containers/volume-nfs:0.8"
-	IscsiServerImage     string = "gcr.io/google_containers/volume-iscsi:0.1"
-	GlusterfsServerImage string = "gcr.io/google_containers/volume-gluster:0.2"
-	CephServerImage      string = "gcr.io/google_containers/volume-ceph:0.1"
-	RbdServerImage       string = "gcr.io/google_containers/volume-rbd:0.1"
+	NfsServerImage       string = "k8s.gcr.io/volume-nfs:0.8"
+	IscsiServerImage     string = "k8s.gcr.io/volume-iscsi:0.1"
+	GlusterfsServerImage string = "k8s.gcr.io/volume-gluster:0.2"
+	CephServerImage      string = "k8s.gcr.io/volume-ceph:0.1"
+	RbdServerImage       string = "k8s.gcr.io/volume-rbd:0.1"
 )
 
 const (

--- a/test/e2e/instrumentation/logging/utils/logging_pod.go
+++ b/test/e2e/instrumentation/logging/utils/logging_pod.go
@@ -101,7 +101,7 @@ func (p *loadLoggingPod) Start(f *framework.Framework) error {
 			Containers: []api_v1.Container{
 				{
 					Name:  loggingContainerName,
-					Image: "gcr.io/google_containers/logs-generator:v0.1.0",
+					Image: "k8s.gcr.io/logs-generator:v0.1.0",
 					Env: []api_v1.EnvVar{
 						{
 							Name:  "LOGS_GENERATOR_LINES_TOTAL",

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -77,7 +77,7 @@ func stackdriverExporterPodSpec(metricName string, metricValue int64) corev1.Pod
 		Containers: []corev1.Container{
 			{
 				Name:            "stackdriver-exporter",
-				Image:           "gcr.io/google-containers/sd-dummy-exporter:v0.1.0",
+				Image:           "k8s.gcr.io/sd-dummy-exporter:v0.1.0",
 				ImagePullPolicy: corev1.PullPolicy("Always"),
 				Command:         []string{"/sd_dummy_exporter", "--pod-id=$(POD_ID)", "--metric-name=" + metricName, fmt.Sprintf("--metric-value=%v", metricValue)},
 				Env: []corev1.EnvVar{

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -242,7 +242,7 @@ func (t *dnsTestCommon) createDNSServer(aRecords map[string]string) {
 			Containers: []v1.Container{
 				{
 					Name:  "dns",
-					Image: "gcr.io/google_containers/k8s-dns-dnsmasq-amd64:1.14.5",
+					Image: "k8s.gcr.io/k8s-dns-dnsmasq-amd64:1.14.5",
 					Command: []string{
 						"/usr/sbin/dnsmasq",
 						"-u", "root",

--- a/test/e2e/testing-manifests/ingress/http/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/http/rc.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: echoheaders
-        image: gcr.io/google_containers/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.6
         ports:
         - containerPort: 8080
         readinessProbe:

--- a/test/e2e/testing-manifests/ingress/nginx/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/nginx/rc.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.1
+      - image: k8s.gcr.io/nginx-ingress-controller:0.9.0-beta.1
         livenessProbe:
           httpGet:
             path: /healthz

--- a/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/rc.yaml
@@ -11,6 +11,6 @@ spec:
     spec:
       containers:
       - name: echoheaders-https
-        image: gcr.io/google_containers/echoserver:1.6
+        image: k8s.gcr.io/echoserver:1.6
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/serviceloadbalancer/haproxyrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/haproxyrc.yaml
@@ -17,7 +17,7 @@ spec:
         version: v1
     spec:
       containers:
-      - image: gcr.io/google_containers/servicelb:0.1
+      - image: k8s.gcr.io/servicelb:0.1
         imagePullPolicy: Always
         livenessProbe:
           httpGet:

--- a/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
+++ b/test/e2e/testing-manifests/serviceloadbalancer/netexecrc.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: netexec
-        image: gcr.io/google_containers/netexec:1.4
+        image: k8s.gcr.io/netexec:1.4
         ports:
         - containerPort: 8080
           # This is to force these pods to land on different hosts.

--- a/test/e2e/testing-manifests/statefulset/cassandra/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/cassandra/tester.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: gcr.io/google-containers/cassandra-e2e-test:0.1
+        image: k8s.gcr.io/cassandra-e2e-test:0.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: etcd
-        image: gcr.io/google_containers/etcd-amd64:2.2.5
+        image: k8s.gcr.io/etcd-amd64:2.2.5
         imagePullPolicy: Always
         ports:
         - containerPort: 2380

--- a/test/e2e/testing-manifests/statefulset/etcd/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/etcd/tester.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: gcr.io/google-containers/etcd-statefulset-e2e-test:0.0
+        image: k8s.gcr.io/etcd-statefulset-e2e-test:0.0
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-galera/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: gcr.io/google_containers/galera-install:0.1
+        image: k8s.gcr.io/galera-install:0.1
         imagePullPolicy: Always
         args:
         - "--work-dir=/work-dir"
@@ -41,7 +41,7 @@ spec:
           mountPath: "/etc/mysql"
       containers:
       - name: mysql
-        image: gcr.io/google_containers/mysql-galera:e2e
+        image: k8s.gcr.io/mysql-galera:e2e
         ports:
         - containerPort: 3306
           name: mysql
@@ -55,7 +55,7 @@ spec:
         - --defaults-file=/etc/mysql/my-galera.cnf
         - --user=root
         readinessProbe:
-          # TODO: If docker exec is buggy just use gcr.io/google_containers/mysql-healthz:1.0
+          # TODO: If docker exec is buggy just use k8s.gcr.io/mysql-healthz:1.0
           exec:
             command:
             - sh

--- a/test/e2e/testing-manifests/statefulset/mysql-upgrade/tester.yaml
+++ b/test/e2e/testing-manifests/statefulset/mysql-upgrade/tester.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: test-server
-        image: gcr.io/google-containers/mysql-e2e-test:0.1
+        image: k8s.gcr.io/mysql-e2e-test:0.1
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/nginx/statefulset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: gcr.io/google_containers/nginx-slim:0.8
+        image: k8s.gcr.io/nginx-slim:0.8
         ports:
         - containerPort: 80
           name: web

--- a/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/redis/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: gcr.io/google_containers/redis-install-3.2.0:e2e
+        image: k8s.gcr.io/redis-install-3.2.0:e2e
         imagePullPolicy: Always
         args:
         - "--install-into=/opt"

--- a/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
+++ b/test/e2e/testing-manifests/statefulset/zookeeper/statefulset.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       initContainers:
       - name: install
-        image: gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e
+        image: k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e
         imagePullPolicy: Always
         args:
         - "--install-into=/opt"

--- a/test/e2e_node/conformance/build/Makefile
+++ b/test/e2e_node/conformance/build/Makefile
@@ -15,7 +15,7 @@
 # Build the node-test image.
 #
 # Usage:
-#   [ARCH=amd64] [REGISTRY="gcr.io/google_containers"] [BIN_DIR="../../../../_output/bin"] make (build|push) VERSION={some_version_number e.g. 0.1}
+#   [ARCH=amd64] [REGISTRY="k8s.gcr.io"] [BIN_DIR="../../../../_output/bin"] make (build|push) VERSION={some_version_number e.g. 0.1}
 
 # SYSTEM_SPEC_NAME is the name of the system spec used for the node conformance
 # test. The specs are expected to be in SYSTEM_SPEC_DIR.
@@ -23,7 +23,7 @@ SYSTEM_SPEC_NAME?=
 SYSTEM_SPEC_DIR?=../../system/specs
 
 # TODO(random-liu): Add this into release progress.
-REGISTRY?=gcr.io/google_containers
+REGISTRY?=k8s.gcr.io
 ARCH?=amd64
 # BIN_DIR is the directory to find binaries, overwrite with ../../../../_output/bin
 # for local development.
@@ -76,10 +76,10 @@ endif
 	docker build --pull -t ${IMAGE_NAME}-${ARCH}:${VERSION} ${TEMP_DIR}
 
 push: build
-	gcloud docker -- push ${IMAGE_NAME}-${ARCH}:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${IMAGE_NAME}-${ARCH}:${VERSION}
 ifeq ($(ARCH),amd64)
 	docker tag ${IMAGE_NAME}-${ARCH}:${VERSION} ${IMAGE_NAME}:${VERSION}
-	gcloud docker -- push ${IMAGE_NAME}:${VERSION}
+	gcloud docker --server=k8s.gcr.io -- push ${IMAGE_NAME}:${VERSION}
 endif
 
 .PHONY: all

--- a/test/e2e_node/conformance/run_test.sh
+++ b/test/e2e_node/conformance/run_test.sh
@@ -44,7 +44,7 @@ SKIP=${SKIP:-""}
 TEST_ARGS=${TEST_ARGS:-""}
 
 # REGISTRY is the image registry for node test image.
-REGISTRY=${REGISTRY:-"gcr.io/google_containers"}
+REGISTRY=${REGISTRY:-"k8s.gcr.io"}
 
 # ARCH is the architecture of current machine, the script will use this to
 # select corresponding test container image.

--- a/test/e2e_node/docker_test.go
+++ b/test/e2e_node/docker_test.go
@@ -100,7 +100,7 @@ var _ = framework.KubeDescribe("Docker features [Feature:Docker]", func() {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{{
 						Name:  containerName,
-						Image: "gcr.io/google_containers/nginx-slim:0.7",
+						Image: "k8s.gcr.io/nginx-slim:0.7",
 					}},
 				},
 			})

--- a/test/e2e_node/gke_environment_test.go
+++ b/test/e2e_node/gke_environment_test.go
@@ -83,7 +83,7 @@ func checkIPTables() (err error) {
 // checkPublicGCR checks the access to the public Google Container Registry by
 // pulling the busybox image.
 func checkPublicGCR() error {
-	const image = "gcr.io/google-containers/busybox"
+	const image = "k8s.gcr.io/busybox"
 	output, err := runCommand("docker", "images", "-q", image)
 	if len(output) != 0 {
 		if _, err := runCommand("docker", "rmi", "-f", image); err != nil {
@@ -157,7 +157,7 @@ func checkDockerConfig() error {
 // checkDockerNetworkClient checks client networking by pinging an external IP
 // address from a container.
 func checkDockerNetworkClient() error {
-	const imageName = "gcr.io/google-containers/busybox"
+	const imageName = "k8s.gcr.io/busybox"
 	output, err := runCommand("docker", "run", "--rm", imageName, "sh", "-c", "ping -w 5 -q google.com")
 	if err != nil {
 		return err
@@ -172,7 +172,7 @@ func checkDockerNetworkClient() error {
 // within a container and accessing it from outside.
 func checkDockerNetworkServer() error {
 	const (
-		imageName     = "gcr.io/google-containers/nginx:1.7.9"
+		imageName     = "k8s.gcr.io/nginx:1.7.9"
 		hostAddr      = "127.0.0.1"
 		hostPort      = "8088"
 		containerPort = "80"

--- a/test/e2e_node/image_id_test.go
+++ b/test/e2e_node/image_id_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = framework.KubeDescribe("ImageID", func() {
 
-	busyBoxImage := "gcr.io/google_containers/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
+	busyBoxImage := "k8s.gcr.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff"
 
 	f := framework.NewDefaultFramework("image-id-test")
 

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -47,10 +47,10 @@ const (
 // before test running so that the image pulling won't fail in actual test.
 var NodeImageWhiteList = sets.NewString(
 	"google/cadvisor:latest",
-	"gcr.io/google-containers/stress:v1",
+	"k8s.gcr.io/stress:v1",
 	busyboxImage,
-	"gcr.io/google_containers/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
-	"gcr.io/google_containers/node-problem-detector:v0.4.1",
+	"k8s.gcr.io/busybox@sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff",
+	"k8s.gcr.io/node-problem-detector:v0.4.1",
 	imageutils.GetE2EImage(imageutils.NginxSlim),
 	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.Netexec),

--- a/test/e2e_node/jenkins/gci-init-gpu.yaml
+++ b/test/e2e_node/jenkins/gci-init-gpu.yaml
@@ -2,7 +2,7 @@
 
 runcmd:
   - modprobe configs
-  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e BASE_DIR=/rootfs/nvidia --privileged gcr.io/google_containers/cos-nvidia-driver-install@sha256:cb55c7971c337fece62f2bfe858662522a01e43ac9984a2dd1dd5c71487d225c
+  - docker run -v /dev:/dev -v /home/kubernetes/bin/nvidia:/rootfs/nvidia -v /etc/os-release:/rootfs/etc/os-release -v /proc/sysrq-trigger:/sysrq -e BASE_DIR=/rootfs/nvidia --privileged k8s.gcr.io/cos-nvidia-driver-install@sha256:cb55c7971c337fece62f2bfe858662522a01e43ac9984a2dd1dd5c71487d225c
   - mount /tmp /tmp -o remount,exec,suid
   - usermod -a -G docker jenkins
   - mkdir -p /var/lib/kubelet

--- a/test/e2e_node/memory_eviction_test.go
+++ b/test/e2e_node/memory_eviction_test.go
@@ -272,7 +272,7 @@ func getMemhogPod(podName string, ctnName string, res v1.ResourceRequirements) *
 			Containers: []v1.Container{
 				{
 					Name:            ctnName,
-					Image:           "gcr.io/google-containers/stress:v1",
+					Image:           "k8s.gcr.io/stress:v1",
 					ImagePullPolicy: "Always",
 					Env:             env,
 					// 60 min timeout * 60s / tick per 10s = 360 ticks before timeout => ~11.11Mi/tick

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -45,7 +45,7 @@ var _ = framework.KubeDescribe("NodeProblemDetector", func() {
 		pollInterval   = 1 * time.Second
 		pollConsistent = 5 * time.Second
 		pollTimeout    = 1 * time.Minute
-		image          = "gcr.io/google_containers/node-problem-detector:v0.4.1"
+		image          = "k8s.gcr.io/node-problem-detector:v0.4.1"
 	)
 	f := framework.NewDefaultFramework("node-problem-detector")
 	var c clientset.Interface

--- a/test/e2e_node/remote/node_conformance.go
+++ b/test/e2e_node/remote/node_conformance.go
@@ -53,7 +53,7 @@ func commandToString(c *exec.Cmd) string {
 
 // Image path constants.
 const (
-	conformanceRegistry         = "gcr.io/google_containers"
+	conformanceRegistry         = "k8s.gcr.io"
 	conformanceArch             = runtime.GOARCH
 	conformanceTarfile          = "node_conformance.tar"
 	conformanceTestBinary       = "e2e_node.test"

--- a/test/e2e_node/runtime_conformance_test.go
+++ b/test/e2e_node/runtime_conformance_test.go
@@ -275,13 +275,13 @@ while true; do sleep 1; done
 				},
 				{
 					description: "should not be able to pull non-existing image from gcr.io",
-					image:       "gcr.io/google_containers/invalid-image:invalid-tag",
+					image:       "k8s.gcr.io/invalid-image:invalid-tag",
 					phase:       v1.PodPending,
 					waiting:     true,
 				},
 				{
 					description: "should be able to pull image from gcr.io",
-					image:       "gcr.io/google_containers/alpine-with-bash:1.0",
+					image:       "k8s.gcr.io/alpine-with-bash:1.0",
 					phase:       v1.PodRunning,
 					waiting:     false,
 				},

--- a/test/fixtures/doc-yaml/admin/high-availability/etcd.yaml
+++ b/test/fixtures/doc-yaml/admin/high-availability/etcd.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   hostNetwork: true
   containers:
-  - image: gcr.io/google_containers/etcd:2.0.9
+  - image: k8s.gcr.io/etcd:2.0.9
     name: etcd-container
     command:
     - /usr/local/bin/etcd

--- a/test/fixtures/doc-yaml/admin/high-availability/kube-apiserver.yaml
+++ b/test/fixtures/doc-yaml/admin/high-availability/kube-apiserver.yaml
@@ -6,7 +6,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-apiserver
-    image: gcr.io/google_containers/kube-apiserver:9680e782e08a1a1c94c656190011bd02
+    image: k8s.gcr.io/kube-apiserver:9680e782e08a1a1c94c656190011bd02
     command:
     - /bin/sh
     - -c

--- a/test/fixtures/doc-yaml/admin/high-availability/kube-controller-manager.yaml
+++ b/test/fixtures/doc-yaml/admin/high-availability/kube-controller-manager.yaml
@@ -10,7 +10,7 @@ spec:
     - /usr/local/bin/kube-controller-manager --master=127.0.0.1:8080 --cluster-name=e2e-test-bburns
       --cluster-cidr=10.245.0.0/16 --allocate-node-cidrs=true --cloud-provider=gce  --service-account-private-key-file=/srv/kubernetes/server.key
       --v=2 1>>/var/log/kube-controller-manager.log --leader-elect 2>&1
-    image: gcr.io/google_containers/kube-controller-manager:fda24638d51a48baa13c35337fcd4793
+    image: k8s.gcr.io/kube-controller-manager:fda24638d51a48baa13c35337fcd4793
     livenessProbe:
       httpGet:
         path: /healthz

--- a/test/fixtures/doc-yaml/admin/high-availability/kube-scheduler.yaml
+++ b/test/fixtures/doc-yaml/admin/high-availability/kube-scheduler.yaml
@@ -6,7 +6,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-scheduler
-    image: gcr.io/google_containers/kube-scheduler:34d0b8f8b31e27937327961528739bc9
+    image: k8s.gcr.io/kube-scheduler:34d0b8f8b31e27937327961528739bc9
     command:
     - /bin/sh
     - -c

--- a/test/fixtures/doc-yaml/admin/limitrange/invalid-pod.yaml
+++ b/test/fixtures/doc-yaml/admin/limitrange/invalid-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/google_containers/serve_hostname
+    image: k8s.gcr.io/serve_hostname
     resources:
       limits:
         cpu: "3"

--- a/test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml
+++ b/test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/google_containers/serve_hostname
+    image: k8s.gcr.io/serve_hostname
     resources:
       limits:
         cpu: "1"

--- a/test/fixtures/doc-yaml/user-guide/downward-api/dapi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/downward-api/dapi-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: gcr.io/google_containers/busybox
+      image: k8s.gcr.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: MY_POD_NAME

--- a/test/fixtures/doc-yaml/user-guide/liveness/exec-liveness.yaml
+++ b/test/fixtures/doc-yaml/user-guide/liveness/exec-liveness.yaml
@@ -10,7 +10,7 @@ spec:
     - /bin/sh
     - -c
     - echo ok > /tmp/health; sleep 10; rm -rf /tmp/health; sleep 600
-    image: gcr.io/google_containers/busybox
+    image: k8s.gcr.io/busybox
     livenessProbe:
       exec:
         command:

--- a/test/fixtures/doc-yaml/user-guide/liveness/http-liveness.yaml
+++ b/test/fixtures/doc-yaml/user-guide/liveness/http-liveness.yaml
@@ -8,7 +8,7 @@ spec:
   containers:
   - args:
     - /server
-    image: gcr.io/google_containers/liveness
+    image: k8s.gcr.io/liveness
     livenessProbe:
       httpGet:
         path: /healthz

--- a/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/multi-pod.yaml
@@ -42,7 +42,7 @@ metadata:
 spec:
   containers:
   - name: kubernetes-serve-hostname
-    image: gcr.io/google_containers/serve_hostname
+    image: k8s.gcr.io/serve_hostname
     resources:
       limits:
         cpu: "1"

--- a/test/fixtures/doc-yaml/user-guide/secrets/secret-env-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/secrets/secret-env-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: gcr.io/google_containers/busybox
+      image: k8s.gcr.io/busybox
       command: [ "/bin/sh", "-c", "env" ]
       env:
         - name: MY_SECRET_DATA

--- a/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml
+++ b/test/fixtures/doc-yaml/user-guide/secrets/secret-pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: test-container
-      image: gcr.io/google_containers/mounttest:0.8
+      image: k8s.gcr.io/mounttest:0.8
       command: [ "/mt", "--file_content=/etc/secret-volume/data-1" ]
       volumeMounts:
           # name must match the volume name below

--- a/test/fixtures/pkg/kubectl/builder/kitten-rc.yaml
+++ b/test/fixtures/pkg/kubectl/builder/kitten-rc.yaml
@@ -13,7 +13,7 @@ spec:
         version: kitten
     spec:
       containers:
-      - image: gcr.io/google_containers/update-demo:kitten
+      - image: k8s.gcr.io/update-demo:kitten
         name: update-demo
         ports:
         - containerPort: 80

--- a/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
@@ -30,7 +30,7 @@ items:
   spec:
     containers:
     - name: kubernetes-serve-hostname
-      image: gcr.io/google_containers/serve_hostname
+      image: k8s.gcr.io/serve_hostname
       resources:
         limits:
           cpu: "1"

--- a/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
+++ b/test/fixtures/pkg/kubectl/cmd/set/multi-resource-yaml.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0
 ---
 apiVersion: v1
 kind: ReplicationController
@@ -30,4 +30,4 @@ spec:
     spec:
       containers:
       - name: mock-container
-        image: gcr.io/google-containers/pause:2.0
+        image: k8s.gcr.io/pause:2.0

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -97,7 +97,7 @@ push() {
   fi
   for arch in ${archs}; do
     TAG=$(<${IMAGE}/VERSION)
-    gcloud docker -- push ${REGISTRY}/${IMAGE}-${arch}:${TAG}
+    gcloud docker --server=k8s.gcr.io -- push ${REGISTRY}/${IMAGE}-${arch}:${TAG}
   done
 }
 

--- a/test/images/iperf/BASEIMAGE
+++ b/test/images/iperf/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=gcr.io/google_containers/ubuntu-slim:0.12
-arm=gcr.io/google_containers/ubuntu-slim-arm:0.12
-arm64=gcr.io/google_containers/ubuntu-slim-arm64:0.12
-ppc64le=gcr.io/google_containers/ubuntu-slim-ppc64le:0.12
+amd64=k8s.gcr.io/ubuntu-slim:0.12
+arm=k8s.gcr.io/ubuntu-slim-arm:0.12
+arm64=k8s.gcr.io/ubuntu-slim-arm64:0.12
+ppc64le=k8s.gcr.io/ubuntu-slim-ppc64le:0.12

--- a/test/images/logs-generator/README.md
+++ b/test/images/logs-generator/README.md
@@ -33,7 +33,7 @@ line in a given run of the container.
 Image is located in the public repository of Google Container Registry under the name
 
 ```
-gcr.io/google_containers/logs-generator:v0.1.1
+k8s.gcr.io/logs-generator:v0.1.1
 ```
 
 ## Examples
@@ -42,13 +42,13 @@ gcr.io/google_containers/logs-generator:v0.1.1
 docker run -i \
   -e "LOGS_GENERATOR_LINES_TOTAL=10" \
   -e "LOGS_GENERATOR_DURATION=1s" \
-  gcr.io/google_containers/logs-generator:v0.1.1
+  k8s.gcr.io/logs-generator:v0.1.1
 ```
 
 ```
 kubectl run logs-generator \
   --generator=run-pod/v1 \
-  --image=gcr.io/google_containers/logs-generator:v0.1.1 \
+  --image=k8s.gcr.io/logs-generator:v0.1.1 \
   --restart=Never \
   --env "LOGS_GENERATOR_LINES_TOTAL=1000" \
   --env "LOGS_GENERATOR_DURATION=1m"

--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=gcr.io/google-containers/debian-base-amd64:0.2
-arm=gcr.io/google-containers/debian-base-arm:0.2
-arm64=gcr.io/google-containers/debian-base-arm64:0.2
-ppc64le=gcr.io/google-containers/debian-base-ppc64le:0.2
+amd64=k8s.gcr.io/debian-base-amd64:0.2
+arm=k8s.gcr.io/debian-base-arm:0.2
+arm64=k8s.gcr.io/debian-base-arm64:0.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.2

--- a/test/images/pets/redis-installer/BASEIMAGE
+++ b/test/images/pets/redis-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=gcr.io/google-containers/debian-base-amd64:0.2
-arm=gcr.io/google-containers/debian-base-arm:0.2
-arm64=gcr.io/google-containers/debian-base-arm64:0.2
-ppc64le=gcr.io/google-containers/debian-base-ppc64le:0.2
+amd64=k8s.gcr.io/debian-base-amd64:0.2
+arm=k8s.gcr.io/debian-base-arm:0.2
+arm64=k8s.gcr.io/debian-base-arm64:0.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.2

--- a/test/images/pets/redis-installer/README.md
+++ b/test/images/pets/redis-installer/README.md
@@ -4,7 +4,7 @@ The image in this directory is the init container for contrib/pets/redis but for
 
 You can execute the image locally via:
 ```
-$ docker run -it gcr.io/google_containers/redis-install-3.2.0:e2e --cmd --install-into=/opt --work-dir=/work-dir
+$ docker run -it k8s.gcr.io/redis-install-3.2.0:e2e --cmd --install-into=/opt --work-dir=/work-dir
 ```
 To share the installation with other containers mount the appropriate volumes as `--install-into` and `--work-dir`, where `install-into` is the directory to install redis into, and `work-dir` is the directory to install the user/admin supplied on-{start,change} hook scripts.
 

--- a/test/images/pets/zookeeper-installer/BASEIMAGE
+++ b/test/images/pets/zookeeper-installer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=gcr.io/google-containers/debian-base-amd64:0.2
-arm=gcr.io/google-containers/debian-base-arm:0.2
-arm64=gcr.io/google-containers/debian-base-arm64:0.2
-ppc64le=gcr.io/google-containers/debian-base-ppc64le:0.2
+amd64=k8s.gcr.io/debian-base-amd64:0.2
+arm=k8s.gcr.io/debian-base-arm:0.2
+arm64=k8s.gcr.io/debian-base-arm64:0.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.2

--- a/test/images/pets/zookeeper-installer/README.md
+++ b/test/images/pets/zookeeper-installer/README.md
@@ -4,7 +4,7 @@ The image in this directory is the init container for contrib/pets/zookeeper but
 
 You can execute the image locally via:
 ```
-$ docker run -it gcr.io/google_containers/zookeeper-install-3.5.0-alpha:e2e --cmd --install-into=/opt --work-dir=/work-dir
+$ docker run -it k8s.gcr.io/zookeeper-install-3.5.0-alpha:e2e --cmd --install-into=/opt --work-dir=/work-dir
 ```
 To share the installation with other containers mount the appropriate volumes as `--install-into` and `--work-dir`, where `install-into` is the directory to install zookeeper into, and `work-dir` is the directory to install the user/admin supplied on-{start,change} hook scripts.
 

--- a/test/images/resource-consumer/BASEIMAGE
+++ b/test/images/resource-consumer/BASEIMAGE
@@ -1,4 +1,4 @@
-amd64=gcr.io/google-containers/debian-base-amd64:0.2
-arm=gcr.io/google-containers/debian-base-arm:0.2
-arm64=gcr.io/google-containers/debian-base-arm64:0.2
-ppc64le=gcr.io/google-containers/debian-base-ppc64le:0.2
+amd64=k8s.gcr.io/debian-base-amd64:0.2
+arm=k8s.gcr.io/debian-base-arm:0.2
+arm64=k8s.gcr.io/debian-base-arm64:0.2
+ppc64le=k8s.gcr.io/debian-base-ppc64le:0.2

--- a/test/images/resource-consumer/README.md
+++ b/test/images/resource-consumer/README.md
@@ -48,7 +48,7 @@ Custom metrics in Prometheus format are exposed on "/metrics" endpoint.
 
 ###CURL example
 ```console
-$ kubectl run resource-consumer --image=gcr.io/google_containers/resource_consumer:beta --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080
+$ kubectl run resource-consumer --image=k8s.gcr.io/resource_consumer:beta --expose --service-overrides='{ "spec": { "type": "LoadBalancer" } }' --port 8080
 $ kubectl get services resource-consumer
 ```
 
@@ -62,7 +62,7 @@ $ curl --data "millicores=300&durationSec=600" http://<EXTERNAL-IP>:8080/Consume
 
 ## Image
 
-Docker image of Resource Consumer can be found in Google Container Registry as gcr.io/google_containers/resource_consumer:beta
+Docker image of Resource Consumer can be found in Google Container Registry as k8s.gcr.io/resource_consumer:beta
 
 ## Use cases
 

--- a/test/images/serve-hostname/README.md
+++ b/test/images/serve-hostname/README.md
@@ -15,19 +15,19 @@ $ make all-push
 
 # Build for linux/amd64 (default)
 $ make push ARCH=amd64
-# ---> gcr.io/google_containers/serve_hostname-amd64:TAG
+# ---> k8s.gcr.io/serve_hostname-amd64:TAG
 
 $ make push ARCH=arm
-# ---> gcr.io/google_containers/serve_hostname-arm:TAG
+# ---> k8s.gcr.io/serve_hostname-arm:TAG
 
 $ make push ARCH=arm64
-# ---> gcr.io/google_containers/serve_hostname-arm64:TAG
+# ---> k8s.gcr.io/serve_hostname-arm64:TAG
 
 $ make push ARCH=ppc64le
-# ---> gcr.io/google_containers/serve_hostname-ppc64le:TAG
+# ---> k8s.gcr.io/serve_hostname-ppc64le:TAG
 
 $ make push ARCH=s390x
-# ---> gcr.io/google_containers/serve_hostname-s390x:TAG
+# ---> k8s.gcr.io/serve_hostname-s390x:TAG
 ```
 
 Of course, if you don't want to push the images, run `make all-container` or `make container ARCH={target_arch}` instead.

--- a/test/images/volumes-tester/ceph/Makefile
+++ b/test/images/volumes-tester/ceph/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.1
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 
 all: push
 
@@ -24,7 +24,7 @@ image:
 	docker tag $(PREFIX)/volume-ceph $(PREFIX)/volume-ceph:$(TAG)  # Add the version tag to the latest image
 
 push: image
-	gcloud docker -- push $(PREFIX)/volume-ceph # Push image tagged as latest to repository
-	gcloud docker -- push $(PREFIX)/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-ceph # Push image tagged as latest to repository
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-ceph:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/gluster/Makefile
+++ b/test/images/volumes-tester/gluster/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.4
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 
 all: push
 
@@ -24,7 +24,7 @@ image:
 	docker tag $(PREFIX)/volume-gluster $(PREFIX)/volume-gluster:$(TAG)  # Add the version tag to the latest image
 
 push: image
-	gcloud docker -- push $(PREFIX)/volume-gluster # Push image tagged as latest to repository
-	gcloud docker -- push $(PREFIX)/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-gluster # Push image tagged as latest to repository
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-gluster:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/iscsi/Makefile
+++ b/test/images/volumes-tester/iscsi/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.1
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 
 all: push
 
@@ -34,8 +34,8 @@ block:
 
 push: image
 	# Push image tagged as latest to repository
-	gcloud docker -- push $(PREFIX)/volume-iscsi
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-iscsi
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker -- push $(PREFIX)/volume-iscsi:$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-iscsi:$(TAG)
 
 clean:

--- a/test/images/volumes-tester/nfs/Makefile
+++ b/test/images/volumes-tester/nfs/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.8
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 
 all: push
 
@@ -24,7 +24,7 @@ image:
 	docker tag $(PREFIX)/volume-nfs $(PREFIX)/volume-nfs:$(TAG) # Add the version tag to the latest image
 
 push: image
-	gcloud docker -- push $(PREFIX)/volume-nfs # Push image tagged as latest to repository
-	gcloud docker -- push $(PREFIX)/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-nfs # Push image tagged as latest to repository
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-nfs:$(TAG) # Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
 
 clean:

--- a/test/images/volumes-tester/rbd/Makefile
+++ b/test/images/volumes-tester/rbd/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TAG = 0.1
-PREFIX = gcr.io/google_containers
+PREFIX = k8s.gcr.io
 
 all: push
 
@@ -34,8 +34,8 @@ block:
 
 push: image
 	# Push image tagged as latest to repository
-	gcloud docker -- push $(PREFIX)/volume-rbd
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-rbd
 	# Push version tagged image to repository (since this image is already pushed it will simply create or update version tag)
-	gcloud docker -- push $(PREFIX)/volume-rbd:$(TAG)
+	gcloud docker --server=k8s.gcr.io -- push $(PREFIX)/volume-rbd:$(TAG)
 
 clean:

--- a/test/integration/benchmark-controller.json
+++ b/test/integration/benchmark-controller.json
@@ -17,7 +17,7 @@
        "spec": {
            "containers": [{
              "name": "test-container",
-             "image": "gcr.io/google_containers/pause-amd64:3.0"
+             "image": "k8s.gcr.io/pause-amd64:3.0"
            }]
        }
     }

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -27,7 +27,7 @@ import (
 const (
 	// When these values are updated, also update cmd/kubelet/app/options/options.go
 	// A copy of these values exist in e2e/framework/util.go.
-	currentPodInfraContainerImageName    = "gcr.io/google_containers/pause"
+	currentPodInfraContainerImageName    = "k8s.gcr.io/pause"
 	currentPodInfraContainerImageVersion = "3.0"
 )
 

--- a/test/integration/master/master_test.go
+++ b/test/integration/master/master_test.go
@@ -279,7 +279,7 @@ var deploymentExtensions string = `
       "spec": {
         "containers": [{
           "name": "nginx",
-          "image": "gcr.io/google-containers/nginx:1.7.9"
+          "image": "k8s.gcr.io/nginx:1.7.9"
         }]
       }
     }
@@ -306,7 +306,7 @@ var deploymentApps string = `
       "spec": {
         "containers": [{
           "name": "nginx",
-          "image": "gcr.io/google-containers/nginx:1.7.9"
+          "image": "k8s.gcr.io/nginx:1.7.9"
         }]
       }
     }

--- a/test/kubemark/resources/cluster-autoscaler_template.json
+++ b/test/kubemark/resources/cluster-autoscaler_template.json
@@ -14,7 +14,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.0.0",
                 "command": [
                     "./run.sh",
                     "--kubernetes=https://{{master_ip}}:443?inClusterConfig=0&useServiceAccount=0&auth=/kubeconfig/cluster_autoscaler.kubeconfig",

--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -33,7 +33,7 @@
 				"containers": [
 				{
 					"name": "heapster",
-					"image": "gcr.io/google_containers/heapster:v1.3.0",
+					"image": "k8s.gcr.io/heapster:v1.3.0",
 					"resources": {
 						"requests": {
 							"cpu": "{{METRICS_CPU}}m",
@@ -55,7 +55,7 @@
 				},
 				{
 					"name": "eventer",
-					"image": "gcr.io/google_containers/heapster:v1.3.0",
+					"image": "k8s.gcr.io/heapster:v1.3.0",
 					"resources": {
 						"requests": {
 							"memory": "{{EVENTER_MEM}}Ki"

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -93,7 +93,7 @@ spec:
             cpu: {{HOLLOW_PROXY_CPU}}m
             memory: {{HOLLOW_PROXY_MEM}}Ki
       - name: hollow-node-problem-detector
-        image: gcr.io/google_containers/node-problem-detector:v0.4.1
+        image: k8s.gcr.io/node-problem-detector:v0.4.1
         env:
         - name: NODE_NAME
           valueFrom:

--- a/test/kubemark/resources/start-kubemark-master.sh
+++ b/test/kubemark/resources/start-kubemark-master.sh
@@ -692,7 +692,7 @@ fi
 
 # Setup docker flags and load images of the master components.
 assemble-docker-flags
-DOCKER_REGISTRY="gcr.io/google_containers"
+DOCKER_REGISTRY="k8s.gcr.io"
 load-docker-images
 
 readonly audit_policy_file="/etc/audit_policy.config"

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	e2eRegistry     = "gcr.io/kubernetes-e2e-test-images"
-	gcRegistry      = "gcr.io/google-containers"
+	gcRegistry      = "k8s.gcr.io"
 	PrivateRegistry = "gcr.io/k8s-authenticated-test"
 	sampleRegistry  = "gcr.io/google-samples"
 )


### PR DESCRIPTION
Refactor references to gcr.io/google-containers and gcr.io/google_containers to refer to the k8s.gcr.io alias, instead. Using the alias increases brevity, decreases typos, and allows for the underlying repo to be changed more easily.

Signed-off-by: Jake Sanders <jsand@google.com>

```release-note
NONE
```
