### PR TITLE
Fixes a bug about `FakeDockerClient` and add some unit tests

### DIFF
--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -90,10 +90,21 @@ func TestListContainers(t *testing.T) {
 			Annotations:  configs[i].Annotations,
 		}}, expected...)
 	}
+	filter := &runtimeapi.ContainerFilter{
+		Id:            expected[1].Id,
+		State:         &runtimeapi.ContainerStateValue{State: expected[1].State},
+		PodSandboxId:  expected[1].PodSandboxId,
+		LabelSelector: expected[1].Labels,
+	}
 	containers, err := ds.ListContainers(nil)
 	assert.NoError(t, err)
 	assert.Len(t, containers, len(expected))
 	assert.Equal(t, expected, containers)
+
+	containers, err = ds.ListContainers(filter)
+	assert.NoError(t, err)
+	assert.Len(t, containers, 1)
+	assert.Contains(t, containers, expected[1])
 }
 
 // TestContainerStatus tests the basic lifecycle operations and verify that

--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -376,6 +376,21 @@ func (f *FakeDockerClient) popError(op string) error {
 	return nil
 }
 
+func toCRIContainerState(state string) string {
+	// Convert the status of a container returned by ListContainers
+	// to docker container status
+	switch {
+	case strings.HasPrefix(state, StatusCreatedPrefix):
+		return "created"
+	case strings.HasPrefix(state, StatusRunningPrefix):
+		return "running"
+	case strings.HasPrefix(state, StatusExitedPrefix):
+		return "exited"
+	default:
+		return "unknown"
+	}
+}
+
 // ListContainers is a test-spy implementation of Interface.ListContainers.
 // It adds an entry "list" to the internal method call record.
 func (f *FakeDockerClient) ListContainers(options dockertypes.ContainerListOptions) ([]dockertypes.Container, error) {
@@ -410,7 +425,7 @@ func (f *FakeDockerClient) ListContainers(options dockertypes.ContainerListOptio
 		var filtered []dockertypes.Container
 		for _, container := range containerList {
 			for _, statusFilter := range statusFilters {
-				if container.Status == statusFilter {
+				if statusFilter == toCRIContainerState(container.Status) {
 					filtered = append(filtered, container)
 					break
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- Add unit tests for docker images service
- Fixes a bug about `FakeDockerClient`: 
   Convert the state of a container returned by ListContainers to docker container state
- Improve the unit test for ListContainers service


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
