### PR TITLE
Fix docker push authentication

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -218,6 +218,13 @@ function create-and-upload-hollow-node-image {
 # Use bazel rule to create a docker image for hollow-node and upload
 # it to the appropriate docker container registry for the cloud provider.
 function create-and-upload-hollow-node-image-bazel {
+  # https://github.com/bazelbuild/rules_docker#authorization
+  # we need docker-credential-gcr to get authed properly
+  if ! [ -x "$(command -v docker-credential-gcr)" ]; then
+    gcloud components install docker-credential-gcr
+  fi
+  docker-credential-gcr configure-docker
+
   RETRIES=3
   for attempt in $(seq 1 ${RETRIES}); do
     if ! bazel run //cluster/images/kubemark:push --define PROJECT="${PROJECT}"; then


### PR DESCRIPTION
ref https://github.com/bazelbuild/rules_docker#authorization
without `docker-credential-gcr` even I have correct ACL, I get 
```
containerregistry.client.v2_2.docker_http_.BadStateException: Bad status during token exchange: 401
{"errors":[{"code":"DENIED","message":"Unable to access the repository, please check that you have permission to access it."}]}
```

tested within the same container and it works after installing.
Not sure if this is the best place to put it? It's the only job utilize the bazel push rule for now though.

/assign @shyamjvs @mikedanese @ixdy 

