### PR TITLE
[DO NOT MERGE] Add support for experimental-userns-remap-root-uid and experimental-userns-remap-root-gid options to match the remapping used by the container runtime.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -171,6 +171,11 @@ type KubeletFlags struct {
 	// run on restore
 	BootstrapCheckpointPath string
 
+	// When user namespaces are enabled, use this uid for root uid in the containers
+	ExperimentalUserNSRootUID int32
+	// When user namespaces are enabled, use this gid for root gid in the containers
+	ExperimentalUserNSRootGID int32
+
 	// DEPRECATED FLAGS
 	// minimumGCAge is the minimum age for a finished container before it is
 	// garbage collected.
@@ -243,7 +248,9 @@ func NewKubeletFlags() *KubeletFlags {
 		HostPIDSources:      []string{kubetypes.AllSource},
 		HostIPCSources:      []string{kubetypes.AllSource},
 		// TODO(#56523): default CAdvisorPort to 0 (disabled) and deprecate it
-		CAdvisorPort: 4194,
+		CAdvisorPort:              4194,
+		ExperimentalUserNSRootUID: 0,
+		ExperimentalUserNSRootGID: 0,
 	}
 }
 
@@ -393,6 +400,8 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.BoolVar(&f.ExitOnLockContention, "exit-on-lock-contention", f.ExitOnLockContention, "Whether kubelet should exit upon lock-file contention.")
 	fs.StringVar(&f.SeccompProfileRoot, "seccomp-profile-root", f.SeccompProfileRoot, "<Warning: Alpha feature> Directory path for seccomp profiles.")
 	fs.StringVar(&f.BootstrapCheckpointPath, "bootstrap-checkpoint-path", f.BootstrapCheckpointPath, "<Warning: Alpha feature> Path to to the directory where the checkpoints are stored")
+	fs.Int32Var(&f.ExperimentalUserNSRootUID, "experimental-userns-remap-root-uid", f.ExperimentalUserNSRootUID, "When user namespaces are enabled, use this gid for root gid in the containers.")
+	fs.Int32Var(&f.ExperimentalUserNSRootGID, "experimental-userns-remap-root-gid", f.ExperimentalUserNSRootGID, "When user namespaces are enabled, use this gid for root gid in the containers.")
 
 	// DEPRECATED FLAGS
 	fs.StringVar(&f.BootstrapKubeconfig, "experimental-bootstrap-kubeconfig", f.BootstrapKubeconfig, "")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -933,7 +933,9 @@ func RunKubelet(kubeFlags *options.KubeletFlags, kubeCfg *kubeletconfiginternal.
 		kubeFlags.KeepTerminatedPodVolumes,
 		kubeFlags.NodeLabels,
 		kubeFlags.SeccompProfileRoot,
-		kubeFlags.BootstrapCheckpointPath)
+		kubeFlags.BootstrapCheckpointPath,
+		kubeFlags.ExperimentalUserNSRootUID,
+		kubeFlags.ExperimentalUserNSRootGID)
 	if err != nil {
 		return fmt.Errorf("failed to create kubelet: %v", err)
 	}
@@ -1017,7 +1019,9 @@ func CreateAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	keepTerminatedPodVolumes bool,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
-	bootstrapCheckpointPath string) (k kubelet.Bootstrap, err error) {
+	bootstrapCheckpointPath string,
+	experimentalUserNSRootUID int32,
+	experimentalUserNSRootGID int32) (k kubelet.Bootstrap, err error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 
@@ -1050,7 +1054,9 @@ func CreateAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		keepTerminatedPodVolumes,
 		nodeLabels,
 		seccompProfileRoot,
-		bootstrapCheckpointPath)
+		bootstrapCheckpointPath,
+		experimentalUserNSRootUID,
+		experimentalUserNSRootGID)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -233,6 +233,8 @@ LOG_DIR=${LOG_DIR:-"/tmp"}
 CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"}
 CONTAINER_RUNTIME_ENDPOINT=${CONTAINER_RUNTIME_ENDPOINT:-""}
 IMAGE_SERVICE_ENDPOINT=${IMAGE_SERVICE_ENDPOINT:-""}
