### PR TITLE
Cluster Autoscaler 1.0.2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.2-beta1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Almost the same as 1.0.2-beta1. Provides mainly Node Autoprovisioning fixes. 