### PR TITLE
Update envelope.Service to use []byte in place of string.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -226,18 +226,18 @@ type testEnvelopeService struct {
 	disabled bool
 }
 
-func (t *testEnvelopeService) Decrypt(data string) ([]byte, error) {
+func (t *testEnvelopeService) Decrypt(data []byte) ([]byte, error) {
 	if t.disabled {
 		return nil, fmt.Errorf("Envelope service was disabled")
 	}
-	return base64.StdEncoding.DecodeString(data)
+	return base64.StdEncoding.DecodeString(string(data))
 }
 
-func (t *testEnvelopeService) Encrypt(data []byte) (string, error) {
+func (t *testEnvelopeService) Encrypt(data []byte) ([]byte, error) {
 	if t.disabled {
-		return "", fmt.Errorf("Envelope service was disabled")
+		return nil, fmt.Errorf("Envelope service was disabled")
 	}
-	return base64.StdEncoding.EncodeToString(data), nil
+	return []byte(base64.StdEncoding.EncodeToString(data)), nil
 }
 
 func (t *testEnvelopeService) SetDisabledStatus(status bool) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
@@ -42,22 +42,22 @@ type testEnvelopeService struct {
 	keyVersion string
 }
 
-func (t *testEnvelopeService) Decrypt(data string) ([]byte, error) {
+func (t *testEnvelopeService) Decrypt(data []byte) ([]byte, error) {
 	if t.disabled {
 		return nil, fmt.Errorf("Envelope service was disabled")
 	}
-	dataChunks := strings.SplitN(data, ":", 2)
+	dataChunks := strings.SplitN(string(data), ":", 2)
 	if len(dataChunks) != 2 {
 		return nil, fmt.Errorf("invalid data encountered for decryption: %s. Missing key version", data)
 	}
 	return base64.StdEncoding.DecodeString(dataChunks[1])
 }
 
-func (t *testEnvelopeService) Encrypt(data []byte) (string, error) {
+func (t *testEnvelopeService) Encrypt(data []byte) ([]byte, error) {
 	if t.disabled {
-		return "", fmt.Errorf("Envelope service was disabled")
+		return nil, fmt.Errorf("Envelope service was disabled")
 	}
-	return t.keyVersion + ":" + base64.StdEncoding.EncodeToString(data), nil
+	return []byte(t.keyVersion + ":" + base64.StdEncoding.EncodeToString(data)), nil
 }
 
 func (t *testEnvelopeService) SetDisabledStatus(status bool) {


### PR DESCRIPTION
In accordance to discussion with @lavalamp in [KMS Plugins API design doc](https://docs.google.com/document/d/1S_Wgn-psI0Z7SYGvp-83ePte5oUNMr4244uanGLYUmw/edit?usp=sharing).

Modifies envelope transformer introduced by #49350.

@lavalamp @destijl @kksriram

```release-note
NONE
```
