### PR TITLE
Update get.go to use server-side printing

### DIFF
--- a/pkg/kubectl/cmd/resource/BUILD
+++ b/pkg/kubectl/cmd/resource/BUILD
@@ -21,11 +21,13 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -355,6 +355,11 @@ func hasCondition(conditions []metav1beta1.TableRowCondition, t metav1beta1.RowC
 // DecorateTable if you receive a table from a remote server before calling PrintTable.
 func PrintTable(table *metav1beta1.Table, output io.Writer, options PrintOptions) error {
 	if !options.NoHeaders {
+		// avoid printing headers if we have no rows to display
+		if len(table.Rows) == 0 {
+			return nil
+		}
+
 		first := true
 		for _, column := range table.ColumnDefinitions {
 			if !options.Wide && column.Priority != 0 {
@@ -413,7 +418,6 @@ func DecorateTable(table *metav1beta1.Table, options PrintOptions) error {
 		for i := range columns {
 			if columns[i].Format == "name" && columns[i].Type == "string" {
 				nameColumn = i
-				fmt.Printf("found name column: %d\n", i)
 				break
 			}
 		}


### PR DESCRIPTION
Addresses part of https://github.com/kubernetes/kubernetes/issues/58536
Adds support for server-side changes implemented in https://github.com/kubernetes/kubernetes/pull/40848 and updated in https://github.com/kubernetes/kubernetes/pull/59059

@deads2k per our discussion, opening this as a separate PR.
This wires through a per-request use of `as=Table;...` header parameters 
using the resource builder from the `kube get` command.



#### Items to consider going forward:

- [ ] Figure out how to handle sorting when dealing with multiple Table objects from the server
- [ ] Figure out sorting when dealing with a mixed response from the server consisting of Tables and normal resources (`--sort-by` is handled in this PR by falling back to old behavior)
-  [ ] Filtering: How should we filter Table objects? Separate filter for rows? Filter on jsonpath? We have access to partial object metadata for each table row - not enough to know how to filter pods, for example but we could request that the original object be included along with each Table.Row by adding an `includeObject` param in the client request.

#### Resources that do not yet support Table output

- [x] Namespaces
- [x] Services
- [ ] Service catalog resources: https://github.com/kubernetes-incubator/service-catalog/blob/master/pkg/apis/servicecatalog/v1beta1/types.go

**Release note**:
```release-note
NONE
```
