### PR TITLE
Make sure the ports are valid when parsing portString

### DIFF
--- a/pkg/kubectl/service_basic.go
+++ b/pkg/kubectl/service_basic.go
@@ -89,14 +89,25 @@ func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 	if err != nil {
 		return 0, intstr.FromInt(0), err
 	}
+
+	if errs := validation.IsValidPortNum(port); len(errs) != 0 {
+		return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+	}
+
 	if len(portStringSlice) == 1 {
 		return int32(port), intstr.FromInt(int(port)), nil
 	}
 
 	var targetPort intstr.IntOrString
 	if portNum, err := strconv.Atoi(portStringSlice[1]); err != nil {
+		if errs := validation.IsValidPortName(portStringSlice[1]); len(errs) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+		}
 		targetPort = intstr.FromString(portStringSlice[1])
 	} else {
+		if errs := validation.IsValidPortNum(portNum); len(errs) != 0 {
+			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
+		}
 		targetPort = intstr.FromInt(portNum)
 	}
 	return int32(port), targetPort, nil

--- a/pkg/kubectl/service_basic_test.go
+++ b/pkg/kubectl/service_basic_test.go
@@ -116,6 +116,20 @@ func TestServiceBasicGenerate(t *testing.T) {
 			expectErr: false,
 		},
 		{
+			name:        "invalid-port",
+			tcp:         []string{"65536"},
+			clusterip:   "None",
+			serviceType: v1.ServiceTypeClusterIP,
+			expectErr:   true,
+		},
+		{
+			name:        "invalid-port-mapping",
+			tcp:         []string{"8080:-abc"},
+			clusterip:   "None",
+			serviceType: v1.ServiceTypeClusterIP,
+			expectErr:   true,
+		},
+		{
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
We need ensure the ports are valid when parsing `portString`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
