### PR TITLE
Fix duplicate externalIP in "kubectl get service"

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -826,12 +826,12 @@ func getServiceExternalIP(svc *api.Service, wide bool) string {
 	case api.ServiceTypeLoadBalancer:
 		lbIps := loadBalancerStatusStringer(svc.Status.LoadBalancer, wide)
 		if len(svc.Spec.ExternalIPs) > 0 {
-			results := []string{}
+			results := sets.NewString()
 			if len(lbIps) > 0 {
-				results = append(results, strings.Split(lbIps, ",")...)
+				results.Insert(strings.Split(lbIps, ",")...)
 			}
-			results = append(results, svc.Spec.ExternalIPs...)
-			return strings.Join(results, ",")
+			results.Insert(svc.Spec.ExternalIPs...)
+			return strings.Join(results.List(), ",")
 		}
 		if len(lbIps) > 0 {
 			return lbIps


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes the "External-IP" column in "kubectl get service" print unique IPs
 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
duplicate External IPs are deleted in "kubectl get service"
```
