### PR TITLE
Allow to set DNS domain for e2e tests

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -273,7 +273,7 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 			// have to change dns prefix because of the dynamic namespace
 			input := generated.ReadOrDie(mkpath("cassandra-statefulset.yaml"))
 
-			output := strings.Replace(string(input), "cassandra-0.cassandra.default.svc.cluster.local", "cassandra-0.cassandra."+ns+".svc.cluster.local", -1)
+			output := strings.Replace(string(input), "cassandra-0.cassandra.default.svc."+framework.TestContext.DNSDomain, "cassandra-0.cassandra."+ns+".svc."+framework.TestContext.DNSDomain, -1)
 
 			statefulsetYaml := "/tmp/cassandra-statefulset.yaml"
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -106,6 +106,9 @@ type TestContextType struct {
 	// Indicates what path the kubernetes-anywhere is installed on
 	KubernetesAnywherePath string
 
+	// DNS domain to use
+	DNSDomain string
+
 	// Viper-only parameters.  These will in time replace all flags.
 
 	// Example: Create a file 'e2e.json' with the following:
@@ -202,6 +205,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.ImageServiceEndpoint, "image-service-endpoint", "", "The image service endpoint of cluster VM instances.")
 	flag.StringVar(&TestContext.DockershimCheckpointDir, "dockershim-checkpoint-dir", "/var/lib/dockershim/sandbox", "The directory for dockershim to store sandbox checkpoints.")
 	flag.StringVar(&TestContext.KubernetesAnywherePath, "kubernetes-anywhere-path", "/workspace/kubernetes-anywhere", "Which directory kubernetes-anywhere is installed to.")
