### PR TITLE
Set etcd version based on kubernetes version

### DIFF
--- a/cmd/kubeadm/app/constants/BUILD
+++ b/cmd/kubeadm/app/constants/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/constants",
     deps = [
         "//pkg/util/version:go_default_library",
+        "//pkg/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -110,3 +110,46 @@ func TestAddSelfHostedPrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDefaultEtcdVersion(t *testing.T) {
+	var tests = []struct {
+		k8sversion, expected string
+	}{
+		{
+			// unknown version. Should return current default
+			k8sversion: "",
+			expected:   DefaultEtcdVersion,
+		},
+		{
+			// non-semantic version. Should return current default
+			k8sversion: "foo",
+			expected:   DefaultEtcdVersion,
+		},
+		{
+			// same major version, but way higher minor version. Should return current default
+			k8sversion: "v1.99999.0",
+			expected:   DefaultEtcdVersion,
+		},
+		{
+			// version way higher than current. Should return current default
+			k8sversion: "v10.2.3",
+			expected:   DefaultEtcdVersion,
+		},
+		{
+			// version lower than current. Should return etcd version for previous releases
+			k8sversion: "v1.0.0",
+			expected:   DefaultEtcdVersionForPreviousKubernetesRelease,
+		},
+	}
+	for _, rt := range tests {
+		actual := GetDefaultEtcdVersion(rt.k8sversion)
+		if actual != rt.expected {
+			t.Errorf(
+				"failed GetDefaultEtcdVersion:\n\tk8sversion: %s\n\texpected: %s\n\t  actual: %s",
+				rt.k8sversion,
+				rt.expected,
+				actual,
+			)
+		}
+	}
+}

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -31,7 +31,7 @@ func GetCoreImage(image, repoPrefix, k8sVersion, overrideImage string) string {
 	}
 	kubernetesImageTag := kubeadmutil.KubernetesVersionToImageTag(k8sVersion)
 	return map[string]string{
-		constants.Etcd:                  fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "etcd", runtime.GOARCH, constants.DefaultEtcdVersion),
+		constants.Etcd:                  fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "etcd", runtime.GOARCH, constants.GetDefaultEtcdVersion(k8sVersion)),
 		constants.KubeAPIServer:         fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-apiserver", runtime.GOARCH, kubernetesImageTag),
 		constants.KubeControllerManager: fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-controller-manager", runtime.GOARCH, kubernetesImageTag),
 		constants.KubeScheduler:         fmt.Sprintf("%s/%s-%s:%s", repoPrefix, "kube-scheduler", runtime.GOARCH, kubernetesImageTag),


### PR DESCRIPTION
**What this PR does / why we need it**:
If kubeadm is used to deploy lower version of kubernetes than
kubeadm itself, it should be able to set etcd version accordingly.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#530

**Special notes for your reviewer**:
/area kubeadm
/sig cluster-lifecycle

**Release note**:
```release-note
NONE
```
