### PR TITLE
Make kubectl explain print the Kind and APIVersion of the resource

### DIFF
--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -129,5 +129,5 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 		return fmt.Errorf("Couldn't find resource for %q", gvk)
 	}
 
-	return explain.PrintModelDescription(fieldsPath, out, schema, recursive)
+	return explain.PrintModelDescription(fieldsPath, out, schema, gvk, recursive)
 }

--- a/pkg/kubectl/explain/BUILD
+++ b/pkg/kubectl/explain/BUILD
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )

--- a/pkg/kubectl/explain/explain.go
+++ b/pkg/kubectl/explain/explain.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kube-openapi/pkg/util/proto"
 )
 
@@ -47,7 +48,7 @@ func SplitAndParseResourceRequest(inResource string, mapper meta.RESTMapper) (st
 // PrintModelDescription prints the description of a specific model or dot path.
 // If recursive, all components nested within the fields of the schema will be
 // printed.
-func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, recursive bool) error {
+func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema, gvk schema.GroupVersionKind, recursive bool) error {
 	fieldName := ""
 	if len(fieldsPath) != 0 {
 		fieldName = fieldsPath[len(fieldsPath)-1]
@@ -60,5 +61,5 @@ func PrintModelDescription(fieldsPath []string, w io.Writer, schema proto.Schema
 	}
 	b := fieldsPrinterBuilder{Recursive: recursive}
 	f := &Formatter{Writer: w, Wrap: 80}
-	return PrintModel(fieldName, f, b, schema)
+	return PrintModel(fieldName, f, b, schema, gvk)
 }

--- a/pkg/kubectl/explain/model_printer_test.go
+++ b/pkg/kubectl/explain/model_printer_test.go
@@ -24,11 +24,12 @@ import (
 )
 
 func TestModel(t *testing.T) {
-	schema := resources.LookupResource(schema.GroupVersionKind{
+	gvk := schema.GroupVersionKind{
 		Group:   "",
 		Version: "v1",
 		Kind:    "OneKind",
-	})
+	}
+	schema := resources.LookupResource(gvk)
 	if schema == nil {
 		t.Fatal("Couldn't find schema v1.OneKind")
 	}
@@ -38,7 +39,10 @@ func TestModel(t *testing.T) {
 		want string
 	}{
 		{
-			want: `DESCRIPTION:
+			want: `KIND:     OneKind
+VERSION:  v1
+
+DESCRIPTION:
      OneKind has a short description
 
 FIELDS:
@@ -58,7 +62,10 @@ FIELDS:
 			path: []string{},
 		},
 		{
-			want: `RESOURCE: field1 <Object>
+			want: `KIND:     OneKind
+VERSION:  v1
+
+RESOURCE: field1 <Object>
 
 DESCRIPTION:
      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ut lacus ac
@@ -90,7 +97,10 @@ FIELDS:
 			path: []string{"field1"},
 		},
 		{
-			want: `FIELD: string <string>
+			want: `KIND:     OneKind
+VERSION:  v1
+
+FIELD:    string <string>
 
 DESCRIPTION:
      This string must be a string
@@ -98,7 +108,10 @@ DESCRIPTION:
 			path: []string{"field1", "string"},
 		},
 		{
-			want: `FIELD: array <[]integer>
+			want: `KIND:     OneKind
+VERSION:  v1
+
+FIELD:    array <[]integer>
 
 DESCRIPTION:
      This array must be an array of int
@@ -111,7 +124,7 @@ DESCRIPTION:
 
 	for _, test := range tests {
 		buf := bytes.Buffer{}
-		if err := PrintModelDescription(test.path, &buf, schema, false); err != nil {
+		if err := PrintModelDescription(test.path, &buf, schema, gvk, false); err != nil {
 			t.Fatalf("Failed to PrintModelDescription for path %v: %v", test.path, err)
 		}
 		got := buf.String()


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubectl explain currently doesn't print out the Kind and APIversion of the resource being explained. When running `kubectl explain hpa.spec`, for example, there is no way of knowing whether you're looking at the `autoscaling/v1` or the `autoscaling/v2beta1` version. 
Also, `kubectl explain` is often used as a reference when writing YAML/JSON object manifests. It allows you to look up everything except the API version. Currently, you either need to know the API Version of a resource by heart or look it up in the online API docs. 
This PR fixes both problems by having `kubectl explain` print out the full Kind and APIVersion of the resource it is explaining.

Here are a few examples of the new output:
```
$ kubectl explain deploy
KIND:     Deployment
VERSION:  extensions/v1beta1

DESCRIPTION:
...


$ kubectl explain hpa.spec
KIND:     HorizontalPodAutoscaler
VERSION:  autoscaling/v1

RESOURCE: spec <Object>

DESCRIPTION:
...


$ kubectl explain hpa.spec.maxReplicas
KIND:     HorizontalPodAutoscaler
VERSION:  autoscaling/v1

FIELD:    maxReplicas <integer>

DESCRIPTION:
...


$ kubectl explain hpa.spec --recursive
KIND:     HorizontalPodAutoscaler
VERSION:  autoscaling/v1

RESOURCE: spec <Object>

DESCRIPTION:
     behaviour of autoscaler. More info:
     https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.

     specification of a horizontal pod autoscaler.

FIELDS:
   maxReplicas	<integer>
   minReplicas	<integer>
   scaleTargetRef	<Object>
      apiVersion	<string>
      kind	<string>
      name	<string>
   targetCPUUtilizationPercentage	<integer>
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubectl explain now prints out the Kind and API version of the resource being explained
```
