### PR TITLE
Remove hack for CLUSTER_IP_RANGE in e2e framework no longer needed

### DIFF
--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -347,8 +347,4 @@ func AfterReadingAllFlags(t *TestContextType) {
 			t.Host = defaultHost
 		}
 	}
-	// Reset the cluster IP range flag to CLUSTER_IP_RANGE env var, if defined.
-	if clusterIPRange := os.Getenv("CLUSTER_IP_RANGE"); clusterIPRange != "" {
-		t.CloudConfig.ClusterIPRange = clusterIPRange
-	}
 }


### PR DESCRIPTION
As discussed in https://github.com/kubernetes/test-infra/pull/5386#discussion_r149523537, we no longer need it as we're using the flag to pass the value.

/cc @krzyzacy 