### PR TITLE
Provide validation for trailing period

### DIFF
--- a/pkg/kubectl/explain/field_lookup.go
+++ b/pkg/kubectl/explain/field_lookup.go
@@ -78,10 +78,14 @@ func (f *fieldLookup) VisitKind(k *proto.Kind) {
 	if f.SaveLeafSchema(k) {
 		return
 	}
-
-	subSchema, ok := k.Fields[f.Path[0]]
+	var field string = f.Path[0]
+	if len(f.Path) > 1 && f.Path[1] == "" {
+		// validate the last field which can be accidently ended with period
+		field = field + "." + f.Path[1]
+	}
+	subSchema, ok := k.Fields[field]
 	if !ok {
-		f.Error = fmt.Errorf("field %q does not exist", f.Path[0])
+		f.Error = fmt.Errorf("field %q does not exist", field)
 		return
 	}
 


### PR DESCRIPTION
With the nature of kubectl explain usage, user can accidentally add a
trailing period. For example, “kubectl explain svc.status.xyz.”,
currently the error message is, field "" does not exist which is
confusing. Provide a better a validation with this fix as, field
“xyz.” does not exist.

Fixes #54891

Co-Authored-By: Nikhita Raghunath nikitaraghunath@gmail.com

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
