### PR TITLE
Mentioned StatefulSet in docs for scale command.

### DIFF
--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -31,7 +31,7 @@ import (
 
 var (
 	scaleLong = templates.LongDesc(i18n.T(`
-		Set a new size for a Deployment, ReplicaSet, StatefulSel, Replication Controller,
+		Set a new size for a Deployment, ReplicaSet, StatefulSet, Replication Controller,
 		or Job.
 
 		Scale also allows users to specify one or more preconditions for the scale action.

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -31,7 +31,8 @@ import (
 
 var (
 	scaleLong = templates.LongDesc(i18n.T(`
-		Set a new size for a Deployment, ReplicaSet, Replication Controller, or Job.
+		Set a new size for a Deployment, ReplicaSet, StatefulSel, Replication Controller,
+		or Job.
 
 		Scale also allows users to specify one or more preconditions for the scale action.
 


### PR DESCRIPTION
**Special notes for your reviewer**: This is a small docs fix. The StatefulSet should be included in the list of supported types for scale action. See https://kubernetes.io/docs/tasks/run-application/scale-stateful-set/#kubectl-scale

This is my first PR, so apologies if I get lost in the process. I'm a Googler (konryd@g{mail,oogle}) - I believe I should rely on the company CLA signature.

```release-note
NONE
```