### PR TITLE
Add sig storage label to multizone static PV test

### DIFF
--- a/test/e2e/multicluster/ubernetes_lite.go
+++ b/test/e2e/multicluster/ubernetes_lite.go
@@ -58,7 +58,7 @@ var _ = SIGDescribe("Multi-AZ Clusters", func() {
 		SpreadRCOrFail(f, int32((2*zoneCount)+1), image)
 	})
 
-	It("should schedule pods in the same zones as statically provisioned PVs", func() {
+	It("should schedule pods in the same zones as statically provisioned PVs [sig-storage]", func() {
 		PodsUseStaticPVsOrFail(f, (2*zoneCount)+1, image)
 	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds sig storage tag to e2e test so it shows up on our testgrid dashboard

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
