### PR TITLE
Work around heapster panic

### DIFF
--- a/pkg/kubelet/stats/BUILD
+++ b/pkg/kubelet/stats/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/kubelet/server/stats:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/google/cadvisor/fs:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v2:go_default_library",

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -235,13 +235,13 @@ func makeFakeImageFsUsage(fsUUID string) *runtimeapi.FilesystemUsage {
 func checkCRICPUAndMemoryStats(assert *assert.Assertions, actual statsapi.ContainerStats, cs *runtimeapi.ContainerStats) {
 	assert.Equal(cs.Cpu.Timestamp, actual.CPU.Time.UnixNano())
 	assert.Equal(cs.Cpu.UsageCoreNanoSeconds.Value, *actual.CPU.UsageCoreNanoSeconds)
-	assert.Nil(actual.CPU.UsageNanoCores)
+	assert.Zero(*actual.CPU.UsageNanoCores)
 
 	assert.Equal(cs.Memory.Timestamp, actual.Memory.Time.UnixNano())
 	assert.Nil(actual.Memory.AvailableBytes)
 	assert.Nil(actual.Memory.UsageBytes)
 	assert.Equal(cs.Memory.WorkingSetBytes.Value, *actual.Memory.WorkingSetBytes)
-	assert.Nil(actual.Memory.RSSBytes)
+	assert.Zero(*actual.Memory.RSSBytes)
 	assert.Nil(actual.Memory.PageFaults)
 	assert.Nil(actual.Memory.MajorPageFaults)
 }


### PR DESCRIPTION
For https://github.com/kubernetes/kubernetes/issues/54962.

Work around https://github.com/kubernetes/kubernetes/issues/54962 for now. It is blocking the cri-containerd cluster e2e test, and it seems that heapster update takes time.

@yujuhong @yguo0905 

```release-note
none

```