### PR TITLE
GKE misc fixes

### DIFF
--- a/cluster/addons/rbac/legacy-kubelet-user-disable/kubelet-binding.yaml
+++ b/cluster/addons/rbac/legacy-kubelet-user-disable/kubelet-binding.yaml
@@ -10,5 +10,8 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:node
+  name: system:node-bootstrapper
 subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet

--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -273,11 +273,6 @@ if [[ -n "${DISABLE_DOCKER_LIVE_RESTORE:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} DISABLE_DOCKER_LIVE_RESTORE"
 fi
 
-# Override default docker storage driver.
-if [[ -n "${DOCKER_STORAGE_DRIVER:-}" ]]; then
-  PROVIDER_VARS="${PROVIDER_VARS:-} DOCKER_STORAGE_DRIVER"
-fi
-
 # Override default GLBC image
 if [[ -n "${GCE_GLBC_IMAGE:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} GCE_GLBC_IMAGE"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -310,11 +310,6 @@ if [[ -n "${DISABLE_DOCKER_LIVE_RESTORE:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} DISABLE_DOCKER_LIVE_RESTORE"
 fi
 
-# Override default docker storage driver.
-if [[ -n "${DOCKER_STORAGE_DRIVER:-}" ]]; then
-  PROVIDER_VARS="${PROVIDER_VARS:-} DOCKER_STORAGE_DRIVER"
-fi
-
 # Override default GLBC image
 if [[ -n "${GCE_GLBC_IMAGE:-}" ]]; then
   PROVIDER_VARS="${PROVIDER_VARS:-} GCE_GLBC_IMAGE"

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -852,12 +852,6 @@ function assemble-docker-flags {
     docker_opts+=" --live-restore=false"
   fi
 
-  # Override docker storage driver if the environment variable is set
-
-  if [[ -n "${DOCKER_STORAGE_DRIVER:-}" ]]; then
-    docker_opts+=" --storage-driver=${DOCKER_STORAGE_DRIVER}"
-  fi
-
   echo "DOCKER_OPTS=\"${docker_opts} ${EXTRA_DOCKER_OPTS:-}\"" > /etc/default/docker
 
   if [[ "${use_net_plugin}" == "true" ]]; then


### PR DESCRIPTION

gce: readd node-bootstrap to kubelet user 
We still need to be able to create and read CSRs from the kubelet user.

revert #55512

Fixes https://github.com/kubernetes/kubernetes/issues/55189

```release-note
NONE
```
