### PR TITLE
Fix protobuf generator for aliases to repeated types

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/generator.go
@@ -513,10 +513,13 @@ func memberTypeToProtobufField(locator ProtobufLocator, field *protoField, t *ty
 				log.Printf("failed to alias: %s %s: err %v", t.Name, t.Underlying.Name, err)
 				return err
 			}
-			if field.Extras == nil {
-				field.Extras = make(map[string]string)
+			// If this is not an alias to a slice, cast to the alias
+			if !field.Repeated {
+				if field.Extras == nil {
+					field.Extras = make(map[string]string)
+				}
+				field.Extras["(gogoproto.casttype)"] = strconv.Quote(locator.CastTypeName(t.Name))
 			}
-			field.Extras["(gogoproto.casttype)"] = strconv.Quote(locator.CastTypeName(t.Name))
 		}
 	case types.Slice:
 		if t.Elem.Name.Name == "byte" && len(t.Elem.Name.Package) == 0 {


### PR DESCRIPTION
Currently if a type has an alias the generator will fail generating protobuf. This prevents the problem.

```release-note
NONE
```
