### PR TITLE
Fix dangling attach errors

### DIFF
--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -13,6 +13,7 @@ go_library(
         "device_util.go",
         "device_util_unsupported.go",
         "doc.go",
+        "error.go",
         "fs_unsupported.go",
         "io_util.go",
         "metrics.go",
@@ -41,6 +42,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ] + select({

--- a/pkg/volume/util/error.go
+++ b/pkg/volume/util/error.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	k8stypes "k8s.io/apimachinery/pkg/types"
+)
+
+// This error on attach indicates volume is attached to a different node
+// than we expected.
+type DanglingAttachError struct {
+	msg         string
+	CurrentNode k8stypes.NodeName
+	DevicePath  string
+}
+
+func (err *DanglingAttachError) Error() string {
+	return err.msg
+}
+
+func NewDanglingError(msg string, node k8stypes.NodeName, devicePath string) error {
+	return &DanglingAttachError{
+		msg:         msg,
+		CurrentNode: node,
+		DevicePath:  devicePath,
+	}
+}


### PR DESCRIPTION
Detach volumes from shutdown nodes and ensure that
dangling volumes are handled correctly in AWS

Fixes https://github.com/kubernetes/kubernetes/issues/52573 

```release-note
Implement correction mechanism for dangling volumes attached for deleted pods
```
