### PR TITLE
add example for kubectl config unset, this will help user use

### DIFF
--- a/pkg/kubectl/cmd/config/unset.go
+++ b/pkg/kubectl/cmd/config/unset.go
@@ -35,10 +35,19 @@ type unsetOptions struct {
 	propertyName string
 }
 
-var unset_long = templates.LongDesc(`
+var (
+	unsetLong = templates.LongDesc(`
 	Unsets an individual value in a kubeconfig file
 
 	PROPERTY_NAME is a dot delimited name where each token represents either an attribute name or a map key.  Map keys may not contain dots.`)
+
+	unsetExample = templates.Examples(`
+		# Unset the current-context.
+		kubectl config unset current-context
+
+		# Unset namespace in foo context.
+		kubectl config unset contexts.foo.namespace`)
+)
 
 func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobra.Command {
 	options := &unsetOptions{configAccess: configAccess}
@@ -46,8 +55,9 @@ func NewCmdConfigUnset(out io.Writer, configAccess clientcmd.ConfigAccess) *cobr
 	cmd := &cobra.Command{
 		Use: "unset PROPERTY_NAME",
 		DisableFlagsInUseLine: true,
-		Short: i18n.T("Unsets an individual value in a kubeconfig file"),
-		Long:  unset_long,
+		Short:   i18n.T("Unsets an individual value in a kubeconfig file"),
+		Long:    unsetLong,
+		Example: unsetExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(options.complete(cmd, args))
 			cmdutil.CheckErr(options.run(out))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
