### PR TITLE
Ensure GCE AlphaFeatureGate initialized

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce.go
+++ b/pkg/cloudprovider/providers/gce/gce.go
@@ -240,6 +240,8 @@ func generateCloudConfig(configFile *ConfigFile) (cloudConfig *CloudConfig, err 
 	cloudConfig.TokenSource = google.ComputeTokenSource("")
 	cloudConfig.UseMetadataServer = true
 
+	featureMap := make(map[string]bool)
+	cloudConfig.AlphaFeatureGate = &AlphaFeatureGate{featureMap}
 	if configFile != nil {
 		if configFile.Global.ApiEndpoint != "" {
 			cloudConfig.ApiEndpoint = configFile.Global.ApiEndpoint


### PR DESCRIPTION
If no config file is specified for the controller-manager,
the GCE CloudConfig.AlphaFeatureGate property is not initialized.

This can cause a panic when checking for alpha features in the GCE
provider.

```release-note
NONE 
```

Closes #55544