### PR TITLE
Add the iptables wait flag change to more places

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -592,7 +592,7 @@ func getIPTablesRestoreWaitFlag(exec utilexec.Interface, protocol Protocol) []st
 		return nil
 	}
 
-	return []string{"--wait=2"}
+	return []string{WaitSecondsString}
 }
 
 // getIPTablesRestoreVersionString runs "iptables-restore --version" to get the version string

--- a/pkg/util/iptables/iptables_test.go
+++ b/pkg/util/iptables/iptables_test.go
@@ -1165,7 +1165,7 @@ func TestRestoreAllWait(t *testing.T) {
 	}
 
 	commandSet := sets.NewString(fcmd.CombinedOutputLog[2]...)
-	if !commandSet.HasAll("iptables-restore", "--wait=2", "--counters", "--noflush") {
+	if !commandSet.HasAll("iptables-restore", WaitSecondsString, "--counters", "--noflush") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
 
@@ -1214,8 +1214,8 @@ func TestRestoreAllWaitOldIptablesRestore(t *testing.T) {
 	if !commandSet.HasAll("iptables-restore", "--counters", "--noflush") {
 		t.Errorf("wrong CombinedOutput() log, got %s", fcmd.CombinedOutputLog[2])
 	}
-	if commandSet.HasAny("--wait=2") {
-		t.Errorf("wrong CombinedOutput() log (unexpected --wait=2 option), got %s", fcmd.CombinedOutputLog[2])
+	if commandSet.HasAny(WaitSecondsString) {
+		t.Errorf("wrong CombinedOutput() log (unexpected %s option), got %s", WaitSecondsString, fcmd.CombinedOutputLog[2])
 	}
 
 	if fcmd.CombinedOutputCalls != 3 {


### PR DESCRIPTION
There were a few places that the last PR (https://github.com/kubernetes/kubernetes/pull/54763) missed because the flags that PR covered were of the form `-w2`.  Some of the code had `--wait=2`.  This changes that code to use the same global variable for the wait setting so that everything is consistent.