### PR TITLE
Automated cherry pick of #55166

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/volumes.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes.go
@@ -57,7 +57,7 @@ func getHostPathVolumesForTheControlPlane(cfg *kubeadmapi.MasterConfiguration) c
 
 	// If external etcd is specified, mount the directories needed for accessing the CA/serving certs and the private key
 	if len(cfg.Etcd.Endpoints) != 0 {
-		etcdVols, etcdVolMounts := getEtcdCertVolumes(cfg.Etcd)
+		etcdVols, etcdVolMounts := getEtcdCertVolumes(cfg.Etcd, cfg.CertificatesDir)
 		mounts.AddHostPathMounts(kubeadmconstants.KubeAPIServer, etcdVols, etcdVolMounts)
 	}
 
@@ -121,14 +121,15 @@ func (c *controlPlaneHostPathMounts) GetVolumeMounts(component string) []v1.Volu
 }
 
 // getEtcdCertVolumes returns the volumes/volumemounts needed for talking to an external etcd cluster
-func getEtcdCertVolumes(etcdCfg kubeadmapi.Etcd) ([]v1.Volume, []v1.VolumeMount) {
+func getEtcdCertVolumes(etcdCfg kubeadmapi.Etcd, k8sCertificatesDir string) ([]v1.Volume, []v1.VolumeMount) {
 	certPaths := []string{etcdCfg.CAFile, etcdCfg.CertFile, etcdCfg.KeyFile}
 	certDirs := sets.NewString()
 	for _, certPath := range certPaths {
 		certDir := filepath.Dir(certPath)
 		// Ignore ".", which is the result of passing an empty path.
-		// Also ignore the cert directories that already may be mounted; /etc/ssl/certs and /etc/pki. If the etcd certs are in there, it's okay, we don't have to do anything
-		if certDir == "." || strings.HasPrefix(certDir, caCertsVolumePath) || strings.HasPrefix(certDir, caCertsPkiVolumePath) {
+		// Also ignore the cert directories that already may be mounted; /etc/ssl/certs, /etc/pki or Kubernetes CertificatesDir
+		// If the etcd certs are in there, it's okay, we don't have to do anything
+		if certDir == "." || strings.HasPrefix(certDir, caCertsVolumePath) || strings.HasPrefix(certDir, caCertsPkiVolumePath) || strings.HasPrefix(certDir, k8sCertificatesDir) {
 			continue
 		}
 		// Filter out any existing hostpath mounts in the list that contains a subset of the path

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -30,6 +30,7 @@ import (
 
 func TestGetEtcdCertVolumes(t *testing.T) {
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
+	k8sCertifcatesDir := "/etc/kubernetes/pki"
 	var tests = []struct {
 		ca, cert, key string
 		vol           []v1.Volume
@@ -56,6 +57,14 @@ func TestGetEtcdCertVolumes(t *testing.T) {
 			ca:       "/etc/pki/my-etcd-ca.crt",
 			cert:     "/etc/pki/my-etcd.crt",
 			key:      "/etc/pki/my-etcd.key",
+			vol:      []v1.Volume{},
+			volMount: []v1.VolumeMount{},
+		},
+		{
+			// Should ignore files in Kubernetes PKI directory (and subdirs)
+			ca:       k8sCertifcatesDir + "/ca/my-etcd-ca.crt",
+			cert:     k8sCertifcatesDir + "/my-etcd.crt",
+			key:      k8sCertifcatesDir + "/my-etcd.key",
 			vol:      []v1.Volume{},
 			volMount: []v1.VolumeMount{},
 		},
@@ -228,7 +237,7 @@ func TestGetEtcdCertVolumes(t *testing.T) {
 			CAFile:   rt.ca,
 			CertFile: rt.cert,
 			KeyFile:  rt.key,
-		})
+		}, k8sCertifcatesDir)
 		if !reflect.DeepEqual(actualVol, rt.vol) {
 			t.Errorf(
 				"failed getEtcdCertVolumes:\n\texpected: %v\n\t  actual: %v",
@@ -376,14 +385,14 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 			},
 		},
 		{
-			// Should ignore files in /etc/ssl/certs
+			// Should ignore files in /etc/ssl/certs and in CertificatesDir
 			cfg: &kubeadmapi.MasterConfiguration{
 				CertificatesDir: testCertsDir,
 				Etcd: kubeadmapi.Etcd{
 					Endpoints: []string{"foo"},
 					CAFile:    "/etc/certs/etcd/my-etcd-ca.crt",
-					CertFile:  "/var/lib/certs/etcd/my-etcd.crt",
-					KeyFile:   "/var/lib/certs/etcd/my-etcd.key",
+					CertFile:  testCertsDir + "/etcd/my-etcd.crt",
+					KeyFile:   "/var/lib/etcd/certs/my-etcd.key",
 				},
 			},
 			vol: map[string][]v1.Volume{
@@ -419,7 +428,7 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 						Name: "etcd-certs-1",
 						VolumeSource: v1.VolumeSource{
 							HostPath: &v1.HostPathVolumeSource{
-								Path: "/var/lib/certs/etcd",
+								Path: "/var/lib/etcd/certs",
 								Type: &hostPathDirectoryOrCreate,
 							},
 						},
@@ -494,7 +503,7 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 					},
 					{
 						Name:      "etcd-certs-1",
-						MountPath: "/var/lib/certs/etcd",
+						MountPath: "/var/lib/etcd/certs",
 						ReadOnly:  true,
 					},
 				},


### PR DESCRIPTION
Cherry pick of #55166 on release-1.8.

#55166: kubeadm: don't create duplicate volume/mount



**Release note**:
```release-note
- kubeadm: fixed bug with incorrect static pod manifest generation in situation where certificates for external etcd are located in k8s PKI directory, kubernetes/kubeadm#522 
```
