### PR TITLE
Sts per Pod Name Label

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -112,7 +112,8 @@ func identityMatches(set *apps.StatefulSet, pod *v1.Pod) bool {
 	return ordinal >= 0 &&
 		set.Name == parent &&
 		pod.Name == getPodName(set, ordinal) &&
-		pod.Namespace == set.Namespace
+		pod.Namespace == set.Namespace &&
+		pod.Labels[apps.StatefulSetPodNameLabel] == pod.Name
 }
 
 // storageMatches returns true if pod's Volumes cover the set of PersistentVolumeClaims
@@ -187,11 +188,15 @@ func initIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Spec.Subdomain = set.Spec.ServiceName
 }
 
-// updateIdentity updates pod's name, hostname, and subdomain to conform to set's name and headless service.
+// updateIdentity updates pod's name, hostname, and subdomain, and StatefulSetPodNameLabel to conform to set's name
+// and headless service.
 func updateIdentity(set *apps.StatefulSet, pod *v1.Pod) {
 	pod.Name = getPodName(set, getOrdinal(pod))
 	pod.Namespace = set.Namespace
-
+	if pod.Labels == nil {
+		pod.Labels = make(map[string]string)
+	}
+	pod.Labels[apps.StatefulSetPodNameLabel] = pod.Name
 }
 
 // isRunningAndReady returns true if pod is in the PodRunning Phase, if it has a condition of PodReady.

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -78,6 +78,11 @@ func TestIdentityMatches(t *testing.T) {
 	if identityMatches(set, pod) {
 		t.Error("identity matches for a Pod with the wrong namespace")
 	}
+	pod = newStatefulSetPod(set, 1)
+	delete(pod.Labels, apps.StatefulSetPodNameLabel)
+	if identityMatches(set, pod) {
+		t.Error("identity matches for a Pod with the wrong statefulSetPodNameLabel")
+	}
 }
 
 func TestStorageMatches(t *testing.T) {
@@ -126,6 +131,11 @@ func TestUpdateIdentity(t *testing.T) {
 	updateIdentity(set, pod)
 	if !identityMatches(set, pod) {
 		t.Error("updateIdentity failed to update the Pods namespace")
+	}
+	delete(pod.Labels, apps.StatefulSetPodNameLabel)
+	updateIdentity(set, pod)
+	if !identityMatches(set, pod) {
+		t.Error("updateIdentity failed to restore the statefulSetPodName label")
 	}
 }
 

--- a/staging/src/k8s.io/api/apps/v1/types.go
+++ b/staging/src/k8s.io/api/apps/v1/types.go
@@ -28,6 +28,7 @@ const (
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
+	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
 )
 
 // +genclient

--- a/staging/src/k8s.io/api/apps/v1beta1/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta1/types.go
@@ -26,6 +26,7 @@ import (
 const (
 	ControllerRevisionHashLabelKey = "controller-revision-hash"
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
+	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
 )
 
 // ScaleSpec describes the attributes of a scale subresource

--- a/staging/src/k8s.io/api/apps/v1beta2/types.go
+++ b/staging/src/k8s.io/api/apps/v1beta2/types.go
@@ -28,6 +28,7 @@ const (
 	StatefulSetRevisionLabel       = ControllerRevisionHashLabelKey
 	DeprecatedRollbackTo           = "deprecated.deployment.rollback.to"
 	DeprecatedTemplateGeneration   = "deprecated.daemonset.template.generation"
+	StatefulSetPodNameLabel        = "statefulset.kubernetes.io/pod-name"
 )
 
 // ScaleSpec describes the attributes of a scale subresource


### PR DESCRIPTION
**What this PR does / why we need it**:
StatefulSet controller will add a label for each Pod in the StatefulSet. The label is of the form 
`statefulset.kubernetes.io/pod-name: <pod.Name>`. This allows a unique service to be created for each Pod in the StatefulSet.

Fixes  #44103, #28660


```release-note
StatefulSet controller will create a label for each Pod in a StatefulSet. The label is named statefulset.kubernetes.io/pod-name and it is equal to the name of the Pod. This allows users to create a Service per Pod to expose a connection to individual Pods.
```