+USERNS_REMAP_ROOT_UID=${USERNS_REMAP_ROOT_UID:-""}
+USERNS_REMAP_ROOT_GID=${USERNS_REMAP_ROOT_GID:-""}
 CHAOS_CHANCE=${CHAOS_CHANCE:-0.0}
 CPU_CFS_QUOTA=${CPU_CFS_QUOTA:-true}
 ENABLE_HOSTPATH_PROVISIONER=${ENABLE_HOSTPATH_PROVISIONER:-"false"}
@@ -751,6 +753,14 @@ function start_kubelet {
       image_service_endpoint_args="--image-service-endpoint=${IMAGE_SERVICE_ENDPOINT}"
     fi
 
+    userns_remap_args=""
+    if [[ -n "${USERNS_REMAP_ROOT_UID}" ]]; then
+      userns_remap_args="--experimental-userns-remap-root-uid=${USERNS_REMAP_ROOT_UID}"
+      if [[ -n "${USERNS_REMAP_ROOT_GID}" ]]; then
+        userns_remap_args="$userns_remap_args --experimental-userns-remap-root-gid=${USERNS_REMAP_ROOT_GID}"
+      fi
+    fi
+
     all_kubelet_flags=(
       ${priv_arg}
       --v="${LOG_LEVEL}"
@@ -779,6 +789,7 @@ function start_kubelet {
       ${net_plugin_args}
       ${container_runtime_endpoint_args}
       ${image_service_endpoint_args}
+      ${userns_remap_args}
       --port="$KUBELET_PORT"
       ${KUBELET_FLAGS}
     )

--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -46,7 +46,11 @@ func (kl *Kubelet) getRootDir() string {
 // getPodsDir returns the full path to the directory under which pod
 // directories are created.
 func (kl *Kubelet) getPodsDir() string {
-	return filepath.Join(kl.getRootDir(), config.DefaultKubeletPodsDirName)
+	path := filepath.Join(kl.getRootDir(), config.DefaultKubeletPodsDirName)
+	if kl.experimentalUserNSRootUID > 0 {
+		path = fmt.Sprintf("%s-%d.%d", path, kl.experimentalUserNSRootUID, kl.experimentalUserNSRootGID)
+	}
+	return path
 }
 
 // getPluginsDir returns the full path to the directory under which plugin

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -473,6 +473,12 @@ func (kl *Kubelet) GenerateRunContainerOptions(pod *v1.Pod, container *v1.Contai
 			glog.Errorf("Error on creating %q: %v", p, err)
 		} else {
 			opts.PodContainerDir = p
+			if err := kl.experimentalChownRemap(p); err != nil {
+				glog.Error(err)
+			}
+			if err := kl.experimentalChownRemap(filepath.Join(p, "..")); err != nil {
+				glog.Error(err)
+			}
 		}
 	}
 
@@ -822,7 +828,13 @@ func (kl *Kubelet) makePodDataDirs(pod *v1.Pod) error {
 	if err := os.MkdirAll(kl.getPodDir(uid), 0750); err != nil && !os.IsExist(err) {
 		return err
 	}
+	if err := kl.experimentalChownRemap(kl.getPodDir(uid)); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(kl.getPodVolumesDir(uid), 0750); err != nil && !os.IsExist(err) {
+		return err
+	}
+	if err := kl.experimentalChownRemap(kl.getPodVolumesDir(uid)); err != nil {
 		return err
 	}
 	if err := os.MkdirAll(kl.getPodPluginsDir(uid), 0750); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The long-term goal is to make it possible to use Kubernetes with docker and its `--userns-remap` feature. The immediate goal was to allow `hack/local-up-cluster.sh` to start its pods.

We make the setting of uid/gid used by docker for root explicit via new options, and change ownership of directories from root to these remapped uid/gid.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

This PR does not fully address https://github.com/kubernetes/features/issues/127 but can be one of the steps needed to achieve the full functionality.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
New kubelet options `experimental-userns-remap-root-uid` and `experimental-userns-remap-root-gid` were added to allow matching the user remapping setting of docker deamon. For `hack/local-up-cluster.sh`, environment variables `USERNS_REMAP_ROOT_UID` and `USERNS_REMAP_ROOT_GID` can be used.
```
