### PR TITLE
Automated cherry pick of #55353

### DIFF
--- a/hack/lib/.gitattributes
+++ b/hack/lib/.gitattributes
@@ -1,0 +1,1 @@
+version.sh export-subst

--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -36,6 +36,19 @@ kube::version::get_version_vars() {
     return
   fi
 
+  # If the kubernetes source was exported through git archive, then
+  # we likely don't have a git tree, but these magic values may be filled in.
+  if [[ '$Format:%%$' == "%" ]]; then
+    KUBE_GIT_COMMIT='$Format:%H$'
+    KUBE_GIT_TREE_STATE="git archive"
+    # When a 'git archive' is exported, the '$Format:%D$' below will look
+    # something like 'HEAD -> release-1.8, tag: v1.8.3' where then 'tag: '
+    # can be extracted from it.
+    if [[ '$Format:%D$' =~ tag:\ (v[^ ]+) ]]; then
+     KUBE_GIT_VERSION="${BASH_REMATCH[1]}"
+    fi
+  fi
+
   local git=(git --work-tree "${KUBE_ROOT}")
 
   if [[ -n ${KUBE_GIT_COMMIT-} ]] || KUBE_GIT_COMMIT=$("${git[@]}" rev-parse "HEAD^{commit}" 2>/dev/null); then

--- a/pkg/version/base.go
+++ b/pkg/version/base.go
@@ -51,9 +51,13 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
+
+	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
+	// companion .gitattributes file containing 'export-subst' in this same
+	// directory.  See also https://git-scm.com/docs/gitattributes
 	gitVersion   string = "v1.7.11-beta.0+$Format:%h$"
-	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
+	gitCommit    string = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string = ""            // state of git tree, either "clean" or "dirty"
 
 	buildDate string = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )

--- a/staging/src/k8s.io/client-go/pkg/version/base.go
+++ b/staging/src/k8s.io/client-go/pkg/version/base.go
@@ -51,9 +51,13 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
+
+	// NOTE: The $Format strings are replaced during 'git archive' thanks to the
+	// companion .gitattributes file containing 'export-subst' in this same
+	// directory.  See also https://git-scm.com/docs/gitattributes
 	gitVersion   string = "v1.7.11-beta.0+$Format:%h$"
-	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
+	gitCommit    string = "$Format:%H$" // sha1 from git, output of $(git rev-parse HEAD)
+	gitTreeState string = ""            // state of git tree, either "clean" or "dirty"
 
 	buildDate string = "1970-01-01T00:00:00Z" // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )


### PR DESCRIPTION
Cherry pick of #55353 on release-1.7.

#55353: Capture git export-subst strings in version.sh for 'git