### PR TITLE
Audit support resource wildcard matching 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/types.go
@@ -226,10 +226,19 @@ type GroupResources struct {
 	// The empty string represents the core API group.
 	// +optional
 	Group string
-	// Resources is a list of resources within the API group. Subresources are
-	// matched using a "/" to indicate the subresource. For example, "pods/log"
-	// would match request to the log subresource of pods. The top level resource
-	// does not match subresources, "pods" doesn't match "pods/log".
+	// Resources is a list of resources this rule applies to.
+	//
+	// For example:
+	// 'pods' matches pods.
+	// 'pods/log' matches the log subresource of pods.
+	// '*' matches all resources and their subresources.
+	// 'pods/*' matches all subresources of pods.
+	// '*/scale' matches all scale subresources.
+	//
+	// If wildcard is present, the validation rule will ensure resources do not
+	// overlap with each other.
+	//
+	// An empty list implies all resources and subresources in this API groups apply.
 	// +optional
 	Resources []string
 	// ResourceNames is a list of resource instance names that the policy matches.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/generated.proto
@@ -114,10 +114,19 @@ message GroupResources {
   // +optional
   optional string group = 1;
 
-  // Resources is a list of resources within the API group. Subresources are
-  // matched using a "/" to indicate the subresource. For example, "pods/logs"
-  // would match request to the logs subresource of pods. The top level resource
-  // does not match subresources, "pods" doesn't match "pods/logs".
+  // Resources is a list of resources this rule applies to.
+  // 
+  // For example:
+  // 'pods' matches pods.
+  // 'pods/log' matches the log subresource of pods.
+  // '*' matches all resources and their subresources.
+  // 'pods/*' matches all subresources of pods.
+  // '*/scale' matches all scale subresources.
+  // 
+  // If wildcard is present, the validation rule will ensure resources do not
+  // overlap with each other.
+  // 
+  // An empty list implies all resources and subresources in this API groups apply.
   // +optional
   repeated string resources = 2;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1alpha1/types.go
@@ -233,10 +233,19 @@ type GroupResources struct {
 	// The empty string represents the core API group.
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
-	// Resources is a list of resources within the API group. Subresources are
-	// matched using a "/" to indicate the subresource. For example, "pods/logs"
-	// would match request to the logs subresource of pods. The top level resource
-	// does not match subresources, "pods" doesn't match "pods/logs".
+	// Resources is a list of resources this rule applies to.
+	//
+	// For example:
+	// 'pods' matches pods.
+	// 'pods/log' matches the log subresource of pods.
+	// '*' matches all resources and their subresources.
+	// 'pods/*' matches all subresources of pods.
+	// '*/scale' matches all scale subresources.
+	//
+	// If wildcard is present, the validation rule will ensure resources do not
+	// overlap with each other.
+	//
+	// An empty list implies all resources and subresources in this API groups apply.
 	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 	// ResourceNames is a list of resource instance names that the policy matches.

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/generated.proto
@@ -118,10 +118,19 @@ message GroupResources {
   // +optional
   optional string group = 1;
 
-  // Resources is a list of resources within the API group. Subresources are
-  // matched using a "/" to indicate the subresource. For example, "pods/log"
-  // would match request to the log subresource of pods. The top level resource
-  // does not match subresources, "pods" doesn't match "pods/log".
+  // Resources is a list of resources this rule applies to.
+  // 
+  // For example:
+  // 'pods' matches pods.
+  // 'pods/log' matches the log subresource of pods.
+  // '*' matches all resources and their subresources.
+  // 'pods/*' matches all subresources of pods.
+  // '*/scale' matches all scale subresources.
+  // 
+  // If wildcard is present, the validation rule will ensure resources do not
+  // overlap with each other.
+  // 
+  // An empty list implies all resources and subresources in this API groups apply.
   // +optional
   repeated string resources = 2;
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/audit/v1beta1/types.go
@@ -229,10 +229,19 @@ type GroupResources struct {
 	// The empty string represents the core API group.
 	// +optional
 	Group string `json:"group,omitempty" protobuf:"bytes,1,opt,name=group"`
-	// Resources is a list of resources within the API group. Subresources are
-	// matched using a "/" to indicate the subresource. For example, "pods/log"
-	// would match request to the log subresource of pods. The top level resource
-	// does not match subresources, "pods" doesn't match "pods/log".
+	// Resources is a list of resources this rule applies to.
+	//
+	// For example:
+	// 'pods' matches pods.
+	// 'pods/log' matches the log subresource of pods.
+	// '*' matches all resources and their subresources.
+	// 'pods/*' matches all subresources of pods.
+	// '*/scale' matches all scale subresources.
+	//
+	// If wildcard is present, the validation rule will ensure resources do not
+	// overlap with each other.
+	//
+	// An empty list implies all resources and subresources in this API groups apply.
 	// +optional
 	Resources []string `json:"resources,omitempty" protobuf:"bytes,2,rep,name=resources"`
 	// ResourceNames is a list of resource instance names that the policy matches.

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -160,11 +160,11 @@ func ruleMatchesResource(r *audit.PolicyRule, attrs authorizer.Attributes) bool 
 
 	apiGroup := attrs.GetAPIGroup()
 	resource := attrs.GetResource()
+	subresource := attrs.GetSubresource()
+	combinedResource := resource
 	// If subresource, the resource in the policy must match "(resource)/(subresource)"
-	//
-	// TODO: consider adding options like "pods/*" to match all subresources.
-	if sr := attrs.GetSubresource(); sr != "" {
-		resource = resource + "/" + sr
+	if subresource != "" {
+		combinedResource = resource + "/" + subresource
 	}
 
 	name := attrs.GetName()
@@ -175,8 +175,17 @@ func ruleMatchesResource(r *audit.PolicyRule, attrs authorizer.Attributes) bool 
 				return true
 			}
 			for _, res := range gr.Resources {
-				if res == resource {
-					if len(gr.ResourceNames) == 0 || hasString(gr.ResourceNames, name) {
+				if len(gr.ResourceNames) == 0 || hasString(gr.ResourceNames, name) {
+					// match "*"
+					if res == combinedResource || res == "*" {
+						return true
+					}
+					// match "*/subresource"
+					if len(subresource) > 0 && strings.HasPrefix(res, "*/") && subresource == strings.TrimLeft(res, "*/") {
+						return true
+					}
+					// match "resource/*"
+					if strings.HasSuffix(res, "/*") && resource == strings.TrimRight(res, "/*") {
 						return true
 					}
 				}

--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker_test.go
@@ -105,6 +105,21 @@ var (
 			Verbs:     []string{"get"},
 			Resources: []audit.GroupResources{{Resources: []string{"pods/log"}}},
 		},
+		"getPodWildcardMatching": {
+			Level:     audit.LevelRequest,
+			Verbs:     []string{"get"},
+			Resources: []audit.GroupResources{{Resources: []string{"*"}}},
+		},
+		"getPodResourceWildcardMatching": {
+			Level:     audit.LevelRequest,
+			Verbs:     []string{"get"},
+			Resources: []audit.GroupResources{{Resources: []string{"*/log"}}},
+		},
+		"getPodSubResourceWildcardMatching": {
+			Level:     audit.LevelRequest,
+			Verbs:     []string{"get"},
+			Resources: []audit.GroupResources{{Resources: []string{"pods/*"}}},
+		},
 		"getClusterRoles": {
 			Level: audit.LevelRequestResponse,
 			Verbs: []string{"get"},
@@ -208,6 +223,9 @@ func testAuditLevel(t *testing.T, stages []audit.Stage) {
 	test(t, "nonResource", audit.LevelNone, stages, stages, "getPodLogs", "getPods")
 
 	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodLogs", "getPods")
+	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodWildcardMatching")
+	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodResourceWildcardMatching")
+	test(t, "subresource", audit.LevelRequest, stages, stages, "getPodSubResourceWildcardMatching")
 
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

audit policy support "resource/subresources" wildcard matching "resource/*", "*/subresource","*"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55305

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[advanced audit] support subresources wildcard matching.
```
