### PR TITLE
kubeadm: Make swap check as an error

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -545,7 +545,7 @@ func (swc SwapCheck) Check() (warnings, errors []error) {
 	}
 
 	if len(buf) > 1 {
-		return []error{fmt.Errorf("running with swap on is not supported. Please disable swap or set kubelet's --fail-swap-on flag to false")}, nil
+		return nil, []error{fmt.Errorf("running with swap on is not supported. Please disable swap")}
 	}
 
 	return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on amount of support issues where warning about enabled
swap not noticed or ignored, it will be better to make this
check as an error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:
cc @luxas 
attention @jpbetz : this change planned to be also cherrypicked to 1.8 branch.
/area kubeadm
/sig cluster-lifecycle 

**Release note**:
```release-note
kubeadm now produces error during preflight checks if swap is enabled. Users, who can setup kubelet to run in unsupported environment with enabled swap, will be able to skip that preflight check.
```
