### PR TITLE
Stop using VersionedObject in resource.Builder, use unstructured

### DIFF
--- a/pkg/kubectl/apply.go
+++ b/pkg/kubectl/apply.go
@@ -72,59 +72,33 @@ func GetModifiedConfiguration(info *resource.Info, annotate bool, codec runtime.
 	// First serialize the object without the annotation to prevent recursion,
 	// then add that serialization to it as the annotation and serialize it again.
 	var modified []byte
-	if info.VersionedObject != nil {
-		// If an object was read from input, use that version.
-		accessor, err := meta.Accessor(info.VersionedObject)
-		if err != nil {
-			return nil, err
-		}
 
-		// Get the current annotations from the object.
-		annots := accessor.GetAnnotations()
-		if annots == nil {
-			annots = map[string]string{}
-		}
+	// Otherwise, use the server side version of the object.
+	accessor := info.Mapping.MetadataAccessor
+	// Get the current annotations from the object.
+	annots, err := accessor.Annotations(info.Object)
+	if err != nil {
+		return nil, err
+	}
 
-		original := annots[api.LastAppliedConfigAnnotation]
-		delete(annots, api.LastAppliedConfigAnnotation)
-		accessor.SetAnnotations(annots)
-		// TODO: this needs to be abstracted - there should be no assumption that versioned object
-		// can be marshalled to JSON.
-		modified, err = runtime.Encode(codec, info.VersionedObject)
-		if err != nil {
-			return nil, err
-		}
+	if annots == nil {
+		annots = map[string]string{}
+	}
 
-		if annotate {
-			annots[api.LastAppliedConfigAnnotation] = string(modified)
-			accessor.SetAnnotations(annots)
-			// TODO: this needs to be abstracted - there should be no assumption that versioned object
-			// can be marshalled to JSON.
-			modified, err = runtime.Encode(codec, info.VersionedObject)
-			if err != nil {
-				return nil, err
-			}
-		}
+	original := annots[api.LastAppliedConfigAnnotation]
+	delete(annots, api.LastAppliedConfigAnnotation)
+	if err := accessor.SetAnnotations(info.Object, annots); err != nil {
+		return nil, err
+	}
 
-		// Restore the object to its original condition.
-		annots[api.LastAppliedConfigAnnotation] = original
-		accessor.SetAnnotations(annots)
-	} else {
-		// Otherwise, use the server side version of the object.
-		accessor := info.Mapping.MetadataAccessor
-		// Get the current annotations from the object.
-		annots, err := accessor.Annotations(info.Object)
-		if err != nil {
-			return nil, err
-		}
+	modified, err = runtime.Encode(codec, info.Object)
+	if err != nil {
+		return nil, err
+	}
 
-		if annots == nil {
-			annots = map[string]string{}
-		}
-
-		original := annots[api.LastAppliedConfigAnnotation]
-		delete(annots, api.LastAppliedConfigAnnotation)
-		if err := accessor.SetAnnotations(info.Object, annots); err != nil {
+	if annotate {
+		annots[api.LastAppliedConfigAnnotation] = string(modified)
+		if err := info.Mapping.MetadataAccessor.SetAnnotations(info.Object, annots); err != nil {
 			return nil, err
 		}
 
@@ -132,24 +106,12 @@ func GetModifiedConfiguration(info *resource.Info, annotate bool, codec runtime.
 		if err != nil {
 			return nil, err
 		}
+	}
 
-		if annotate {
-			annots[api.LastAppliedConfigAnnotation] = string(modified)
-			if err := info.Mapping.MetadataAccessor.SetAnnotations(info.Object, annots); err != nil {
-				return nil, err
-			}
-
-			modified, err = runtime.Encode(codec, info.Object)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		// Restore the object to its original condition.
-		annots[api.LastAppliedConfigAnnotation] = original
-		if err := info.Mapping.MetadataAccessor.SetAnnotations(info.Object, annots); err != nil {
-			return nil, err
-		}
+	// Restore the object to its original condition.
+	annots[api.LastAppliedConfigAnnotation] = original
+	if err := info.Mapping.MetadataAccessor.SetAnnotations(info.Object, annots); err != nil {
+		return nil, err
 	}
 
 	return modified, nil

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -189,13 +189,10 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 	changeCause := f.Command(cmd, false)
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	b := f.NewBuilder()
-	if o.local {
-		b = b.Local()
-	} else {
-		b = b.Unstructured()
-	}
-	b = b.ContinueOnError().
+	b := f.NewBuilder().
+		Unstructured().
+		LocalParam(o.local).
+		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		IncludeUninitialized(includeUninitialized).

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -189,23 +189,31 @@ func (o AnnotateOptions) RunAnnotate(f cmdutil.Factory, cmd *cobra.Command) erro
 	changeCause := f.Command(cmd, false)
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-
-	var b *resource.Builder
-	if o.local {
-		b = f.NewBuilder().
-			Local(f.ClientForMapping)
-	} else {
-		b = f.NewUnstructuredBuilder().
-			LabelSelectorParam(o.selector).
-			ResourceTypeOrNameArgs(o.all, o.resources...).
-			Latest()
-	}
-	r := b.ContinueOnError().
+	b := f.NewBuilder().
+		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		IncludeUninitialized(includeUninitialized).
-		Flatten().
-		Do()
+		Flatten()
+
+	if !o.local {
+		// call this method here, as it requires an api call
+		// and will cause the command to fail when there is
+		// no connection to a server
+		mapper, typer, err := f.UnstructuredObject()
+		if err != nil {
+			return err
+		}
+
+		b = b.LabelSelectorParam(o.selector).
+			Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+			ResourceTypeOrNameArgs(o.all, o.resources...).
+			Latest()
+	} else {
+		b = b.Local(f.ClientForMapping)
+	}
+
+	r := b.Do()
 	if err := r.Err(); err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -198,18 +198,6 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		return err
 	}
 
-	if options.Prune {
-		mapper, _, err := f.UnstructuredObject()
-		if err != nil {
-			return err
-		}
-
-		options.PruneResources, err = parsePruneResources(mapper, cmdutil.GetFlagStringArray(cmd, "prune-whitelist"))
-		if err != nil {
-			return err
-		}
-	}
-
 	// include the uninitialized objects by default if --prune is true
 	// unless explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, options.Prune)
@@ -225,6 +213,13 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		Do()
 	if err := r.Err(); err != nil {
 		return err
+	}
+
+	if options.Prune {
+		options.PruneResources, err = parsePruneResources(r.Mapper().RESTMapper, cmdutil.GetFlagStringArray(cmd, "prune-whitelist"))
+		if err != nil {
+			return err
+		}
 	}
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")

--- a/pkg/kubectl/cmd/apply.go
+++ b/pkg/kubectl/cmd/apply.go
@@ -198,7 +198,7 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 		return err
 	}
 
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,8 @@ func RunApply(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opti
 	// include the uninitialized objects by default if --prune is true
 	// unless explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, options.Prune)
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -126,7 +126,6 @@ func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) 
 		Unstructured().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
-		Latest().
 		Flatten().
 		Do()
 

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -122,13 +122,19 @@ func (o *SetLastAppliedOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) 
 }
 
 func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) error {
-	r := f.NewUnstructuredBuilder().
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
 		Latest().
 		Flatten().
 		Do()
-	err := r.Err()
+	err = r.Err()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -122,29 +122,19 @@ func (o *SetLastAppliedOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) 
 }
 
 func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) error {
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		NamespaceParam(o.Namespace).DefaultNamespace().
 		FilenameParam(o.EnforceNamespace, &o.FilenameOptions).
 		Latest().
 		Flatten().
 		Do()
-	err = r.Err()
-	if err != nil {
-		return err
-	}
 
-	err = r.Visit(func(info *resource.Info, err error) error {
+	err := r.Visit(func(info *resource.Info, err error) error {
 		if err != nil {
 			return err
 		}
-
-		patchBuf, diffBuf, patchType, err := editor.GetApplyPatch(info.VersionedObject, o.Codec)
+		patchBuf, diffBuf, patchType, err := editor.GetApplyPatch(info.Object, o.Codec)
 		if err != nil {
 			return err
 		}
@@ -157,16 +147,16 @@ func (o *SetLastAppliedOptions) Validate(f cmdutil.Factory, cmd *cobra.Command) 
 				return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%v\nfrom server for:", info), info.Source, err)
 			}
 		}
-		oringalBuf, err := kubectl.GetOriginalConfiguration(info.Mapping, info.Object)
+		originalBuf, err := kubectl.GetOriginalConfiguration(info.Mapping, info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr(fmt.Sprintf("retrieving current configuration of:\n%v\nfrom server for:", info), info.Source, err)
 		}
-		if oringalBuf == nil && !o.CreateAnnotation {
+		if originalBuf == nil && !o.CreateAnnotation {
 			return cmdutil.UsageErrorf(cmd, "no last-applied-configuration annotation found on resource: %s, to create the annotation, run the command with --create-annotation", info.Name)
 		}
 
 		//only add to PatchBufferList when changed
-		if !bytes.Equal(cmdutil.StripComments(oringalBuf), cmdutil.StripComments(diffBuf)) {
+		if !bytes.Equal(cmdutil.StripComments(originalBuf), cmdutil.StripComments(diffBuf)) {
 			p := PatchBuffer{Patch: patchBuf, PatchType: patchType}
 			o.PatchBufferList = append(o.PatchBufferList, p)
 			o.InfoList = append(o.InfoList, info)
@@ -234,7 +224,7 @@ func (o *SetLastAppliedOptions) getPatch(info *resource.Info) ([]byte, []byte, e
 	objMap := map[string]map[string]map[string]string{}
 	metadataMap := map[string]map[string]string{}
 	annotationsMap := map[string]string{}
-	localFile, err := runtime.Encode(o.Codec, info.VersionedObject)
+	localFile, err := runtime.Encode(o.Codec, info.Object)
 	if err != nil {
 		return nil, localFile, err
 	}

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -112,7 +112,7 @@ func (o *SetLastAppliedOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) 
 	o.Codec = f.JSONEncoder()
 
 	var err error
-	o.Mapper, o.Typer = f.UnstructuredObject()
+	o.Mapper, o.Typer = f.Object()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/apply_set_last_applied.go
+++ b/pkg/kubectl/cmd/apply_set_last_applied.go
@@ -112,7 +112,7 @@ func (o *SetLastAppliedOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) 
 	o.Codec = f.JSONEncoder()
 
 	var err error
-	o.Mapper, o.Typer, err = f.UnstructuredObject()
+	o.Mapper, o.Typer = f.UnstructuredObject()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -87,13 +87,8 @@ func (o *ViewLastAppliedOptions) Complete(f cmdutil.Factory, args []string) erro
 		return err
 	}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(enforceNamespace, args...).

--- a/pkg/kubectl/cmd/apply_view_last_applied.go
+++ b/pkg/kubectl/cmd/apply_view_last_applied.go
@@ -87,7 +87,13 @@ func (o *ViewLastAppliedOptions) Complete(f cmdutil.Factory, args []string) erro
 		return err
 	}
 
-	r := f.NewUnstructuredBuilder().
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(enforceNamespace, args...).

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -144,6 +144,7 @@ func (p *AttachOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, argsIn [
 	}
 
 	builder := f.NewBuilder().
+		Internal().
 		NamespaceParam(namespace).DefaultNamespace()
 
 	switch len(argsIn) {

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -94,11 +94,13 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
 		Flatten().
 		Do()
+
 	if err := r.Err(); err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/autoscale.go
+++ b/pkg/kubectl/cmd/autoscale.go
@@ -91,6 +91,7 @@ func RunAutoscale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/pkg/kubectl/cmd/certificates.go
+++ b/pkg/kubectl/cmd/certificates.go
@@ -168,6 +168,7 @@ func (options *CertificateOptions) modifyCertificateCondition(f cmdutil.Factory,
 		return err
 	}
 	r := f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		FilenameParam(false, &options.FilenameOptions).
 		ResourceNames("certificatesigningrequest", options.csrNames...).

--- a/pkg/kubectl/cmd/clusterinfo.go
+++ b/pkg/kubectl/cmd/clusterinfo.go
@@ -73,6 +73,7 @@ func RunClusterInfo(f cmdutil.Factory, out io.Writer, cmd *cobra.Command) error 
 
 	// TODO use generalized labels once they are implemented (#341)
 	b := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		LabelSelectorParam("kubernetes.io/cluster-service=true").
 		ResourceTypeOrNameArgs(false, []string{"services"}...).

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -128,7 +128,9 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 	}
 
 	// build the builder
-	o.builder = f.NewBuilder().LocalParam(o.local)
+	o.builder = f.NewBuilder().
+		Internal().
+		LocalParam(o.local)
 	if !o.local {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 		if err != nil {

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -128,22 +128,20 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 	}
 
 	// build the builder
-	o.builder = f.NewBuilder()
+	o.builder = f.NewBuilder().LocalParam(o.local)
 	if !o.local {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 		if err != nil {
 			return err
 		}
-		o.builder = o.builder.Schema(schema)
-	} else {
-		o.builder = o.builder.Local()
+		o.builder.Schema(schema)
 	}
 
 	cmdNamespace, _, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
-	o.builder = o.builder.NamespaceParam(cmdNamespace).
+	o.builder.NamespaceParam(cmdNamespace).
 		ContinueOnError().
 		FilenameParam(false, &o.FilenameOptions).
 		Flatten()

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -136,7 +136,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 		}
 		o.builder = o.builder.Schema(schema)
 	} else {
-		o.builder = o.builder.Local(f.ClientForMapping)
+		o.builder = o.builder.Local()
 	}
 
 	cmdNamespace, _, err := f.DefaultNamespace()

--- a/pkg/kubectl/cmd/convert.go
+++ b/pkg/kubectl/cmd/convert.go
@@ -129,14 +129,14 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.C
 
 	// build the builder
 	o.builder = f.NewBuilder()
-	if o.local {
-		o.builder = o.builder.Local(f.ClientForMapping)
-	} else {
+	if !o.local {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 		if err != nil {
 			return err
 		}
 		o.builder = o.builder.Schema(schema)
+	} else {
+		o.builder = o.builder.Local(f.ClientForMapping)
 	}
 
 	cmdNamespace, _, err := f.DefaultNamespace()

--- a/pkg/kubectl/cmd/convert_test.go
+++ b/pkg/kubectl/cmd/convert_test.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -98,30 +99,30 @@ func TestConvertObject(t *testing.T) {
 		},
 	}
 
-	f, tf, _, _ := cmdtesting.NewAPIFactory()
-	tf.UnstructuredClient = &fake.RESTClient{
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-			return nil, nil
-		}),
-	}
-	tf.Namespace = "test"
-	buf := bytes.NewBuffer([]byte{})
-
 	for _, tc := range testcases {
-		cmd := NewCmdConvert(f, buf)
-		cmd.Flags().Set("filename", tc.file)
-		cmd.Flags().Set("output-version", tc.outputVersion)
-		cmd.Flags().Set("local", "true")
-		cmd.Flags().Set("output", "go-template")
-
 		for _, field := range tc.fields {
-			buf.Reset()
-			tf.Printer, _ = printers.NewTemplatePrinter([]byte(field.template))
-			cmd.Run(cmd, []string{})
-			if buf.String() != field.expected {
-				t.Errorf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputVersion, field.expected, buf.String())
-			}
+			t.Run(fmt.Sprintf("%s %s", tc.name, field), func(t *testing.T) {
+				f, tf, _, _ := cmdtesting.NewAPIFactory()
+				tf.UnstructuredClient = &fake.RESTClient{
+					Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+						t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+						return nil, nil
+					}),
+				}
+				tf.Namespace = "test"
+
+				buf := bytes.NewBuffer([]byte{})
+				cmd := NewCmdConvert(f, buf)
+				cmd.Flags().Set("filename", tc.file)
+				cmd.Flags().Set("output-version", tc.outputVersion)
+				cmd.Flags().Set("local", "true")
+				cmd.Flags().Set("output", "go-template")
+				tf.Printer, _ = printers.NewTemplatePrinter([]byte(field.template))
+				cmd.Run(cmd, []string{})
+				if buf.String() != field.expected {
+					t.Errorf("unexpected output when converting %s to %q, expected: %q, but got %q", tc.file, tc.outputVersion, field.expected, buf.String())
+				}
+			})
 		}
 	}
 }

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -184,12 +184,13 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		return err
 	}
 
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -184,13 +184,8 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		return err
 	}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -205,6 +200,7 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 
 	dryRun := cmdutil.GetFlagBool(cmd, "dry-run")
 	output := cmdutil.GetFlagString(cmd, "output")
