### PR TITLE
Stop running unit tests outside of Bazel.

### DIFF
--- a/hack/jenkins/test-dockerized.sh
+++ b/hack/jenkins/test-dockerized.sh
@@ -55,7 +55,6 @@ make generated_files
 go install ./cmd/...
 ./hack/install-etcd.sh
 
-make test
 make test-cmd
 make test-integration
 ./hack/test-update-storage-objects.sh


### PR DESCRIPTION
We tried this a while ago, but had to revert because Bazel did not have
race detection. Now it does.

Previous issue: #40602 and #52443

Relevant parties: @ixdy @mikedanese @smarterclayton @deads2k @liggitt 

/sig testing

```release-note
NONE
```