### PR TITLE
Fix namespace support in kubectl aging plugin

### DIFF
--- a/pkg/kubectl/plugins/examples/aging/aging.rb
+++ b/pkg/kubectl/plugins/examples/aging/aging.rb
@@ -22,7 +22,8 @@ class Numeric
   end
 end
 
-pods_json = `kubectl get pods -o json`
+namespace = ENV['KUBECTL_PLUGINS_CURRENT_NAMESPACE'] || 'default'
+pods_json = `kubectl --namespace #{namespace} get pods -o json`
 pods_parsed = JSON.parse(pods_json)
 
 puts "The Magnificent Aging Plugin."

--- a/pkg/kubectl/plugins/examples/aging/plugin.yaml
+++ b/pkg/kubectl/plugins/examples/aging/plugin.yaml
@@ -2,7 +2,4 @@ name: "aging"
 shortDesc: "Aging shows pods by age"
 longDesc: >
   Aging shows pods from the current namespace by age.
-  Once we have plugin support for global flags through 
-  env vars (planned for V1) we'll be able to switch
-  between namespaces using the --namespace flag.
 command: ./aging.rb


### PR DESCRIPTION
The example plugin's comments mentioned the namespace support
limitation, awaiting kubectl to implement environment variable
propagation. Now that 1.8 is out, the requirement is satisfied.

This commit adds use of the conveyed namespace information to the
plugin example.

Fixes #55255

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
