### PR TITLE
k8s.io/client-go/{kubernetes,rest}: remove dependency on pflag

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/BUILD
@@ -18,7 +18,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/google/gofuzz:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/gopkg.in/inf.v0:go_default_library",
     ],
 )
@@ -38,7 +37,6 @@ go_library(
     importpath = "k8s.io/apimachinery/pkg/api/resource",
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/gopkg.in/inf.v0:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -25,8 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	flag "github.com/spf13/pflag"
-
 	inf "gopkg.in/inf.v0"
 )
 
@@ -746,44 +744,4 @@ func (q *Quantity) Copy() *Quantity {
 		d:      infDecAmount{tmp.Set(q.d.Dec)},
 		Format: q.Format,
 	}
-}
-
-// qFlag is a helper type for the Flag function
-type qFlag struct {
-	dest *Quantity
-}
-
-// Sets the value of the internal Quantity. (used by flag & pflag)
-func (qf qFlag) Set(val string) error {
-	q, err := ParseQuantity(val)
-	if err != nil {
-		return err
-	}
-	// This copy is OK because q will not be referenced again.
-	*qf.dest = q
-	return nil
-}
-
-// Converts the value of the internal Quantity to a string. (used by flag & pflag)
-func (qf qFlag) String() string {
-	return qf.dest.String()
-}
-
-// States the type of flag this is (Quantity). (used by pflag)
-func (qf qFlag) Type() string {
-	return "quantity"
-}
-
-// QuantityFlag is a helper that makes a quantity flag (using standard flag package).
-// Will panic if defaultValue is not a valid quantity.
-func QuantityFlag(flagName, defaultValue, description string) *Quantity {
-	q := MustParse(defaultValue)
-	flag.Var(NewQuantityFlagValue(&q), flagName, description)
-	return &q
-}
-
-// NewQuantityFlagValue returns an object that can be used to back a flag,
-// pointing at the given Quantity variable.
-func NewQuantityFlagValue(q *Quantity) flag.Value {
-	return qFlag{q}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -24,7 +24,6 @@ import (
 	"unicode"
 
 	fuzz "github.com/google/gofuzz"
-	"github.com/spf13/pflag"
 
 	inf "gopkg.in/inf.v0"
 )
@@ -1056,21 +1055,6 @@ func TestCopy(t *testing.T) {
 	c.Set(6)
 	if q.Value() == 6 {
 		t.Errorf("Copy didn't")
-	}
-}
-
-func TestQFlagSet(t *testing.T) {
-	qf := qFlag{&Quantity{}}
-	qf.Set("1Ki")
-	if e, a := "1Ki", qf.String(); e != a {
-		t.Errorf("Unexpected result %v != %v", e, a)
-	}
-}
-
-func TestQFlagIsPFlag(t *testing.T) {
-	var pfv pflag.Value = qFlag{}
-	if e, a := "quantity", pfv.Type(); e != a {
-		t.Errorf("Unexpected result %v != %v", e, a)
 	}
 }
 

--- a/staging/src/k8s.io/metrics/Godeps/Godeps.json
+++ b/staging/src/k8s.io/metrics/Godeps/Godeps.json
@@ -71,10 +71,6 @@
 			"Rev": "05fbef0ca5da472bbf96c9322b84a53edc03c9fd"
 		},
 		{
-			"ImportPath": "github.com/spf13/pflag",
-			"Rev": "583c0c0531f06d5278b7d917446061adc344b5cd"
-		},
-		{
 			"ImportPath": "golang.org/x/crypto/ssh/terminal",
 			"Rev": "49796115aa4b964c318aad4f3084fdb41e9aa067"
 		},


### PR DESCRIPTION
This change removes an unused pflag utility which cuts a client-go transitive dependency on that library.

Verified using `go list`

```
go list -f '{{join .Deps "\n"}}' k8s.io/kubernetes/vendor/k8s.io/client-go/kubernetes \
    | xargs go list -f '{{if not .Standard}}{{.ImportPath}}{{end}}' \
    | grep pflag
```

/cc @sttts @kubernetes/sig-api-machinery-pr-reviews 

Edit: it looks like k8s.io/client-go/tools/clientcmd still imports this. So practically, if you're loading from a kubeconfig you're going to get the import. Might still be a good cleanup to make though.

```release-note
NONE
```
