### PR TITLE
Node e2e: add a cloud-init script to disable live-restore in node e2e test

### DIFF
--- a/test/e2e_node/jenkins/cos-init-disable-live-restore.yaml
+++ b/test/e2e_node/jenkins/cos-init-disable-live-restore.yaml
@@ -1,0 +1,23 @@
+#cloud-config
+#
+# This cloud-init configuration file disables Docker live-restore.
+
+runcmd:
+  - cp /usr/lib/systemd/system/docker.service /etc/systemd/system/docker.service
+  - sed -i '/^ExecStart=\/usr\/bin\/dockerd/ s/$/ --live-restore=false/' /etc/systemd/system/docker.service
+  - systemctl daemon-reload
+  - systemctl restart docker
+  - mount /tmp /tmp -o remount,exec,suid
+  - usermod -a -G docker jenkins
+  - mkdir -p /var/lib/kubelet
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs
+  - mount --bind /home/kubernetes/containerized_mounter/ /home/kubernetes/containerized_mounter/
+  - mount -o remount, exec /home/kubernetes/containerized_mounter/
+  - wget https://dl.k8s.io/gci-mounter/mounter.tar -O /tmp/mounter.tar
+  - tar xvf /tmp/mounter.tar -C /home/kubernetes/containerized_mounter/rootfs
+  - mkdir -p /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --rbind /var/lib/kubelet /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --make-rshared /home/kubernetes/containerized_mounter/rootfs/var/lib/kubelet
+  - mount --bind /proc /home/kubernetes/containerized_mounter/rootfs/proc
+  - mount --bind /dev /home/kubernetes/containerized_mounter/rootfs/dev
+  - rm /tmp/mounter.tar


### PR DESCRIPTION
This cloud-init config will be used in tests in https://github.com/kubernetes/test-infra.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
None
```

/assign @yujuhong 
/cc @abgworrall @dchen1107 