### PR TITLE
busybox image: add symlink for /bin/tee

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -31,6 +31,8 @@ docker_build(
         "/usr/bin/busybox": "/bin/busybox",
         "/usr/sbin/busybox": "/bin/busybox",
         "/sbin/busybox": "/bin/busybox",
+        # tee is used to send logs to /var/log and stdout, e.g. by kops
+        "/bin/tee": "/bin/busybox",
     },
 )
 


### PR DESCRIPTION
This makes the bazel image more similar to the bash build, which uses
the image from the docker registry.

tee is used by e.g. kops to send logs to both a /var/log file and to
stdout (which is then captured by docker).

```release-note
Add /bin/tee symlink to bazel build for busybox, so that CI builds have /bin/tee
```
