### PR TITLE
#50598: Added more test cases for nodeShouldRunDaemonPod

### DIFF
--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1594,6 +1594,76 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			shouldSchedule:        true,
 			shouldContinueRunning: true,
 		},
+		{
+			predicateName: "ErrPodAffinityNotMatch",
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: v1.PodSpec{
+							Affinity: &v1.Affinity{
+								NodeAffinity: &v1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+										NodeSelectorTerms: []v1.NodeSelectorTerm{
+											{
+												MatchExpressions: []v1.NodeSelectorRequirement{
+													{
+														Key:      "type",
+														Operator: v1.NodeSelectorOpIn,
+														Values:   []string{"test"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantToRun:             false,
+			shouldSchedule:        false,
+			shouldContinueRunning: false,
+		},
+		{
+			predicateName: "ShouldRunDaemonPod",
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: v1.PodSpec{
+							Affinity: &v1.Affinity{
+								NodeAffinity: &v1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{
+										NodeSelectorTerms: []v1.NodeSelectorTerm{
+											{
+												MatchExpressions: []v1.NodeSelectorRequirement{
+													{
+														Key:      "type",
+														Operator: v1.NodeSelectorOpIn,
+														Values:   []string{"production"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			wantToRun:             true,
+			shouldSchedule:        true,
+			shouldContinueRunning: true,
+		},
 	}
 
 	for i, c := range cases {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -518,6 +518,12 @@ func resourcePodSpec(nodeName, memory, cpu string) v1.PodSpec {
 	}
 }
 
+func resourceContainerSpec(memory, cpu string) v1.ResourceRequirements {
+	return v1.ResourceRequirements {
+		Requests: allocatableResources(memory, cpu),
+	}
+}
+
 func resourcePodSpecWithoutNodeName(memory, cpu string) v1.PodSpec {
 	return v1.PodSpec{
 		Containers: []v1.Container{{
@@ -1400,6 +1406,7 @@ func setDaemonSetCritical(ds *extensions.DaemonSet) {
 
 func TestNodeShouldRunDaemonPod(t *testing.T) {
 	cases := []struct {
+		predicateName									 string
 		podsOnNode                                       []*v1.Pod
 		nodeCondition                                    []v1.NodeCondition
 		ds                                               *extensions.DaemonSet
@@ -1407,6 +1414,7 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 		err                                              error
 	}{
 		{
+			predicateName: "ShouldRunDaemonPod",
 			ds: &extensions.DaemonSet{
 				Spec: extensions.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
@@ -1423,6 +1431,7 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			shouldContinueRunning: true,
 		},
 		{
+			predicateName: "InsufficientResourceError",
 			ds: &extensions.DaemonSet{
 				Spec: extensions.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
@@ -1439,6 +1448,7 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			shouldContinueRunning: true,
 		},
 		{
+			predicateName: "ErrPodNotMatchHostName",
 			ds: &extensions.DaemonSet{
 				Spec: extensions.DaemonSetSpec{
 					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
@@ -1455,6 +1465,7 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			shouldContinueRunning: false,
 		},
 		{
+			predicateName: "ErrPodNotFitsHostPorts",
 			podsOnNode: []*v1.Pod{
 				{
 					Spec: v1.PodSpec{
@@ -1487,13 +1498,116 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			shouldSchedule:        false,
 			shouldContinueRunning: false,
 		},
+		{
+			predicateName: "InsufficientResourceError",
+			podsOnNode: []*v1.Pod{
+				{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{{
+							Ports: []v1.ContainerPort{{
+								HostPort: 666,
+							}},
+							Resources: resourceContainerSpec("50M", "0.5"),
+						}},
+					},
+				},
+			},
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: resourcePodSpec("", "100M", "0.5"),
+					},
+				},
+			},
+			wantToRun:             true,
+			shouldSchedule:        false,
+			shouldContinueRunning: true,
+		},
+		{
+			predicateName: "ShouldRunDaemonPod",
+			podsOnNode: []*v1.Pod{
+				{
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{{
+							Ports: []v1.ContainerPort{{
+								HostPort: 666,
+							}},
+							Resources: resourceContainerSpec("50M", "0.5"),
+						}},
+					},
+				},
+			},
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: resourcePodSpec("", "50M", "0.5"),
+					},
+				},
+			},
+			wantToRun:             true,
+			shouldSchedule:        true,
+			shouldContinueRunning: true,
+		},
+		{
+			predicateName: "ErrNodeSelectorNotMatch",
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: v1.PodSpec{
+							NodeSelector: simpleDaemonSetLabel2,
+						},
+					},
+				},
+			},
+			wantToRun:             false,
+			shouldSchedule:        false,
+			shouldContinueRunning: false,
+		},
+		{
+			predicateName: "ShouldRunDaemonPod",
+			ds: &extensions.DaemonSet{
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: simpleDaemonSetLabel},
+					Template: v1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: simpleDaemonSetLabel,
+						},
+						Spec: v1.PodSpec{
+							NodeSelector: simpleDaemonSetLabel,
+						},
+					},
+				},
+			},
+			wantToRun:             true,
+			shouldSchedule:        true,
+			shouldContinueRunning: true,
+		},
 	}
 
 	for i, c := range cases {
 		for _, strategy := range updateStrategies() {
-			node := newNode("test-node", nil)
+			node := newNode("test-node", simpleDaemonSetLabel)
 			node.Status.Conditions = append(node.Status.Conditions, c.nodeCondition...)
 			node.Status.Allocatable = allocatableResources("100M", "1")
+
+			attachedVolumes := make([]v1.AttachedVolume, 1)
+			attachedVolumes[0] = v1.AttachedVolume{
+				Name: v1.UniqueVolumeName("test"),
+			}
+			node.Status.VolumesAttached = attachedVolumes
+
 			manager, _, _ := newTestController()
 			manager.nodeStore.Add(node)
 			for _, p := range c.podsOnNode {
@@ -1504,16 +1618,16 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			wantToRun, shouldSchedule, shouldContinueRunning, err := manager.nodeShouldRunDaemonPod(node, c.ds)
 
 			if wantToRun != c.wantToRun {
-				t.Errorf("[%v] expected wantToRun: %v, got: %v", i, c.wantToRun, wantToRun)
+				t.Errorf("[%v] strategy: %v, predicateName: %v expected wantToRun: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.wantToRun, wantToRun)
 			}
 			if shouldSchedule != c.shouldSchedule {
-				t.Errorf("[%v] expected shouldSchedule: %v, got: %v", i, c.shouldSchedule, shouldSchedule)
+				t.Errorf("[%v] strategy: %v, predicateName: %v expected shouldSchedule: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.shouldSchedule, shouldSchedule)
 			}
 			if shouldContinueRunning != c.shouldContinueRunning {
-				t.Errorf("[%v] expected shouldContinueRunning: %v, got: %v", i, c.shouldContinueRunning, shouldContinueRunning)
+				t.Errorf("[%v] strategy: %v, predicateName: %v expected shouldContinueRunning: %v, got: %v", i, c.ds.Spec.UpdateStrategy.Type, c.predicateName, c.shouldContinueRunning, shouldContinueRunning)
 			}
 			if err != c.err {
-				t.Errorf("[%v] expected err: %v, got: %v", i, c.err, err)
+				t.Errorf("[%v] strategy: %v, predicateName: %v expected err: %v, got: %v", i, c.predicateName, c.ds.Spec.UpdateStrategy.Type, c.err, err)
 			}
 		}
 	}

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1406,7 +1406,7 @@ func setDaemonSetCritical(ds *extensions.DaemonSet) {
 
 func TestNodeShouldRunDaemonPod(t *testing.T) {
 	cases := []struct {
-		predicateName									 string
+		predicateName					 string
 		podsOnNode                                       []*v1.Pod
 		nodeCondition                                    []v1.NodeCondition
 		ds                                               *extensions.DaemonSet

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -1601,13 +1601,6 @@ func TestNodeShouldRunDaemonPod(t *testing.T) {
 			node := newNode("test-node", simpleDaemonSetLabel)
 			node.Status.Conditions = append(node.Status.Conditions, c.nodeCondition...)
 			node.Status.Allocatable = allocatableResources("100M", "1")
-
-			attachedVolumes := make([]v1.AttachedVolume, 1)
-			attachedVolumes[0] = v1.AttachedVolume{
-				Name: v1.UniqueVolumeName("test"),
-			}
-			node.Status.VolumesAttached = attachedVolumes
-
 			manager, _, _ := newTestController()
 			manager.nodeStore.Add(node)
 			for _, p := range c.podsOnNode {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -519,7 +519,7 @@ func resourcePodSpec(nodeName, memory, cpu string) v1.PodSpec {
 }
 
 func resourceContainerSpec(memory, cpu string) v1.ResourceRequirements {
-	return v1.ResourceRequirements {
+	return v1.ResourceRequirements{
 		Requests: allocatableResources(memory, cpu),
 	}
 }
@@ -1406,7 +1406,7 @@ func setDaemonSetCritical(ds *extensions.DaemonSet) {
 
 func TestNodeShouldRunDaemonPod(t *testing.T) {
 	cases := []struct {
-		predicateName					 string
+		predicateName                                    string
 		podsOnNode                                       []*v1.Pod
 		nodeCondition                                    []v1.NodeCondition
 		ds                                               *extensions.DaemonSet


### PR DESCRIPTION
**What this PR does / why we need it**:
Covered more predicates for `nodeShouldRunDaemonPod` test

**Which issue(s) this PR fixes**:
Fixes #50598

**Special notes for your reviewer**:
I've introduced `predicateName` parameter in order to easier determine what is covered. 
Currently we have:
- ShouldRunDaemonPod
- InsufficientResourceError
- ErrPodNotMatchHostName
- ErrPodNotFitsHostPorts
- ErrNodeSelectorNotMatch

TODO:
- ErrDiskConflict
- ErrPodAffinityNotMatch
- ErrTaintsTolerationsNotMatch

for more predicates take a look at [predicates/errors.go](https://github.com/kubernetes/kubernetes/blob/58fd063a6cfee1854cb64c0c45f808d7d2cc5fea/plugin/pkg/scheduler/algorithm/predicates/error.go#L25)

