### PR TITLE
Print apiVersion info when failed to execute kubectl apply -f XXX.yaml

### DIFF
--- a/pkg/controller/garbagecollector/operations.go
+++ b/pkg/controller/garbagecollector/operations.go
@@ -34,7 +34,7 @@ import (
 // namespace> tuple to a unversioned.APIResource struct.
 func (gc *GarbageCollector) apiResource(apiVersion, kind string) (*metav1.APIResource, error) {
 	fqKind := schema.FromAPIVersionAndKind(apiVersion, kind)
-	mapping, err := gc.restMapper.RESTMapping(fqKind.GroupKind(), apiVersion)
+	mapping, err := gc.restMapper.RESTMapping(fqKind.GroupKind(), fqKind.Version)
 	if err != nil {
 		return nil, newRESTMappingError(kind, apiVersion)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
@@ -52,6 +52,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/errors.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // AmbiguousResourceError is returned if the RESTMapper finds multiple matches for a resource
@@ -85,11 +86,26 @@ func (e *NoResourceMatchError) Error() string {
 
 // NoKindMatchError is returned if the RESTMapper can't find any match for a kind
 type NoKindMatchError struct {
-	PartialKind schema.GroupVersionKind
+	// GroupKind is the API group and kind that was searched
+	GroupKind schema.GroupKind
+	// SearchedVersions is the optional list of versions the search was restricted to
+	SearchedVersions []string
 }
 
 func (e *NoKindMatchError) Error() string {
-	return fmt.Sprintf("no matches for %v", e.PartialKind)
+	searchedVersions := sets.NewString()
+	for _, v := range e.SearchedVersions {
+		searchedVersions.Insert(schema.GroupVersion{Group: e.GroupKind.Group, Version: v}.String())
+	}
+
+	switch len(searchedVersions) {
+	case 0:
+		return fmt.Sprintf("no matches for kind %q in group %q", e.GroupKind.Kind, e.GroupKind.Group)
+	case 1:
+		return fmt.Sprintf("no matches for kind %q in version %q", e.GroupKind.Kind, searchedVersions.List()[0])
+	default:
+		return fmt.Sprintf("no matches for kind %q in versions %q", e.GroupKind.Kind, searchedVersions.List())
+	}
 }
 
 func IsNoMatchError(err error) bool {

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/multirestmapper.go
@@ -179,7 +179,7 @@ func (m MultiRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*
 	if len(errors) > 0 {
 		return nil, utilerrors.NewAggregate(errors)
 	}
-	return nil, &NoKindMatchError{PartialKind: gk.WithVersion("")}
+	return nil, &NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
 }
 
 // RESTMappings returns all possible RESTMappings for the provided group kind, or an error
@@ -204,7 +204,7 @@ func (m MultiRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) (
 		return nil, utilerrors.NewAggregate(errors)
 	}
 	if len(allMappings) == 0 {
-		return nil, &NoKindMatchError{PartialKind: gk.WithVersion("")}
+		return nil, &NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
 	}
 	return allMappings, nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority.go
@@ -153,7 +153,7 @@ func kindMatches(pattern schema.GroupVersionKind, kind schema.GroupVersionKind) 
 }
 
 func (m PriorityRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string) (mapping *RESTMapping, err error) {
-	mappings, err := m.Delegate.RESTMappings(gk)
+	mappings, err := m.Delegate.RESTMappings(gk, versions...)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/priority_test.go
@@ -234,13 +234,13 @@ func TestPriorityRESTMapperRESTMapping(t *testing.T) {
 			name:   "empty",
 			mapper: PriorityRESTMapper{Delegate: MultiRESTMapper{}},
 			input:  schema.GroupKind{Kind: "Foo"},
-			err:    &NoKindMatchError{PartialKind: schema.GroupVersionKind{Kind: "Foo"}},
+			err:    &NoKindMatchError{GroupKind: schema.GroupKind{Kind: "Foo"}},
 		},
 		{
 			name:   "ignore not found",
-			mapper: PriorityRESTMapper{Delegate: MultiRESTMapper{fixedRESTMapper{err: &NoKindMatchError{PartialKind: schema.GroupVersionKind{Kind: "IGNORE_THIS"}}}}},
+			mapper: PriorityRESTMapper{Delegate: MultiRESTMapper{fixedRESTMapper{err: &NoKindMatchError{GroupKind: schema.GroupKind{Kind: "IGNORE_THIS"}}}}},
 			input:  schema.GroupKind{Kind: "Foo"},
-			err:    &NoKindMatchError{PartialKind: schema.GroupVersionKind{Kind: "Foo"}},
+			err:    &NoKindMatchError{GroupKind: schema.GroupKind{Kind: "Foo"}},
 		},
 		{
 			name:   "accept first failure",

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/restmapper.go
@@ -472,7 +472,7 @@ func (m *DefaultRESTMapper) RESTMapping(gk schema.GroupKind, versions ...string)
 		return nil, err
 	}
 	if len(mappings) == 0 {
-		return nil, &NoKindMatchError{PartialKind: gk.WithVersion("")}
+		return nil, &NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
 	}
 	// since we rely on RESTMappings method
 	// take the first match and return to the caller
@@ -510,7 +510,7 @@ func (m *DefaultRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string
 	}
 
 	if len(potentialGVK) == 0 {
-		return nil, &NoKindMatchError{PartialKind: gk.WithVersion("")}
+		return nil, &NoKindMatchError{GroupKind: gk, SearchedVersions: versions}
 	}
 
 	for _, gvk := range potentialGVK {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes https://github.com/kubernetes/kubernetes/issues/55216

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
