### PR TITLE
WIP: Support bulk polling of AWS volumes

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -362,6 +362,15 @@ type Volumes interface {
 
 	// Check if disks specified in argument map are still attached to their respective nodes.
 	DisksAreAttached(map[types.NodeName][]KubernetesVolumeID) (map[types.NodeName]map[KubernetesVolumeID]bool, error)
+
+	// GetBulkVolumeStatus returns the status of multiple volumes (likely most/all volumes)
+	GetBulkVolumeStatus(volumes []KubernetesVolumeID) (map[KubernetesVolumeID]VolumeStatus, error)
+}
+
+type VolumeStatus struct {
+	VolumeName KubernetesVolumeID
+	NodeName   types.NodeName
+	DevicePath string
 }
 
 // InstanceGroups is an interface for managing cloud-managed instance groups / autoscaling instance groups
@@ -2151,6 +2160,99 @@ func (c *Cloud) DisksAreAttached(nodeDisks map[types.NodeName][]KubernetesVolume
 	}
 
 	return attached, nil
+}
+
+func (c *Cloud) GetBulkVolumeStatus(volumes []KubernetesVolumeID) (map[KubernetesVolumeID]VolumeStatus, error) {
+	statuses := make(map[KubernetesVolumeID]VolumeStatus)
+
+	volumeIDMap := make(map[awsVolumeID]KubernetesVolumeID)
+	for _, volume := range volumes {
+		volumeID, err := volume.mapToAWSVolumeID()
+		if err != nil {
+			return nil, fmt.Errorf("error mapping volume %q to aws id: %v", volume, err)
+		}
+		volumeIDMap[volumeID] = volume
+	}
+
+	// We don't filter by volume id; we expect we are fetching most volumes
+	request := &ec2.DescribeVolumesInput{}
+	ec2Volumes, err := c.ec2.DescribeVolumes(request)
+	if err != nil {
+		return statuses, fmt.Errorf("error describing volumes: %v", err)
+	}
+
+	instanceIdToName := make(map[awsInstanceID]types.NodeName)
+	{
+		instanceIDSet := sets.NewString()
+		for _, volume := range ec2Volumes {
+			volumeID := awsVolumeID(aws.StringValue(volume.VolumeId))
+			if volumeIDMap[volumeID] == "" {
+				// We aren't interested in this volume
+				continue
+			}
+			for _, a := range volume.Attachments {
+				instanceID := aws.StringValue(a.InstanceId)
+				if instanceID != "" {
+					instanceIDSet.Insert(instanceID)
+				}
+			}
+		}
+
+		if instanceIDSet.Len() != 0 {
+			var instanceIDs []awsInstanceID
+			for _, id := range instanceIDSet.List() {
+				instanceIDs = append(instanceIDs, awsInstanceID(id))
+			}
+
+			cacheCriteria := cacheCriteria{
+				// MaxAge not required, because we only care about node name, which should not change
+				HasInstances: instanceIDs, // refresh so we fetch all these instances
+			}
+
+			snapshot, err := c.instanceCache.describeAllInstancesCached(cacheCriteria)
+			if err != nil {
+				return nil, err
+			}
+
+			instances := snapshot.FindInstances(instanceIDs)
+			for _, instanceID := range instanceIDs {
+				instance := instances[instanceID]
+				if instance != nil {
+					// We'll log this later
+					instanceIdToName[instanceID] = mapInstanceToNodeName(instance)
+				}
+			}
+		}
+	}
+
+	for _, ec2Volume := range ec2Volumes {
+		var status VolumeStatus
+
+		volumeID := awsVolumeID(aws.StringValue(ec2Volume.VolumeId))
+		kubernetesVolumeName := volumeIDMap[volumeID]
+		if kubernetesVolumeName == "" {
+			// We aren't interested in this volume
+			continue
+		}
+
+		status.VolumeName = kubernetesVolumeName
+
+		for _, a := range ec2Volume.Attachments {
+			instanceID := awsInstanceID(aws.StringValue(a.InstanceId))
+			nodeName := instanceIdToName[instanceID]
+			if nodeName == "" {
+				glog.Warningf("volume %q attached to unknown instance %q", volumeID, instanceID)
+				// This is not good - we'll treat the volume as detached, but we likely won't be able to attach it
+			} else {
+				status.NodeName = nodeName
+				status.DevicePath = aws.StringValue(a.Device)
+			}
+		}
+
+		statuses[kubernetesVolumeName] = status
+	}
+
+	return statuses, nil
 }
 
 // Gets the current load balancer state

