### PR TITLE
Using --show-labels with incompatible ‘kubectl get’ arguments should …

### DIFF
--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -145,7 +145,7 @@ func NewCmdGet(f cmdutil.Factory, out io.Writer, errOut io.Writer) *cobra.Comman
 		Example: getExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.Complete(f, cmd, args))
-			cmdutil.CheckErr(options.Validate())
+			cmdutil.CheckErr(options.Validate(cmd))
 			cmdutil.CheckErr(options.Run(f, cmd, args))
 		},
 		SuggestFor: []string{"list", "ps"},
@@ -209,9 +209,15 @@ func (options *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 }
 
 // Validate checks the set of flags provided by the user.
-func (options *GetOptions) Validate() error {
+func (options *GetOptions) Validate(cmd *cobra.Command) error {
 	if len(options.Raw) > 0 && (options.Watch || options.WatchOnly || len(options.LabelSelector) > 0 || options.Export) {
 		return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
+	}
+	if cmdutil.GetFlagBool(cmd, "show-labels") {
+		outputOption := cmd.Flags().Lookup("output").Value.String()
+		if outputOption != "" && outputOption != "wide" {
+			return fmt.Errorf("--show-labels option cannot be used with %s printer", outputOption)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
…error out

**What this PR does / why we need it**:
According to @ahmetb 's [issue](https://github.com/kubernetes/kubernetes/issues/55290)  
Under specific circumstances, current behavior is that the `--show-labels` simply doesn’t make a difference since it’s not applicable.  

**Which issue(s) this PR fixes** :
Fixes #55290 

**Release note**:

```release-note
NONE
```