+	flag.StringVar(&TestContext.DNSDomain, "dns-domain", "cluster.local", "DNS domain to use.")
 }
 
 // Register flags specific to the cluster e2e test suite.

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -133,7 +133,7 @@ func createProbeCommand(namesToResolve []string, hostEntries []string, ptrLookup
 
 	podARecByUDPFileName := fmt.Sprintf("%s_udp@PodARecord", fileNamePrefix)
 	podARecByTCPFileName := fmt.Sprintf("%s_tcp@PodARecord", fileNamePrefix)
-	probeCmd += fmt.Sprintf(`podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".%s.pod.cluster.local"}');`, namespace)
+	probeCmd += fmt.Sprintf(`podARec=$$(hostname -i| awk -F. '{print $$1"-"$$2"-"$$3"-"$$4".%s.pod.%s"}');`, namespace, framework.TestContext.DNSDomain)
 	probeCmd += fmt.Sprintf(`test -n "$$(dig +notcp +noall +answer +search $${podARec} A)" && echo OK > /results/%s;`, podARecByUDPFileName)
 	probeCmd += fmt.Sprintf(`test -n "$$(dig +tcp +noall +answer +search $${podARec} A)" && echo OK > /results/%s;`, podARecByTCPFileName)
 	fileNames = append(fileNames, podARecByUDPFileName)
@@ -275,14 +275,14 @@ var _ = SIGDescribe("DNS", func() {
 		namesToResolve := []string{
 			"kubernetes.default",
 			"kubernetes.default.svc",
-			"kubernetes.default.svc.cluster.local",
+			fmt.Sprintf("kubernetes.default.svc.%s", framework.TestContext.DNSDomain),
 		}
 		// Added due to #8512. This is critical for GCE and GKE deployments.
 		if framework.ProviderIs("gce", "gke") {
 			namesToResolve = append(namesToResolve, "google.com")
 			namesToResolve = append(namesToResolve, "metadata")
 		}
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", dnsTestPodHostName, dnsTestServiceName, f.Namespace.Name)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", dnsTestPodHostName, dnsTestServiceName, f.Namespace.Name, framework.TestContext.DNSDomain)
 		hostEntries := []string{hostFQDN, dnsTestPodHostName}
 		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, hostEntries, "", "wheezy", f.Namespace.Name)
 		jessieProbeCmd, jessieFileNames := createProbeCommand(namesToResolve, hostEntries, "", "jessie", f.Namespace.Name)
@@ -360,7 +360,7 @@ var _ = SIGDescribe("DNS", func() {
 			f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(headlessService.Name, nil)
 		}()
 
-		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.cluster.local", podHostname, serviceName, f.Namespace.Name)
+		hostFQDN := fmt.Sprintf("%s.%s.%s.svc.%s", podHostname, serviceName, f.Namespace.Name, framework.TestContext.DNSDomain)
 		hostNames := []string{hostFQDN, podHostname}
 		namesToResolve := []string{hostFQDN}
 		wheezyProbeCmd, wheezyFileNames := createProbeCommand(namesToResolve, hostNames, "", "wheezy", f.Namespace.Name)
@@ -391,7 +391,7 @@ var _ = SIGDescribe("DNS", func() {
 			f.ClientSet.CoreV1().Services(f.Namespace.Name).Delete(externalNameService.Name, nil)
 		}()
 
-		hostFQDN := fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, f.Namespace.Name)
+		hostFQDN := fmt.Sprintf("%s.%s.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.DNSDomain)
 		wheezyProbeCmd, wheezyFileName := createTargetedProbeCommand(hostFQDN, "CNAME", "wheezy")
 		jessieProbeCmd, jessieFileName := createTargetedProbeCommand(hostFQDN, "CNAME", "jessie")
 		By("Running these commands on wheezy: " + wheezyProbeCmd + "\n")

--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/test/e2e/framework"
 
 	. "github.com/onsi/ginkgo"
 )
@@ -90,8 +91,8 @@ func (t *dnsFederationsConfigMapTest) validate() {
 		By(fmt.Sprintf("Validating federation labels %v do not exist", t.labels))
 
 		for _, label := range t.labels {
-			var federationDNS = fmt.Sprintf("e2e-dns-configmap.%s.%s.svc.cluster.local.",
-				t.f.Namespace.Name, label)
+			var federationDNS = fmt.Sprintf("e2e-dns-configmap.%s.%s.svc.%s.",
+				t.f.Namespace.Name, label, framework.TestContext.DNSDomain)
 			predicate := func(actual []string) bool {
 				return len(actual) == 0
 			}
@@ -99,10 +100,10 @@ func (t *dnsFederationsConfigMapTest) validate() {
 		}
 	} else {
 		for label := range federations {
-			var federationDNS = fmt.Sprintf("%s.%s.%s.svc.cluster.local.",
-				t.utilService.ObjectMeta.Name, t.f.Namespace.Name, label)
-			var localDNS = fmt.Sprintf("%s.%s.svc.cluster.local.",
-				t.utilService.ObjectMeta.Name, t.f.Namespace.Name)
+			var federationDNS = fmt.Sprintf("%s.%s.%s.svc.%s.",
+				t.utilService.ObjectMeta.Name, t.f.Namespace.Name, label, framework.TestContext.DNSDomain)
+			var localDNS = fmt.Sprintf("%s.%s.svc.%s.",
+				t.utilService.ObjectMeta.Name, t.f.Namespace.Name, framework.TestContext.DNSDomain)
 			// Check local mapping. Checking a remote mapping requires
 			// creating an arbitrary DNS record which is not possible at the
 			// moment.

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -134,7 +134,7 @@ var _ = SIGDescribe("ClusterDns [Feature:Example]", func() {
 		_, err = framework.LookForStringInPodExec(namespaces[0].Name, podName, []string{"python", "-c", queryDns}, "ok", dnsReadyTimeout)
 		Expect(err).NotTo(HaveOccurred(), "waiting for output from pod exec")
 
-		updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, "dns-backend.development.svc.cluster.local", fmt.Sprintf("dns-backend.%s.svc.cluster.local", namespaces[0].Name))
+		updatedPodYaml := prepareResourceWithReplacedString(frontendPodYaml, "dns-backend.development.svc."+framework.TestContext.DNSDomain, fmt.Sprintf("dns-backend.%s.svc."+framework.TestContext.DNSDomain, namespaces[0].Name))
 
 		// create a pod in each namespace
 		for _, ns := range namespaces {

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1196,7 +1196,7 @@ var _ = SIGDescribe("Services", func() {
 		By("Verifying pods for RC " + t.Name)
 		framework.ExpectNoError(framework.VerifyPods(t.Client, t.Namespace, t.Name, false, 1))
 
-		svcName := fmt.Sprintf("%v.%v.svc.cluster.local", serviceName, f.Namespace.Name)
+		svcName := fmt.Sprintf("%v.%v.svc.%s", serviceName, f.Namespace.Name, framework.TestContext.DNSDomain)
 		By("Waiting for endpoints of Service with DNS name " + svcName)
 
 		execPodName := framework.CreateExecPodOrFail(f.ClientSet, f.Namespace.Name, "execpod-", nil)


### PR DESCRIPTION
**What this PR does / why we need it**: PR allows to set dns domain for e2e tesst to use.  `cluster.local` was hardcoded in all tests. 
When cluster was deployed with different dns domain some e2e would fail. Especially 2 conformance tests.

**Release note**:
```release-note
Added --dns-domain option for e2e tests. Defaults to `cluster.local`
```