--- a/pkg/volume/aws_ebs/attacher_test.go
+++ b/pkg/volume/aws_ebs/attacher_test.go
@@ -340,3 +340,7 @@ func (testcase *testcase) GetVolumeLabels(volumeName aws.KubernetesVolumeID) (ma
 func (testcase *testcase) GetDiskPath(volumeName aws.KubernetesVolumeID) (string, error) {
 	return "", errors.New("Not implemented")
 }
+
+func (testcase *testcase) GetBulkVolumeStatus(volumes []aws.KubernetesVolumeID) (map[aws.KubernetesVolumeID]aws.VolumeStatus, error) {
+	return nil, errors.New("Not implemented")
+}

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -138,7 +138,7 @@ type VolumePlugin interface {
 
 	// SupportsBulkVolumeVerification checks if volume plugin type is capable
 	// of enabling bulk polling of all nodes. This can speed up verification of
-	// attached volumes by quite a bit, but underlying pluging must support it.
+	// attached volumes by quite a bit, but underlying plugin must support it.
 	SupportsBulkVolumeVerification() bool
 }
 

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -175,6 +175,13 @@ type ActualStateOfWorldAttacherUpdater interface {
 	AddVolumeToReportAsAttached(volumeName v1.UniqueVolumeName, nodeName types.NodeName)
 }
 
+// ActualStateOfWorldVolumeManager is a set of operations for the actual state of the world,
+// that only apply to the volumemanager, not to kubelet implementations.
+type ActualStateOfWorldVolumeManager interface {
+	// ReportVolumeStatus updates the the status of all volumes in the system
+	ReportVolumeStatus(pluginName string, volumes map[v1.UniqueVolumeName]volume.VolumeStatus, volumeSpecs map[v1.UniqueVolumeName]*volume.Spec) error
+}
+
 // VolumeLogger defines a set of operations for generating volume-related logging and error msgs
 type VolumeLogger interface {
 	// Creates a detailed msg that can be used in logs

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -207,8 +207,28 @@ func (og *operationGenerator) GenerateBulkVolumeVerifyFunc(
 				newAttacherErr)
 			return nil
 		}
-		bulkVolumeVerifier, ok := volumeAttacher.(volume.BulkVolumeVerifier)
 
+		bulkVolumeStatus, ok := volumeAttacher.(volume.BulkVolumeStatus)
+		if ok {
+			volumes, bulkStatusErr := bulkVolumeStatus.GetBulkVolumeStatus(volumeSpecMap)
+			if bulkStatusErr != nil {
+				glog.Errorf("Error checking status of all volumes:  %v", bulkStatusErr)
+				return nil
+			}
+
+			nameToSpec := make(map[v1.UniqueVolumeName]*volume.Spec)
+			for k, v := range volumeSpecMap {
+				nameToSpec[v] = k
+			}
+			if err := actualStateOfWorld.(ActualStateOfWorldVolumeManager).ReportVolumeStatus(pluginName, volumes, nameToSpec); err != nil {
+				glog.Errorf("ReportVolumeStatus failed: %v", err)
+			}
+
+			// Always stop here - don't fall back to other implementations
+			return nil
+		}
+
+		bulkVolumeVerifier, ok := volumeAttacher.(volume.BulkVolumeVerifier)
 		if !ok {
 			glog.Errorf("BulkVerifyVolume failed to type assert attacher %q", bulkVolumeVerifier)
 			return nil

--- a/pkg/volume/util/volumehelper/volumehelper.go
+++ b/pkg/volume/util/volumehelper/volumehelper.go
@@ -115,7 +115,7 @@ func notRunning(statuses []v1.ContainerStatus) bool {
 }
 
 // SplitUniqueName splits the unique name to plugin name and volume name strings. It expects the uniqueName to follow
-// the fromat plugin_name/volume_name and the plugin name must be namespaced as descibed by the plugin interface,
+// the format plugin_name/volume_name and the plugin name must be namespaced as described by the plugin interface,
 // i.e. namespace/plugin containing exactly one '/'. This means the unique name will always be in the form of
 // plugin_namespace/plugin/volume_name, see k8s.io/kubernetes/pkg/volume/plugins.go VolumePlugin interface
 // description and pkg/volume/util/volumehelper/volumehelper.go GetUniqueVolumeNameFromSpec that constructs

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -193,6 +193,19 @@ type BulkVolumeVerifier interface {
 	BulkVerifyVolumes(volumesByNode map[types.NodeName][]*Spec) (map[types.NodeName]map[*Spec]bool, error)
 }
 
+type BulkVolumeStatus interface {
+	// GetBulkVolumeStatus returns the attachment state of all the specified volumes
+	GetBulkVolumeStatus(volumeSpecMap map[*Spec]v1.UniqueVolumeName) (map[v1.UniqueVolumeName]VolumeStatus, error)
+}
+
+type VolumeStatus struct {
+	// AttachedToNodes is a list of nodes this volumes is attached to.
+	AttachedToNodes []types.NodeName
+
+	// DevicePath contains the path on the node where the volume is attached
+	DevicePath string
+}
+
 // Detacher can detach a volume from a node.
 type Detacher interface {
 	// Detach the given volume from the node with the given Name.


### PR DESCRIPTION
This synchronizes the attach/detach controller with the actual state of
the world, regardless of the current state of the actual state of the
world.

This should give us much better failure detection / diagnosis & recovery.