### PR TITLE
Update of elasticsearch kibana version

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.6.4
 
 VOLUME ["/data"]
 EXPOSE 9200 9300

--- a/cluster/addons/fluentd-elasticsearch/es-image/Makefile
+++ b/cluster/addons/fluentd-elasticsearch/es-image/Makefile
@@ -16,7 +16,7 @@
 
 PREFIX = gcr.io/google-containers
 IMAGE = elasticsearch
-TAG = v5.6.2
+TAG = v5.6.4
 
 build:
 	docker build --pull -t $(PREFIX)/$(IMAGE):$(TAG) .

--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -54,7 +54,7 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: elasticsearch-logging
-    version: v5.6.2
+    version: v5.6.4
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -63,17 +63,17 @@ spec:
   selector:
     matchLabels:
       k8s-app: elasticsearch-logging
-      version: v5.6.2
+      version: v5.6.4
   template:
     metadata:
       labels:
         k8s-app: elasticsearch-logging
-        version: v5.6.2
+        version: v5.6.4
         kubernetes.io/cluster-service: "true"
     spec:
       serviceAccountName: elasticsearch-logging
       containers:
-      - image: gcr.io/google-containers/elasticsearch:v5.6.2
+      - image: gcr.io/google-containers/elasticsearch:v5.6.4
         name: elasticsearch-logging
         resources:
           # need more cpu upon initialization, therefore burstable class

--- a/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
+++ b/cluster/addons/fluentd-elasticsearch/kibana-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - name: kibana-logging
-        image: docker.elastic.co/kibana/kibana:5.6.2
+        image: docker.elastic.co/kibana/kibana:5.6.4
         resources:
           # need more cpu upon initialization, therefore burstable class
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updated elasticsearch and kibana version to version 5.6.4
This was motivated by @crassirostris in https://github.com/kubernetes/kubernetes/pull/54215#issuecomment-343003874

**Release note**:
```release-note
[fluentd-elasticsearch addon] Elasticsearch and Kibana are updated to version 5.6.4
```
