### PR TITLE
Use full gopath for externalTypes

### DIFF
--- a/pkg/apis/admission/v1alpha1/doc.go
+++ b/pkg/apis/admission/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admission
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/admission/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/admission/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admission/v1alpha1
 

--- a/pkg/apis/admissionregistration/v1alpha1/doc.go
+++ b/pkg/apis/admissionregistration/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/admissionregistration
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/admissionregistration/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/admissionregistration/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/admissionregistration/v1alpha1
 

--- a/pkg/apis/apps/v1/doc.go
+++ b/pkg/apis/apps/v1/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/apps/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/apps/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1
 

--- a/pkg/apis/apps/v1beta1/doc.go
+++ b/pkg/apis/apps/v1beta1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/apps/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1beta1
 

--- a/pkg/apis/apps/v1beta2/doc.go
+++ b/pkg/apis/apps/v1beta2/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/apps
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/apps/v1beta2
+// +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta2
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/apps/v1beta2
 

--- a/pkg/apis/authentication/v1/doc.go
+++ b/pkg/apis/authentication/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authentication
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/authentication/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/authentication/v1
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1

--- a/pkg/apis/authentication/v1beta1/doc.go
+++ b/pkg/apis/authentication/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authentication
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/authentication/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/authentication/v1beta1
 // +groupName=authentication.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authentication/v1beta1

--- a/pkg/apis/authorization/v1/doc.go
+++ b/pkg/apis/authorization/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authorization
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/authorization/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/authorization/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1
 

--- a/pkg/apis/authorization/v1beta1/doc.go
+++ b/pkg/apis/authorization/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/authorization
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/authorization/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/authorization/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/authorization/v1beta1
 

--- a/pkg/apis/autoscaling/v1/doc.go
+++ b/pkg/apis/autoscaling/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/autoscaling/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/autoscaling/v1
 

--- a/pkg/apis/autoscaling/v2beta1/doc.go
+++ b/pkg/apis/autoscaling/v2beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/autoscaling/v2beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v2beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/autoscaling/v2beta1
 

--- a/pkg/apis/batch/v1/doc.go
+++ b/pkg/apis/batch/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/batch/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/batch/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v1
 

--- a/pkg/apis/batch/v1beta1/doc.go
+++ b/pkg/apis/batch/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/batch/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/batch/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v1beta1
 

--- a/pkg/apis/batch/v2alpha1/doc.go
+++ b/pkg/apis/batch/v2alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/batch
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/batch/v2alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/batch/v2alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/batch/v2alpha1
 

--- a/pkg/apis/certificates/v1beta1/doc.go
+++ b/pkg/apis/certificates/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/certificates
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/certificates/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/certificates/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/certificates/v1beta1
 

--- a/pkg/apis/core/v1/doc.go
+++ b/pkg/apis/core/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/core
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/core/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/core/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/core/v1
 

--- a/pkg/apis/extensions/v1beta1/doc.go
+++ b/pkg/apis/extensions/v1beta1/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/autoscaling
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/extensions/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/extensions/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/extensions/v1beta1
 

--- a/pkg/apis/imagepolicy/v1alpha1/doc.go
+++ b/pkg/apis/imagepolicy/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/imagepolicy
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/imagepolicy/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/imagepolicy/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/imagepolicy/v1alpha1
 

--- a/pkg/apis/networking/v1/doc.go
+++ b/pkg/apis/networking/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/networking
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/networking/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/networking/v1
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/extensions
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/networking/v1

--- a/pkg/apis/policy/v1beta1/doc.go
+++ b/pkg/apis/policy/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/policy
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/policy/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/policy/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/policy/v1beta1
 

--- a/pkg/apis/rbac/v1/doc.go
+++ b/pkg/apis/rbac/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/rbac/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1
 

--- a/pkg/apis/rbac/v1alpha1/doc.go
+++ b/pkg/apis/rbac/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/rbac/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1alpha1
 

--- a/pkg/apis/rbac/v1beta1/doc.go
+++ b/pkg/apis/rbac/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/rbac
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/rbac/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/rbac/v1beta1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/rbac/v1beta1
 

--- a/pkg/apis/scheduling/v1alpha1/doc.go
+++ b/pkg/apis/scheduling/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/scheduling
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/scheduling/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/scheduling/v1alpha1
 // +groupName=scheduling.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/scheduling/v1alpha1

--- a/pkg/apis/settings/v1alpha1/doc.go
+++ b/pkg/apis/settings/v1alpha1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/settings
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/settings/v1alpha1
+// +k8s:conversion-gen-external-types=k8s.io/api/settings/v1alpha1
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/settings/v1alpha1
 

--- a/pkg/apis/storage/v1/doc.go
+++ b/pkg/apis/storage/v1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/storage
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/storage/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/storage/v1
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1

--- a/pkg/apis/storage/v1beta1/doc.go
+++ b/pkg/apis/storage/v1beta1/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/pkg/apis/storage
-// +k8s:conversion-gen-external-types=../../../../vendor/k8s.io/api/storage/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/storage/v1beta1
 // +groupName=storage.k8s.io
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../vendor/k8s.io/api/storage/v1beta1

--- a/staging/src/k8s.io/client-go/scale/scheme/appsv1beta1/doc.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/appsv1beta1/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/client-go/scale/scheme
-// +k8s:conversion-gen-external-types=../../../../../k8s.io/api/apps/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta1
 
 package appsv1beta1 // import "k8s.io/client-go/scale/scheme/appsv1beta1"

--- a/staging/src/k8s.io/client-go/scale/scheme/appsv1beta2/doc.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/appsv1beta2/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/client-go/scale/scheme
-// +k8s:conversion-gen-external-types=../../../../../k8s.io/api/apps/v1beta2
+// +k8s:conversion-gen-external-types=k8s.io/api/apps/v1beta2
 
 package appsv1beta2 // import "k8s.io/client-go/scale/scheme/appsv1beta2"

--- a/staging/src/k8s.io/client-go/scale/scheme/autoscalingv1/doc.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/autoscalingv1/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/client-go/scale/scheme
-// +k8s:conversion-gen-external-types=../../../../../k8s.io/api/autoscaling/v1
+// +k8s:conversion-gen-external-types=k8s.io/api/autoscaling/v1
 
 package autoscalingv1 // import "k8s.io/client-go/scale/scheme/autoscalingv1"

--- a/staging/src/k8s.io/client-go/scale/scheme/extensionsv1beta1/doc.go
+++ b/staging/src/k8s.io/client-go/scale/scheme/extensionsv1beta1/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 // +k8s:conversion-gen=k8s.io/kubernetes/vendor/k8s.io/client-go/scale/scheme
-// +k8s:conversion-gen-external-types=../../../../../k8s.io/api/extensions/v1beta1
+// +k8s:conversion-gen-external-types=k8s.io/api/extensions/v1beta1
 
 package extensionsv1beta1 // import "k8s.io/client-go/scale/scheme/extensionsv1beta1"

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -275,7 +275,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			externalTypes := externalTypesValues[0]
 			glog.V(5).Infof("  external types tags: %q", externalTypes)
 			var err error
-			typesPkg, err = context.AddDirectory(filepath.Join(pkg.Path, externalTypes))
+			typesPkg, err = context.AddDirectory(externalTypes)
 			if err != nil {
 				glog.Fatalf("cannot import package %s", externalTypes)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is using full gopath when specifying external types for generator, instead of relative ones. 

Context: if you vendor Kube and reference Kube conversions via tags, the given relative name is most certainly wrong because the vendor/ directory is not inside Kube anymore. Absolute paths fix this.

**Release note**:
```release-note
NONE
```
