### PR TITLE
Fix kubeproxy in hack/local-up-cluster.sh

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -737,7 +737,7 @@ function start_kubeproxy {
     PROXY_LOG=${LOG_DIR}/kube-proxy.log
 
     cat <<EOF > /tmp/kube-proxy.yaml
-apiVersion: componentconfig/v1alpha1
+apiVersion: kubeproxy.config.k8s.io/v1alpha1
 kind: KubeProxyConfiguration
 clientConnection:
   kubeconfig: ${CERT_DIR}/kube-proxy.kubeconfig


### PR DESCRIPTION
hack/local-up-cluster.sh was broken by https://github.com/kubernetes/kubernetes/pull/53645

Fixed it following instruction in https://github.com/kubernetes/kubernetes/pull/53645#issuecomment-342178172.

Thanks to @MrHohn who pointed me to the original PR, saving me another hour scratching my head.

@xiangpengzhao @luxas @ncdc

