### PR TITLE
Use HPA permissions to read custom metrics in Custom Metrics e2e test

### DIFF
--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor/google.golang.org/api/monitoring/v3:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/rbac/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -21,6 +21,7 @@ import (
 	gcm "google.golang.org/api/monitoring/v3"
 	corev1 "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
+	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
@@ -30,6 +31,25 @@ var (
 	UnusedMetricName  = "unused-metric"
 	CustomMetricValue = int64(448)
 	UnusedMetricValue = int64(446)
+	// HPAPermissions is a ClusterRoleBinding that grants unauthenticated user permissions granted for
+	// HPA for testing purposes, i.e. it should grant permission to read custom metrics.
+	HPAPermissions = &rbac.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom-metrics-reader",
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "system:controller:horizontal-pod-autoscaler",
+		},
+		Subjects: []rbac.Subject{
+			{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "Group",
+				Name:     "system:unauthenticated",
+			},
+		},
+	}
 )
 
 // StackdriverExporterDeployment is a Deployment of simple application that exports a metric of

--- a/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
@@ -104,6 +104,9 @@ func testAdapter(f *framework.Framework, kubeClient clientset.Interface, customM
 	}
 	defer CleanupAdapter()
 
+	_, err = kubeClient.Rbac().ClusterRoleBindings().Create(HPAPermissions)
+	defer kubeClient.Rbac().ClusterRoleBindings().Delete("custom-metrics-reader", &metav1.DeleteOptions{})
+
 	// Run application that exports the metric
 	err = createSDExporterPods(f, kubeClient)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes e2e test for Stackdriver Custom Metrics on GKE. With PR: https://github.com/kubernetes/kubernetes/pull/55387 it will be also necessary for analogous test on GCE.

**Release note**:
```release-note
NONE
```
