### PR TITLE
Cluster Autoscaler 1.0.2

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Provides ready-to-launch Node Autoprovisioning on GKE, fixes couple issues around GPUs in GCP and AWS and fixes api calls problems on AWS.

```release-note
Cluster Autoscaler 1.0.2
```
