### PR TITLE
Fix typo in rbac setup in configure-helper.sh

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1779,7 +1779,7 @@ function start-kube-addons {
   if [[ "${REGISTER_MASTER_KUBELET:-false}" == "true" ]]; then
     setup-addon-manifests "addons" "rbac/legacy-kubelet-user"
   else
-    setup-addon-manifests "addons" "rbac/legacy-kubelet-user-disabled"
+    setup-addon-manifests "addons" "rbac/legacy-kubelet-user-disable"
   fi
 
   if [[ "${ENABLE_POD_SECURITY_POLICY:-}" == "true" ]]; then


### PR DESCRIPTION
Fixed a typo which was causing script to break while creating a GKE cluster.

Specifically, the line  "setup-addon-manifests 'addons' 'rbac/legacy-kubelet-user-disabled' " was meant to refer to the directory cluster/addons/rbac/legacy-kubelet-user-disable. The extra "d" at the end of "disable" was causing the script to break.

Original PR: #53144

Release Note:
```release-note
None
```