+	mapper := r.Mapper().RESTMapper
 
 	count := 0
 	err = r.Visit(func(info *resource.Info, err error) error {

--- a/pkg/kubectl/cmd/create_clusterrole_test.go
+++ b/pkg/kubectl/cmd/create_clusterrole_test.go
@@ -444,13 +444,15 @@ func TestClusterRoleValidate(t *testing.T) {
 	}
 
 	for name, test := range tests {
-		test.clusterRoleOptions.Mapper, _ = f.Object()
-		err := test.clusterRoleOptions.Validate()
-		if test.expectErr && err == nil {
-			t.Errorf("%s: expect error happens, but validate passes.", name)
-		}
-		if !test.expectErr && err != nil {
-			t.Errorf("%s: unexpected error: %v", name, err)
-		}
+		t.Run(name, func(t *testing.T) {
+			test.clusterRoleOptions.Mapper, _ = f.Object()
+			err := test.clusterRoleOptions.Validate()
+			if test.expectErr && err == nil {
+				t.Errorf("%s: expect error happens, but validate passes.", name)
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("%s: unexpected error: %v", name, err)
+			}
+		})
 	}
 }

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -170,14 +170,15 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 	}
 
 	// Set up client based support.
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
 	o.Mapper = mapper
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -169,16 +169,9 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 		return err
 	}
 
-	// Set up client based support.
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
-	o.Mapper = mapper
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -193,6 +186,7 @@ func (o *DeleteOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args 
 		return err
 	}
 	o.Result = r
+	o.Mapper = r.Mapper().RESTMapper
 
 	o.f = f
 	// Set up writer

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -116,10 +116,16 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
 	// include the uninitialized objects by default
 	// unless user explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, true)
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(enforceNamespace, options).

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/pkg/kubectl"
@@ -116,16 +115,11 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 		return cmdutil.UsageErrorf(cmd, "Required resource not specified.")
 	}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	// include the uninitialized objects by default
 	// unless user explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, true)
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().AllNamespaces(allNamespaces).
 		FilenameParam(enforceNamespace, options).
