### PR TITLE
Correct clean up actions in e2e tests

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//vendor/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1:go_default_library",
     ],
 )

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"sync"
 	"testing"
 	"time"
 
@@ -249,55 +248,13 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	}
 })
 
-type CleanupActionHandle *int
-
-var cleanupActionsLock sync.Mutex
-var cleanupActions = map[CleanupActionHandle]func(){}
-
-// AddCleanupAction installs a function that will be called in the event of the
-// whole test being terminated.  This allows arbitrary pieces of the overall
-// test to hook into SynchronizedAfterSuite().
-func AddCleanupAction(fn func()) CleanupActionHandle {
-	p := CleanupActionHandle(new(int))
-	cleanupActionsLock.Lock()
-	defer cleanupActionsLock.Unlock()
-	cleanupActions[p] = fn
-	return p
-}
-
-// RemoveCleanupAction removes a function that was installed by
-// AddCleanupAction.
-func RemoveCleanupAction(p CleanupActionHandle) {
-	cleanupActionsLock.Lock()
-	defer cleanupActionsLock.Unlock()
-	delete(cleanupActions, p)
-}
-
-// RunCleanupActions runs all functions installed by AddCleanupAction.  It does
-// not remove them (see RemoveCleanupAction) but it does run unlocked, so they
-// may remove themselves.
-func RunCleanupActions() {
-	list := []func(){}
-	func() {
-		cleanupActionsLock.Lock()
-		defer cleanupActionsLock.Unlock()
-		for _, fn := range cleanupActions {
-			list = append(list, fn)
-		}
-	}()
-	// Run unlocked.
-	for _, fn := range list {
-		fn()
-	}
-}
-
 // Similar to SynchornizedBeforeSuite, we want to run some operations only once (such as collecting cluster logs).
 // Here, the order of functions is reversed; first, the function which runs everywhere,
 // and then the function that only runs on the first Ginkgo node.
 var _ = ginkgo.SynchronizedAfterSuite(func() {
 	// Run on all Ginkgo nodes
 	framework.Logf("Running AfterSuite actions on all node")
-	RunCleanupActions()
+	framework.RunCleanupActions()
 }, func() {
 	// Run only Ginkgo on node 1
 	framework.Logf("Running AfterSuite actions on node 1")

--- a/test/e2e/storage/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/persistent_volumes-vsphere.go
@@ -131,7 +131,8 @@ var _ = SIGDescribe("PersistentVolumes:vsphere", func() {
 		3. Delete Volume (vmdk)
 	*/
 	framework.AddCleanupAction(func() {
-		if len(volumePath) > 0 {
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(ns) > 0 && len(volumePath) > 0 {
 			framework.ExpectNoError(waitForVSphereDiskToDetach(vsp, volumePath, node))
 			vsp.DeleteVolume(volumePath)
 		}

--- a/test/e2e/storage/vsphere_scale.go
+++ b/test/e2e/storage/vsphere_scale.go
@@ -114,8 +114,11 @@ var _ = SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 		Remove labels from all the nodes
 	*/
 	framework.AddCleanupAction(func() {
-		for _, node := range nodes.Items {
-			framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(namespace) > 0 {
+			for _, node := range nodes.Items {
+				framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
+			}
 		}
 	})
 

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -73,7 +73,7 @@ var _ = SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 			framework.Failf("Unable to find ready and schedulable Node")
 		}
 		if !isNodeLabeled {
-			nodeLabelValue := "vsphere_e2e_" + string(uuid.NewUUID())
+			nodeLabelValue = "vsphere_e2e_" + string(uuid.NewUUID())
 			nodeKeyValueLabel = make(map[string]string)
 			nodeKeyValueLabel["vsphere_e2e_label"] = nodeLabelValue
 			framework.AddOrUpdateLabelOnNode(client, nodeName, "vsphere_e2e_label", nodeLabelValue)
@@ -81,7 +81,8 @@ var _ = SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 		}
 	})
 	framework.AddCleanupAction(func() {
-		if len(nodeLabelValue) > 0 {
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(namespace) > 0 && len(nodeLabelValue) > 0 {
 			framework.RemoveLabelOffNode(client, nodeName, "vsphere_e2e_label")
 		}
 	})

--- a/test/e2e/storage/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere_volume_placement.go
@@ -77,11 +77,14 @@ var _ = SIGDescribe("Volume Placement", func() {
 		2. Delete VMDK volume
 	*/
 	framework.AddCleanupAction(func() {
-		if len(node1KeyValueLabel) > 0 {
-			framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
-		}
-		if len(node2KeyValueLabel) > 0 {
-			framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(ns) > 0 {
+			if len(node1KeyValueLabel) > 0 {
+				framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
+			}
+			if len(node2KeyValueLabel) > 0 {
+				framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
+			}
 		}
 	})
 	/*


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Remove the duplicate "cleanup action" code in `test/e2e/e2e.go`, and use the clean up code in test/e2e/framework instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55505 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
