### PR TITLE
Fix ipvs/proxy getLocalIPs inconsistency with iptables/proxy

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -798,7 +798,7 @@ func getLocalIPs(endpointsMap proxyEndpointsMap) map[types.NamespacedName]sets.S
 	for svcPortName := range endpointsMap {
 		for _, ep := range endpointsMap[svcPortName] {
 			if ep.isLocal {
-				// If the endpoint has a bad format, ipPart() will log an
+				// If the endpoint has a bad format, utilproxy.IPPart() will log an
 				// error and ep.IPPart() will return a null string.
 				if ip := ep.IPPart(); ip != "" {
 					nsn := svcPortName.NamespacedName

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -1264,6 +1264,14 @@ func Test_getLocalIPs(t *testing.T) {
 			{Namespace: "ns2", Name: "ep2"}: sets.NewString("2.2.2.2", "2.2.2.22", "2.2.2.3"),
 			{Namespace: "ns4", Name: "ep4"}: sets.NewString("4.4.4.4", "4.4.4.6"),
 		},
+	}, {
+		// Case[5]: named port local and bad endpoints IP
+		endpointsMap: map[proxy.ServicePortName][]*endpointsInfo{
+			makeServicePortName("ns1", "ep1", "p11"): {
+				{endpoint: "bad ip:11", isLocal: true},
+			},
+		},
+		expected: map[types.NamespacedName]sets.String{},
 	}}
 
 	for tci, tc := range testCases {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1466,14 +1466,18 @@ func writeLine(buf *bytes.Buffer, words ...string) {
 
 func getLocalIPs(endpointsMap proxyEndpointsMap) map[types.NamespacedName]sets.String {
 	localIPs := make(map[types.NamespacedName]sets.String)
-	for svcPort := range endpointsMap {
-		for _, ep := range endpointsMap[svcPort] {
+	for svcPortName := range endpointsMap {
+		for _, ep := range endpointsMap[svcPortName] {
 			if ep.isLocal {
-				nsn := svcPort.NamespacedName
-				if localIPs[nsn] == nil {
-					localIPs[nsn] = sets.NewString()
+				// If the endpoint has a bad format, utilproxy.IPPart() will log an
+				// error and ep.IPPart() will return a null string.
+				if ip := ep.IPPart(); ip != "" {
+					nsn := svcPortName.NamespacedName
+					if localIPs[nsn] == nil {
+						localIPs[nsn] = sets.NewString()
+					}
+					localIPs[nsn].Insert(ip)
 				}
-				localIPs[nsn].Insert(ep.IPPart()) // just the IP part
 			}
 		}
 	}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -2017,6 +2017,14 @@ func Test_getLocalIPs(t *testing.T) {
 			{Namespace: "ns2", Name: "ep2"}: sets.NewString("2.2.2.2", "2.2.2.22", "2.2.2.3"),
 			{Namespace: "ns4", Name: "ep4"}: sets.NewString("4.4.4.4", "4.4.4.6"),
 		},
+	}, {
+		// Case[5]: named port local and bad endpoints IP
+		endpointsMap: map[proxy.ServicePortName][]*endpointsInfo{
+			makeServicePortName("ns1", "ep1", "p11"): {
+				{endpoint: "bad ip:11", isLocal: true},
+			},
+		},
+		expected: map[types.NamespacedName]sets.String{},
 	}}
 
 	for tci, tc := range testCases {

--- a/pkg/proxy/util/endpoints.go
+++ b/pkg/proxy/util/endpoints.go
@@ -32,12 +32,17 @@ func IPPart(s string) string {
 		return s
 	}
 	// Must be IP:port
-	ip, _, err := net.SplitHostPort(s)
+	host, _, err := net.SplitHostPort(s)
 	if err != nil {
 		glog.Errorf("Error parsing '%s': %v", s, err)
 		return ""
 	}
-	return ip
+	// Check if host string is a valid IP address
+	if ip := net.ParseIP(host); ip != nil {
+		glog.Errorf("invalid IP part '%s'", host)
+		return host
+	}
+	return ""
 }
 
 // ToCIDR returns a host address of the form <ip-address>/32 for

--- a/pkg/proxy/util/endpoints_test.go
+++ b/pkg/proxy/util/endpoints_test.go
@@ -35,6 +35,7 @@ func TestIPPart(t *testing.T) {
 		{"[2001:db8::2:2]:9999", "2001:db8::2:2", noError},
 		{"1.2.3.4::9999", "", "too many colons"},
 		{"1.2.3.4:[0]", "", "unexpected '[' in address"},
+		{"1.2.3:8080", "", "invalid ip part"},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* Fix ipvs/proxy `getLocalIPs()` inconsistency with iptables/proxy

* validate the ip address before pkg/proxy/util IPPart() return ip string.

**Which issue(s) this PR fixes** :
Fixes #55612

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
