### PR TITLE
Fix nil pointer dereference in #54640

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/kubeadm/fuzzer/fuzzer.go
@@ -17,8 +17,11 @@ limitations under the License.
 package fuzzer
 
 import (
+	"time"
+
 	"github.com/google/gofuzz"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
@@ -30,6 +33,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			c.FuzzNoCustom(obj)
 			obj.KubernetesVersion = "v10"
 			obj.API.BindPort = 20
+			obj.TokenTTL = &metav1.Duration{Duration: 1 * time.Hour}
 			obj.API.AdvertiseAddress = "foo"
 			obj.Networking.ServiceSubnet = "foo"
 			obj.Networking.DNSDomain = "foo"

--- a/cmd/kubeadm/app/apis/kubeadm/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/types.go
@@ -36,7 +36,7 @@ type MasterConfiguration struct {
 	AuthorizationModes []string
 
 	Token    string
-	TokenTTL metav1.Duration
+	TokenTTL *metav1.Duration
 
 	APIServerExtraArgs         map[string]string
 	ControllerManagerExtraArgs map[string]string

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -76,8 +76,8 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 		obj.CertificatesDir = DefaultCertificatesDir
 	}
 
-	if obj.TokenTTL.Duration == 0 {
-		obj.TokenTTL = metav1.Duration{
+	if obj.TokenTTL == nil {
+		obj.TokenTTL = &metav1.Duration{
 			Duration: constants.DefaultTokenDuration,
 		}
 	}

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -35,8 +35,8 @@ type MasterConfiguration struct {
 	NodeName           string     `json:"nodeName"`
 	AuthorizationModes []string   `json:"authorizationModes,omitempty"`
 
-	Token    string          `json:"token"`
-	TokenTTL metav1.Duration `json:"tokenTTL"`
+	Token    string           `json:"token"`
+	TokenTTL *metav1.Duration `json:"tokenTTL,omitempty"`
 
 	APIServerExtraArgs         map[string]string `json:"apiServerExtraArgs,omitempty"`
 	ControllerManagerExtraArgs map[string]string `json:"controllerManagerExtraArgs,omitempty"`

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.conversion.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -119,7 +120,7 @@ func autoConvert_v1alpha1_MasterConfiguration_To_kubeadm_MasterConfiguration(in 
 	out.NodeName = in.NodeName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
-	out.TokenTTL = in.TokenTTL
+	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.APIServerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.APIServerExtraArgs))
 	out.ControllerManagerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.ControllerManagerExtraArgs))
 	out.SchedulerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.SchedulerExtraArgs))
@@ -151,7 +152,7 @@ func autoConvert_kubeadm_MasterConfiguration_To_v1alpha1_MasterConfiguration(in 
 	out.NodeName = in.NodeName
 	out.AuthorizationModes = *(*[]string)(unsafe.Pointer(&in.AuthorizationModes))
 	out.Token = in.Token
-	out.TokenTTL = in.TokenTTL
+	out.TokenTTL = (*v1.Duration)(unsafe.Pointer(in.TokenTTL))
 	out.APIServerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.APIServerExtraArgs))
 	out.ControllerManagerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.ControllerManagerExtraArgs))
 	out.SchedulerExtraArgs = *(*map[string]string)(unsafe.Pointer(&in.SchedulerExtraArgs))

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
@@ -114,7 +115,15 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.TokenTTL = in.TokenTTL
+	if in.TokenTTL != nil {
+		in, out := &in.TokenTTL, &out.TokenTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.APIServerExtraArgs != nil {
 		in, out := &in.APIServerExtraArgs, &out.APIServerExtraArgs
 		*out = make(map[string]string, len(*in))

--- a/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/kubeadm/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package kubeadm
 
 import (
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	reflect "reflect"
@@ -119,7 +120,15 @@ func (in *MasterConfiguration) DeepCopyInto(out *MasterConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	out.TokenTTL = in.TokenTTL
+	if in.TokenTTL != nil {
+		in, out := &in.TokenTTL, &out.TokenTTL
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(v1.Duration)
+			**out = **in
+		}
+	}
 	if in.APIServerExtraArgs != nil {
 		in, out := &in.APIServerExtraArgs, &out.APIServerExtraArgs
 		*out = make(map[string]string, len(*in))

--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/renstrom/dedent"
 	"github.com/spf13/cobra"
@@ -134,6 +135,7 @@ func NewCmdConfigUploadFromFile(out io.Writer, kubeConfigFile *string) *cobra.Co
 // NewCmdConfigUploadFromFlags returs cobra.Command for "kubeadm config upload from-flags" command
 func NewCmdConfigUploadFromFlags(out io.Writer, kubeConfigFile *string) *cobra.Command {
 	cfg := &kubeadmapiext.MasterConfiguration{}
+	cfg.TokenTTL = &metav1.Duration{Duration: 24 * time.Hour}
 	legacyscheme.Scheme.Default(cfg)
 
 	var featureGatesString string

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -30,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -103,6 +104,7 @@ var (
 // NewCmdInit returns "kubeadm init" command.
 func NewCmdInit(out io.Writer) *cobra.Command {
 	cfg := &kubeadmapiext.MasterConfiguration{}
+	cfg.TokenTTL = &metav1.Duration{Duration: 24 * time.Hour}
 	legacyscheme.Scheme.Default(cfg)
 
 	var cfgPath string
@@ -181,7 +183,7 @@ func AddInitConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.MasterConfigur
 	)
 	flagSet.DurationVar(
 		&cfg.TokenTTL.Duration, "token-ttl", cfg.TokenTTL.Duration,
-		"The duration before the bootstrap token is automatically deleted. 0 means 'never expires'.",
+		"The duration before the bootstrap token is automatically deleted. 0 means 'never expires'. If unset, the TTL defaults to 24 hours.",
 	)
 	flagSet.StringVar(featureGatesString, "feature-gates", *featureGatesString, "A set of key=value pairs that describe feature gates for various features. "+
 		"Options are:\n"+strings.Join(features.KnownFeatures(&features.InitFeatureGates), "\n"))

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -58,7 +58,6 @@ func TestPrintConfiguration(t *testing.T) {
 	  serviceSubnet: ""
 	nodeName: ""
 	token: ""
-	tokenTTL: 0s
 	unifiedControlPlaneImage: ""
 `),
 		},
@@ -90,7 +89,6 @@ func TestPrintConfiguration(t *testing.T) {
 	  serviceSubnet: 10.96.0.1/12
 	nodeName: ""
 	token: ""
-	tokenTTL: 0s
 	unifiedControlPlaneImage: ""
 `),
 		},


### PR DESCRIPTION
@mattmoyer  Not sure if this is exactly what is needed, but it should prevent the [nil pointer dereference](https://github.com/kubernetes/kubernetes/pull/54640#issuecomment-342388670) encountered by `pull-kubernetes-verify`. 