### PR TITLE
Fix .git rsync filter for prow

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -720,7 +720,7 @@ function kube::build::sync_to_container() {
   # necessary.
   kube::build::rsync \
     --delete \
-    --filter='H /.git/' \
+    --filter='H /.git' \
     --filter='- /.make/' \
     --filter='- /_tmp/' \
     --filter='- /_output/' \


### PR DESCRIPTION
**What this PR does / why we need it**:
The prow bootstrap job uses the [`--separate-git-dir`](https://git-scm.com/docs/git-init#git-init---separate-git-dirltgitdirgt) flag when cloning the target repo. This leaves a text file named `./.git` containing the path to the git dir instead of the typical `./.git/` directory right in the working tree.

This modifies the rsync filter to filter out this file *or* directory, so that jobs that use the build container system aren't tripped up by a text file that points to a directory that doesn't exist in the build container system.

**Release note**:
```release-note
NONE
```