@@ -182,11 +176,7 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 }
 
 func DescribeMatchingResources(f cmdutil.Factory, namespace, rsrc, prefix string, describerSettings *printers.DescriberSettings, out io.Writer, originalError error) error {
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-	r := resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), unstructured.UnstructuredJSONScheme).
+	r := f.NewBuilder().Unstructured().
 		NamespaceParam(namespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(true, rsrc).
 		SingleResourceType().

--- a/pkg/kubectl/cmd/describe.go
+++ b/pkg/kubectl/cmd/describe.go
@@ -176,7 +176,8 @@ func RunDescribe(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, a
 }
 
 func DescribeMatchingResources(f cmdutil.Factory, namespace, rsrc, prefix string, describerSettings *printers.DescriberSettings, out io.Writer, originalError error) error {
-	r := f.NewBuilder().Unstructured().
+	r := f.NewBuilder().
+		Unstructured().
 		NamespaceParam(namespace).DefaultNamespace().
 		ResourceTypeOrNameArgs(true, rsrc).
 		SingleResourceType().

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -408,12 +408,18 @@ func RunDiff(f cmdutil.Factory, diff *DiffProgram, options *DiffOptions, from, t
 
 	printer := Printer{}
 
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
 		Flatten().

--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -280,7 +280,7 @@ func (obj InfoObject) toMap(data []byte) (map[string]interface{}, error) {
 }
 
 func (obj InfoObject) Local() (map[string]interface{}, error) {
-	data, err := runtime.Encode(obj.Encoder, obj.Info.VersionedObject)
+	data, err := runtime.Encode(obj.Encoder, obj.Info.Object)
 	if err != nil {
 		return nil, err
 	}
@@ -408,24 +408,18 @@ func RunDiff(f cmdutil.Factory, diff *DiffProgram, options *DiffOptions, from, t
 
 	printer := Printer{}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	cmdNamespace, enforceNamespace, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
 
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
 		Flatten().
 		Do()
-	err = r.Err()
-	if err != nil {
+	if err := r.Err(); err != nil {
 		return err
 	}
 

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -237,6 +237,7 @@ func (o *DrainOptions) SetupDrain(cmd *cobra.Command, args []string) error {
 	}
 
 	builder := o.Factory.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		ResourceNames("nodes", args...).
 		SingleResourceType().

--- a/pkg/kubectl/cmd/expose.go
+++ b/pkg/kubectl/cmd/expose.go
@@ -127,6 +127,7 @@ func RunExpose(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []stri
 
 	mapper, typer := f.Object()
 	r := f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -308,10 +308,7 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 		if o.local {
 			mapper, _ = f.Object()
 		} else {
-			mapper, _, err = f.UnstructuredObject()
-			if err != nil {
-				return err
-			}
+			mapper, _ = f.UnstructuredObject()
 		}
 		if o.outputFormat != "" {
 			return f.PrintObject(cmd, o.local, mapper, outputObj, o.out)

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -191,25 +191,32 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 	changeCause := f.Command(cmd, false)
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	var b *resource.Builder
-	if o.local {
-		b = f.NewBuilder().
-			Local(f.ClientForMapping)
-	} else {
-		b = f.NewUnstructuredBuilder().
-			LabelSelectorParam(o.selector).
-			ResourceTypeOrNameArgs(o.all, o.resources...).
-			Latest()
-	}
-
-	one := false
-	r := b.ContinueOnError().
+	b := f.NewBuilder().
+		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		IncludeUninitialized(includeUninitialized).
-		Flatten().
-		Do().
-		IntoSingleItemImplied(&one)
+		Flatten()
+
+	if !o.local {
+		// call this method here, as it requires an api call
+		// and will cause the command to fail when there is
+		// no connection to a server
+		mapper, typer, err := f.UnstructuredObject()
+		if err != nil {
+			return err
+		}
+
+		b = b.LabelSelectorParam(o.selector).
+			Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+			ResourceTypeOrNameArgs(o.all, o.resources...).
+			Latest()
+	} else {
+		b = b.Local(f.ClientForMapping)
+	}
+
+	one := false
+	r := b.Do().IntoSingleItemImplied(&one)
 	if err := r.Err(); err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/label.go
+++ b/pkg/kubectl/cmd/label.go
@@ -191,13 +191,9 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 	changeCause := f.Command(cmd, false)
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	b := f.NewBuilder()
-	if o.local {
-		b = b.Local()
-	} else {
-		b = b.Unstructured()
-	}
-	b = b.
+	b := f.NewBuilder().
+		Unstructured().
+		LocalParam(o.local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -304,16 +300,10 @@ func (o *LabelOptions) RunLabel(f cmdutil.Factory, cmd *cobra.Command) error {
 			return nil
 		}
 
-		var mapper meta.RESTMapper
-		if o.local {
-			mapper, _ = f.Object()
-		} else {
-			mapper, _ = f.UnstructuredObject()
-		}
 		if o.outputFormat != "" {
-			return f.PrintObject(cmd, o.local, mapper, outputObj, o.out)
+			return f.PrintObject(cmd, o.local, r.Mapper().RESTMapper, outputObj, o.out)
 		}
-		f.PrintSuccess(mapper, false, o.out, info.Mapping.Resource, info.Name, o.dryrun, dataChangeMsg)
+		f.PrintSuccess(r.Mapper().RESTMapper, false, o.out, info.Mapping.Resource, info.Name, o.dryrun, dataChangeMsg)
 		return nil
 	})
 }

--- a/pkg/kubectl/cmd/logs.go
+++ b/pkg/kubectl/cmd/logs.go
@@ -193,6 +193,7 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Comm
 
 	if o.Object == nil {
 		builder := f.NewBuilder().
+			Internal().
 			NamespaceParam(o.Namespace).DefaultNamespace().
 			SingleResourceType()
 		if o.ResourceArg != "" {

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -153,7 +153,13 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		return fmt.Errorf("unable to parse %q: %v", patch, err)
 	}
 
-	r := f.NewUnstructuredBuilder().
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -222,11 +222,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 			if len(options.OutputFormat) > 0 && options.OutputFormat != "name" {
 				return f.PrintResourceInfoForCommand(cmd, info, out)
 			}
-			mapper, _, err := f.UnstructuredObject()
-			if err != nil {
-				return err
-			}
-			f.PrintSuccess(mapper, options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
+			f.PrintSuccess(r.Mapper().RESTMapper, options.OutputFormat == "name", out, info.Mapping.Resource, info.Name, false, dataChangedMsg)
 
 			// if object was not successfully patched, exit with error code 1
 			if !didPatch {

--- a/pkg/kubectl/cmd/patch.go
+++ b/pkg/kubectl/cmd/patch.go
@@ -153,13 +153,8 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 		return fmt.Errorf("unable to parse %q: %v", patch, err)
 	}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &options.FilenameOptions).
@@ -196,7 +191,6 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 				// Copy the resource info and update with the result of applying the user's patch
 				infoCopy := *info
 				infoCopy.Object = patchedObj
-				infoCopy.VersionedObject = patchedObj
 				if patch, patchType, err := cmdutil.ChangeResourcePatch(&infoCopy, f.Command(cmd, true)); err == nil {
 					if recordedObj, err := helper.Patch(info.Namespace, info.Name, patchType, patch); err != nil {
 						glog.V(4).Infof("error recording reason: %v", err)
@@ -244,7 +238,7 @@ func RunPatch(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 		count++
 
-		originalObjJS, err := runtime.Encode(unstructured.UnstructuredJSONScheme, info.VersionedObject)
+		originalObjJS, err := runtime.Encode(unstructured.UnstructuredJSONScheme, info.Object)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -188,7 +188,8 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		}
 	}
 
-	r := f.NewBuilder().Unstructured().
+	r := f.NewBuilder().
+		Unstructured().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -120,12 +120,13 @@ func RunReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []str
 		return fmt.Errorf("--timeout must have --force specified")
 	}
 
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -248,7 +249,8 @@ func forceReplace(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []s
 		return err
 	}
 
-	r = f.NewUnstructuredBuilder().
+	r = f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/resource/BUILD
+++ b/pkg/kubectl/cmd/resource/BUILD
@@ -56,6 +56,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/streaming:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/dynamic:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -232,7 +232,13 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 		return options.watch(f, cmd, args)
 	}
 
-	r := f.NewUnstructuredBuilder().
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(options.Namespace).DefaultNamespace().AllNamespaces(options.AllNamespaces).
 		FilenameParam(options.ExplicitNamespace, &options.FilenameOptions).
 		LabelSelectorParam(options.LabelSelector).
@@ -439,12 +445,18 @@ func (options *GetOptions) raw(f cmdutil.Factory) error {
 // watch starts a client-side watch of one or more resources.
 // TODO: remove the need for arguments here.
 func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	mapper, typer, err := f.UnstructuredObject()
+	if err != nil {
+		return err
+	}
+
 	// TODO: this could be better factored
 	// include uninitialized objects when watching on a single object
 	// unless explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, len(args) == 2)
 
-	r := f.NewUnstructuredBuilder().
+	r := f.NewBuilder().
+		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
 		NamespaceParam(options.Namespace).DefaultNamespace().AllNamespaces(options.AllNamespaces).
 		FilenameParam(options.ExplicitNamespace, &options.FilenameOptions).
 		LabelSelectorParam(options.LabelSelector).
@@ -456,7 +468,7 @@ func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []s
 		SingleResourceType().
 		Latest().
 		Do()
-	err := r.Err()
+	err = r.Err()
 	if err != nil {
 		return err
 	}

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -232,13 +232,8 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 		return options.watch(f, cmd, args)
 	}
 
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		NamespaceParam(options.Namespace).DefaultNamespace().AllNamespaces(options.AllNamespaces).
 		FilenameParam(options.ExplicitNamespace, &options.FilenameOptions).
 		LabelSelectorParam(options.LabelSelector).
@@ -315,13 +310,15 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 	for ix := range objs {
 		var mapping *meta.RESTMapping
 		var original runtime.Object
-
+		var info *resource.Info
 		if sorter != nil {
-			mapping = infos[sorter.OriginalPosition(ix)].Mapping
-			original = infos[sorter.OriginalPosition(ix)].Object
+			info = infos[sorter.OriginalPosition(ix)]
+			mapping = info.Mapping
+			original = info.Object
 		} else {
-			mapping = infos[ix].Mapping
-			original = infos[ix].Object
+			info = infos[ix]
+			mapping = info.Mapping
+			original = info.Object
 		}
 		if shouldGetNewPrinterForMapping(printer, lastMapping, mapping) {
 			if printer != nil {
@@ -360,11 +357,10 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 			lastMapping = mapping
 		}
 
-		// try to convert before apply filter func
-		decodedObj, _ := kubectl.DecodeUnknownObject(original)
+		typedObj := info.AsInternal()
 
 		// filter objects if filter has been defined for current object
-		if isFiltered, err := filterFuncs.Filter(decodedObj, filterOpts); isFiltered {
+		if isFiltered, err := filterFuncs.Filter(typedObj, filterOpts); isFiltered {
 			if err == nil {
 				filteredResourceCount++
 				continue
@@ -394,7 +390,7 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 				resourcePrinter.EnsurePrintWithKind(resourceName)
 			}
 
-			if err := printer.PrintObj(decodedObj, w); err != nil {
+			if err := printer.PrintObj(typedObj, w); err != nil {
 				if !errs.Has(err.Error()) {
 					errs.Insert(err.Error())
 					allErrs = append(allErrs, err)
@@ -402,7 +398,7 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 			}
 			continue
 		}
-		objToPrint := decodedObj
+		objToPrint := typedObj
 		if printer.IsGeneric() {
 			// use raw object as recieved from the builder when using generic
 			// printer instead of decodedObj
@@ -445,18 +441,13 @@ func (options *GetOptions) raw(f cmdutil.Factory) error {
 // watch starts a client-side watch of one or more resources.
 // TODO: remove the need for arguments here.
 func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
 	// TODO: this could be better factored
 	// include uninitialized objects when watching on a single object
 	// unless explicitly set --include-uninitialized=false
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, len(args) == 2)
 
 	r := f.NewBuilder().
-		Unstructured(f.UnstructuredClientForMapping, mapper, typer).
+		Unstructured().
 		NamespaceParam(options.Namespace).DefaultNamespace().AllNamespaces(options.AllNamespaces).
 		FilenameParam(options.ExplicitNamespace, &options.FilenameOptions).
 		LabelSelectorParam(options.LabelSelector).
@@ -468,8 +459,7 @@ func (options *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []s
 		SingleResourceType().
 		Latest().
 		Do()
-	err = r.Err()
-	if err != nil {
+	if err := r.Err(); err != nil {
 		return err
 	}
 	infos, err := r.Infos()

--- a/pkg/kubectl/cmd/resource/get_test.go
+++ b/pkg/kubectl/cmd/resource/get_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/apimachinery/pkg/runtime/serializer/streaming"
+	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	restclient "k8s.io/client-go/rest"
@@ -208,15 +209,49 @@ func testComponentStatusData() *api.ComponentStatusList {
 // Verifies that schemas that are not in the master tree of Kubernetes can be retrieved via Get.
 func TestGetUnknownSchemaObject(t *testing.T) {
 	f, tf, _, _ := cmdtesting.NewAPIFactory()
+	tf.WithCustomScheme()
 	_, _, codec, _ := cmdtesting.NewTestFactory()
 	tf.Printer = &testPrinter{}
 	tf.OpenAPISchemaFunc = openapitesting.CreateOpenAPISchemaFunc(openapiSchemaPath)
+
+	obj := &cmdtesting.ExternalType{
+		Kind:       "Type",
+		APIVersion: "apitest/unlikelyversion",
+		Name:       "foo",
+	}
+
 	tf.UnstructuredClient = &fake.RESTClient{
 		NegotiatedSerializer: unstructuredSerializer,
-		Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, cmdtesting.NewInternalType("", "", "foo"))},
+		Resp: &http.Response{
+			StatusCode: 200, Header: defaultHeader(),
+			Body: objBody(codec, obj),
+		},
 	}
 	tf.Namespace = "test"
 	tf.ClientConfig = defaultClientConfig()
+
+	mapper, _, err := f.UnstructuredObject()
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := mapper.RESTMapping(schema.GroupKind{Group: "apitest", Kind: "Type"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	convertedObj, err := m.ConvertToVersion(&unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"kind":       "Type",
+			"apiVersion": "apitest/unlikelyversion",
+			"name":       "foo",
+		},
+	}, schema.GroupVersion{Group: "apitest", Version: "unlikelyversion"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(convertedObj, obj) {
+		t.Fatalf("unexpected conversion of unstructured object to structured: %s", diff.ObjectReflectDiff(convertedObj, obj))
+	}
+
 	buf := bytes.NewBuffer([]byte{})
 	errBuf := bytes.NewBuffer([]byte{})
 
@@ -229,6 +264,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	if len(actual) != len(expected) {
 		t.Fatalf("expected: %#v, but actual: %#v", expected, actual)
 	}
+	t.Logf("actual: %#v", actual[0])
 	for i, obj := range actual {
 		expectedJSON := runtime.EncodeOrDie(codec, expected[i])
 		expectedMap := map[string]interface{}{}
@@ -236,7 +272,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		actualJSON := runtime.EncodeOrDie(scheme.Codecs.LegacyCodec(), obj)
+		actualJSON := runtime.EncodeOrDie(codec, obj)
 		actualMap := map[string]interface{}{}
 		if err := encjson.Unmarshal([]byte(actualJSON), &actualMap); err != nil {
 			t.Fatal(err)
@@ -381,30 +417,32 @@ func TestGetObjectsFiltered(t *testing.T) {
 	}
 
 	for i, test := range testCases {
-		t.Logf("%d", i)
-		f, tf, codec, _ := cmdtesting.NewAPIFactory()
-		tf.Printer = &testPrinter{GenericPrinter: test.genericPrinter}
-		tf.UnstructuredClient = &fake.RESTClient{
-			GroupVersion:         schema.GroupVersion{Version: "v1"},
-			NegotiatedSerializer: unstructuredSerializer,
-			Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, test.resp)},
-		}
-		tf.Namespace = "test"
-		buf := bytes.NewBuffer([]byte{})
-		errBuf := bytes.NewBuffer([]byte{})
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f, tf, codec, _ := cmdtesting.NewAPIFactory()
+			tf.WithLegacyScheme()
+			tf.Printer = &testPrinter{GenericPrinter: test.genericPrinter}
+			tf.UnstructuredClient = &fake.RESTClient{
+				GroupVersion:         schema.GroupVersion{Version: "v1"},
+				NegotiatedSerializer: unstructuredSerializer,
+				Resp:                 &http.Response{StatusCode: 200, Header: defaultHeader(), Body: objBody(codec, test.resp)},
+			}
+			tf.Namespace = "test"
+			buf := bytes.NewBuffer([]byte{})
+			errBuf := bytes.NewBuffer([]byte{})
 
-		cmd := NewCmdGet(f, buf, errBuf)
-		cmd.SetOutput(buf)
-		for k, v := range test.flags {
-			cmd.Flags().Lookup(k).Value.Set(v)
-		}
-		cmd.Run(cmd, test.args)
+			cmd := NewCmdGet(f, buf, errBuf)
+			cmd.SetOutput(buf)
+			for k, v := range test.flags {
+				cmd.Flags().Lookup(k).Value.Set(v)
+			}
+			cmd.Run(cmd, test.args)
 
-		verifyObjects(t, test.expect, tf.Printer.(*testPrinter).Objects)
+			verifyObjects(t, test.expect, tf.Printer.(*testPrinter).Objects)
 
-		if len(buf.String()) == 0 {
-			t.Errorf("%d: unexpected empty output", i)
-		}
+			if len(buf.String()) == 0 {
+				t.Errorf("%d: unexpected empty output", i)
+			}
+		})
 	}
 }
 

--- a/pkg/kubectl/cmd/resource/get_test.go
+++ b/pkg/kubectl/cmd/resource/get_test.go
@@ -230,7 +230,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfig = defaultClientConfig()
 
-	mapper, _ := f.UnstructuredObject()
+	mapper, _ := f.Object()
 	m, err := mapper.RESTMapping(schema.GroupKind{Group: "apitest", Kind: "Type"})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kubectl/cmd/resource/get_test.go
+++ b/pkg/kubectl/cmd/resource/get_test.go
@@ -230,10 +230,7 @@ func TestGetUnknownSchemaObject(t *testing.T) {
 	tf.Namespace = "test"
 	tf.ClientConfig = defaultClientConfig()
 
-	mapper, _, err := f.UnstructuredObject()
-	if err != nil {
-		t.Fatal(err)
-	}
+	mapper, _ := f.UnstructuredObject()
 	m, err := mapper.RESTMapping(schema.GroupKind{Group: "apitest", Kind: "Type"})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -192,7 +192,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 	var keepOldName bool
 	var replicasDefaulted bool
 
-	mapper, typer := f.Object()
+	mapper, _ := f.Object()
 
 	if len(filename) != 0 {
 		schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
@@ -223,11 +223,8 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 		}
 		newRc, ok = obj.(*api.ReplicationController)
 		if !ok {
-			if gvks, _, err := typer.ObjectKinds(obj); err == nil {
-				return cmdutil.UsageErrorf(cmd, "%s contains a %v not a ReplicationController", filename, gvks[0])
-			}
-			glog.V(4).Infof("Object %#v is not a ReplicationController", obj)
-			return cmdutil.UsageErrorf(cmd, "%s does not specify a valid ReplicationController", filename)
+			glog.V(4).Infof("Object %T is not a ReplicationController", obj)
+			return cmdutil.UsageErrorf(cmd, "%s contains a %v not a ReplicationController", filename, obj.GetObjectKind().GroupVersionKind())
 		}
 		infos, err := request.Infos()
 		if err != nil || len(infos) != 1 {

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -201,39 +201,35 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 		}
 
 		request := f.NewBuilder().
-			Internal().
+			Unstructured().
 			Schema(schema).
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(enforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}}).
+			Flatten().
 			Do()
-		obj, err := request.Object()
+		infos, err := request.Infos()
 		if err != nil {
 			return err
 		}
-		var ok bool
-		// Handle filename input from stdin. The resource builder always returns an api.List
-		// when creating resource(s) from a stream.
-		if list, ok := obj.(*v1.List); ok {
-			if len(list.Items) > 1 {
-				return cmdutil.UsageErrorf(cmd, "%s specifies multiple items", filename)
-			}
-			if len(list.Items) == 0 {
-				return cmdutil.UsageErrorf(cmd, "please make sure %s exists and is not empty", filename)
-			}
-			obj = list.Items[0].Object
+		// Handle filename input from stdin.
+		if len(infos) > 1 {
+			return cmdutil.UsageErrorf(cmd, "%s specifies multiple items", filename)
 		}
-		newRc, ok = obj.(*api.ReplicationController)
-		if !ok {
-			glog.V(4).Infof("Object %T is not a ReplicationController", obj)
-			return cmdutil.UsageErrorf(cmd, "%s contains a %v not a ReplicationController", filename, obj.GetObjectKind().GroupVersionKind())
+		if len(infos) == 0 {
+			return cmdutil.UsageErrorf(cmd, "please make sure %s exists and is not empty", filename)
 		}
-		infos, err := request.Infos()
-		if err != nil || len(infos) != 1 {
-			glog.V(2).Infof("was not able to recover adequate information to discover if .spec.replicas was defaulted")
-		} else {
-			replicasDefaulted = isReplicasDefaulted(infos[0])
+
+		switch t := infos[0].AsVersioned().(type) {
+		case *v1.ReplicationController:
+			replicasDefaulted = t.Spec.Replicas == nil
+			newRc, _ = infos[0].AsInternal().(*api.ReplicationController)
+		}
+		if newRc == nil {
+			glog.V(4).Infof("Object %T is not a ReplicationController", infos[0].Object)
+			return cmdutil.UsageErrorf(cmd, "%s contains a %v not a ReplicationController", filename, infos[0].Object.GetObjectKind().GroupVersionKind())
 		}
 	}
+
 	// If the --image option is specified, we need to create a new rc with at least one different selector
 	// than the old rc. This selector is the hash of the rc, with a suffix to provide uniqueness for
 	// same-image updates.
@@ -390,16 +386,4 @@ func findNewName(args []string, oldRc *api.ReplicationController) string {
 		return newName
 	}
 	return ""
-}
-
-func isReplicasDefaulted(info *resource.Info) bool {
-	if info == nil {
-		// was unable to recover versioned info
-		return false
-	}
-	switch t := info.AsVersioned().(type) {
-	case *v1.ReplicationController:
-		return t.Spec.Replicas == nil
-	}
-	return false
 }

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -395,11 +395,11 @@ func findNewName(args []string, oldRc *api.ReplicationController) string {
 }
 
 func isReplicasDefaulted(info *resource.Info) bool {
-	if info == nil || info.VersionedObject == nil {
+	if info == nil {
 		// was unable to recover versioned info
 		return false
 	}
-	switch t := info.VersionedObject.(type) {
+	switch t := info.AsVersioned().(type) {
 	case *v1.ReplicationController:
 		return t.Spec.Replicas == nil
 	}

--- a/pkg/kubectl/cmd/rollingupdate.go
+++ b/pkg/kubectl/cmd/rollingupdate.go
@@ -201,6 +201,7 @@ func RunRollingUpdate(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args
 		}
 
 		request := f.NewBuilder().
+			Internal().
 			Schema(schema).
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(enforceNamespace, &resource.FilenameOptions{Recursive: false, Filenames: []string{filename}}).

--- a/pkg/kubectl/cmd/rollout/rollout_history.go
+++ b/pkg/kubectl/cmd/rollout/rollout_history.go
@@ -80,6 +80,7 @@ func RunHistory(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []str
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/kubectl/cmd/rollout/rollout_pause.go
+++ b/pkg/kubectl/cmd/rollout/rollout_pause.go
@@ -114,6 +114,7 @@ func (o *PauseConfig) CompletePause(f cmdutil.Factory, cmd *cobra.Command, out i
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/kubectl/cmd/rollout/rollout_resume.go
+++ b/pkg/kubectl/cmd/rollout/rollout_resume.go
@@ -112,6 +112,7 @@ func (o *ResumeConfig) CompleteResume(f cmdutil.Factory, cmd *cobra.Command, out
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/kubectl/cmd/rollout/rollout_status.go
+++ b/pkg/kubectl/cmd/rollout/rollout_status.go
@@ -83,6 +83,7 @@ func RunStatus(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, args []stri
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/kubectl/cmd/rollout/rollout_undo.go
+++ b/pkg/kubectl/cmd/rollout/rollout_undo.go
@@ -113,6 +113,7 @@ func (o *UndoOptions) CompleteUndo(f cmdutil.Factory, cmd *cobra.Command, out io
 	}
 
 	r := f.NewBuilder().
+		Internal().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		ResourceTypeOrNameArgs(true, args...).

--- a/pkg/kubectl/cmd/run.go
+++ b/pkg/kubectl/cmd/run.go
@@ -354,6 +354,7 @@ func RunRun(f cmdutil.Factory, cmdIn io.Reader, cmdOut, cmdErr io.Writer, cmd *c
 					return err
 				}
 				r := f.NewBuilder().
+					Internal().
 					ContinueOnError().
 					NamespaceParam(namespace).DefaultNamespace().
 					ResourceNames(obj.Mapping.Resource, name).

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -105,6 +105,7 @@ func RunScale(f cmdutil.Factory, out io.Writer, cmd *cobra.Command, args []strin
 
 	mapper, _ := f.Object()
 	r := f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, options).

--- a/pkg/kubectl/cmd/set/BUILD
+++ b/pkg/kubectl/cmd/set/BUILD
@@ -19,7 +19,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd/set",
     visibility = ["//build/visible_to:pkg_kubectl_cmd_set_CONSUMERS"],
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/rbac:go_default_library",
         "//pkg/kubectl:go_default_library",
         "//pkg/kubectl/cmd/templates:go_default_library",

--- a/pkg/kubectl/cmd/set/helper.go
+++ b/pkg/kubectl/cmd/set/helper.go
@@ -126,14 +126,7 @@ type patchFn func(*resource.Info) ([]byte, error)
 // the changes in the object. Encoder must be able to encode the info into the appropriate destination type.
 // This function returns whether the mutation function made any change in the original object.
 func CalculatePatch(patch *Patch, encoder runtime.Encoder, mutateFn patchFn) bool {
-	versioned, err := patch.Info.Mapping.ConvertToVersion(patch.Info.Object, patch.Info.Mapping.GroupVersionKind.GroupVersion())
-	if err != nil {
-		patch.Err = err
-		return true
-	}
-	patch.Info.VersionedObject = versioned
-
-	patch.Before, patch.Err = runtime.Encode(encoder, patch.Info.VersionedObject)
+	patch.Before, patch.Err = runtime.Encode(encoder, patch.Info.Object)
 	patch.After, patch.Err = mutateFn(patch.Info)
 	if patch.Err != nil {
 		return true
@@ -142,7 +135,7 @@ func CalculatePatch(patch *Patch, encoder runtime.Encoder, mutateFn patchFn) boo
 		return false
 	}
 
-	patch.Patch, patch.Err = strategicpatch.CreateTwoWayMergePatch(patch.Before, patch.After, patch.Info.VersionedObject)
+	patch.Patch, patch.Err = strategicpatch.CreateTwoWayMergePatch(patch.Before, patch.After, patch.Info.Object)
 	return true
 }
 

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -236,6 +236,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 
 	if len(o.From) != 0 {
 		b := f.NewBuilder().
+			LocalParam(o.Local).
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
 			FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -246,8 +247,6 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 				LabelSelectorParam(o.Selector).
 				ResourceTypeOrNameArgs(o.All, o.From).
 				Latest()
-		} else {
-			b = b.Local()
 		}
 
 		infos, err := b.Do().Infos()
@@ -304,18 +303,16 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 	}
 
 	b := f.NewBuilder().
+		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		Flatten()
 
 	if !o.Local {
-		b = b.
-			LabelSelectorParam(o.Selector).
+		b.LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...).
 			Latest()
-	} else {
-		b = b.Local()
 	}
 
 	o.Infos, err = b.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -241,13 +241,13 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 			FilenameParam(enforceNamespace, &o.FilenameOptions).
 			Flatten()
 
-		if o.Local {
-			b = b.Local(f.ClientForMapping)
-		} else {
+		if !o.Local {
 			b = b.
 				LabelSelectorParam(o.Selector).
 				ResourceTypeOrNameArgs(o.All, o.From).
 				Latest()
+		} else {
+			b = b.Local(f.ClientForMapping)
 		}
 
 		infos, err := b.Do().Infos()
@@ -309,13 +309,13 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
 		Flatten()
 
-	if o.Local {
-		b = b.Local(f.ClientForMapping)
-	} else {
+	if !o.Local {
 		b = b.
 			LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...).
 			Latest()
+	} else {
+		b = b.Local(f.ClientForMapping)
 	}
 
 	o.Infos, err = b.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_env.go
+++ b/pkg/kubectl/cmd/set/set_env.go
@@ -236,6 +236,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 
 	if len(o.From) != 0 {
 		b := f.NewBuilder().
+			Internal().
 			LocalParam(o.Local).
 			ContinueOnError().
 			NamespaceParam(cmdNamespace).DefaultNamespace().
@@ -303,6 +304,7 @@ func (o *EnvOptions) RunEnv(f cmdutil.Factory) error {
 	}
 
 	b := f.NewBuilder().
+		Internal().
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -143,6 +143,7 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		Internal().
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -149,7 +149,12 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		IncludeUninitialized(includeUninitialized).
 		Flatten()
 
-	if o.Local {
+	if !o.Local {
+		builder = builder.
+			LabelSelectorParam(o.Selector).
+			ResourceTypeOrNameArgs(o.All, o.Resources...).
+			Latest()
+	} else {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
 		// for the specified resource.
@@ -158,11 +163,6 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		}
 
 		builder = builder.Local(f.ClientForMapping)
-	} else {
-		builder = builder.
-			LabelSelectorParam(o.Selector).
-			ResourceTypeOrNameArgs(o.All, o.Resources...).
-			Latest()
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_image.go
+++ b/pkg/kubectl/cmd/set/set_image.go
@@ -143,6 +143,7 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -150,8 +151,7 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		Flatten()
 
 	if !o.Local {
-		builder = builder.
-			LabelSelectorParam(o.Selector).
+		builder.LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, o.Resources...).
 			Latest()
 	} else {
@@ -161,8 +161,6 @@ func (o *ImageOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		if len(o.Resources) > 0 {
 			return resource.LocalResourceError
 		}
-
-		builder = builder.Local()
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -151,7 +151,12 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		IncludeUninitialized(includeUninitialized).
 		Flatten()
 
-	if o.Local {
+	if !o.Local {
+		builder = builder.
+			LabelSelectorParam(o.Selector).
+			ResourceTypeOrNameArgs(o.All, args...).
+			Latest()
+	} else {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
 		// for the specified resource.
@@ -160,11 +165,6 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		}
 
 		builder = builder.Local(f.ClientForMapping)
-	} else {
-		builder = builder.
-			LabelSelectorParam(o.Selector).
-			ResourceTypeOrNameArgs(o.All, args...).
-			Latest()
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -145,6 +145,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -152,19 +153,18 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 		Flatten()
 
 	if !o.Local {
-		builder = builder.
-			LabelSelectorParam(o.Selector).
+		builder.LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, args...).
 			Latest()
 	} else {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
 		// for the specified resource.
+		// TODO: this should be in the builder - if someone specifies tuples, fail when
+		// local is true
 		if len(args) > 0 {
 			return resource.LocalResourceError
 		}
-
-		builder = builder.Local()
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_resources.go
+++ b/pkg/kubectl/cmd/set/set_resources.go
@@ -145,6 +145,7 @@ func (o *ResourcesOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		Internal().
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -135,7 +135,11 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		IncludeUninitialized(includeUninitialized).
 		Flatten()
 
-	if o.local {
+	if !o.local {
+		o.builder = o.builder.
+			ResourceTypeOrNameArgs(o.all, o.resources...).
+			Latest()
+	} else {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
 		// for the specified resource.
@@ -144,10 +148,6 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		}
 
 		o.builder = o.builder.Local(f.ClientForMapping)
-	} else {
-		o.builder = o.builder.
-			ResourceTypeOrNameArgs(o.all, o.resources...).
-			Latest()
 	}
 
 	o.PrintObject = func(obj runtime.Object) error {

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -129,6 +129,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	o.builder = f.NewBuilder().
+		Internal().
 		LocalParam(o.local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -147,7 +147,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 			return resource.LocalResourceError
 		}
 
-		o.builder = o.builder.Local(f.ClientForMapping)
+		o.builder = o.builder.Local()
 	}
 
 	o.PrintObject = func(obj runtime.Object) error {
@@ -181,15 +181,12 @@ func (o *SelectorOptions) RunSelector() error {
 	return r.Visit(func(info *resource.Info, err error) error {
 		patch := &Patch{Info: info}
 		CalculatePatch(patch, o.encoder, func(info *resource.Info) ([]byte, error) {
-			versioned, err := info.Mapping.ConvertToVersion(info.Object, info.Mapping.GroupVersionKind.GroupVersion())
-			if err != nil {
-				return nil, err
-			}
-			patch.Info.VersionedObject = versioned
-			selectErr := updateSelectorForObject(info.VersionedObject, *o.selector)
+			versioned := info.AsVersioned()
+			patch.Info.Object = versioned
+			selectErr := updateSelectorForObject(info.Object, *o.selector)
 
 			if selectErr == nil {
-				return runtime.Encode(o.encoder, info.VersionedObject)
+				return runtime.Encode(o.encoder, info.Object)
 			}
 			return nil, selectErr
 		})
@@ -198,7 +195,7 @@ func (o *SelectorOptions) RunSelector() error {
 			return patch.Err
 		}
 		if o.local || o.dryrun {
-			return o.PrintObject(info.VersionedObject)
+			return o.PrintObject(info.Object)
 		}
 
 		patched, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch)

--- a/pkg/kubectl/cmd/set/set_selector.go
+++ b/pkg/kubectl/cmd/set/set_selector.go
@@ -129,6 +129,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	o.builder = f.NewBuilder().
+		LocalParam(o.local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.fileOptions).
@@ -136,7 +137,7 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		Flatten()
 
 	if !o.local {
-		o.builder = o.builder.
+		o.builder.
 			ResourceTypeOrNameArgs(o.all, o.resources...).
 			Latest()
 	} else {
@@ -146,8 +147,6 @@ func (o *SelectorOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args [
 		if len(o.resources) > 0 {
 			return resource.LocalResourceError
 		}
-
-		o.builder = o.builder.Local()
 	}
 
 	o.PrintObject = func(obj runtime.Object) error {

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -130,6 +130,7 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	resources := args[:len(args)-1]
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		Internal().
 		LocalParam(saConfig.local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_serviceaccount.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount.go
@@ -129,7 +129,9 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	saConfig.serviceAccountName = args[len(args)-1]
 	resources := args[:len(args)-1]
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder().ContinueOnError().
+	builder := f.NewBuilder().
+		LocalParam(saConfig.local).
+		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &saConfig.fileNameOptions).
 		IncludeUninitialized(includeUninitialized).
@@ -137,8 +139,6 @@ func (saConfig *serviceAccountConfig) Complete(f cmdutil.Factory, cmd *cobra.Com
 	if !saConfig.local {
 		builder.ResourceTypeOrNameArgs(saConfig.all, resources...).
 			Latest()
-	} else {
-		builder = builder.Local()
 	}
 	saConfig.infos, err = builder.Do().Infos()
 	if err != nil {

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -66,32 +66,34 @@ func TestSetServiceAccountLocal(t *testing.T) {
 		{yaml: "../../../../test/fixtures/doc-yaml/user-guide/deployment.yaml", apiGroup: "extensions"},
 	}
 
-	f, tf, _, _ := cmdtesting.NewAPIFactory()
-	tf.Client = &fake.RESTClient{
-		GroupVersion: schema.GroupVersion{Version: "v1"},
-		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
-			return nil, nil
-		}),
-	}
-	tf.Namespace = "test"
-	out := new(bytes.Buffer)
-	cmd := NewCmdServiceAccount(f, out, out)
-	cmd.SetOutput(out)
-	cmd.Flags().Set("output", "yaml")
-	cmd.Flags().Set("local", "true")
-	for _, input := range inputs {
-		testapi.Default = testapi.Groups[input.apiGroup]
-		tf.Printer = printers.NewVersionedPrinter(&printers.YAMLPrinter{}, testapi.Default.Converter(), *testapi.Default.GroupVersion())
-		saConfig := serviceAccountConfig{fileNameOptions: resource.FilenameOptions{
-			Filenames: []string{input.yaml}},
-			out:   out,
-			local: true}
-		err := saConfig.Complete(f, cmd, []string{serviceAccount})
-		assert.NoError(t, err)
-		err = saConfig.Run()
-		assert.NoError(t, err)
-		assert.Contains(t, out.String(), "serviceAccountName: "+serviceAccount, fmt.Sprintf("serviceaccount not updated for %s", input.yaml))
+	for i, input := range inputs {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f, tf, _, _ := cmdtesting.NewAPIFactory()
+			tf.Client = &fake.RESTClient{
+				GroupVersion: schema.GroupVersion{Version: "v1"},
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
+					return nil, nil
+				}),
+			}
+			tf.Namespace = "test"
+			out := new(bytes.Buffer)
+			cmd := NewCmdServiceAccount(f, out, out)
+			cmd.SetOutput(out)
+			cmd.Flags().Set("output", "yaml")
+			cmd.Flags().Set("local", "true")
+			testapi.Default = testapi.Groups[input.apiGroup]
+			tf.Printer = printers.NewVersionedPrinter(&printers.YAMLPrinter{}, testapi.Default.Converter(), *testapi.Default.GroupVersion())
+			saConfig := serviceAccountConfig{fileNameOptions: resource.FilenameOptions{
+				Filenames: []string{input.yaml}},
+				out:   out,
+				local: true}
+			err := saConfig.Complete(f, cmd, []string{serviceAccount})
+			assert.NoError(t, err)
+			err = saConfig.Run()
+			assert.NoError(t, err)
+			assert.Contains(t, out.String(), "serviceAccountName: "+serviceAccount, fmt.Sprintf("serviceaccount not updated for %s", input.yaml))
+		})
 	}
 }
 

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -133,7 +133,12 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		IncludeUninitialized(includeUninitialized).
 		Flatten()
 
-	if o.Local {
+	if !o.Local {
+		builder = builder.
+			LabelSelectorParam(o.Selector).
+			ResourceTypeOrNameArgs(o.All, args...).
+			Latest()
+	} else {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
 		// for the specified resource.
@@ -142,11 +147,6 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		}
 
 		builder = builder.Local(f.ClientForMapping)
-	} else {
-		builder = builder.
-			LabelSelectorParam(o.Selector).
-			ResourceTypeOrNameArgs(o.All, args...).
-			Latest()
 	}
 
 	o.Infos, err = builder.Do().Infos()

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -126,6 +126,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
 	builder := f.NewBuilder().
+		Internal().
 		LocalParam(o.Local).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/rbac"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -126,7 +125,17 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder().
+	builder := f.NewBuilder()
+	if o.Local {
+		// if a --local flag was provided, and a resource was specified in the form
+		// <resource>/<name>, fail immediately as --local cannot query the api server
+		// for the specified resource.
+		if len(args) > 0 {
+			return resource.LocalResourceError
+		}
+		builder = builder.Local()
+	}
+	builder = builder.
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
 		FilenameParam(enforceNamespace, &o.FilenameOptions).
@@ -138,15 +147,6 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 			LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, args...).
 			Latest()
-	} else {
-		// if a --local flag was provided, and a resource was specified in the form
-		// <resource>/<name>, fail immediately as --local cannot query the api server
-		// for the specified resource.
-		if len(args) > 0 {
-			return resource.LocalResourceError
-		}
-
-		builder = builder.Local(f.ClientForMapping)
 	}
 
 	o.Infos, err = builder.Do().Infos()
@@ -219,9 +219,8 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 
 		transformed, err := updateSubjectForObject(info.Object, subjects, fn)
 		if transformed && err == nil {
-			// TODO: switch UpdatePodSpecForObject to work on v1.PodSpec, use info.VersionedObject, and avoid conversion completely
-			versionedEncoder := legacyscheme.Codecs.EncoderForVersion(o.Encoder, info.Mapping.GroupVersionKind.GroupVersion())
-			return runtime.Encode(versionedEncoder, info.Object)
+			// TODO: switch UpdatePodSpecForObject to work on v1.PodSpec
+			return runtime.Encode(o.Encoder, info.AsVersioned())
 		}
 		return nil, err
 	})
@@ -256,7 +255,7 @@ func (o *SubjectOptions) Run(f cmdutil.Factory, fn updateSubjects) error {
 
 		shortOutput := o.Output == "name"
 		if len(o.Output) > 0 && !shortOutput {
-			return o.PrintObject(o.Mapper, info.Object, o.Out)
+			return o.PrintObject(o.Mapper, info.AsVersioned(), o.Out)
 		}
 		f.PrintSuccess(o.Mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, false, "subjects updated")
 	}

--- a/pkg/kubectl/cmd/set/set_subject.go
+++ b/pkg/kubectl/cmd/set/set_subject.go
@@ -125,7 +125,14 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 	}
 
 	includeUninitialized := cmdutil.ShouldIncludeUninitialized(cmd, false)
-	builder := f.NewBuilder()
+	builder := f.NewBuilder().
+		LocalParam(o.Local).
+		ContinueOnError().
+		NamespaceParam(cmdNamespace).DefaultNamespace().
+		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		IncludeUninitialized(includeUninitialized).
+		Flatten()
+
 	if o.Local {
 		// if a --local flag was provided, and a resource was specified in the form
 		// <resource>/<name>, fail immediately as --local cannot query the api server
@@ -133,16 +140,7 @@ func (o *SubjectOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []
 		if len(args) > 0 {
 			return resource.LocalResourceError
 		}
-		builder = builder.Local()
-	}
-	builder = builder.
-		ContinueOnError().
-		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, &o.FilenameOptions).
-		IncludeUninitialized(includeUninitialized).
-		Flatten()
-
-	if !o.Local {
+	} else {
 		builder = builder.
 			LabelSelectorParam(o.Selector).
 			ResourceTypeOrNameArgs(o.All, args...).

--- a/pkg/kubectl/cmd/taint.go
+++ b/pkg/kubectl/cmd/taint.go
@@ -150,6 +150,7 @@ func (o *TaintOptions) Complete(f cmdutil.Factory, out io.Writer, cmd *cobra.Com
 		return cmdutil.UsageErrorf(cmd, err.Error())
 	}
 	o.builder = f.NewBuilder().
+		Internal().
 		ContinueOnError().
 		NamespaceParam(namespace).DefaultNamespace()
 	if o.selector != "" {

--- a/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list-fail/3.original
+++ b/pkg/kubectl/cmd/testdata/edit/testcase-apply-edit-last-applied-list-fail/3.original
@@ -1,7 +1,7 @@
 # Please edit the 'last-applied-configuration' annotations below.
 # Lines beginning with a '#' will be ignored, and an empty file will abort the edit.
 #
-# The edited file had a syntax error: unable to get type info from the object "*unstructured.Unstructured": Object 'apiVersion' is missing in 'unstructured object has no version'
+# The edited file had a syntax error: unable to get type info from the object "*unstructured.Unstructured": Object 'apiVersion' is missing in 'object has no apiVersion field'
 #
 apiVersion: v1
 items:

--- a/pkg/kubectl/cmd/testing/BUILD
+++ b/pkg/kubectl/cmd/testing/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/pkg/kubectl/cmd/testing/BUILD
+++ b/pkg/kubectl/cmd/testing/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -522,19 +521,6 @@ func (f *FakeFactory) NewBuilder() *resource.Builder {
 	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
 }
 
-func (f *FakeFactory) NewUnstructuredBuilder() *resource.Builder {
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		cmdutil.CheckErr(err)
-	}
-	return resource.NewBuilder(
-		mapper,
-		f.CategoryExpander(),
-		typer,
-		resource.ClientMapperFunc(f.UnstructuredClientForMapping),
-		unstructured.UnstructuredJSONScheme)
-}
-
 func (f *FakeFactory) DefaultResourceFilterOptions(cmd *cobra.Command, withNamespace bool) *printers.PrintOptions {
 	return &printers.PrintOptions{}
 }
@@ -847,19 +833,6 @@ func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, out
 func (f *fakeAPIFactory) NewBuilder() *resource.Builder {
 	mapper, typer := f.Object()
 	return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.ClientForMapping), f.Decoder(true))
-}
-
-func (f *fakeAPIFactory) NewUnstructuredBuilder() *resource.Builder {
-	mapper, typer, err := f.UnstructuredObject()
-	if err != nil {
-		cmdutil.CheckErr(err)
-	}
-	return resource.NewBuilder(
-		mapper,
-		f.CategoryExpander(),
-		typer,
-		resource.ClientMapperFunc(f.UnstructuredClientForMapping),
-		unstructured.UnstructuredJSONScheme)
 }
 
 func (f *fakeAPIFactory) SuggestedPodTemplateResources() []schema.GroupResource {

--- a/pkg/kubectl/cmd/testing/fake.go
+++ b/pkg/kubectl/cmd/testing/fake.go
@@ -285,14 +285,14 @@ func (f *FakeFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 	return legacyscheme.Registry.RESTMapper(), f.tf.Typer
 }
 
-func (f *FakeFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+func (f *FakeFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper) {
 	groupResources := testDynamicResources()
 	mapper := discovery.NewRESTMapper(groupResources, meta.InterfacesForUnstructuredConversion(legacyscheme.Registry.InterfacesFor))
 	typer := discovery.NewUnstructuredObjectTyper(groupResources)
 
 	fakeDs := &fakeCachedDiscoveryClient{}
-	expander, err := cmdutil.NewShortcutExpander(mapper, fakeDs)
-	return expander, typer, err
+	expander := cmdutil.NewShortcutExpander(mapper, fakeDs)
+	return expander, typer
 }
 
 func (f *FakeFactory) CategoryExpander() categories.CategoryExpander {
@@ -519,7 +519,7 @@ func (f *FakeFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, output
 
 func (f *FakeFactory) NewBuilder() *resource.Builder {
 	mapper, typer := f.Object()
-	unstructuredMapper, unstructuredTyper, _ := f.UnstructuredObject()
+	unstructuredMapper, unstructuredTyper := f.UnstructuredObject()
 
 	return resource.NewBuilder(
 		&resource.Mapper{
@@ -608,7 +608,7 @@ func (f *fakeAPIFactory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
 	return testapi.Default.RESTMapper(), legacyscheme.Scheme
 }
 
-func (f *fakeAPIFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error) {
+func (f *fakeAPIFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper) {
 	groupResources := testDynamicResources()
 	mapper := discovery.NewRESTMapper(
 		groupResources,
@@ -629,8 +629,8 @@ func (f *fakeAPIFactory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectTy
 
 	typer := discovery.NewUnstructuredObjectTyper(groupResources)
 	fakeDs := &fakeCachedDiscoveryClient{}
-	expander, err := cmdutil.NewShortcutExpander(mapper, fakeDs)
-	return expander, typer, err
+	expander := cmdutil.NewShortcutExpander(mapper, fakeDs)
+	return expander, typer
 }
 
 func (f *fakeAPIFactory) Decoder(bool) runtime.Decoder {
@@ -865,7 +865,7 @@ func (f *fakeAPIFactory) PrinterForMapping(cmd *cobra.Command, isLocal bool, out
 
 func (f *fakeAPIFactory) NewBuilder() *resource.Builder {
 	mapper, typer := f.Object()
-	unstructuredMapper, unstructuredTyper, _ := f.UnstructuredObject()
+	unstructuredMapper, unstructuredTyper := f.UnstructuredObject()
 
 	return resource.NewBuilder(
 		&resource.Mapper{

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -9,7 +9,6 @@ go_library(
     srcs = [
         "cached_discovery.go",
         "clientcache.go",
-        "discovery.go",
         "factory.go",
         "factory_builder.go",
         "factory_client_access.go",

--- a/pkg/kubectl/cmd/util/BUILD
+++ b/pkg/kubectl/cmd/util/BUILD
@@ -9,6 +9,7 @@ go_library(
     srcs = [
         "cached_discovery.go",
         "clientcache.go",
+        "discovery.go",
         "factory.go",
         "factory_builder.go",
         "factory_client_access.go",

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -107,7 +107,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 	if err != nil {
 		return err
 	}
-	mapper, _ := f.UnstructuredObject()
+	mapper, _ := f.Object()
 	b := f.NewBuilder().Unstructured()
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -107,12 +107,12 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 	if err != nil {
 		return err
 	}
-	mapper, typer, err := f.UnstructuredObject()
+	mapper, _, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	b := f.NewBuilder().Unstructured(f.UnstructuredClientForMapping, mapper, typer)
+	b := f.NewBuilder().Unstructured()
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server
 		b = b.ResourceTypeOrNameArgs(true, args...).Latest()
@@ -132,7 +132,8 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 
 	o.updatedResultGetter = func(data []byte) *resource.Result {
 		// resource builder to read objects from edited data
-		return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), unstructured.UnstructuredJSONScheme).
+		return f.NewBuilder().
+			Unstructured().
 			Stream(bytes.NewReader(data), "edited-file").
 			IncludeUninitialized(includeUninitialized).
 			ContinueOnError().

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -107,11 +107,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 	if err != nil {
 		return err
 	}
-	mapper, _, err := f.UnstructuredObject()
-	if err != nil {
-		return err
-	}
-
+	mapper, _ := f.UnstructuredObject()
 	b := f.NewBuilder().Unstructured()
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -107,12 +107,12 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 	if err != nil {
 		return err
 	}
-	mapper, _, err := f.UnstructuredObject()
+	mapper, typer, err := f.UnstructuredObject()
 	if err != nil {
 		return err
 	}
 
-	b := f.NewUnstructuredBuilder()
+	b := f.NewBuilder().Unstructured(f.UnstructuredClientForMapping, mapper, typer)
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server
 		b = b.ResourceTypeOrNameArgs(true, args...).Latest()
@@ -132,7 +132,7 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 
 	o.updatedResultGetter = func(data []byte) *resource.Result {
 		// resource builder to read objects from edited data
-		return f.NewUnstructuredBuilder().
+		return resource.NewBuilder(mapper, f.CategoryExpander(), typer, resource.ClientMapperFunc(f.UnstructuredClientForMapping), unstructured.UnstructuredJSONScheme).
 			Stream(bytes.NewReader(data), "edited-file").
 			IncludeUninitialized(includeUninitialized).
 			ContinueOnError().

--- a/pkg/kubectl/cmd/util/editor/editoptions.go
+++ b/pkg/kubectl/cmd/util/editor/editoptions.go
@@ -108,7 +108,8 @@ func (o *EditOptions) Complete(f cmdutil.Factory, out, errOut io.Writer, args []
 		return err
 	}
 	mapper, _ := f.Object()
-	b := f.NewBuilder().Unstructured()
+	b := f.NewBuilder().
+		Unstructured()
 	if o.EditMode == NormalEditMode || o.EditMode == ApplyEditMode {
 		// when do normal edit or apply edit we need to always retrieve the latest resource from server
 		b = b.ResourceTypeOrNameArgs(true, args...).Latest()

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -251,10 +251,9 @@ type BuilderFactory interface {
 	PrintResourceInfoForCommand(cmd *cobra.Command, info *resource.Info, out io.Writer) error
 	// PrintSuccess prints message after finishing mutating operations
 	PrintSuccess(mapper meta.RESTMapper, shortOutput bool, out io.Writer, resource, name string, dryRun bool, operation string)
-	// One stop shopping for a structured Builder
+	// NewBuilder returns an object that assists in loading objects from both disk and the server
+	// and which implements the common patterns for CLI interactions with generic resources.
 	NewBuilder() *resource.Builder
-	// One stop shopping for a unstructured Builder
-	NewUnstructuredBuilder() *resource.Builder
 	// PluginLoader provides the implementation to be used to load cli plugins.
 	PluginLoader() plugins.PluginLoader
 	// PluginRunner provides the implementation to be used to run cli plugins.

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -191,7 +191,7 @@ type ObjectMappingFactory interface {
 	Object() (meta.RESTMapper, runtime.ObjectTyper)
 	// Returns interfaces for dealing with arbitrary
 	// runtime.Unstructured. This performs API calls to discover types.
-	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error)
+	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper)
 	// Returns interface for expanding categories like `all`.
 	// TODO: this should probably return an error if the full expander can't be loaded.
 	CategoryExpander() categories.CategoryExpander

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -189,11 +189,7 @@ type ClientAccessFactory interface {
 type ObjectMappingFactory interface {
 	// Returns interfaces for dealing with arbitrary runtime.Objects.
 	Object() (meta.RESTMapper, runtime.ObjectTyper)
-	// Returns interfaces for dealing with arbitrary
-	// runtime.Unstructured. This performs API calls to discover types.
-	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper)
 	// Returns interface for expanding categories like `all`.
-	// TODO: this should probably return an error if the full expander can't be loaded.
 	CategoryExpander() categories.CategoryExpander
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
 	// for working with arbitrary resources and is not guaranteed to point to a Kubernetes APIServer.

--- a/pkg/kubectl/cmd/util/factory.go
+++ b/pkg/kubectl/cmd/util/factory.go
@@ -193,6 +193,7 @@ type ObjectMappingFactory interface {
 	// runtime.Unstructured. This performs API calls to discover types.
 	UnstructuredObject() (meta.RESTMapper, runtime.ObjectTyper, error)
 	// Returns interface for expanding categories like `all`.
+	// TODO: this should probably return an error if the full expander can't be loaded.
 	CategoryExpander() categories.CategoryExpander
 	// Returns a RESTClient for working with the specified RESTMapping or an error. This is intended
 	// for working with arbitrary resources and is not guaranteed to point to a Kubernetes APIServer.

--- a/pkg/kubectl/cmd/util/factory_builder.go
+++ b/pkg/kubectl/cmd/util/factory_builder.go
@@ -190,18 +190,6 @@ func (f *ring2Factory) NewBuilder() *resource.Builder {
 	return resource.NewBuilder(mapper, categoryExpander, typer, clientMapperFunc, f.clientAccessFactory.Decoder(true))
 }
 
-// NewUnstructuredBuilder returns a new resource builder for unstructured api objects.
-func (f *ring2Factory) NewUnstructuredBuilder() *resource.Builder {
-	clientMapperFunc := resource.ClientMapperFunc(f.objectMappingFactory.UnstructuredClientForMapping)
-	mapper, typer, err := f.objectMappingFactory.UnstructuredObject()
-	if err != nil {
-		CheckErr(err)
-	}
-	categoryExpander := f.objectMappingFactory.CategoryExpander()
-
-	return resource.NewBuilder(mapper, categoryExpander, typer, clientMapperFunc, unstructured.UnstructuredJSONScheme)
-}
-
 // PluginLoader loads plugins from a path set by the KUBECTL_PLUGINS_PATH env var.
 // If this env var is not set, it defaults to
 //   "~/.kube/plugins", plus

--- a/pkg/kubectl/cmd/util/factory_client_access.go
+++ b/pkg/kubectl/cmd/util/factory_client_access.go
@@ -310,11 +310,7 @@ func (f *ring0Factory) MapBasedSelectorForObject(object runtime.Object) (string,
 		}
 		return kubectl.MakeLabels(t.Spec.Selector.MatchLabels), nil
 	default:
-		gvks, _, err := legacyscheme.Scheme.ObjectKinds(object)
-		if err != nil {
-			return "", err
-		}
-		return "", fmt.Errorf("cannot extract pod selector from %v", gvks[0])
+		return "", fmt.Errorf("cannot extract pod selector from %T", object)
 	}
 }
 
@@ -332,11 +328,7 @@ func (f *ring0Factory) PortsForObject(object runtime.Object) ([]string, error) {
 	case *extensions.ReplicaSet:
 		return getPorts(t.Spec.Template.Spec), nil
 	default:
-		gvks, _, err := legacyscheme.Scheme.ObjectKinds(object)
-		if err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot extract ports from %v", gvks[0])
+		return nil, fmt.Errorf("cannot extract ports from %T", object)
 	}
 }
 
@@ -354,11 +346,7 @@ func (f *ring0Factory) ProtocolsForObject(object runtime.Object) (map[string]str
 	case *extensions.ReplicaSet:
 		return getProtocols(t.Spec.Template.Spec), nil
 	default:
-		gvks, _, err := legacyscheme.Scheme.ObjectKinds(object)
-		if err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot extract protocols from %v", gvks[0])
+		return nil, fmt.Errorf("cannot extract protocols from %T", object)
 	}
 }
 

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -286,11 +286,7 @@ func (f *ring1Factory) LogsForObject(object, options runtime.Object, timeout tim
 		}
 
 	default:
-		gvks, _, err := legacyscheme.Scheme.ObjectKinds(object)
-		if err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot get the logs from %v", gvks[0])
+		return nil, fmt.Errorf("cannot get the logs from %T", object)
 	}
 
 	sortBy := func(pods []*v1.Pod) sort.Interface { return controller.ByLogging(pods) }
@@ -414,11 +410,7 @@ func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout tim
 		return t, nil
 
 	default:
-		gvks, _, err := legacyscheme.Scheme.ObjectKinds(object)
-		if err != nil {
-			return nil, err
-		}
-		return nil, fmt.Errorf("cannot attach to %v: not implemented", gvks[0])
+		return nil, fmt.Errorf("cannot attach to %T: not implemented", object)
 	}
 
 	sortBy := func(pods []*v1.Pod) sort.Interface { return sort.Reverse(controller.ActivePods(pods)) }

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -108,7 +108,9 @@ func (f *ring1Factory) UnstructuredObject() (meta.RESTMapper, runtime.ObjectType
 		return nil, nil, err
 	}
 
-	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.InterfacesForUnstructured)
+	// allow conversion between typed and unstructured objects
+	interfaces := meta.InterfacesForUnstructuredConversion(legacyscheme.Registry.InterfacesFor)
+	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.VersionInterfacesFunc(interfaces))
 	typer := discovery.NewUnstructuredObjectTyper(groupResources)
 	expander, err := NewShortcutExpander(mapper, discoveryClient)
 	return expander, typer, err

--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -98,13 +98,13 @@ func (f *ring1Factory) objectLoader() (meta.RESTMapper, runtime.ObjectTyper, err
 	interfaces := meta.InterfacesForUnstructuredConversion(legacyscheme.Registry.InterfacesFor)
 	mapper := discovery.NewDeferredDiscoveryRESTMapper(discoveryClient, meta.VersionInterfacesFunc(interfaces))
 	// TODO: should this also indicate it recognizes typed objects?
-	typer := discovery.NewUnstructuredObjectTyper(groupResources)
+	typer := discovery.NewUnstructuredObjectTyper(groupResources, legacyscheme.Scheme)
 	expander := NewShortcutExpander(mapper, discoveryClient)
 	return expander, typer, err
 }
 
 func (f *ring1Factory) Object() (meta.RESTMapper, runtime.ObjectTyper) {
-	return NewLazyObjectLoader(f.objectLoader)
+	return meta.NewLazyObjectLoader(f.objectLoader)
 }
 
 func (f *ring1Factory) CategoryExpander() categories.CategoryExpander {

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -543,7 +543,16 @@ func TestDiscoveryReplaceAliases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unable to create shortcut expander, err = %s", err.Error())
 	}
-	b := resource.NewBuilder(mapper, categories.LegacyCategoryExpander, legacyscheme.Scheme, fakeClient(), testapi.Default.Codec())
+	b := resource.NewBuilder(
+		&resource.Mapper{
+			RESTMapper:   mapper,
+			ObjectTyper:  legacyscheme.Scheme,
+			ClientMapper: fakeClient(),
+			Decoder:      testapi.Default.Codec(),
+		},
+		nil,
+		categories.LegacyCategoryExpander,
+	)
 
 	for _, test := range tests {
 		replaced := b.ReplaceAliases(test.arg)

--- a/pkg/kubectl/cmd/util/factory_test.go
+++ b/pkg/kubectl/cmd/util/factory_test.go
@@ -539,10 +539,7 @@ func TestDiscoveryReplaceAliases(t *testing.T) {
 	}
 
 	ds := &fakeDiscoveryClient{}
-	mapper, err := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
-	if err != nil {
-		t.Fatalf("Unable to create shortcut expander, err = %s", err.Error())
-	}
+	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
 	b := resource.NewBuilder(
 		&resource.Mapper{
 			RESTMapper:   mapper,

--- a/pkg/kubectl/cmd/util/shortcut_restmapper.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"errors"
 	"strings"
 
 	"github.com/golang/glog"
@@ -37,11 +36,8 @@ type shortcutExpander struct {
 
 var _ meta.RESTMapper = &shortcutExpander{}
 
-func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) (shortcutExpander, error) {
-	if client == nil {
-		return shortcutExpander{}, errors.New("Please provide discovery client to shortcut expander")
-	}
-	return shortcutExpander{RESTMapper: delegate, discoveryClient: client}, nil
+func NewShortcutExpander(delegate meta.RESTMapper, client discovery.DiscoveryInterface) shortcutExpander {
+	return shortcutExpander{RESTMapper: delegate, discoveryClient: client}
 }
 
 func (e shortcutExpander) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {

--- a/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
+++ b/pkg/kubectl/cmd/util/shortcut_restmapper_test.go
@@ -71,10 +71,7 @@ func TestReplaceAliases(t *testing.T) {
 	}
 
 	ds := &fakeDiscoveryClient{}
-	mapper, err := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
-	if err != nil {
-		t.Fatalf("Unable to create shortcut expander, err %s", err.Error())
-	}
+	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
 
 	for _, test := range tests {
 		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {
@@ -126,10 +123,7 @@ func TestKindFor(t *testing.T) {
 	}
 
 	ds := &fakeDiscoveryClient{}
-	mapper, err := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
-	if err != nil {
-		t.Fatalf("Unable to create shortcut expander, err %s", err.Error())
-	}
+	mapper := NewShortcutExpander(testapi.Default.RESTMapper(), ds)
 
 	for i, test := range tests {
 		ds.serverResourcesHandler = func() ([]*metav1.APIResourceList, error) {

--- a/pkg/kubectl/resource/BUILD
+++ b/pkg/kubectl/resource/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -177,6 +177,14 @@ func (b *Builder) Unstructured() *Builder {
 	return b
 }
 
+// LocalParam calls Local() if local is true.
+func (b *Builder) LocalParam(local bool) *Builder {
+	if local {
+		b.Local()
+	}
+	return b
+}
+
 // Local will avoid asking the server for results.
 func (b *Builder) Local() *Builder {
 	mapper := *b.mapper

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -168,6 +169,17 @@ func (b *Builder) FilenameParam(enforceNamespace bool, filenameOptions *Filename
 // Local wraps the builder's clientMapper in a DisabledClientMapperForMapping
 func (b *Builder) Local(mapperFunc ClientMapperFunc) *Builder {
 	b.mapper.ClientMapper = DisabledClientForMapping{ClientMapper: ClientMapperFunc(mapperFunc)}
+	return b
+}
+
+// Unstructured updates the builder's ClientMapper, RESTMapper,
+// ObjectTyper, and codec for working with unstructured api objects
+func (b *Builder) Unstructured(mapperFunc ClientMapperFunc, mapper meta.RESTMapper, typer runtime.ObjectTyper) *Builder {
+	b.mapper.RESTMapper = mapper
+	b.mapper.ObjectTyper = typer
+	b.mapper.Decoder = unstructured.UnstructuredJSONScheme
+	b.mapper.ClientMapper = ClientMapperFunc(mapperFunc)
+
 	return b
 }
 

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -263,8 +263,25 @@ var aRC string = `
 }
 `
 
+func newDefaultBuilder() *Builder {
+	return newDefaultBuilderWith(fakeClient())
+}
+
+func newDefaultBuilderWith(client ClientMapper) *Builder {
+	return NewBuilder(
+		&Mapper{
+			RESTMapper:   restmapper,
+			ObjectTyper:  scheme.Scheme,
+			ClientMapper: client,
+			Decoder:      corev1Codec,
+		},
+		nil,
+		categories.LegacyCategoryExpander,
+	)
+}
+
 func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../test/fixtures/pkg/kubectl/builder/kitten-rc.yaml"}})
 
 	test := &testVisitor{}
@@ -279,10 +296,11 @@ func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {
 	if info.Name != "update-demo-kitten" || info.Namespace != "" || info.Object == nil {
 		t.Errorf("unexpected info: %#v", info)
 	}
-	version, ok := info.VersionedObject.(*v1.ReplicationController)
+	obj := info.AsVersioned()
+	version, ok := obj.(*v1.ReplicationController)
 	// versioned object does not have defaulting applied
-	if info.VersionedObject == nil || !ok || version.Spec.Replicas != nil {
-		t.Errorf("unexpected versioned object: %#v", info.VersionedObject)
+	if obj == nil || !ok || version.Spec.Replicas != nil {
+		t.Errorf("unexpected versioned object: %#v", obj)
 	}
 }
 
@@ -303,8 +321,7 @@ func TestNodeBuilder(t *testing.T) {
 		w.Write([]byte(runtime.EncodeOrDie(corev1Codec, node)))
 	}()
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
-		NamespaceParam("test").Stream(r, "STDIN")
+	b := newDefaultBuilder().NamespaceParam("test").Stream(r, "STDIN")
 
 	test := &testVisitor{}
 
@@ -367,7 +384,7 @@ func TestPathBuilderWithMultiple(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+		b := newDefaultBuilder().
 			FilenameParam(false, &FilenameOptions{Recursive: test.recursive, Filenames: []string{test.directory}}).
 			NamespaceParam("test").DefaultNamespace()
 
@@ -426,7 +443,7 @@ func TestPathBuilderWithMultipleInvalid(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+		b := newDefaultBuilder().
 			FilenameParam(false, &FilenameOptions{Recursive: test.recursive, Filenames: []string{test.directory}}).
 			NamespaceParam("test").DefaultNamespace()
 
@@ -441,7 +458,7 @@ func TestPathBuilderWithMultipleInvalid(t *testing.T) {
 }
 
 func TestDirectoryBuilder(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/legacy"}}).
 		NamespaceParam("test").DefaultNamespace()
 
@@ -472,7 +489,7 @@ func TestNamespaceOverride(t *testing.T) {
 	}))
 	defer s.Close()
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{s.URL}}).
 		NamespaceParam("test")
 
@@ -483,7 +500,7 @@ func TestNamespaceOverride(t *testing.T) {
 		t.Fatalf("unexpected response: %v %#v", err, test.Infos)
 	}
 
-	b = NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b = newDefaultBuilder().
 		FilenameParam(true, &FilenameOptions{Recursive: false, Filenames: []string{s.URL}}).
 		NamespaceParam("test")
 
@@ -503,7 +520,7 @@ func TestURLBuilder(t *testing.T) {
 	}))
 	defer s.Close()
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{s.URL}}).
 		NamespaceParam("foo")
 
@@ -532,7 +549,7 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 	}))
 	defer s.Close()
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{s.URL}}).
 		NamespaceParam("test").RequireNamespace()
 
@@ -547,10 +564,9 @@ func TestURLBuilderRequireNamespace(t *testing.T) {
 
 func TestResourceByName(t *testing.T) {
 	pods, _ := testData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-	}), corev1Codec).
-		NamespaceParam("test")
+	})).NamespaceParam("test")
 
 	test := &testVisitor{}
 	singleItemImplied := false
@@ -580,12 +596,12 @@ func TestResourceByName(t *testing.T) {
 
 func TestMultipleResourceByTheSameName(t *testing.T) {
 	pods, svcs := testData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
 		"/namespaces/test/pods/baz":     runtime.EncodeOrDie(corev1Codec, &pods.Items[1]),
 		"/namespaces/test/services/foo": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
 		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svcs.Items[0]),
-	}), corev1Codec).
+	})).
 		NamespaceParam("test")
 
 	test := &testVisitor{}
@@ -632,11 +648,10 @@ func TestRequestModifier(t *testing.T) {
 
 func TestResourceNames(t *testing.T) {
 	pods, svc := testData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
 		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svc.Items[0]),
-	}), corev1Codec).
-		NamespaceParam("test")
+	})).NamespaceParam("test")
 
 	test := &testVisitor{}
 
@@ -660,11 +675,10 @@ func TestResourceNames(t *testing.T) {
 
 func TestResourceNamesWithoutResource(t *testing.T) {
 	pods, svc := testData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
 		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, &svc.Items[0]),
-	}), corev1Codec).
-		NamespaceParam("test")
+	})).NamespaceParam("test")
 
 	test := &testVisitor{}
 
@@ -681,8 +695,7 @@ func TestResourceNamesWithoutResource(t *testing.T) {
 }
 
 func TestResourceByNameWithoutRequireObject(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{}), corev1Codec).
-		NamespaceParam("test")
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{})).NamespaceParam("test")
 
 	test := &testVisitor{}
 	singleItemImplied := false
@@ -715,9 +728,9 @@ func TestResourceByNameWithoutRequireObject(t *testing.T) {
 
 func TestResourceByNameAndEmptySelector(t *testing.T) {
 	pods, _ := testData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo": runtime.EncodeOrDie(corev1Codec, &pods.Items[0]),
-	}), corev1Codec).
+	})).
 		NamespaceParam("test").
 		LabelSelectorParam("").
 		ResourceTypeOrNameArgs(true, "pods", "foo")
@@ -743,10 +756,10 @@ func TestResourceByNameAndEmptySelector(t *testing.T) {
 func TestLabelSelector(t *testing.T) {
 	pods, svc := testData()
 	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
-	}), corev1Codec).
+	})).
 		LabelSelectorParam("a=b").
 		NamespaceParam("test").
 		Flatten()
@@ -774,7 +787,7 @@ func TestLabelSelector(t *testing.T) {
 }
 
 func TestLabelSelectorRequiresKnownTypes(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").
 		NamespaceParam("test").
 		ResourceTypes("unknown")
@@ -787,10 +800,10 @@ func TestLabelSelectorRequiresKnownTypes(t *testing.T) {
 func TestFieldSelector(t *testing.T) {
 	pods, svc := testData()
 	fieldKey := metav1.FieldSelectorQueryParam(corev1GV.String())
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + fieldKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + fieldKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
-	}), corev1Codec).
+	})).
 		FieldSelectorParam("a=b").
 		NamespaceParam("test").
 		Flatten()
@@ -818,7 +831,7 @@ func TestFieldSelector(t *testing.T) {
 }
 
 func TestFieldSelectorRequiresKnownTypes(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		FieldSelectorParam("a=b").
 		NamespaceParam("test").
 		ResourceTypes("unknown")
@@ -829,7 +842,7 @@ func TestFieldSelectorRequiresKnownTypes(t *testing.T) {
 }
 
 func TestSingleResourceType(t *testing.T) {
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").
 		SingleResourceType().
 		ResourceTypeOrNameArgs(true, "pods,services")
@@ -898,8 +911,7 @@ func TestResourceTuple(t *testing.T) {
 					"/nodes/foo":                runtime.EncodeOrDie(corev1Codec, &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}),
 				}
 			}
-
-			b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith(k, t, expectedRequests), corev1Codec).
+			b := newDefaultBuilderWith(fakeClientWith(k, t, expectedRequests)).
 				NamespaceParam("test").DefaultNamespace().
 				ResourceTypeOrNameArgs(true, testCase.args...).RequireObject(requireObject)
 
@@ -930,7 +942,7 @@ func TestResourceTuple(t *testing.T) {
 
 func TestStream(t *testing.T) {
 	r, pods, rc := streamTestData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		NamespaceParam("test").Stream(r, "STDIN").Flatten()
 
 	test := &testVisitor{}
@@ -947,7 +959,7 @@ func TestStream(t *testing.T) {
 
 func TestYAMLStream(t *testing.T) {
 	r, pods, rc := streamYAMLTestData()
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		NamespaceParam("test").Stream(r, "STDIN").Flatten()
 
 	test := &testVisitor{}
@@ -964,7 +976,7 @@ func TestYAMLStream(t *testing.T) {
 
 func TestMultipleObject(t *testing.T) {
 	r, pods, svc := streamTestData()
-	obj, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	obj, err := newDefaultBuilder().
 		NamespaceParam("test").Stream(r, "STDIN").Flatten().
 		Do().Object()
 
@@ -986,7 +998,7 @@ func TestMultipleObject(t *testing.T) {
 
 func TestContinueOnErrorVisitor(t *testing.T) {
 	r, _, _ := streamTestData()
-	req := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	req := newDefaultBuilder().
 		ContinueOnError().
 		NamespaceParam("test").Stream(r, "STDIN").Flatten().
 		Do()
@@ -1015,7 +1027,7 @@ func TestContinueOnErrorVisitor(t *testing.T) {
 }
 
 func TestSingleItemImpliedObject(t *testing.T) {
-	obj, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	obj, err := newDefaultBuilder().
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"}}).
 		Flatten().
@@ -1035,7 +1047,7 @@ func TestSingleItemImpliedObject(t *testing.T) {
 }
 
 func TestSingleItemImpliedObjectNoExtension(t *testing.T) {
-	obj, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	obj, err := newDefaultBuilder().
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/pod"}}).
 		Flatten().
@@ -1057,7 +1069,7 @@ func TestSingleItemImpliedObjectNoExtension(t *testing.T) {
 func TestSingleItemImpliedRootScopedObject(t *testing.T) {
 	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "test"}, Spec: v1.NodeSpec{ExternalID: "test"}}
 	r := streamTestObject(node)
-	infos, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	infos, err := newDefaultBuilder().
 		NamespaceParam("test").DefaultNamespace().
 		Stream(r, "STDIN").
 		Flatten().
@@ -1082,9 +1094,9 @@ func TestSingleItemImpliedRootScopedObject(t *testing.T) {
 func TestListObject(t *testing.T) {
 	pods, _ := testData()
 	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, pods),
-	}), corev1Codec).
+	})).
 		LabelSelectorParam("a=b").
 		NamespaceParam("test").
 		ResourceTypeOrNameArgs(true, "pods").
@@ -1115,10 +1127,10 @@ func TestListObject(t *testing.T) {
 func TestListObjectWithDifferentVersions(t *testing.T) {
 	pods, svc := testData()
 	labelKey := metav1.LabelSelectorQueryParam(corev1GV.String())
-	obj, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	obj, err := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods?" + labelKey + "=a%3Db":     runtime.EncodeOrDie(corev1Codec, pods),
 		"/namespaces/test/services?" + labelKey + "=a%3Db": runtime.EncodeOrDie(corev1Codec, svc),
-	}), corev1Codec).
+	})).
 		LabelSelectorParam("a=b").
 		NamespaceParam("test").
 		ResourceTypeOrNameArgs(true, "pods,services").
@@ -1141,12 +1153,12 @@ func TestListObjectWithDifferentVersions(t *testing.T) {
 
 func TestWatch(t *testing.T) {
 	_, svc := testData()
-	w, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	w, err := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/services?fieldSelector=metadata.name%3Dredis-master&resourceVersion=12&watch=true": watchBody(watch.Event{
 			Type:   watch.Added,
 			Object: &svc.Items[0],
 		}),
-	}), corev1Codec).
+	})).
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/redis-master-service.yaml"}}).Flatten().
 		Do().Watch("12")
