### PR TITLE
kubeadm: Conditionally mount flexvolume

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -72,7 +72,9 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, kubeadmconstants.KubeConfigVolumeName, controllerManagerKubeConfigFile, controllerManagerKubeConfigFile, true, &hostPathFileOrCreate)
 	// Mount for the flexvolume directory (/usr/libexec/kubernetes/kubelet-plugins/volume/exec) directory
 	// Flexvolume dir must NOT be readonly as it is used for third-party plugins to integrate with their storage backends via unix domain socket.
-	mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, flexvolumeDirVolumeName, flexvolumeDirVolumePath, flexvolumeDirVolumePath, false, &hostPathDirectoryOrCreate)
+	if stat, err := os.Stat(flexvolumeDirVolumePath); err == nil && stat.IsDir() {
+		mounts.NewHostPathMount(kubeadmconstants.KubeControllerManager, flexvolumeDirVolumeName, flexvolumeDirVolumePath, flexvolumeDirVolumePath, false, &hostPathDirectoryOrCreate)
+	}
 
 	// HostPath volumes for the scheduler
 	// Read-only mount for the scheduler kubeconfig file

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -306,15 +306,6 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 			},
 		},
 	}
-	volMap[kubeadmconstants.KubeControllerManager]["flexvolume-dir"] = v1.Volume{
-		Name: "flexvolume-dir",
-		VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{
-				Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
-				Type: &hostPathDirectoryOrCreate,
-			},
-		},
-	}
 	volMap[kubeadmconstants.KubeScheduler] = map[string]v1.Volume{}
 	volMap[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.Volume{
 		Name: "kubeconfig",
@@ -352,11 +343,6 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		Name:      "kubeconfig",
 		MountPath: "/etc/kubernetes/controller-manager.conf",
 		ReadOnly:  true,
-	}
-	volMountMap[kubeadmconstants.KubeControllerManager]["flexvolume-dir"] = v1.VolumeMount{
-		Name:      "flexvolume-dir",
-		MountPath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
-		ReadOnly:  false,
 	}
 	volMountMap[kubeadmconstants.KubeScheduler] = map[string]v1.VolumeMount{}
 	volMountMap[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.VolumeMount{
@@ -431,15 +417,6 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 			},
 		},
 	}
-	volMap2[kubeadmconstants.KubeControllerManager]["flexvolume-dir"] = v1.Volume{
-		Name: "flexvolume-dir",
-		VolumeSource: v1.VolumeSource{
-			HostPath: &v1.HostPathVolumeSource{
-				Path: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
-				Type: &hostPathDirectoryOrCreate,
-			},
-		},
-	}
 	volMap2[kubeadmconstants.KubeScheduler] = map[string]v1.Volume{}
 	volMap2[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.Volume{
 		Name: "kubeconfig",
@@ -487,11 +464,6 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 		Name:      "kubeconfig",
 		MountPath: "/etc/kubernetes/controller-manager.conf",
 		ReadOnly:  true,
-	}
-	volMountMap2[kubeadmconstants.KubeControllerManager]["flexvolume-dir"] = v1.VolumeMount{
-		Name:      "flexvolume-dir",
-		MountPath: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec",
-		ReadOnly:  false,
 	}
 	volMountMap2[kubeadmconstants.KubeScheduler] = map[string]v1.VolumeMount{}
 	volMountMap2[kubeadmconstants.KubeScheduler]["kubeconfig"] = v1.VolumeMount{


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kubernetes/kubeadm/issues/476

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/476

```release-note
kubeadm: Fix a bug on some OSes where the kubelet tried to mount a volume path that is non-existent and on a read-only filesystem 
```

/cc @luxas 