### PR TITLE
Return original error instead of negotiation one

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers.go
@@ -104,6 +104,12 @@ func SerializeObject(mediaType string, encoder runtime.Encoder, w http.ResponseW
 func WriteObjectNegotiated(ctx request.Context, s runtime.NegotiatedSerializer, gv schema.GroupVersion, w http.ResponseWriter, req *http.Request, statusCode int, object runtime.Object) {
 	serializer, err := negotiation.NegotiateOutputSerializer(req, s)
 	if err != nil {
+		// if original statusCode was not successful we need to return the original error
+		// we cannot hide it behind negotiation problems
+		if statusCode < http.StatusOK || statusCode >= http.StatusBadRequest {
+			WriteRawJSON(int(statusCode), object, w)
+			return
+		}
 		status := ErrorToAPIStatus(err)
 		WriteRawJSON(int(status.Code), status, w)
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
When the requested type (eg. `text/html`) is not available and we're trying to hit an endpoint to which a user is for unauthorized we'll get 406, instead of 403. The reason for that is that, even if error happens we're trying to match the serializer, which fails and results in swallowing error, instead of returning raw json, for example. 

This fix returns raw json for such situations.

**Release note**:
```release-note
NONE
```