@@ -1173,7 +1185,7 @@ func TestWatch(t *testing.T) {
 }
 
 func TestWatchMultipleError(t *testing.T) {
-	_, err := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	_, err := newDefaultBuilder().
 		NamespaceParam("test").DefaultNamespace().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"}}).Flatten().
 		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../../examples/guestbook/legacy/redis-master-controller.yaml"}}).Flatten().
@@ -1196,11 +1208,11 @@ func TestLatest(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: "baz", Namespace: "test", ResourceVersion: "15"},
 	}
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("", t, map[string]string{
+	b := newDefaultBuilderWith(fakeClientWith("", t, map[string]string{
 		"/namespaces/test/pods/foo":     runtime.EncodeOrDie(corev1Codec, newPod),
 		"/namespaces/test/pods/bar":     runtime.EncodeOrDie(corev1Codec, newPod2),
 		"/namespaces/test/services/baz": runtime.EncodeOrDie(corev1Codec, newSvc),
-	}), corev1Codec).
+	})).
 		NamespaceParam("other").Stream(r, "STDIN").Flatten().Latest()
 
 	test := &testVisitor{}
@@ -1232,7 +1244,7 @@ func TestReceiveMultipleErrors(t *testing.T) {
 		w2.Write([]byte(runtime.EncodeOrDie(corev1Codec, &svc.Items[0])))
 	}()
 
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClient(), corev1Codec).
+	b := newDefaultBuilder().
 		Stream(r, "1").Stream(r2, "2").
 		ContinueOnError()
 

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -277,7 +277,7 @@ func newDefaultBuilderWith(client ClientMapper) *Builder {
 		},
 		nil,
 		categories.LegacyCategoryExpander,
