### PR TITLE
MountPath: return invalid error when linux absolute path contain ':'

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1964,6 +1964,10 @@ func ValidateVolumeMounts(mounts []core.VolumeMount, volumes sets.String, contai
 			if len(p) < 2 || ((p[0] < 'A' || p[0] > 'Z') && (p[0] < 'a' || p[0] > 'z')) || p[1] != ':' {
 				allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must be an absolute path"))
 			}
+		} else {
+			if strings.Contains(mnt.MountPath, ":") {
+				allErrs = append(allErrs, field.Invalid(idxPath.Child("mountPath"), mnt.MountPath, "must not contain ':'"))
+			}
 		}
 		mountpoints.Insert(mnt.MountPath)
 		if len(mnt.SubPath) > 0 {

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3812,6 +3812,7 @@ func TestValidateVolumeMounts(t *testing.T) {
 		"name not found":                         {{Name: "", MountPath: "/foo"}},
 		"empty mountpath":                        {{Name: "abc", MountPath: ""}},
 		"relative mountpath":                     {{Name: "abc", MountPath: "bar"}},
+		"contain ':' in linux absolute path":     {{Name: "abc", MountPath: "/foo:bar"}},
 		"mountpath collision":                    {{Name: "foo", MountPath: "/path/a"}, {Name: "bar", MountPath: "/path/a"}},
 		"absolute subpath":                       {{Name: "abc", MountPath: "/bar", SubPath: "/baz"}},
 		"windows absolute subpath":               {{Name: "abc", MountPath: "D", SubPath: ""}},


### PR DESCRIPTION
To avoid people write MountPath like this `/host/proc:ro,rslave`.

```
volumeMounts:
        - mountPath: /host/proc:ro,rslave
          name: procfs
```
Mount options in above mount path can take effect, although it is not recommended.