### PR TITLE
Check RegisterMetricAndTrackRateLimiterUsage error when starting controller

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -247,7 +247,10 @@ func StartControllers(s *options.CloudControllerManagerServer, kubeconfig *restc
 				}
 			}
 
-			routeController := routecontroller.New(routes, client("route-controller"), sharedInformers.Core().V1().Nodes(), s.ClusterName, clusterCIDR)
+			routeController, err := routecontroller.New(routes, client("route-controller"), sharedInformers.Core().V1().Nodes(), s.ClusterName, clusterCIDR)
+			if err != nil {
+				glog.Errorf("Failed to start route controller: %v", err)
+			}
 			go routeController.Run(stop, s.RouteReconciliationPeriod.Duration)
 			time.Sleep(wait.Jitter(s.ControllerStartInterval.Duration, ControllerStartJitter))
 		}

--- a/cmd/kube-controller-manager/app/batch.go
+++ b/cmd/kube-controller-manager/app/batch.go
@@ -32,11 +32,15 @@ func startJobController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}] {
 		return false, nil
 	}
-	go job.NewJobController(
+	jobController, err := job.NewJobController(
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.InformerFactory.Batch().V1().Jobs(),
 		ctx.ClientBuilder.ClientOrDie("job-controller"),
-	).Run(int(ctx.Options.ConcurrentJobSyncs), ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating jobController: %v", err)
+	}
+	go jobController.Run(int(ctx.Options.ConcurrentJobSyncs), ctx.Stop)
 	return true, nil
 }
 

--- a/cmd/kube-controller-manager/app/extensions.go
+++ b/cmd/kube-controller-manager/app/extensions.go
@@ -68,11 +68,15 @@ func startReplicaSetController(ctx ControllerContext) (bool, error) {
 	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}] {
 		return false, nil
 	}
-	go replicaset.NewReplicaSetController(
+	replicasetController, err := replicaset.NewReplicaSetController(
 		ctx.InformerFactory.Extensions().V1beta1().ReplicaSets(),
 		ctx.InformerFactory.Core().V1().Pods(),
 		ctx.ClientBuilder.ClientOrDie("replicaset-controller"),
 		replicaset.BurstReplicas,
-	).Run(int(ctx.Options.ConcurrentRSSyncs), ctx.Stop)
+	)
+	if err != nil {
+		return true, fmt.Errorf("error creating replicasetController: %v", err)
+	}
+	go replicasetController.Run(int(ctx.Options.ConcurrentRSSyncs), ctx.Stop)
 	return true, nil
 }

