### PR TITLE
Fix prometheus-to-sd sidecar in metadata proxy

### DIFF
--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -56,6 +56,17 @@ spec:
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
           - --api-override={{ prometheus_to_sd_endpoint }}
           - --source=metadata_proxy:http://127.0.0.1:989?whitelisted=request_count
+          - --pod-id=$(POD_NAME)
+          - --namespace-id=$(POD_NAMESPACE)
+        env:
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/metadata-proxy-ready: "true"

--- a/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
+++ b/cluster/addons/metadata-proxy/gce/metadata-proxy.yaml
@@ -43,11 +43,11 @@ spec:
           privileged: true
         resources:
           requests:
-            memory: "16Mi"
-            cpu: "15m"
+            memory: "32Mi"
+            cpu: "30m"
           limits:
-            memory: "16Mi"
-            cpu: "15m"
+            memory: "32Mi"
+            cpu: "30m"
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
         image: gcr.io/google_containers/prometheus-to-sd:v0.2.2
@@ -56,13 +56,6 @@ spec:
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons
           - --api-override={{ prometheus_to_sd_endpoint }}
           - --source=metadata_proxy:http://127.0.0.1:989?whitelisted=request_count
-        resources:
-          requests:
-            memory: "16Mi"
-            cpu: "15m"
-          limits:
-            memory: "16Mi"
-            cpu: "15m"
       # END_PROMETHEUS_TO_SD
       nodeSelector:
         beta.kubernetes.io/metadata-proxy-ready: "true"


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/55695#issuecomment-344300188

This is making 2 changes:
- restoring resource requests and limits of the metadata-proxy sidecar as it was before, and remove them for prom-to-sd sidecar (best effort) like at everywhere else
- pass pod name and namespace args to prom-to-sd sidecar (because just noticed)

/cc @ihmccreery @loburm @crassirostris - Does this make sense?