### PR TITLE
Fix DownwardAPI volume API doc

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -74197,20 +74197,20 @@
     ],
     "properties": {
      "fieldRef": {
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.",
       "$ref": "#/definitions/io.k8s.api.core.v1.ObjectFieldSelector"
      },
      "mode": {
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
       "type": "integer",
       "format": "int32"
      },
      "path": {
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded.",
       "type": "string"
      },
      "resourceFieldRef": {
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required.",
       "$ref": "#/definitions/io.k8s.api.core.v1.ResourceFieldSelector"
      }
     }
@@ -74224,7 +74224,7 @@
       "format": "int32"
      },
      "items": {
-      "description": "Items is a list of downward API volume file",
+      "description": "Items is a list of DownwardAPIVolumeFile objects.",
       "type": "array",
       "items": {
        "$ref": "#/definitions/io.k8s.api.core.v1.DownwardAPIVolumeFile"

--- a/api/swagger-spec/apps_v1.json
+++ b/api/swagger-spec/apps_v1.json
@@ -7304,7 +7304,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -7322,20 +7322,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/apps_v1beta1.json
+++ b/api/swagger-spec/apps_v1beta1.json
@@ -4938,7 +4938,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -4956,20 +4956,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/apps_v1beta2.json
+++ b/api/swagger-spec/apps_v1beta2.json
@@ -7303,7 +7303,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -7321,20 +7321,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/batch_v1.json
+++ b/api/swagger-spec/batch_v1.json
@@ -2278,7 +2278,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -2296,20 +2296,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/batch_v1beta1.json
+++ b/api/swagger-spec/batch_v1beta1.json
@@ -2333,7 +2333,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -2351,20 +2351,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/batch_v2alpha1.json
+++ b/api/swagger-spec/batch_v2alpha1.json
@@ -2333,7 +2333,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -2351,20 +2351,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/extensions_v1beta1.json
+++ b/api/swagger-spec/extensions_v1beta1.json
@@ -7946,7 +7946,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -7964,20 +7964,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/settings.k8s.io_v1alpha1.json
+++ b/api/swagger-spec/settings.k8s.io_v1alpha1.json
@@ -2120,7 +2120,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -2138,20 +2138,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/api/swagger-spec/v1.json
+++ b/api/swagger-spec/v1.json
@@ -21865,7 +21865,7 @@
       "items": {
        "$ref": "v1.DownwardAPIVolumeFile"
       },
-      "description": "Items is a list of downward API volume file"
+      "description": "Items is a list of DownwardAPIVolumeFile objects."
      },
      "defaultMode": {
       "type": "integer",
@@ -21883,20 +21883,20 @@
     "properties": {
      "path": {
       "type": "string",
-      "description": "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'"
+      "description": "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded."
      },
      "fieldRef": {
       "$ref": "v1.ObjectFieldSelector",
-      "description": "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported."
+      "description": "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported."
      },
      "resourceFieldRef": {
       "$ref": "v1.ResourceFieldSelector",
-      "description": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported."
+      "description": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required."
      },
      "mode": {
       "type": "integer",
       "format": "int32",
-      "description": "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
+      "description": "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set."
      }
     }
    },

--- a/docs/api-reference/apps/v1/definitions.html
+++ b/docs/api-reference/apps/v1/definitions.html
@@ -1094,7 +1094,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3707,28 +3707,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/apps/v1beta1/definitions.html
+++ b/docs/api-reference/apps/v1beta1/definitions.html
@@ -1088,7 +1088,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3760,28 +3760,28 @@ The StatefulSet guarantees that a given network identity will always map to the 
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/apps/v1beta2/definitions.html
+++ b/docs/api-reference/apps/v1beta2/definitions.html
@@ -1159,7 +1159,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4376,28 +4376,28 @@ The StatefulSet guarantees that a given network identity will always map to the 
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v1/definitions.html
+++ b/docs/api-reference/batch/v1/definitions.html
@@ -884,7 +884,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3040,28 +3040,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v1beta1/definitions.html
+++ b/docs/api-reference/batch/v1beta1/definitions.html
@@ -925,7 +925,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3074,28 +3074,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/batch/v2alpha1/definitions.html
+++ b/docs/api-reference/batch/v2alpha1/definitions.html
@@ -884,7 +884,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3047,28 +3047,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/extensions/v1beta1/definitions.html
+++ b/docs/api-reference/extensions/v1beta1/definitions.html
@@ -1314,7 +1314,7 @@ Examples: <code>/foo</code> would allow <code>/foo</code>, <code>/foo/</code> an
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -4399,28 +4399,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
+++ b/docs/api-reference/settings.k8s.io/v1alpha1/definitions.html
@@ -1229,7 +1229,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -3807,28 +3807,28 @@ When an object is created, the system will populate this list with the current s
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/docs/api-reference/v1/definitions.html
+++ b/docs/api-reference/v1/definitions.html
@@ -726,7 +726,7 @@ span.icon > [class^="icon-"], span.icon > [class*=" icon-"] { cursor: default; }
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">items</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of downward API volume file</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Items is a list of DownwardAPIVolumeFile objects.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_downwardapivolumefile">v1.DownwardAPIVolumeFile</a> array</p></td>
 <td class="tableblock halign-left valign-top"></td>
@@ -8798,28 +8798,28 @@ Examples:<br>
 <tbody>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">path</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the <em>..</em> path. Must be utf-8 encoded. The first item of the relative path must not start with <em>..</em></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">path is the relative path name of the file to be created. Must not start with <code>..</code> or <code>/</code>, must not contain <em>..</em> in it. Must be utf-8 encoded.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">true</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">string</p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_objectfieldselector">v1.ObjectFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. <code>limits.cpu</code>, <code>requests.memory</code>) are currently. When specified, the <code>containerName</code> field and the <code>resource</code> field in the reference are both required.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><a href="#_v1_resourcefieldselector">v1.ResourceFieldSelector</a></p></td>
 <td class="tableblock halign-left valign-top"></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">mode</p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">false</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">integer (int32)</p></td>
 <td class="tableblock halign-left valign-top"></td>

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1213,16 +1213,21 @@ type DownwardAPIVolumeSource struct {
 
 // Represents a single file containing information from the downward API
 type DownwardAPIVolumeFile struct {
-	// Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+	// path is the relative path name of the file to be created.
+	// Must not start with `..` or `/`, must not contain '..' in it.
+	// Must be utf-8 encoded.
 	Path string
-	// Required: Selects a field of the pod: only annotations, labels, name, namespace and uid are supported.
+	// fieldRef selects a field of the pod: only annotations, labels, name,
+	// namespace and uid (added in v1.8) are supported.
 	// +optional
 	FieldRef *ObjectFieldSelector
-	// Selects a resource of the container: only resources limits and requests
-	// (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+	// resourceFieldRef selects a resource of the container: only resources
+	// limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently.
+	// When specified, the `containerName` field and the `resource` field in
+	// the reference are both required.
 	// +optional
 	ResourceFieldRef *ResourceFieldSelector
-	// Optional: mode bits to use on this file, must be a value between 0
+	// mode is the mode bits to use on this file, must be a value between 0
 	// and 0777. If not specified, the volume defaultMode will be used.
 	// This might be in conflict with other options that affect the file
 	// mode, like fsGroup, and the result can be other mode bits set.

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -808,19 +808,24 @@ message DownwardAPIProjection {
 
 // DownwardAPIVolumeFile represents information to create the file containing the pod field
 message DownwardAPIVolumeFile {
-  // Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+  // path is the relative path name of the file to be created.
+  // Must not start with `..` or `/`, must not contain '..' in it.
+  // Must be utf-8 encoded.
   optional string path = 1;
 
-  // Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+  // fieldRef selects a field of the pod: only annotations, labels, name,
+  // namespace and uid (added in v1.8) are supported.
   // +optional
   optional ObjectFieldSelector fieldRef = 2;
 
-  // Selects a resource of the container: only resources limits and requests
-  // (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+  // resourceFieldRef selects a resource of the container: only resources
+  // limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently.
+  // When specified, the `containerName` field and the `resource` field in
+  // the reference are both required.
   // +optional
   optional ResourceFieldSelector resourceFieldRef = 3;
 
-  // Optional: mode bits to use on this file, must be a value between 0
+  // mode is the mode bits to use on this file, must be a value between 0
   // and 0777. If not specified, the volume defaultMode will be used.
   // This might be in conflict with other options that affect the file
   // mode, like fsGroup, and the result can be other mode bits set.
@@ -831,7 +836,7 @@ message DownwardAPIVolumeFile {
 // DownwardAPIVolumeSource represents a volume containing downward API info.
 // Downward API volumes support ownership management and SELinux relabeling.
 message DownwardAPIVolumeSource {
-  // Items is a list of downward API volume file
+  // Items is a list of DownwardAPIVolumeFile objects.
   // +optional
   repeated DownwardAPIVolumeFile items = 1;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4941,7 +4941,7 @@ type ComponentStatusList struct {
 // DownwardAPIVolumeSource represents a volume containing downward API info.
 // Downward API volumes support ownership management and SELinux relabeling.
 type DownwardAPIVolumeSource struct {
-	// Items is a list of downward API volume file
+	// Items is a list of DownwardAPIVolumeFile objects.
 	// +optional
 	Items []DownwardAPIVolumeFile `json:"items,omitempty" protobuf:"bytes,1,rep,name=items"`
 	// Optional: mode bits to use on created files by default. Must be a
@@ -4959,16 +4959,21 @@ const (
 
 // DownwardAPIVolumeFile represents information to create the file containing the pod field
 type DownwardAPIVolumeFile struct {
-	// Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'
+	// path is the relative path name of the file to be created.
+	// Must not start with `..` or `/`, must not contain '..' in it.
+	// Must be utf-8 encoded.
 	Path string `json:"path" protobuf:"bytes,1,opt,name=path"`
-	// Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.
+	// fieldRef selects a field of the pod: only annotations, labels, name,
+	// namespace and uid (added in v1.8) are supported.
 	// +optional
 	FieldRef *ObjectFieldSelector `json:"fieldRef,omitempty" protobuf:"bytes,2,opt,name=fieldRef"`
-	// Selects a resource of the container: only resources limits and requests
-	// (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+	// resourceFieldRef selects a resource of the container: only resources
+	// limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently.
+	// When specified, the `containerName` field and the `resource` field in
+	// the reference are both required.
 	// +optional
 	ResourceFieldRef *ResourceFieldSelector `json:"resourceFieldRef,omitempty" protobuf:"bytes,3,opt,name=resourceFieldRef"`
-	// Optional: mode bits to use on this file, must be a value between 0
+	// mode is the mode bits to use on this file, must be a value between 0
 	// and 0777. If not specified, the volume defaultMode will be used.
 	// This might be in conflict with other options that affect the file
 	// mode, like fsGroup, and the result can be other mode bits set.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -422,10 +422,10 @@ func (DownwardAPIProjection) SwaggerDoc() map[string]string {
 
 var map_DownwardAPIVolumeFile = map[string]string{
 	"":                 "DownwardAPIVolumeFile represents information to create the file containing the pod field",
-	"path":             "Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the '..' path. Must be utf-8 encoded. The first item of the relative path must not start with '..'",
-	"fieldRef":         "Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.",
-	"resourceFieldRef": "Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.",
-	"mode":             "Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
+	"path":             "path is the relative path name of the file to be created. Must not start with `..` or `/`, must not contain '..' in it. Must be utf-8 encoded.",
+	"fieldRef":         "fieldRef selects a field of the pod: only annotations, labels, name, namespace and uid (added in v1.8) are supported.",
+	"resourceFieldRef": "resourceFieldRef selects a resource of the container: only resources limits and requests (e.g. `limits.cpu`, `requests.memory`) are currently. When specified, the `containerName` field and the `resource` field in the reference are both required.",
+	"mode":             "mode is the mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 }
 
 func (DownwardAPIVolumeFile) SwaggerDoc() map[string]string {
@@ -434,7 +434,7 @@ func (DownwardAPIVolumeFile) SwaggerDoc() map[string]string {
 
 var map_DownwardAPIVolumeSource = map[string]string{
 	"":            "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
-	"items":       "Items is a list of downward API volume file",
+	"items":       "Items is a list of DownwardAPIVolumeFile objects.",
 	"defaultMode": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The API documentation generated for `downwardAPI` volume type is buggy.
Referring to: https://kubernetes.io/docs/api-reference/v1.8/#downwardapivolumefile-v1-core

- The `fieldRef` field is optional, but documented as required.
- The newly added support to `metadata.uid` was excluded from the "only supported" fields
- The `resourceFieldRef` field named some fields that can be specified, but that list is not (and never will be) exhaustive. “ephemeral-storage" for example has been excluded.
- We'd better clearly state *here* that `containerName` and `resource` fields are both required when injecting resources info using a downwardAPI volume.

**Which issue(s) this PR fixes**:
Stated above

**Special notes for your reviewer**:
This is purely an API documentation change. Code behavior not affected.

**Release note**:
```release-note
NONE
```
