### PR TITLE
Turn on metadata concealment by default in config-default

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -167,9 +167,7 @@ fi
 
 # Enable metadata concealment by firewalling pod traffic to the metadata server
 # and run a proxy daemonset on nodes.
-#
-# TODO(#8867) Enable by default.
-ENABLE_METADATA_CONCEALMENT="${ENABLE_METADATA_CONCEALMENT:-false}" # true, false
+ENABLE_METADATA_CONCEALMENT="${ENABLE_METADATA_CONCEALMENT:-true}" # true, false
 if [[ ${ENABLE_METADATA_CONCEALMENT:-} == "true" ]]; then
   # Put the necessary label on the node so the daemonset gets scheduled.
   NODE_LABELS="${NODE_LABELS},beta.kubernetes.io/metadata-proxy-ready=true"


### PR DESCRIPTION
To match config-test.sh. This was the reason I was failing to reproduce issue https://github.com/kubernetes/kubernetes/issues/55695 locally while using kube-up.

/cc @crassirostris @porridge 