### PR TITLE
Checking Cinder disk when tickers are delivered

### DIFF
--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -240,7 +240,6 @@ func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath 
 	defer timer.Stop()
 
 	for {
-		probeAttachedVolume()
 		select {
 		case <-ticker.C:
 			glog.V(5).Infof("Checking Cinder disk %q is attached.", volumeID)


### PR DESCRIPTION
Cinder's WaitForAttach() runs probeAttachedVolume() 2 times per
second(L243 and L247), that triggers SCSI rescan and generates many udev "change"
events.

**Release note**:
```release-note
NONE
```
