### PR TITLE
 Add RequiredOneOf and associated error type for field validation.

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -932,8 +932,7 @@ func validateGlusterfsVolumeSource(glusterfs *core.GlusterfsVolumeSource, fldPat
 func validateFlockerVolumeSource(flocker *core.FlockerVolumeSource, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if len(flocker.DatasetName) == 0 && len(flocker.DatasetUUID) == 0 {
-		//TODO: consider adding a RequiredOneOf() error for this and similar cases
-		allErrs = append(allErrs, field.Required(fldPath, "one of datasetName and datasetUUID is required"))
+		allErrs = append(allErrs, field.RequiredOneOf(fldPath, []string{"datasetName", "datasetUUID"}, "exactly one must have a value"))
 	}
 	if len(flocker.DatasetName) != 0 && len(flocker.DatasetUUID) != 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath, "resource", "datasetName and datasetUUID can not be specified simultaneously"))
@@ -966,7 +965,7 @@ func validateDownwardAPIVolumeFile(file *core.DownwardAPIVolumeFile, fldPath *fi
 	} else if file.ResourceFieldRef != nil {
 		allErrs = append(allErrs, validateContainerResourceFieldSelector(file.ResourceFieldRef, &validContainerResourceFieldPathExpressions, fldPath.Child("resourceFieldRef"), true)...)
 	} else {
-		allErrs = append(allErrs, field.Required(fldPath, "one of fieldRef and resourceFieldRef is required"))
+		allErrs = append(allErrs, field.RequiredOneOf(fldPath, []string{"fieldRef", "resourceFieldRef"}, "exactly one must have a value"))
 	}
 	if file.Mode != nil && (*file.Mode > 0777 || *file.Mode < 0) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("mode"), *file.Mode, fileModeErrorMsg))
@@ -1986,7 +1985,7 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path) field.ErrorLis
 	}
 
 	if numSources == 0 {
-		allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`"))
+		allErrs = append(allErrs, field.RequiredOneOf(fldPath, []string{"fieldRef", "resourceFieldRef", "configMapKeyRef", "secretKeyRef"}, "exactly one must have a value"))
 	} else if len(ev.Value) != 0 {
 		if numSources != 0 {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not be specified when `value` is not empty"))
@@ -2081,7 +2080,7 @@ func ValidateEnvFrom(vars []core.EnvFromSource, fldPath *field.Path) field.Error
 		}
 
 		if numSources == 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `configMapRef` or `secretRef`"))
+			allErrs = append(allErrs, field.RequiredOneOf(fldPath, []string{"configMapRef", "secretRef"}, "exactly one must have a value"))
 		} else if numSources > 1 {
 			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not have more than one field specified at a time"))
 		}

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -2778,8 +2778,8 @@ func TestValidateVolumes(t *testing.T) {
 					},
 				},
 			},
-			errtype:  field.ErrorTypeRequired,
-			errfield: "flocker",
+			errtype:  field.ErrorTypeRequiredOneOf,
+			errfield: "flocker: datasetName,datasetUUID",
 		},
 		{
 			name: "both specified",
@@ -4320,7 +4320,7 @@ func TestValidateEnv(t *testing.T) {
 				Name:      "abc",
 				ValueFrom: &core.EnvVarSource{},
 			}},
-			expectedError: "[0].valueFrom: Invalid value: \"\": must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`",
+			expectedError: "[0].valueFrom: fieldRef,resourceFieldRef,configMapKeyRef,secretKeyRef: One of the values is required: \"\": exactly one must have a value",
 		},
 		{
 			name: "valueFrom.fieldRef and valueFrom.secretKeyRef specified",
@@ -4656,7 +4656,7 @@ func TestValidateEnvFrom(t *testing.T) {
 			envs: []core.EnvFromSource{
 				{},
 			},
-			expectedError: "field: Invalid value: \"\": must specify one of: `configMapRef` or `secretRef`",
+			expectedError: "field: configMapRef,secretRef: One of the values is required: \"\": exactly one must have a value",
 		},
 		{
 			name: "multiple refs",

--- a/pkg/apis/settings/validation/validation.go
+++ b/pkg/apis/settings/validation/validation.go
@@ -40,7 +40,7 @@ func ValidatePodPresetSpec(spec *settings.PodPresetSpec, fldPath *field.Path) fi
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(&spec.Selector, fldPath.Child("selector"))...)
 
 	if spec.Env == nil && spec.EnvFrom == nil && spec.VolumeMounts == nil && spec.Volumes == nil {
-		allErrs = append(allErrs, field.Required(fldPath.Child("volumes", "env", "envFrom", "volumeMounts"), "must specify at least one"))
+		allErrs = append(allErrs, field.RequiredOneOf(fldPath, []string{"volumes", "env", "envFrom", "volumeMounts"}, "exactly one must have a value"))
 	}
 
 	vols, vErrs := apivalidation.ValidateVolumes(spec.Volumes, fldPath.Child("volumes"))

--- a/pkg/apis/settings/validation/validation_test.go
+++ b/pkg/apis/settings/validation/validation_test.go
@@ -56,7 +56,7 @@ func TestValidateEmptyPodPresetItems(t *testing.T) {
 	}
 
 	errList := ValidatePodPreset(emptyPodPreset)
-	if !strings.Contains(errList.ToAggregate().Error(), "must specify at least one") {
+	if !strings.Contains(errList.ToAggregate().Error(), "exactly one must have a value") {
 		t.Fatal("empty pod preset with label selector should return an error")
 	}
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -98,6 +98,9 @@ const (
 	// provided (e.g. empty strings, null values, or empty arrays).  See
 	// Required().
 	ErrorTypeRequired ErrorType = "FieldValueRequired"
+	// ErrorTypeRequiredOneOf is used to report at lease one of required
+	// values that are not provided.
+	ErrorTypeRequiredOneOf ErrorType = "FieldValueRequiredOneOf"
 	// ErrorTypeDuplicate is used to report collisions of values that must be
 	// unique (e.g. unique IDs).  See Duplicate().
 	ErrorTypeDuplicate ErrorType = "FieldValueDuplicate"
@@ -128,6 +131,8 @@ func (t ErrorType) String() string {
 		return "Not found"
 	case ErrorTypeRequired:
 		return "Required value"
+	case ErrorTypeRequiredOneOf:
+		return "One of the values is required"
 	case ErrorTypeDuplicate:
 		return "Duplicate value"
 	case ErrorTypeInvalid:
@@ -156,6 +161,12 @@ func NotFound(field *Path, value interface{}) *Error {
 // values, or empty arrays).
 func Required(field *Path, detail string) *Error {
 	return &Error{ErrorTypeRequired, field.String(), "", detail}
+}
+
+// RequiredOneOf returns a *Error indicating "one of values required".  This is used
+// to report at least one of required values that are not provided.
+func RequiredOneOf(field *Path, fields []string, detail string) *Error {
+	return &Error{ErrorTypeRequiredOneOf, fmt.Sprintf("%s: %s", field.String(), strings.Join(fields, ",")), "", detail}
 }
 
 // Duplicate returns a *Error indicating "duplicate value".  This is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
 Add RequiredOneOf and associated error type for field validation of at least one of fields is required.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
