### PR TITLE
code-generator: move kube group list out of client-gen

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -40,6 +40,7 @@ informergen=$(kube::util::find-binary "informer-gen")
 
 GROUP_VERSIONS=(${KUBE_AVAILABLE_GROUP_VERSIONS})
 GV_DIRS=()
+INTERNAL_DIRS=()
 for gv in "${GROUP_VERSIONS[@]}"; do
 	# add items, but strip off any leading apis/ you find to match command expectations
 	api_dir=$(kube::util::group-version-to-pkg-path "${gv}")
@@ -47,19 +48,30 @@ for gv in "${GROUP_VERSIONS[@]}"; do
 	nopkg_dir=${nopkg_dir#vendor/k8s.io/api/}
 	pkg_dir=${nopkg_dir#apis/}
 
+
 	# skip groups that aren't being served, clients for these don't matter
     if [[ " ${KUBE_NONSERVER_GROUP_VERSIONS} " == *" ${gv} "* ]]; then
       continue
     fi
 
 	GV_DIRS+=("${pkg_dir}")
+
+	# collect internal groups
+	int_group="${pkg_dir%/*}/"
+	if [[ "${pkg_dir}" = core/* ]]; then
+	    int_group="api/"
+	fi
+    if ! [[ " ${INTERNAL_DIRS[@]:-} " =~ " ${int_group} " ]]; then
+        INTERNAL_DIRS+=("${int_group}")
+    fi
 done
 # delimit by commas for the command
 GV_DIRS_CSV=$(IFS=',';echo "${GV_DIRS[*]// /,}";IFS=$)
+INTERNAL_DIRS_CSV=$(IFS=',';echo "${INTERNAL_DIRS[*]// /,}";IFS=$)
 
 # This can be called with one flag, --verify-only, so it works for both the
 # update- and verify- scripts.
-${clientgen} "$@"
+${clientgen} --input-base="k8s.io/kubernetes/pkg/apis" --input="${INTERNAL_DIRS_CSV}" "$@"
 ${clientgen} --output-base "${KUBE_ROOT}/vendor" --clientset-path="k8s.io/client-go" --clientset-name="kubernetes" --input-base="k8s.io/kubernetes/vendor/k8s.io/api" --input="${GV_DIRS_CSV}" "$@"
 
 listergen_internal_apis=(

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -53,26 +53,8 @@ type CustomArgs struct {
 	FakeClient bool
 }
 
-var defaultInput = []string{
-	"api/",
-	"admissionregistration/",
-	"authentication/",
-	"authorization/",
-	"autoscaling/",
-	"batch/",
-	"certificates/",
-	"extensions/",
-	"rbac/",
-	"storage/",
-	"apps/",
-	"policy/",
-	"scheduling/",
-	"settings/",
-	"networking/",
-}
-
 func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
-	pflag.Var(NewGVPackagesValue(&ca.GroupVersionToInputPath, &ca.Groups, defaultInput), "input", "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\".")
+	pflag.Var(NewGVPackagesValue(&ca.GroupVersionToInputPath, &ca.Groups, nil), "input", "group/versions that client-gen will generate clients for. At most one version per group is allowed. Specified in the format \"group1/version1,group2/version2...\".")
 	pflag.Var(NewGVTypesValue(&ca.IncludedTypesOverrides, []string{}), "included-types-overrides", "list of group/version/type for which client should be generated. By default, client is generated for all types which have genclient in types.go. This overrides that. For each groupVersion in this list, only the types mentioned here will be included. The default check of genclient will be used for other group versions.")
 	pflag.StringVar(&ca.InputBasePath, "input-base", "k8s.io/kubernetes/pkg/apis", "base path to look for the api group.")
 	pflag.StringVarP(&ca.ClientsetName, "clientset-name", "n", "internalclientset", "the name of the generated clientset package.")


### PR DESCRIPTION
We had a hard-coded group list in the client-gen code for the internal Kubernetes api groups. For the external groups, we collected the actual GVs in update-codegen.sh. This PR does the latter for internal groups as well.