### PR TITLE
Automated cherry pick of #54780

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/BUILD
@@ -30,6 +30,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
@@ -398,6 +399,69 @@ func TestPreserveInt(t *testing.T) {
 	num2 := num["num2"].(int64)
 	if num1 != 9223372036854775807 || num2 != 1000000 {
 		t.Errorf("Expected %v, got %v, %v", `9223372036854775807, 1000000`, num1, num2)
+	}
+}
+
+func TestPatch(t *testing.T) {
+	stopCh, apiExtensionClient, clientPool, err := testserver.StartDefaultServer()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer close(stopCh)
+
+	noxuDefinition := testserver.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuVersionClient, err := testserver.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, clientPool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ns := "not-the-default"
+	noxuNamespacedResourceClient := noxuVersionClient.Resource(&metav1.APIResource{
+		Name:       noxuDefinition.Spec.Names.Plural,
+		Namespaced: true,
+	}, ns)
+
+	noxuInstanceToCreate := testserver.NewNoxuInstance(ns, "foo")
+	createdNoxuInstance, err := noxuNamespacedResourceClient.Create(noxuInstanceToCreate)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	patch := []byte(`{"num": {"num2":999}}`)
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// a patch with no change
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, patch)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// an empty patch
+	createdNoxuInstance, err = noxuNamespacedResourceClient.Patch("foo", types.MergePatchType, []byte(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	originalJSON, err := runtime.Encode(unstructured.UnstructuredJSONScheme, createdNoxuInstance)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	gottenNoxuInstance, err := runtime.Decode(unstructured.UnstructuredJSONScheme, originalJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Check if int is preserved.
+	unstructuredObj := gottenNoxuInstance.(*unstructured.Unstructured).Object
+	num := unstructuredObj["num"].(map[string]interface{})
+	num1 := num["num1"].(int64)
+	num2 := num["num2"].(int64)
+	if num1 != 9223372036854775807 || num2 != 999 {
+		t.Errorf("Expected %v, got %v, %v", `9223372036854775807, 999`, num1, num2)
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -332,8 +332,11 @@ func (s *store) GuaranteedUpdate(
 				if err != nil {
 					return err
 				}
-				mustCheckData = false
-				continue
+				if !bytes.Equal(data, origState.data) {
+					// original data changed, restart loop
+					mustCheckData = false
+					continue
+				}
 			}
 			return decode(s.codec, s.versioner, origState.data, out, origState.rev)
 		}


### PR DESCRIPTION
Cherry pick of #54780 on release-1.8.

#54780: partial fix crd patch failing

```
The apiserver handles empty patch request, e.g. by kubectl, correctly now.
```