### PR TITLE
Fix an unreachable kubectl explain field lookup test

### DIFF
--- a/pkg/kubectl/explain/field_lookup_test.go
+++ b/pkg/kubectl/explain/field_lookup_test.go
@@ -69,9 +69,9 @@ func TestFindField(t *testing.T) {
 			gotPath = path.GetPath().String()
 		}
 
-		if gotErr != test.err && gotPath != test.expectedPath {
-			t.Errorf("LookupSchemaForField(schema, %v) = (%v, %v), expected (%s, %v)",
-				test.path, gotErr, gotPath, test.expectedPath, test.err)
+		if gotErr != test.err || gotPath != test.expectedPath {
+			t.Errorf("LookupSchemaForField(schema, %v) = (path: %q, err: %q), expected (path: %q, err: %q)",
+				test.path, gotPath, gotErr, test.expectedPath, test.err)
 		}
 	}
 }


### PR DESCRIPTION
In error case, the condition `gotErr != test.err && gotPath !=
test.expectedPath` never fulfill because in this case both gotPath and
test.expectedPath are always an empty string. So the err “err:  `field "what?"
does not exist`” doesn’t get tasted. For example, if you change the value of
`err:` to anything, the test still will pass. Also, since gotPath is empty
string in case of err, in the output error we probably don’t want to display
path. 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes an unreachable unit test.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
