### PR TITLE
Add ephemeral storage resource usage for container

### DIFF
--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -117,6 +117,10 @@ type ContainerStats struct {
 	// Logs.UsedBytes is the number of bytes used for the container logs.
 	// +optional
 	Logs *FsStats `json:"logs,omitempty"`
+	// Stats pertaining to container usage of ephemeral-storage of root filesystem resources.
+	// EphemeralStorage.UsedBytes is the number of bytes used for ephemeral-storage in root filesystem.
+	// +optional
+	EphemeralStorage *FsStats `json:"ephemeral-storage,omitempty"`
 	// User defined metrics that are exposed by containers in the pod. Typically, we expect only one container in the pod to be exposing user defined metrics. In the event of multiple containers exposing metrics, they will be combined here.
 	// +patchMergeKey=name
 	// +patchStrategy=merge

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -205,11 +205,13 @@ func TestCadvisorListPodStats(t *testing.T) {
 	assert.EqualValues(t, testTime(creationTime, seedPod0Container0).Unix(), con.StartTime.Time.Unix())
 	checkCPUStats(t, "Pod0Container0", seedPod0Container0, con.CPU)
 	checkMemoryStats(t, "Pod0Conainer0", seedPod0Container0, infos["/pod0-c0"], con.Memory)
+	checkEphemeralStorageStats(t, "Pod0Container0", seedPod0Container0, con.EphemeralStorage)
 
 	con = indexCon[cName01]
 	assert.EqualValues(t, testTime(creationTime, seedPod0Container1).Unix(), con.StartTime.Time.Unix())
 	checkCPUStats(t, "Pod0Container1", seedPod0Container1, con.CPU)
 	checkMemoryStats(t, "Pod0Container1", seedPod0Container1, infos["/pod0-c1"], con.Memory)
+	checkEphemeralStorageStats(t, "Pod0Container1", seedPod0Container1, con.EphemeralStorage)
 
 	assert.EqualValues(t, testTime(creationTime, seedPod0Infra).Unix(), ps.StartTime.Time.Unix())
 	checkNetworkStats(t, "Pod0", seedPod0Infra, ps.Network)
@@ -223,6 +225,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 	checkCPUStats(t, "Pod1Container0", seedPod1Container, con.CPU)
 	checkMemoryStats(t, "Pod1Container0", seedPod1Container, infos["/pod1-c0"], con.Memory)
 	checkNetworkStats(t, "Pod1", seedPod1Infra, ps.Network)
+	checkEphemeralStorageStats(t, "Pod1Container0", seedPod1Container, con.EphemeralStorage)
 
 	// Validate Pod2 Results
 	ps, found = indexPods[prf2]
@@ -233,6 +236,7 @@ func TestCadvisorListPodStats(t *testing.T) {
 	checkCPUStats(t, "Pod2Container0", seedPod2Container, con.CPU)
 	checkMemoryStats(t, "Pod2Container0", seedPod2Container, infos["/pod2-c0"], con.Memory)
 	checkNetworkStats(t, "Pod2", seedPod2Infra, ps.Network)
+	checkEphemeralStorageStats(t, "Pod2Container0", seedPod2Container, con.EphemeralStorage)
 }
 
 func TestCadvisorImagesFsStats(t *testing.T) {

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -84,9 +84,18 @@ func cadvisorInfoToContainerStats(name string, info *cadvisorapiv2.ContainerInfo
 			Inodes:         rootFs.Inodes,
 		}
 
+		result.EphemeralStorage = &statsapi.FsStats{
+			Time:           metav1.NewTime(cstat.Timestamp),
+			AvailableBytes: &rootFs.Available,
+			CapacityBytes:  &rootFs.Capacity,
+			InodesFree:     rootFs.InodesFree,
+			Inodes:         rootFs.Inodes,
+		}
+
 		if rootFs.Inodes != nil && rootFs.InodesFree != nil {
 			logsInodesUsed := *rootFs.Inodes - *rootFs.InodesFree
 			result.Logs.InodesUsed = &logsInodesUsed
+			result.EphemeralStorage.InodesUsed = &logsInodesUsed
 		}
 	}
 
@@ -111,12 +120,16 @@ func cadvisorInfoToContainerStats(name string, info *cadvisorapiv2.ContainerInfo
 			if cfs.TotalUsageBytes != nil && result.Logs != nil {
 				logsUsage := *cfs.TotalUsageBytes - *cfs.BaseUsageBytes
 				result.Logs.UsedBytes = &logsUsage
+				totalUsage := *cfs.TotalUsageBytes
+				result.EphemeralStorage.UsedBytes = &totalUsage
 			}
 		}
 		if cfs.InodeUsage != nil && result.Rootfs != nil {
 			rootInodes := *cfs.InodeUsage
 			result.Rootfs.InodesUsed = &rootInodes
+			result.EphemeralStorage.InodesUsed = &rootInodes
 		}
+
 	}
 
 	result.UserDefinedMetrics = cadvisorInfoToUserDefinedMetrics(info)

--- a/pkg/kubelet/stats/stats_provider_test.go
+++ b/pkg/kubelet/stats/stats_provider_test.go
@@ -535,6 +535,12 @@ func checkMemoryStats(t *testing.T, label string, seed int, info cadvisorapiv2.C
 	}
 }
 
+func checkEphemeralStorageStats(t *testing.T, label string, seed int, stats *statsapi.FsStats) {
+	assert.EqualValues(t, testTime(timestamp, seed).Unix(), stats.Time.Time.Unix(), label+".EphemeralStorage.Time")
+	assert.EqualValues(t, seed+offsetFsTotalUsageBytes, *stats.UsedBytes)
+	assert.EqualValues(t, seed+offsetFsInodeUsage, *stats.InodesUsed)
+}
+
 func checkFsStats(t *testing.T, label string, seed int, stats *statsapi.FsStats) {
 	assert.EqualValues(t, seed+offsetFsCapacity, *stats.CapacityBytes, label+".CapacityBytes")
 	assert.EqualValues(t, seed+offsetFsAvailable, *stats.AvailableBytes, label+".AvailableBytes")


### PR DESCRIPTION
After the feature of local ephemeral storage isolation is added, we need
to expose this resource usage information. This PR is the first step to
expose it at container level in summary API.

