### PR TITLE
Define un-resolvable of predicate failures for preemption to use

### DIFF
--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -71,8 +71,12 @@ func EmptyMetadataProducer(pod *v1.Pod, nodeNameToInfo map[string]*schedulercach
 	return nil
 }
 
+// PredicateFailureReason represents a failed predicate with:
+// 1. Failure reason
+// 2. If this failure is unresolvable by preemption.
 type PredicateFailureReason interface {
 	GetReason() string
+	IsUnResolvableByPreemption() bool
 }
 
 type GetEquivalencePodFunc func(pod *v1.Pod) interface{}

--- a/plugin/pkg/scheduler/api/types.go
+++ b/plugin/pkg/scheduler/api/types.go
@@ -166,8 +166,16 @@ type ExtenderArgs struct {
 	NodeNames *[]string
 }
 
-// FailedNodesMap represents the filtered out nodes, with node names and failure messages
-type FailedNodesMap map[string]string
+// FailureInfo represents a failure from scheduler includes:
+// 1. Failure message
+// 2. If this failure is unresolvable by preemption
+type FailureInfo struct {
+	FailureMsg                 string
+	IsUnResolvableByPreemption bool
+}
+
+// FailedNodesMap represents the filtered out nodes, with node names and failure information
+type FailedNodesMap map[string]FailureInfo
 
 // ExtenderFilterResult represents the results of a filter call to an extender
 type ExtenderFilterResult struct {
@@ -177,7 +185,7 @@ type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string
-	// Filtered out nodes where the pod can't be scheduled and the failure messages
+	// Filtered out nodes where the pod can't be scheduled and the failure information
 	FailedNodes FailedNodesMap
 	// Error message indicating failure
 	Error string

--- a/plugin/pkg/scheduler/api/v1/types.go
+++ b/plugin/pkg/scheduler/api/v1/types.go
@@ -158,8 +158,18 @@ type ExtenderArgs struct {
 	NodeNames *[]string `json:"nodenames,omitempty"`
 }
 
-// FailedNodesMap represents the filtered out nodes, with node names and failure messages
-type FailedNodesMap map[string]string
+// FailureInfo represents a failure from scheduler includes:
+// 1. Failure message
+// 2. If this failure is unresolvable by preemption
+//   For example, ErrNodeSelectorNotMatch can not be fixed by preempting pods from this node.
+//   So it is a unresolvable failure.
+type FailureInfo struct {
+	FailureMsg                 string `json:"failureMsg,omitempty"`
+	IsUnResolvableByPreemption bool   `json:"isUnResolvableByPreemption,omitempty"`
+}
+
+// FailedNodesMap represents the filtered out nodes, with node names and failure information
+type FailedNodesMap map[string]FailureInfo
 
 // ExtenderFilterResult represents the results of a filter call to an extender
 type ExtenderFilterResult struct {
@@ -169,7 +179,7 @@ type ExtenderFilterResult struct {
 	// Filtered set of nodes where the pod can be scheduled; to be populated
 	// only if ExtenderConfig.NodeCacheCapable == true
 	NodeNames *[]string `json:"nodenames,omitempty"`
-	// Filtered out nodes where the pod can't be scheduled and the failure messages
+	// Filtered out nodes where the pod can't be scheduled and the failure information
 	FailedNodes FailedNodesMap `json:"failedNodes,omitempty"`
 	// Error message indicating failure
 	Error string `json:"error,omitempty"`

--- a/plugin/pkg/scheduler/core/extender_test.go
+++ b/plugin/pkg/scheduler/core/extender_test.go
@@ -130,7 +130,10 @@ func (f *FakeExtender) Filter(pod *v1.Pod, nodes []*v1.Node, nodeNameToInfo map[
 		if fits {
 			filtered = append(filtered, node)
 		} else {
-			failedNodesMap[node.Name] = "FakeExtender failed"
+			failedNodesMap[node.Name] = schedulerapi.FailureInfo{
+				FailureMsg:                 "FakeExtender failed",
+				IsUnResolvableByPreemption: false,
+			}
 		}
 	}
 

--- a/plugin/pkg/scheduler/core/generic_scheduler.go
+++ b/plugin/pkg/scheduler/core/generic_scheduler.go
@@ -291,11 +291,12 @@ func findNodesThatFit(
 				return []*v1.Node{}, FailedPredicateMap{}, err
 			}
 
-			for failedNodeName, failedMsg := range failedMap {
+			for failedNodeName, failedInfo := range failedMap {
 				if _, found := failedPredicateMap[failedNodeName]; !found {
 					failedPredicateMap[failedNodeName] = []algorithm.PredicateFailureReason{}
 				}
-				failedPredicateMap[failedNodeName] = append(failedPredicateMap[failedNodeName], predicates.NewFailureReason(failedMsg))
+				failedPredicateMap[failedNodeName] = append(failedPredicateMap[failedNodeName],
+					predicates.NewFailureReason(failedInfo.FailureMsg, failedInfo.IsUnResolvableByPreemption))
 			}
 			filtered = filteredList
 			if len(filtered) == 0 {
@@ -638,7 +639,7 @@ func nodePassesExtendersForPreemption(
 	filteredNodes := []*v1.Node{nodeInfoCopy.Node()}
 	for _, extender := range extenders {
 		var err error
-		var failedNodesMap map[string]string
+		var failedNodesMap schedulerapi.FailedNodesMap
 		filteredNodes, failedNodesMap, err = extender.Filter(pod, filteredNodes, nodeNameToInfo)
 		if err != nil {
 			return false, err
@@ -730,19 +731,9 @@ func nodesWherePreemptionMightHelp(pod *v1.Pod, nodes []*v1.Node, failedPredicat
 		// to rely less on such assumptions in the code when checking does not impose
 		// significant overhead.
 		for _, failedPredicate := range failedPredicates {
-			switch failedPredicate {
-			case
-				predicates.ErrNodeSelectorNotMatch,
-				predicates.ErrPodNotMatchHostName,
-				predicates.ErrTaintsTolerationsNotMatch,
-				predicates.ErrNodeLabelPresenceViolated,
-				predicates.ErrNodeNotReady,
-				predicates.ErrNodeNetworkUnavailable,
-				predicates.ErrNodeUnschedulable,
-				predicates.ErrNodeUnknownCondition:
+			if failedPredicate.IsUnResolvableByPreemption() {
 				unresolvableReasonExist = true
 				break
-				// TODO(bsalamat): Please add affinity failure cases once we have specific affinity failure errors.
 			}
 		}
 		if !found || !unresolvableReasonExist {

--- a/test/integration/scheduler/extender_test.go
+++ b/test/integration/scheduler/extender_test.go
@@ -147,7 +147,10 @@ func (e *Extender) filterUsingNodeCache(args *schedulerapi.ExtenderArgs) (*sched
 		if fits {
 			nodeSlice = append(nodeSlice, nodeName)
 		} else {
-			failedNodesMap[nodeName] = fmt.Sprintf("extender failed: %s", e.name)
+			failedNodesMap[nodeName] = schedulerapi.FailureInfo{
+				FailureMsg:                 fmt.Sprintf("extender failed: %s", e.name),
+				IsUnResolvableByPreemption: false,
+			}
 		}
 	}
 
@@ -185,7 +188,10 @@ func (e *Extender) Filter(args *schedulerapi.ExtenderArgs) (*schedulerapi.Extend
 			if fits {
 				filtered = append(filtered, node)
 			} else {
-				failedNodesMap[node.Name] = fmt.Sprintf("extender failed: %s", e.name)
+				failedNodesMap[node.Name] = schedulerapi.FailureInfo{
+					FailureMsg:                 fmt.Sprintf("extender failed: %s", e.name),
+					IsUnResolvableByPreemption: false,
+				}
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Define ` un-resolvable` of predicate failures for preemption to use. So that when implementing preemption for extender, we will have a way to decide whether preemption is needed for this extender or not.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55415 
Part 1 of: #51656

**Special notes for your reviewer**:
cc @bsalamat for review

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Define unResolvable in scheduler for preemption to use
```
