### PR TITLE
kubeadm: fix crictl command for reset

### DIFF
--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -230,10 +230,21 @@ func TestResetWithDocker(t *testing.T) {
 
 func TestResetWithCrictl(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+			// 2: socket path provided, not runnning with crictl (1x CombinedOutput, 2x Run)
+			func() ([]byte, error) { return []byte("1"), nil },
+			// 3: socket path provided, crictl fails, reset with docker (1x CombinedOuput fail, 1x Run)
+			func() ([]byte, error) { return nil, errors.New("crictl list err") },
+		},
 		RunScript: []fakeexec.FakeRunAction{
+			// 1: socket path not provided, running with docker
+			func() ([]byte, []byte, error) { return nil, nil, nil },
+			// 2: socket path provided, now runnning with crictl (1x CombinedOutput, 2x Run)
 			func() ([]byte, []byte, error) { return nil, nil, nil },
 			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, errors.New("crictl error") },
+			// 3: socket path provided, crictl fails, reset with docker (1x CombinedOuput, 1x Run)
+			func() ([]byte, []byte, error) { return nil, nil, nil },
+			// 4: running with no socket and docker fails (1x Run)
 			func() ([]byte, []byte, error) { return nil, nil, nil },
 		},
 	}
@@ -243,9 +254,13 @@ func TestResetWithCrictl(t *testing.T) {
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 	}
 
+	// 1: socket path not provided, running with docker
 	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "", "crictl")
 	if fcmd.RunCalls != 1 {
 		t.Errorf("expected 1 call to Run, got %d", fcmd.RunCalls)
@@ -254,25 +269,28 @@ func TestResetWithCrictl(t *testing.T) {
 		t.Errorf("expected a call to docker, got %v", fcmd.RunLog[0])
 	}
 
+	// 2: socket path provided, now runnning with crictl (1x CombinedOutput, 2x Run)
 	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "/test.sock", "crictl")
-	if fcmd.RunCalls != 2 {
-		t.Errorf("expected 2 calls to Run, got %d", fcmd.RunCalls)
+	if fcmd.RunCalls != 3 {
+		t.Errorf("expected 3 calls to Run, got %d", fcmd.RunCalls)
 	}
 	if !strings.Contains(fcmd.RunLog[1][2], "crictl") {
 		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
 	}
+	if !strings.Contains(fcmd.RunLog[2][2], "crictl") {
+		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
+	}
 
+	// 3: socket path provided, crictl fails, reset with docker
 	resetWithCrictl(&fexec, newFakeDockerChecker(nil, nil), "/test.sock", "crictl")
 	if fcmd.RunCalls != 4 {
 		t.Errorf("expected 4 calls to Run, got %d", fcmd.RunCalls)
-	}
-	if !strings.Contains(fcmd.RunLog[2][2], "crictl") {
-		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
 	}
 	if !strings.Contains(fcmd.RunLog[3][2], "docker") {
 		t.Errorf("expected a call to docker, got %v", fcmd.RunLog[0])
 	}
 
+	// 4: running with no socket and docker fails (1x Run)
 	resetWithCrictl(&fexec, newFakeDockerChecker(nil, []error{errors.New("test error")}), "", "crictl")
 	if fcmd.RunCalls != 4 {
 		t.Errorf("expected 4 calls to Run, got %d", fcmd.RunCalls)
@@ -281,7 +299,13 @@ func TestResetWithCrictl(t *testing.T) {
 
 func TestReset(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
+		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
+			func() ([]byte, error) { return []byte("1"), nil },
+			func() ([]byte, error) { return []byte("1"), nil },
+			func() ([]byte, error) { return []byte("1"), nil },
+		},
 		RunScript: []fakeexec.FakeRunAction{
+			func() ([]byte, []byte, error) { return nil, nil, nil },
 			func() ([]byte, []byte, error) { return nil, nil, nil },
 			func() ([]byte, []byte, error) { return nil, nil, nil },
 		},
@@ -290,13 +314,17 @@ func TestReset(t *testing.T) {
 		CommandScript: []fakeexec.FakeCommandAction{
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
+			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 		},
 		LookPathFunc: func(cmd string) (string, error) { return cmd, nil },
 	}
 
 	reset(&fexec, newFakeDockerChecker(nil, nil), "/test.sock")
-	if fcmd.RunCalls != 1 {
-		t.Errorf("expected 1 call to Run, got %d", fcmd.RunCalls)
+	if fcmd.RunCalls != 2 {
+		t.Errorf("expected 2 call to Run, got %d", fcmd.RunCalls)
 	}
 	if !strings.Contains(fcmd.RunLog[0][2], "crictl") {
 		t.Errorf("expected a call to crictl, got %v", fcmd.RunLog[0])
@@ -304,10 +332,10 @@ func TestReset(t *testing.T) {
 
 	fexec.LookPathFunc = func(cmd string) (string, error) { return "", errors.New("no crictl") }
 	reset(&fexec, newFakeDockerChecker(nil, nil), "/test.sock")
-	if fcmd.RunCalls != 2 {
-		t.Errorf("expected 2 calls to Run, got %d", fcmd.RunCalls)
+	if fcmd.RunCalls != 3 {
+		t.Errorf("expected 3 calls to Run, got %d", fcmd.RunCalls)
 	}
-	if !strings.Contains(fcmd.RunLog[1][2], "docker") {
+	if !strings.Contains(fcmd.RunLog[2][2], "docker") {
 		t.Errorf("expected a call to docker, got %v", fcmd.RunLog[0])
 	}
 }


### PR DESCRIPTION
Signed-off-by: Antonio Murdaca <runcom@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR is fixing kubeadm reset, we used the wrong command pipeline now that crictl has a new version out. This version targets kube master (1.9-dev) so this is the right fix.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix kubeadm reset crictl command
```

@luxas PTAL
