### PR TITLE
Automated cherry pick of #52360 #52420

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -52,15 +52,18 @@ readonly systemd_services="kubelet docker"
 # file descriptors for large clusters.
 readonly max_scp_processes=25
 
+# TODO: Get rid of all the sourcing of bash dependencies eventually.
 function setup() {
+  KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
   if [[ -z "${use_custom_instance_list}" ]]; then
-    KUBE_ROOT=$(dirname "${BASH_SOURCE}")/../..
     : ${KUBE_CONFIG_FILE:="config-test.sh"}
     source "${KUBE_ROOT}/cluster/kube-util.sh"
     echo "Detecting project"
     detect-project 2>&1
   elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
     echo "Using 'use_custom_instance_list' with gke, skipping check for LOG_DUMP_SSH_KEY and LOG_DUMP_SSH_USER"
+    # Source the below script for the ssh-to-node utility function.
+    source "${KUBE_ROOT}/cluster/gce/util.sh"
   elif [[ -z "${LOG_DUMP_SSH_KEY:-}" ]]; then
     echo "LOG_DUMP_SSH_KEY not set, but required when using log_dump_custom_get_instances"
     exit 1
@@ -71,7 +74,7 @@ function setup() {
 }
 
 function log-dump-ssh() {
-  if [[ -z "${use_custom_instance_list}" ]]; then
+  if [[ "${gcloud_supported_providers}" =~ "${KUBERNETES_PROVIDER}" ]]; then
     ssh-to-node "$@"
     return
   fi

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -63,7 +63,10 @@ function setup() {
   elif [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
     echo "Using 'use_custom_instance_list' with gke, skipping check for LOG_DUMP_SSH_KEY and LOG_DUMP_SSH_USER"
     # Source the below script for the ssh-to-node utility function.
+    # Hack to save and restore the value of the ZONE env as the script overwrites it.
+    local gke_zone="${ZONE:-}"
     source "${KUBE_ROOT}/cluster/gce/util.sh"
+    ZONE="${gke_zone}"
   elif [[ -z "${LOG_DUMP_SSH_KEY:-}" ]]; then
     echo "LOG_DUMP_SSH_KEY not set, but required when using log_dump_custom_get_instances"
     exit 1


### PR DESCRIPTION
Cherry pick of #52360 #52420 on release-1.6.

#52360: Make log-dump use 'gcloud ssh' for GKE also
#52420: Fix bug with gke in logdump

Fixes the issue where node logs are not archived in GKE 1.6 jobs: https://github.com/kubernetes/test-infra/issues/5480