### PR TITLE
Cross-Account ECR Credentials

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -58,6 +58,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/v1/service"
 	"k8s.io/kubernetes/pkg/cloudprovider"
 	"k8s.io/kubernetes/pkg/controller"
+	awscredentialprovider "k8s.io/kubernetes/pkg/credentialprovider/aws"
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -560,6 +561,11 @@ type CloudConfig struct {
 		//yourself in an non-AWS cloud and open an issue, please indicate that in the
 		//issue body.
 		DisableStrictZoneCheck bool
+
+		//The aws provider will lookup docker-login credentials for ECR in each region for
+		//the current AWS account. To lookup credentials for cross-account ECR access, supply
+		//the additional registry IDs.
+		EcrRegistryId []string
 	}
 }
 
@@ -1110,6 +1116,8 @@ func newAWSCloud(config io.Reader, awsServices Services) (*Cloud, error) {
 	// Register regions, in particular for ECR credentials
 	once.Do(func() {
 		RecognizeWellKnownRegions()
+		knownRegions := KnownRegions()
+		awscredentialprovider.RegisterCredentialsProviders(knownRegions, cfg.Global.EcrRegistryId)
 	})
 
 	return awsCloud, nil

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -175,6 +175,46 @@ func TestReadAWSCloudConfig(t *testing.T) {
 		}
 	}
 }
+func TestReadEcrRegistryIdsFromCloudConfig(t *testing.T) {
+	tests := []struct {
+		name string
+
+		reader io.Reader
+		aws    Services
+
+		expectedRegistryIds []string
+	}{
+		{
+			"Missing ECR Registries is syntactically fine",
+			strings.NewReader("[global]"),
+			newMockedFakeAWSServices(TestClusterId),
+			nil,
+		},
+		{
+			"Override default ECR RegistryId by providing one",
+			strings.NewReader("[global]\necrRegistryId = 123456"),
+			newMockedFakeAWSServices(TestClusterId), []string{"123456"},
+		},
+		{
+			"Option of using multiple ECR Registries",
+			strings.NewReader("[global]\necrRegistryId = 123456\n ecrRegistryId = 54321"),
+			newMockedFakeAWSServices(TestClusterId), []string{"123456", "54321"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Running test case %s", test.name)
+		metadata, _ := test.aws.Metadata()
+		cfg, err := readAWSCloudConfig(test.reader, metadata)
+		if err != nil {
+			t.Errorf("Should succeed for case: %s", test.name)
+		}
+		if !reflect.DeepEqual(cfg.Global.EcrRegistryId, test.expectedRegistryIds) {
+			t.Errorf("Incorrect registry IDs (%s vs %s) for case: %s",
+				cfg.Global.EcrRegistryId, test.expectedRegistryIds, test.name)
+		}
+	}
+}
 
 func TestNewAWSCloud(t *testing.T) {
 	tests := []struct {

--- a/pkg/cloudprovider/providers/aws/regions.go
+++ b/pkg/cloudprovider/providers/aws/regions.go
@@ -19,12 +19,10 @@ package aws
 import (
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/util/sets"
-	awscredentialprovider "k8s.io/kubernetes/pkg/credentialprovider/aws"
 	"sync"
 )
 
 // WellKnownRegions is the complete list of regions known to the AWS cloudprovider
-// and credentialprovider.
 var WellKnownRegions = [...]string{
 	// from `aws ec2 describe-regions --region us-east-1 --query Regions[].RegionName | sort`
 	"ap-northeast-1",
@@ -54,7 +52,6 @@ var awsRegionsMutex sync.Mutex
 var awsRegions sets.String
 
 // RecognizeRegion is called for each AWS region we know about.
-// It currently registers a credential provider for that region.
 // There are two paths to discovering a region:
 //  * we hard-code some well-known regions
 //  * if a region is discovered from instance metadata, we add that
@@ -73,8 +70,6 @@ func RecognizeRegion(region string) {
 
 	glog.V(4).Infof("found AWS region %q", region)
 
-	awscredentialprovider.RegisterCredentialsProvider(region)
-
 	awsRegions.Insert(region)
 }
 
@@ -91,4 +86,11 @@ func isRegionValid(region string) bool {
 	defer awsRegionsMutex.Unlock()
 
 	return awsRegions.Has(region)
+}
+
+func KnownRegions() []string {
+	awsRegionsMutex.Lock()
+	defer awsRegionsMutex.Unlock()
+
+	return awsRegions.List()
 }

--- a/pkg/credentialprovider/aws/aws_credentials_test.go
+++ b/pkg/credentialprovider/aws/aws_credentials_test.go
@@ -65,7 +65,7 @@ func TestEcrProvide(t *testing.T) {
 	}
 	image := "foo/bar"
 
-	provider := newEcrProvider("lala-land-1",
+	provider := newEcrProvider("lala-land-1", "*",
 		&testTokenGetter{
 			user:     user,
 			password: password,
@@ -118,7 +118,7 @@ func TestChinaEcrProvide(t *testing.T) {
 	}
 	image := "foo/bar"
 
-	provider := newEcrProvider("cn-foo-1",
+	provider := newEcrProvider("cn-foo-1", "*",
 		&testTokenGetter{
 			user:     user,
 			password: password,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds optional config to the AWS cloud-config that allows overriding of the default ECR registry in AWS. It can also be used to add additional ECR registries which is useful now AWS has "Organisations" where multiple accounts can easily be used by one organisation.

The `ecrRegistryId`s in the config, if present, are used to create the `DockerConfigProvider`s that populate the `DockerKeyring`. When missing, the existing behaviour is unchanged.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #28241 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds an optional `ecrRegistryId` config variable to the AWS cloud-config that allows overriding the default - or including additional - ECR Registry IDs for AWS.
```
