### PR TITLE
A few improvements to the conformance regtesst

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -1,0 +1,15 @@
+This directory contains the regression test for controlling the list of all
+conformance tests.
+
+If you add or remove a conformance test, this test will fail and you will need
+to update the golden list of tests stored in `testdata/`.  Changes to that file
+require review by sig-architecture.
+
+To update the list, run
+
+```console
+$ bazel build //test/conformance:list_conformance_tests
+$ cp bazel-genfiles/test/conformance/conformance.txt test/conformance/testdata
+```
+
+Add the changed file to your PR, then send for review.

--- a/test/conformance/conformance_test.sh
+++ b/test/conformance/conformance_test.sh
@@ -21,5 +21,9 @@
 
 set -o errexit
 
-diff -u test/conformance/testdata/conformance.txt test/conformance/conformance.txt
-echo PASS
+if diff -u test/conformance/testdata/conformance.txt test/conformance/conformance.txt; then
+  echo PASS
+  exit 0
+fi
+echo 'See instructions in test/conformance/README.md'
+exit 1

--- a/test/conformance/testdata/OWNERS
+++ b/test/conformance/testdata/OWNERS
@@ -1,6 +1,8 @@
 # To be owned by sig-architecture.
 # TODO(mml): Exclude parent owners once
 # https://github.com/kubernetes/test-infra/issues/5197 is implemented.
+options:
+  - no_parent_owners: true
 reviewers:
   - bgrant0607
   - smarterclayton


### PR DESCRIPTION
- Set OWNERS files to disallow parent approvers (doesn't work yet, but should be live next week.)
- Document how to fix failing test.
- Add a better error message.

```release-note
NONE
```