--- a/pkg/controller/endpoint/BUILD
+++ b/pkg/controller/endpoint/BUILD
@@ -48,6 +48,7 @@ go_test(
         "//pkg/api/v1/endpoints:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -74,9 +74,12 @@ var (
 
 // NewEndpointController returns a new *EndpointController.
 func NewEndpointController(podInformer coreinformers.PodInformer, serviceInformer coreinformers.ServiceInformer,
-	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface) *EndpointController {
+	endpointsInformer coreinformers.EndpointsInformer, client clientset.Interface) (*EndpointController, error) {
 	if client != nil && client.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.CoreV1().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("endpoint_controller", client.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 	e := &EndpointController{
 		client:           client,
@@ -105,7 +108,7 @@ func NewEndpointController(podInformer coreinformers.PodInformer, serviceInforme
 	e.endpointsLister = endpointsInformer.Lister()
 	e.endpointsSynced = endpointsInformer.Informer().HasSynced
 
-	return e
+	return e, nil
 }
 
 // EndpointController manages selector-based service endpoints.

--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -39,6 +39,7 @@ import (
 	endptspkg "k8s.io/kubernetes/pkg/api/v1/endpoints"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/util/metrics"
 )
 
 var alwaysReady = func() bool { return true }
@@ -137,27 +138,35 @@ type endpointController struct {
 	endpointsStore cache.Store
 }
 
-func newController(url string) *endpointController {
+func newController(url string) (*endpointController, error) {
 	client := clientset.NewForConfigOrDie(&restclient.Config{Host: url, ContentConfig: restclient.ContentConfig{GroupVersion: &legacyscheme.Registry.GroupOrDie(v1.GroupName).GroupVersion}})
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
-	endpoints := NewEndpointController(informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Services(),
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("endpoint_controller")
+	endpoints, err := NewEndpointController(informerFactory.Core().V1().Pods(), informerFactory.Core().V1().Services(),
 		informerFactory.Core().V1().Endpoints(), client)
+	if err != nil {
+		return nil, err
+	}
 	endpoints.podsSynced = alwaysReady
 	endpoints.servicesSynced = alwaysReady
 	endpoints.endpointsSynced = alwaysReady
-	return &endpointController{
+	epc := &endpointController{
 		endpoints,
 		informerFactory.Core().V1().Pods().Informer().GetStore(),
 		informerFactory.Core().V1().Services().Informer().GetStore(),
 		informerFactory.Core().V1().Endpoints().Informer().GetStore(),
 	}
+	return epc, nil
 }
 
 func TestSyncEndpointsItemsPreserveNoSelector(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -181,7 +190,10 @@ func TestSyncEndpointsExistingNilSubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -205,7 +217,10 @@ func TestSyncEndpointsExistingEmptySubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -229,7 +244,10 @@ func TestSyncEndpointsNewNoSubsets(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
 		Spec: v1.ServiceSpec{
@@ -245,7 +263,10 @@ func TestCheckLeftoverEndpoints(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, _ := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -271,7 +292,10 @@ func TestSyncEndpointsProtocolTCP(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -312,7 +336,10 @@ func TestSyncEndpointsProtocolUDP(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -353,7 +380,10 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAll(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -390,7 +420,10 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllNotReady(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -427,7 +460,10 @@ func TestSyncEndpointsItemsEmptySelectorSelectsAllMixed(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -465,7 +501,10 @@ func TestSyncEndpointsItemsPreexisting(t *testing.T) {
 	ns := "bar"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -505,7 +544,10 @@ func TestSyncEndpointsItemsPreexistingIdentical(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			ResourceVersion: "1",
@@ -533,7 +575,10 @@ func TestSyncEndpointsItems(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	addPods(endpoints.podStore, ns, 3, 2, 0)
 	addPods(endpoints.podStore, "blah", 5, 2, 0) // make sure these aren't found!
 	endpoints.serviceStore.Add(&v1.Service{
@@ -574,7 +619,10 @@ func TestSyncEndpointsItemsWithLabels(t *testing.T) {
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	addPods(endpoints.podStore, ns, 3, 2, 0)
 	serviceLabels := map[string]string{"foo": "bar"}
 	endpoints.serviceStore.Add(&v1.Service{
@@ -620,7 +668,10 @@ func TestSyncEndpointsItemsPreexistingLabelsChange(t *testing.T) {
 	ns := "bar"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -683,7 +734,10 @@ func TestWaitsForAllInformersToBeSynced2(t *testing.T) {
 			ns := "other"
 			testServer, endpointsHandler := makeTestServer(t, ns)
 			defer testServer.Close()
-			endpoints := newController(testServer.URL)
+			endpoints, err := newController(testServer.URL)
+			if err != nil {
+				t.Fatalf("error creating endpoint controller: %v", err)
+			}
 			addPods(endpoints.podStore, ns, 1, 1, 0)
 			service := &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
@@ -723,7 +777,10 @@ func TestSyncEndpointsHeadlessService(t *testing.T) {
 	ns := "headless"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -764,7 +821,10 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseFail
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -800,7 +860,10 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyNeverAndPhaseSucc
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",
@@ -836,7 +899,10 @@ func TestSyncEndpointsItemsExcludeNotReadyPodsWithRestartPolicyOnFailureAndPhase
 	ns := "other"
 	testServer, endpointsHandler := makeTestServer(t, ns)
 	defer testServer.Close()
-	endpoints := newController(testServer.URL)
+	endpoints, err := newController(testServer.URL)
+	if err != nil {
+		t.Fatalf("error creating endpoint controller: %v", err)
+	}
 	endpoints.endpointsStore.Add(&v1.Endpoints{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "foo",

--- a/pkg/controller/job/BUILD
+++ b/pkg/controller/job/BUILD
@@ -51,6 +51,7 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -250,7 +250,10 @@ func NewNodeController(
 		})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if allocateNodeCIDRs {

--- a/pkg/controller/podgc/gc_controller.go
+++ b/pkg/controller/podgc/gc_controller.go
@@ -51,9 +51,12 @@ type PodGCController struct {
 	terminatedPodThreshold int
 }
 
-func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInformer, terminatedPodThreshold int) *PodGCController {
+func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInformer, terminatedPodThreshold int) (*PodGCController, error) {
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("gc_controller", kubeClient.Core().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 	gcc := &PodGCController{
 		kubeClient:             kubeClient,
@@ -67,7 +70,7 @@ func NewPodGC(kubeClient clientset.Interface, podInformer coreinformers.PodInfor
 	gcc.podLister = podInformer.Lister()
 	gcc.podListerSynced = podInformer.Informer().HasSynced
 
-	return gcc
+	return gcc, nil
 }
 
 func (gcc *PodGCController) Run(stop <-chan struct{}) {

--- a/pkg/controller/replicaset/BUILD
+++ b/pkg/controller/replicaset/BUILD
@@ -54,6 +54,7 @@ go_test(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/securitycontext:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/controller/route/BUILD
+++ b/pkg/controller/route/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//pkg/cloudprovider:go_default_library",
         "//pkg/cloudprovider/providers/fake:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -65,9 +65,12 @@ type RouteController struct {
 	recorder         record.EventRecorder
 }
 
-func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInformer coreinformers.NodeInformer, clusterName string, clusterCIDR *net.IPNet) *RouteController {
+func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInformer coreinformers.NodeInformer, clusterName string, clusterCIDR *net.IPNet) (*RouteController, error) {
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		err := metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if clusterCIDR == nil {
@@ -89,7 +92,7 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInform
 		recorder:         recorder,
 	}
 
-	return rc
+	return rc, nil
 }
 
 func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -162,12 +162,16 @@ func dcSetup(t *testing.T) (*httptest.Server, framework.CloseFunc, *replicaset.R
 	if err != nil {
 		t.Fatalf("error creating Deployment controller: %v", err)
 	}
-	rm := replicaset.NewReplicaSetController(
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("replicaset_controller")
+	rm, err := replicaset.NewReplicaSetController(
 		informers.Extensions().V1beta1().ReplicaSets(),
 		informers.Core().V1().Pods(),
 		clientset.NewForConfigOrDie(restclient.AddUserAgent(&config, "replicaset-controller")),
 		replicaset.BurstReplicas,
 	)
+	if err != nil {
+		t.Fatalf("error creating replicaset controller: %v", err)
+	}
 	return s, closeFn, rm, dc, informers, clientSet
 }
 

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/pborman/uuid"
 
+	"fmt"
 	apps "k8s.io/api/apps/v1beta1"
 	autoscaling "k8s.io/api/autoscaling/v1"
 	certificates "k8s.io/api/certificates/v1beta1"
@@ -119,7 +120,7 @@ type Config struct {
 }
 
 // NewMasterComponents creates, initializes and starts master components based on the given config.
-func NewMasterComponents(c *Config) *MasterComponents {
+func NewMasterComponents(c *Config) (*MasterComponents, error) {
 	m, s, closeFn := startMasterOrDie(c.MasterConfig, nil, nil)
 	// TODO: Allow callers to pipe through a different master url and create a client/start components using it.
 	glog.Infof("Master %+v", s.URL)
@@ -127,7 +128,10 @@ func NewMasterComponents(c *Config) *MasterComponents {
 	clientset := clientset.NewForConfigOrDie(&restclient.Config{Host: s.URL, ContentConfig: restclient.ContentConfig{GroupVersion: testapi.Groups[v1.GroupName].GroupVersion()}, QPS: c.QPS, Burst: c.Burst})
 	rcStopCh := make(chan struct{})
 	informerFactory := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	controllerManager := replicationcontroller.NewReplicationManager(informerFactory.Core().V1().Pods(), informerFactory.Core().V1().ReplicationControllers(), clientset, c.Burst)
+	controllerManager, err := replicationcontroller.NewReplicationManager(informerFactory.Core().V1().Pods(), informerFactory.Core().V1().ReplicationControllers(), clientset, c.Burst)
+	if err != nil {
+		return nil, fmt.Errorf("error creating replicationcontroller: %v", err)
+	}
 
 	// TODO: Support events once we can cleanly shutdown an event recorder.
 	controllerManager.SetEventRecorder(&record.FakeRecorder{})
@@ -135,7 +139,7 @@ func NewMasterComponents(c *Config) *MasterComponents {
 		informerFactory.Start(rcStopCh)
 		go controllerManager.Run(goruntime.NumCPU(), rcStopCh)
 	}
-	return &MasterComponents{
+	masterComponents := &MasterComponents{
 		ApiServer:         s,
 		KubeMaster:        m,
 		ClientSet:         clientset,
@@ -143,6 +147,7 @@ func NewMasterComponents(c *Config) *MasterComponents {
 		CloseFn:           closeFn,
 		rcStopCh:          rcStopCh,
 	}
+	return masterComponents, nil
 }
 
 // alwaysAllow always allows an action

--- a/test/integration/quota/BUILD
+++ b/test/integration/quota/BUILD
@@ -23,6 +23,7 @@ go_test(
         "//pkg/controller/resourcequota:go_default_library",
         "//pkg/quota/generic:go_default_library",
         "//pkg/quota/install:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//plugin/pkg/admission/resourcequota:go_default_library",
         "//plugin/pkg/admission/resourcequota/apis/resourcequota:go_default_library",
         "//test/integration/framework:go_default_library",

--- a/test/integration/quota/quota_test.go
+++ b/test/integration/quota/quota_test.go
@@ -42,6 +42,7 @@ import (
 	resourcequotacontroller "k8s.io/kubernetes/pkg/controller/resourcequota"
 	"k8s.io/kubernetes/pkg/quota/generic"
 	quotainstall "k8s.io/kubernetes/pkg/quota/install"
+	"k8s.io/kubernetes/pkg/util/metrics"
 	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota"
 	resourcequotaapi "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -90,12 +91,16 @@ func TestQuota(t *testing.T) {
 	defer close(controllerCh)
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	rm := replicationcontroller.NewReplicationManager(
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("replication_controller")
+	rm, err := replicationcontroller.NewReplicationManager(
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset,
 		replicationcontroller.BurstReplicas,
 	)
+	if err != nil {
+		t.Fatalf("error creating replicationcontroller: %v", err)
+	}
 	rm.SetEventRecorder(&record.FakeRecorder{})
 	go rm.Run(3, controllerCh)
 
@@ -285,12 +290,16 @@ func TestQuotaLimitedResourceDenial(t *testing.T) {
 	defer close(controllerCh)
 
 	informers := informers.NewSharedInformerFactory(clientset, controller.NoResyncPeriodFunc())
-	rm := replicationcontroller.NewReplicationManager(
+	metrics.UnregisterMetricAndUntrackRateLimiterUsage("replication_controller")
+	rm, err := replicationcontroller.NewReplicationManager(
 		informers.Core().V1().Pods(),
 		informers.Core().V1().ReplicationControllers(),
 		clientset,
 		replicationcontroller.BurstReplicas,
 	)
+	if err != nil {
+		t.Fatalf("error creating replicationcontroller: %v", err)
+	}
 	rm.SetEventRecorder(&record.FakeRecorder{})
 	go rm.Run(3, controllerCh)
 

--- a/test/integration/replicaset/BUILD
+++ b/test/integration/replicaset/BUILD
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller/replicaset:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/test/integration/replicationcontroller/BUILD
+++ b/test/integration/replicationcontroller/BUILD
@@ -17,6 +17,7 @@ go_test(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller/replication:go_default_library",
+        "//pkg/util/metrics:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

similar to #53592, fix rest part controller when use RegisterMetricAndTrackRateLimiterUsage 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # complements #53571

**Special notes for your reviewer**:

/assign @deads2k 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
