### PR TITLE
mountPath mitigation in linux pod

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -190,6 +190,13 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			if (strings.HasPrefix(containerPath, "/") || strings.HasPrefix(containerPath, "\\")) && !strings.Contains(containerPath, ":") {
 				containerPath = "c:" + containerPath
 			}
+		} else {
+			p := containerPath
+			if len(p) > 1 && ((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) && p[1] == ':' {
+				// mitigate a windows path when it's form of "D:", "e:\foobar" etc
+				p = strings.Replace(p, "\\", "/", -1)
+				containerPath = "/" + strings.Replace(p, ":", "", -1)
+			}
 		}
 
 		propagation, err := translateMountPropagation(mount.MountPropagation)

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -82,6 +82,11 @@ func TestMakeMounts(t *testing.T) {
 						ReadOnly:  true,
 					},
 					{
+						MountPath: "D:",
+						Name:      "disk",
+						ReadOnly:  false,
+					},
+					{
 						MountPath: "/mnt/path4",
 						Name:      "disk4",
 						ReadOnly:  false,
@@ -107,6 +112,14 @@ func TestMakeMounts(t *testing.T) {
 					ContainerPath:  "/mnt/path3",
 					HostPath:       "/mnt/disk",
 					ReadOnly:       true,
+					SELinuxRelabel: false,
+					Propagation:    runtimeapi.MountPropagation_PROPAGATION_HOST_TO_CONTAINER,
+				},
+				{
+					Name:           "disk",
+					ContainerPath:  "/D",
+					HostPath:       "/mnt/disk",
+					ReadOnly:       false,
 					SELinuxRelabel: false,
 					Propagation:    runtimeapi.MountPropagation_PROPAGATION_HOST_TO_CONTAINER,
 				},
@@ -151,6 +164,12 @@ func TestMakeMounts(t *testing.T) {
 						MountPropagation: &propagationHostToContainer,
 					},
 					{
+						MountPath:        "C:\\foobar",
+						Name:             "disk",
+						ReadOnly:         true,
+						MountPropagation: &propagationHostToContainer,
+					},
+					{
 						MountPath: "/mnt/path4",
 						Name:      "disk4",
 						ReadOnly:  false,
@@ -172,6 +191,14 @@ func TestMakeMounts(t *testing.T) {
 				{
 					Name:           "disk",
 					ContainerPath:  "/mnt/path3",
+					HostPath:       "/mnt/disk",
+					ReadOnly:       true,
+					SELinuxRelabel: false,
+					Propagation:    runtimeapi.MountPropagation_PROPAGATION_HOST_TO_CONTAINER,
+				},
+				{
+					Name:           "disk",
+					ContainerPath:  "/C/foobar",
 					HostPath:       "/mnt/disk",
 					ReadOnly:       true,
 					SELinuxRelabel: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When user specify a windows mountPath, e.g. `D:`, there should be mitigation in pod when it's running on Linux otherwise pod mount would fail. (Note: it's a corner scenario when linux user would use windows mountPath in linux pod)
Below is an example, mountPath `D:` would be turned into `/D/` in linux pod

```
---
kind: Pod
apiVersion: v1
metadata:
  name: nginx-azuredisk
spec:
  containers:
  - image: nginx
    name: nginx-azuredisk
    volumeMounts:
    - name: disk01
      mountPath: 'D:'
  volumes:
  - name: disk01
    persistentVolumeClaim:
      claimName: pvc-azuredisk
```

After pod mounting in Linux, `/D` mountPath is created as a mountPath:

```
root@nginx-azuredisk:/# df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay          30G  4.8G   25G  17% /
tmpfs           6.9G     0  6.9G   0% /dev
tmpfs           6.9G     0  6.9G   0% /sys/fs/cgroup
/dev/sdc        4.8G   10M  4.6G   1% /D
/dev/sda1        30G  4.8G   25G  17% /etc/hosts
shm              64M     0   64M   0% /dev/shm
tmpfs           6.9G   12K  6.9G   1% /run/secrets/kubernetes.io/serviceaccount
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55540

**Special notes for your reviewer**:
@liggitt @thockin @brendanburns

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
none
```

/sig storage