### PR TITLE
Fix data race in TestCRD

### DIFF
--- a/cmd/kube-apiserver/app/testing/server_test.go
+++ b/cmd/kube-apiserver/app/testing/server_test.go
@@ -247,7 +247,7 @@ func TestCRD(t *testing.T) {
 	}
 	createErr := make(chan error, 1)
 	go func() {
-		_, err = barComClient.Resource(&metav1.APIResource{Name: "foos", Namespaced: true}, "default").Create(unstructuredFoo)
+		_, err := barComClient.Resource(&metav1.APIResource{Name: "foos", Namespaced: true}, "default").Create(unstructuredFoo)
 		t.Logf("Foo instance create returned: %v", err)
 		if err != nil {
 			createErr <- err


### PR DESCRIPTION
Fix this race:
```
==================
WARNING: DATA RACE
Write at 0x00c42a845350 by goroutine 748:
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.TestCRD()
      cmd/kube-apiserver/app/testing/server_test.go:257 +0x15da
  testing.tRunner()
      /root/.cache/bazel/_bazel_root/e9f728bbd90b3fba632eb31b20e1dacd/external/go_sdk/src/testing/testing.go:746 +0x16c

Previous write at 0x00c42a845350 by goroutine 481:
  k8s.io/kubernetes/cmd/kube-apiserver/app/testing.TestCRD.func2()
      cmd/kube-apiserver/app/testing/server_test.go:250 +0x241
```

Related to #54095