-	)
+	).Internal()
 }
 
 func TestPathBuilderAndVersionedObjectNotDefaulted(t *testing.T) {
@@ -628,7 +628,7 @@ func TestMultipleResourceByTheSameName(t *testing.T) {
 
 func TestRequestModifier(t *testing.T) {
 	var got *rest.Request
-	b := NewBuilder(restmapper, categories.LegacyCategoryExpander, scheme.Scheme, fakeClientWith("test", t, nil), corev1Codec).
+	b := newDefaultBuilderWith(fakeClientWith("test", t, nil)).
 		NamespaceParam("foo").
 		TransformRequests(func(req *rest.Request) {
 			got = req

--- a/pkg/kubectl/resource/mapper.go
+++ b/pkg/kubectl/resource/mapper.go
@@ -25,17 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-// DisabledClientForMapping allows callers to avoid allowing remote calls when handling
-// resources.
-type DisabledClientForMapping struct {
-	ClientMapper
-}
-
-func (f DisabledClientForMapping) ClientForMapping(mapping *meta.RESTMapping) (RESTClient, error) {
-	return nil, nil
-}
-
-// Mapper is a convenience struct for holding references to the three interfaces
+// Mapper is a convenience struct for holding references to the interfaces
 // needed to create Info for arbitrary objects.
 type Mapper struct {
 	runtime.ObjectTyper
@@ -44,17 +34,27 @@ type Mapper struct {
 	runtime.Decoder
 }
 
+// AcceptUnrecognizedObjects will return a mapper that will tolerate objects
+// that are not recognized by the RESTMapper, returning mappings that can
+// perform minimal transformation. Allows working in disconnected mode, or with
+// objects that the server does not recognize. Returned resource.Info objects
+// may have empty resource fields and nil clients.
+func (m *Mapper) AcceptUnrecognizedObjects() *Mapper {
+	copied := *m
+	copied.RESTMapper = NewRelaxedRESTMapper(m.RESTMapper)
+	copied.ClientMapper = NewRelaxedClientMapper(m.ClientMapper)
+	return &copied
+}
+
 // InfoForData creates an Info object for the given data. An error is returned
 // if any of the decoding or client lookup steps fail. Name and namespace will be
 // set into Info if the mapping's MetadataAccessor can retrieve them.
 func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
-	versions := &runtime.VersionedObjects{}
-	_, gvk, err := m.Decode(data, nil, versions)
+	obj, gvk, err := m.Decode(data, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("unable to decode %q: %v", source, err)
 	}
 
-	obj, versioned := versions.Last(), versions.First()
 	mapping, err := m.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %q: %v", source, err)
@@ -70,14 +70,15 @@ func (m *Mapper) InfoForData(data []byte, source string) (*Info, error) {
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 
 	return &Info{
-		Mapping:         mapping,
-		Client:          client,
+		Client:  client,
+		Mapping: mapping,
+
+		Source:          source,
 		Namespace:       namespace,
 		Name:            name,
-		Source:          source,
-		VersionedObject: versioned,
-		Object:          obj,
 		ResourceVersion: resourceVersion,
+
+		Object: obj,
 	}, nil
 }
 
@@ -99,6 +100,7 @@ func (m *Mapper) InfoForObject(obj runtime.Object, preferredGVKs []schema.GroupV
 	if err != nil {
 		return nil, fmt.Errorf("unable to recognize %v: %v", groupVersionKind, err)
 	}
+
 	client, err := m.ClientForMapping(mapping)
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to a server to handle %q: %v", mapping.Resource, err)
@@ -107,13 +109,14 @@ func (m *Mapper) InfoForObject(obj runtime.Object, preferredGVKs []schema.GroupV
 	namespace, _ := mapping.MetadataAccessor.Namespace(obj)
 	resourceVersion, _ := mapping.MetadataAccessor.ResourceVersion(obj)
 	return &Info{
-		Mapping:   mapping,
-		Client:    client,
-		Namespace: namespace,
-		Name:      name,
+		Client:  client,
+		Mapping: mapping,
 
-		Object:          obj,
+		Namespace:       namespace,
+		Name:            name,
 		ResourceVersion: resourceVersion,
+
+		Object: obj,
 	}, nil
 }
 
@@ -151,4 +154,84 @@ func preferredObjectKind(possibilities []schema.GroupVersionKind, preferences []
 
 	// Just pick the first
 	return possibilities[0]
+}
+
+// DisabledClientForMapping allows callers to avoid allowing remote calls when handling
+// resources.
+type DisabledClientForMapping struct {
+	ClientMapper
+}
+
+func (f DisabledClientForMapping) ClientForMapping(mapping *meta.RESTMapping) (RESTClient, error) {
+	return nil, nil
+}
+
+// NewRelaxedClientMapper will return a nil mapping if the object is not a recognized resource.
+func NewRelaxedClientMapper(mapper ClientMapper) ClientMapper {
+	return relaxedClientMapper{mapper}
+}
+
+type relaxedClientMapper struct {
+	ClientMapper
+}
+
+func (f relaxedClientMapper) ClientForMapping(mapping *meta.RESTMapping) (RESTClient, error) {
+	if len(mapping.Resource) == 0 {
+		return nil, nil
+	}
+	return f.ClientMapper.ClientForMapping(mapping)
+}
+
+// NewRelaxedRESTMapper returns a RESTMapper that will tolerate mappings that don't exist in provided
+// RESTMapper, returning a mapping that is a best effort against the current server. This allows objects
+// that the server does not recognize to still be loaded.
+func NewRelaxedRESTMapper(mapper meta.RESTMapper) meta.RESTMapper {
+	return relaxedMapper{mapper}
+}
+
+type relaxedMapper struct {
+	meta.RESTMapper
+}
+
+func (m relaxedMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	mapping, err := m.RESTMapper.RESTMapping(gk, versions...)
+	if err != nil && meta.IsNoMatchError(err) && len(versions) > 0 {
+		return &meta.RESTMapping{
+			GroupVersionKind: gk.WithVersion(versions[0]),
+			MetadataAccessor: meta.NewAccessor(),
+			Scope:            meta.RESTScopeRoot,
+			ObjectConvertor:  identityConvertor{},
+		}, nil
+	}
+	return mapping, err
+}
+func (m relaxedMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	mappings, err := m.RESTMapper.RESTMappings(gk, versions...)
+	if err != nil && meta.IsNoMatchError(err) && len(versions) > 0 {
+		return []*meta.RESTMapping{
+			{
+				GroupVersionKind: gk.WithVersion(versions[0]),
+				MetadataAccessor: meta.NewAccessor(),
+				Scope:            meta.RESTScopeRoot,
+				ObjectConvertor:  identityConvertor{},
+			},
+		}, nil
+	}
+	return mappings, err
+}
+
+type identityConvertor struct{}
+
+var _ runtime.ObjectConvertor = identityConvertor{}
+
+func (c identityConvertor) Convert(in interface{}, out interface{}, context interface{}) error {
+	return fmt.Errorf("unable to convert objects across pointers")
+}
+
+func (c identityConvertor) ConvertToVersion(in runtime.Object, gv runtime.GroupVersioner) (out runtime.Object, err error) {
+	return in, nil
+}
+
+func (c identityConvertor) ConvertFieldLabel(version string, kind string, label string, value string) (string, string, error) {
+	return "", "", fmt.Errorf("unable to convert field labels")
 }

--- a/pkg/kubectl/resource/result.go
+++ b/pkg/kubectl/resource/result.go
@@ -41,6 +41,7 @@ type Result struct {
 	singleItemImplied  bool
 	targetsSingleItems bool
 
+	mapper       *Mapper
 	ignoreErrors []utilerrors.Matcher
 
 	// populated by a call to Infos
@@ -72,6 +73,11 @@ func (r *Result) IgnoreErrors(fns ...ErrMatchFunc) *Result {
 		r.ignoreErrors = append(r.ignoreErrors, utilerrors.Matcher(fn))
 	}
 	return r
+}
+
+// Mapper returns a copy of the builder's mapper.
+func (r *Result) Mapper() *Mapper {
+	return r.mapper
 }
 
 // Err returns one or more errors (via a util.ErrorList) that occurred prior

--- a/pkg/kubectl/resource/selector.go
+++ b/pkg/kubectl/resource/selector.go
@@ -92,13 +92,15 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 		resourceVersion, _ := accessor.ResourceVersion(list)
 		nextContinueToken, _ := accessor.Continue(list)
 		info := &Info{
-			Client:    r.Client,
-			Mapping:   r.Mapping,
-			Namespace: r.Namespace,
+			Client:  r.Client,
+			Mapping: r.Mapping,
 
-			Object:          list,
+			Namespace:       r.Namespace,
 			ResourceVersion: resourceVersion,
+
+			Object: list,
 		}
+
 		if err := fn(info, nil); err != nil {
 			return err
 		}

--- a/pkg/kubectl/resource/visitor.go
+++ b/pkg/kubectl/resource/visitor.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -73,15 +74,22 @@ type ResourceMapping interface {
 // Info contains temporary info to execute a REST call, or show the results
 // of an already completed REST call.
 type Info struct {
-	Client    RESTClient
-	Mapping   *meta.RESTMapping
+	Client RESTClient
+	// Mapping may be nil if the object has no available metadata, but is still parseable
+	// from disk.
+	Mapping *meta.RESTMapping
+	// Namespace will be set if the object is namespaced and has a specified value.
 	Namespace string
 	Name      string
 
 	// Optional, Source is the filename or URL to template file (.json or .yaml),
 	// or stdin to use to handle the resource
 	Source string
-	// Optional, this is the most recent value returned by the server if available
+	// Optional, this is the most recent value returned by the server if available. It will
+	// typically be in unstructured or internal forms, depending on how the Builder was
+	// defined. If retrieved from the server, the Builder expects the mapping client to
+	// decide the final form. Use the AsVersioned, AsUnstructured, and AsInternal helpers
+	// to alter the object versions.
 	Object runtime.Object
 	// Optional, this is the most recent resource version the server knows about for
 	// this type of resource. It may not match the resource version of the object,
@@ -159,6 +167,61 @@ func (i *Info) Watch(resourceVersion string) (watch.Interface, error) {
 // ResourceMapping returns the mapping for this resource and implements ResourceMapping
 func (i *Info) ResourceMapping() *meta.RESTMapping {
 	return i.Mapping
+}
+
+// Internal attempts to convert the provided object to an internal type or returns an error.
+func (i *Info) Internal() (runtime.Object, error) {
+	return i.Mapping.ConvertToVersion(i.Object, i.Mapping.GroupVersionKind.GroupKind().WithVersion(runtime.APIVersionInternal).GroupVersion())
+}
+
+// AsInternal returns the object in internal form if possible, or i.Object if it cannot be
+// converted.
+func (i *Info) AsInternal() runtime.Object {
+	if obj, err := i.Internal(); err == nil {
+		return obj
+	}
+	return i.Object
+}
+
+// Versioned returns the object as a Go type in the mapping's version or returns an error.
+func (i *Info) Versioned() (runtime.Object, error) {
+	return i.Mapping.ConvertToVersion(i.Object, i.Mapping.GroupVersionKind.GroupVersion())
+}
+
+// AsVersioned returns the object as a Go object in the external form if possible (matching the
+// group version kind of the mapping, or i.Object if it cannot be converted.
+func (i *Info) AsVersioned() runtime.Object {
+	if obj, err := i.Versioned(); err == nil {
+		return obj
+	}
+	return i.Object
+}
+
+// Unstructured returns the current object in unstructured form (as a runtime.Unstructured)
+func (i *Info) Unstructured() (runtime.Unstructured, error) {
+	switch t := i.Object.(type) {
+	case runtime.Unstructured:
+		return t, nil
+	case *runtime.Unknown:
+		gvk := i.Mapping.GroupVersionKind
+		out, _, err := unstructured.UnstructuredJSONScheme.Decode(t.Raw, &gvk, nil)
+		return out.(runtime.Unstructured), err
+	default:
+		out := &unstructured.Unstructured{}
+		if err := i.Mapping.Convert(i.Object, out, nil); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+// AsUnstructured returns the object as a Go object in external form as a runtime.Unstructured
+// (map of JSON equivalent values) or as i.Object if it cannot be converted.
+func (i *Info) AsUnstructured() runtime.Object {
+	if out, err := i.Unstructured(); err == nil {
+		return out
+	}
+	return i.Object
 }
 
 // VisitorList implements Visit for the sub visitors it contains. The first error

--- a/pkg/kubectl/resource_filter.go
+++ b/pkg/kubectl/resource_filter.go
@@ -19,7 +19,6 @@ package kubectl
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/printers"
 )
@@ -57,30 +56,10 @@ func filterPods(obj runtime.Object, options printers.PrintOptions) bool {
 
 // Filter loops through a collection of FilterFuncs until it finds one that can filter the given resource
 func (f Filters) Filter(obj runtime.Object, opts *printers.PrintOptions) (bool, error) {
-	// check if the object is unstructured. If so, let's attempt to convert it to a type we can understand
-	// before apply filter func.
-	obj, _ = DecodeUnknownObject(obj)
-
 	for _, filter := range f {
 		if ok := filter(obj, *opts); ok {
 			return true, nil
 		}
 	}
 	return false, nil
-}
-
-// check if the object is unstructured. If so, let's attempt to convert it to a type we can understand.
-func DecodeUnknownObject(obj runtime.Object) (runtime.Object, error) {
-	var err error
-
-	switch obj.(type) {
-	case runtime.Unstructured, *runtime.Unknown:
-		if objBytes, err := runtime.Encode(legacyscheme.Codecs.LegacyCodec(), obj); err == nil {
-			if decodedObj, err := runtime.Decode(legacyscheme.Codecs.UniversalDecoder(), objBytes); err == nil {
-				obj = decodedObj
-			}
-		}
-	}
-
-	return obj, err
 }

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/BUILD
@@ -34,6 +34,7 @@ go_library(
         "firsthit_restmapper.go",
         "help.go",
         "interfaces.go",
+        "lazy.go",
         "meta.go",
         "multirestmapper.go",
         "priority.go",

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/lazy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/lazy.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package meta
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// lazyObject defers loading the mapper and typer until necessary.
+type lazyObject struct {
+	loader func() (RESTMapper, runtime.ObjectTyper, error)
+
+	lock   sync.Mutex
+	loaded bool
+	err    error
+	mapper RESTMapper
+	typer  runtime.ObjectTyper
+}
+
+// NewLazyObjectLoader handles unrecoverable errors when creating a RESTMapper / ObjectTyper by
+// returning those initialization errors when the interface methods are invoked. This defers the
+// initialization and any server calls until a client actually needs to perform the action.
+func NewLazyObjectLoader(fn func() (RESTMapper, runtime.ObjectTyper, error)) (RESTMapper, runtime.ObjectTyper) {
+	obj := &lazyObject{loader: fn}
+	return obj, obj
+}
+
+// init lazily loads the mapper and typer, returning an error if initialization has failed.
+func (o *lazyObject) init() error {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if o.loaded {
+		return o.err
+	}
+	o.mapper, o.typer, o.err = o.loader()
+	o.loaded = true
+	return o.err
+}
+
+var _ RESTMapper = &lazyObject{}
+var _ runtime.ObjectTyper = &lazyObject{}
+
+func (o *lazyObject) KindFor(resource schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	if err := o.init(); err != nil {
+		return schema.GroupVersionKind{}, err
+	}
+	return o.mapper.KindFor(resource)
+}
+
+func (o *lazyObject) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	if err := o.init(); err != nil {
+		return []schema.GroupVersionKind{}, err
+	}
+	return o.mapper.KindsFor(resource)
+}
+
+func (o *lazyObject) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	if err := o.init(); err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return o.mapper.ResourceFor(input)
+}
+
+func (o *lazyObject) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	if err := o.init(); err != nil {
+		return []schema.GroupVersionResource{}, err
+	}
+	return o.mapper.ResourcesFor(input)
+}
+
+func (o *lazyObject) RESTMapping(gk schema.GroupKind, versions ...string) (*RESTMapping, error) {
+	if err := o.init(); err != nil {
+		return nil, err
+	}
+	return o.mapper.RESTMapping(gk, versions...)
+}
+
+func (o *lazyObject) RESTMappings(gk schema.GroupKind, versions ...string) ([]*RESTMapping, error) {
+	if err := o.init(); err != nil {
+		return nil, err
+	}
+	return o.mapper.RESTMappings(gk, versions...)
+}
+
+func (o *lazyObject) ResourceSingularizer(resource string) (singular string, err error) {
+	if err := o.init(); err != nil {
+		return "", err
+	}
+	return o.mapper.ResourceSingularizer(resource)
+}
+
+func (o *lazyObject) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	if err := o.init(); err != nil {
+		return nil, false, err
+	}
+	return o.typer.ObjectKinds(obj)
+}
+
+func (o *lazyObject) Recognizes(gvk schema.GroupVersionKind) bool {
+	if err := o.init(); err != nil {
+		return false
+	}
+	return o.typer.Recognizes(gvk)
+}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/unstructured.go
@@ -21,8 +21,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// InterfacesForUnstructuredConversion returns VersionInterfaces suitable for
+// dealing with unstructured.Unstructured objects and supports conversion
+// from typed objects (provided by parent) to untyped objects.
+func InterfacesForUnstructuredConversion(parent VersionInterfacesFunc) VersionInterfacesFunc {
+	return func(version schema.GroupVersion) (*VersionInterfaces, error) {
+		if i, err := parent(version); err == nil {
+			return &VersionInterfaces{
+				ObjectConvertor:  i.ObjectConvertor,
+				MetadataAccessor: NewAccessor(),
+			}, nil
+		}
+		return InterfacesForUnstructured(version)
+	}
+}
+
 // InterfacesForUnstructured returns VersionInterfaces suitable for
-// dealing with unstructured.Unstructured objects.
+// dealing with unstructured.Unstructured objects. It will return errors for
+// other conversions.
 func InterfacesForUnstructured(schema.GroupVersion) (*VersionInterfaces, error) {
 	return &VersionInterfaces{
 		ObjectConvertor:  &unstructured.UnstructuredObjectConverter{},

--- a/staging/src/k8s.io/client-go/dynamic/dynamic_util.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamic_util.go
@@ -84,7 +84,7 @@ func NewObjectTyper(resources []*metav1.APIResourceList) (runtime.ObjectTyper, e
 // information.
 func (ot *ObjectTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
 	if _, ok := obj.(*unstructured.Unstructured); !ok {
-		return nil, false, fmt.Errorf("type %T is invalid for dynamic object typer", obj)
+		return nil, false, fmt.Errorf("type %T is invalid for determining dynamic object types", obj)
 	}
 	return []schema.GroupVersionKind{obj.GetObjectKind().GroupVersionKind()}, false, nil
 }


### PR DESCRIPTION
Remove the need for kubectl callers to distinguish between unstructured and versioned / type aware builders.  The factory should create a single builder than can be set to return unstructured objects.  Callers can then use one of the new helpers on `resource.Info` to convert the objects into the desired form - `Internal()` for printers, `Typed()` for external versions, and `Unstructured()` to ensure the object is in the right state.  Leverages the new scheme support for unstructured conversion so that higher level callers can perform best effort conversion (get typed versions if you have them, otherwise use default behavior).  

`get.go` demonstrates this by removing the previous logic that depended on the underlying scheme.  Other commands are updated to be consistent.

Includes #55650 and #55647.