### PR TITLE
Don't clobber KUBE_VERBOSE in verify script

### DIFF
--- a/hack/verify-staging-godeps.sh
+++ b/hack/verify-staging-godeps.sh
@@ -19,4 +19,4 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
-KUBE_VERBOSE=3 KUBE_RUN_COPY_OUTPUT=N ${KUBE_ROOT}/hack/update-staging-godeps.sh -d -f "$@"
+KUBE_VERBOSE="${KUBE_VERBOSE:-3}" KUBE_RUN_COPY_OUTPUT=N ${KUBE_ROOT}/hack/update-staging-godeps.sh -d -f "$@"


### PR DESCRIPTION
**What this PR does / why we need it**:
Don't clobber the KUBE_VERBOSE env var if set (but default it to 3 for the verify script if not set).

**Release note**:
```release-note
NONE
```
