### PR TITLE
Enhance label and taint documentation in kubectl

### DIFF
--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -70,7 +70,8 @@ var (
 	labelLong = templates.LongDesc(i18n.T(`
 		Update the labels on a resource.
 
-		* A label must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to %[1]d characters.
+		* A label key and value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to %[1]d characters each.
+		* Optionally, the key can begin with a DNS subdomain prefix and a single '/', like example.com/my-app
 		* If --overwrite is true, then existing labels can be overwritten, otherwise attempting to overwrite a label will result in an error.
 		* If --resource-version is specified, then updates will use this resource version, otherwise the existing resource-version will be used.`))
 

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -58,6 +58,7 @@ var (
 
 		* A taint consists of a key, value, and effect. As an argument here, it is expressed as key=value:effect.
 		* The key must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to %[1]d characters.
+		* Optionally, the key can begin with a DNS subdomain prefix and a single '/', like example.com/my-app
 		* The value must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores, up to %[2]d characters.
 		* The effect must be NoSchedule, PreferNoSchedule or NoExecute.
 		* Currently taint can only apply to node.`))


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds some language around how taint and label keys can have a domain + '/' in front of them.  From the current documentation, it would seem like these are not allowed even though [well known labels](https://kubernetes.io/docs/reference/labels-annotations-taints/) have them.

Also, it seemed unclear (to me) that both the label's key and value can be 63 characters long.  I wanted to clarify this.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
None

**Special notes for your reviewer**:
Phrasing of "_DNS subdomain prefix and '/'_" was copied from [a validator's message](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go#L57) ... I'm unsure if its the best wording, but wanted to be consistent with the validator.

**Release note**:
```release-note
NONE
```
