### PR TITLE
convert failed pod recreation and rollback without restarts DS e2e tests

### DIFF
--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -18,11 +18,13 @@ go_test(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller/daemon:go_default_library",
         "//pkg/util/metrics:go_default_library",
+        "//plugin/pkg/scheduler/schedulercache:go_default_library",
         "//test/integration/framework:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
@@ -31,6 +33,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes/typed/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/client-go/util/retry:go_default_library",
     ],
 )
 

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -26,17 +26,21 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	corev1typed "k8s.io/client-go/kubernetes/typed/core/v1"
+	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	extensionsv1beta1typed "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	"k8s.io/kubernetes/pkg/util/metrics"
+	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -391,5 +395,269 @@ func TestInsufficientCapacityNodeDaemonDoesNotLaunchPod(t *testing.T) {
 		validateFailedPlacementEvent(eventClient, t)
 
 		close(stopCh)
+	}
+}
+
+func getPods(t *testing.T, podClient corev1typed.PodInterface, labelMap map[string]string) *v1.PodList {
+	podSelector := labels.Set(labelMap).AsSelector()
+	options := metav1.ListOptions{LabelSelector: podSelector.String()}
+	pods, err := podClient.List(options)
+	if err != nil {
+		t.Fatalf("failed obtaining a list of pods that match the pod labels %v: %v", labelMap, err)
+	}
+	return pods
+}
+
+func updatePod(t *testing.T, podClient typedv1.PodInterface, podName string, updateFunc func(*v1.Pod)) *v1.Pod {
+	var pod *v1.Pod
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := podClient.Get(podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updateFunc(newPod)
+		pod, err = podClient.Update(newPod)
+		return err
+	}); err != nil {
+		t.Fatalf("failed to update status of pod %q: %v", pod.Name, err)
+	}
+	return pod
+}
+
+func updatePodStatus(t *testing.T, podClient typedv1.PodInterface, podName string, updateStatusFunc func(*v1.Pod)) *v1.Pod {
+	var pod *v1.Pod
+	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		newPod, err := podClient.Get(podName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		updateStatusFunc(newPod)
+		pod, err = podClient.UpdateStatus(newPod)
+		return err
+	}); err != nil {
+		t.Fatalf("failed to update status of pod %q: %v", pod.Name, err)
+	}
+	return pod
+}
+
+// checkAtLeastOnePodWithNewImage checks if there is at least one pod with specific image
+func checkAtLeastOnePodWithImage(podClient corev1typed.PodInterface, image string, t *testing.T) {
+	if err := wait.Poll(2*time.Second, 20*time.Second, func() (bool, error) {
+		pods := getPods(t, podClient, testLabels())
+		for _, pod := range pods.Items {
+			if pod.Spec.Containers[0].Image == image {
+				return true, nil
+			}
+		}
+		return false, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// canScheduleOnNode checks if a given DaemonSet can schedule pods on the given node
+func canScheduleOnNode(node v1.Node, ds *v1beta1.DaemonSet) bool {
+	newPod := daemon.NewPod(ds, node.Name)
+	nodeInfo := schedulercache.NewNodeInfo()
+	nodeInfo.SetNode(&node)
+	fit, _, err := daemon.Predicates(newPod, nodeInfo)
+	if err != nil {
+		return false
+	}
+	return fit
+}
+
+// schedulableNodes returns name list of schedulable nodes for a given DaemonSet
+func schedulableNodes(c clientset.Interface, ds *v1beta1.DaemonSet, t *testing.T) []string {
+	nodeList, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to get a list of schedulable nodes for daemonset %q: %v", ds.Name, err)
+	}
+	nodeNames := make([]string, 0)
+	for _, node := range nodeList.Items {
+		if !canScheduleOnNode(node, ds) {
+			continue
+		}
+		nodeNames = append(nodeNames, node.Name)
+	}
+	return nodeNames
+}
+
+// checkPodsImageAndAvailability checks whether pods have desired image and
+// maxUnavailable requirement is met after a rolling update operation completes
+func checkPodsImageAndAvailability(c clientset.Interface, ds *v1beta1.DaemonSet, image string, maxUnavailable int, podClient corev1typed.PodInterface, t *testing.T) {
+	if err := wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {
+		pods := getPods(t, podClient, testLabels())
+		unavailablePods := 0
+		nodesToUpdatedPodCount := make(map[string]int)
+		for _, pod := range pods.Items {
+			if !metav1.IsControlledBy(&pod, ds) {
+				continue
+			}
+			podImage := pod.Spec.Containers[0].Image
+			if podImage == image {
+				nodesToUpdatedPodCount[pod.Spec.NodeName]++
+			}
+			if !podutil.IsPodAvailable(&pod, ds.Spec.MinReadySeconds, metav1.Now()) {
+				unavailablePods++
+			}
+		}
+		if unavailablePods > maxUnavailable {
+			return false, fmt.Errorf("number of unavailable pods %d is greater than maxUnavailable %d", unavailablePods, maxUnavailable)
+		}
+		// Make sure every pod on the node has been updated
+		nodeNames := schedulableNodes(c, ds, t)
+		for _, node := range nodeNames {
+			if nodesToUpdatedPodCount[node] == 0 {
+				return false, nil
+			}
+		}
+		return true, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A DaemonSet should retry creating failed daemon pods
+func TestRetryCreatingFailedPod(t *testing.T) {
+	for _, strategy := range updateStrategies() {
+		server, closeFn, dc, informers, clientset := setup(t)
+		defer closeFn()
+		ns := framework.CreateTestingNamespace("retry-creating-failed-pod-test", server, t)
+		defer framework.DeleteTestingNamespace(ns, server, t)
+
+		dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+		podClient := clientset.CoreV1().Pods(ns.Name)
+		nodeClient := clientset.CoreV1().Nodes()
+		podInformer := informers.Core().V1().Pods().Informer()
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		informers.Start(stopCh)
+		go dc.Run(5, stopCh)
+
+		dsName := "daemonset"
+		ds := newDaemonSet(dsName, ns.Name)
+		ds.Spec.UpdateStrategy = *strategy
+		ds, err := dsClient.Create(ds)
+		if err != nil {
+			t.Fatalf("failed to create daemonset %q: %v", dsName, err)
+		}
+
+		nodeName := "single-node"
+		node := newNode(nodeName, nil)
+		_, err = nodeClient.Create(node)
+		if err != nil {
+			t.Fatalf("failed to create node %q: %v", nodeName, err)
+		}
+
+		// Validate everything works correctly, include marking pods
+		// as ready and ensure they launch on every node
+		validateDaemonSetPodsAndMarkReady(podClient, podInformer, 1, t)
+		validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 1, t)
+
+		// Set the pod's phase to "Failed"
+		pods := getPods(t, podClient, testLabels())
+		pod := updatePodStatus(t, podClient, pods.Items[0].Name, func(pod *v1.Pod) {
+			pod.Status.Phase = v1.PodFailed
+		})
+
+		// Validate everything works correctly again
+		validateDaemonSetPodsAndMarkReady(podClient, podInformer, 1, t)
+		validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 1, t)
+
+		// Validate the failed pod is re-created
+		pods = getPods(t, podClient, testLabels())
+		pod = &pods.Items[0]
+		if pod.Status.Phase != v1.PodRunning {
+			t.Fatalf("failed to retry create failed pod %q", pod.Name)
+		}
+	}
+}
+
+// A RollingUpdate DaemonSet should rollback without unnecessary restarts
+func TestRollbackWithoutUnnecessaryRestarts(t *testing.T) {
+	server, closeFn, dc, informers, clientset := setup(t)
+	defer closeFn()
+	ns := framework.CreateTestingNamespace("rollback-without-unnecessary-restarts-test", server, t)
+	defer framework.DeleteTestingNamespace(ns, server, t)
+
+	dsClient := clientset.ExtensionsV1beta1().DaemonSets(ns.Name)
+	podClient := clientset.CoreV1().Pods(ns.Name)
+	nodeClient := clientset.CoreV1().Nodes()
+	podInformer := informers.Core().V1().Pods().Informer()
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	informers.Start(stopCh)
+	go dc.Run(5, stopCh)
+
+	// Create a rolling update daemonset
+	dsName := "daemonset"
+	ds := newDaemonSet(dsName, ns.Name)
+	ds.Spec.UpdateStrategy = *newRollbackStrategy()
+	oldImage := "image"
+	ds.Spec.Template.Spec.Containers[0].Image = oldImage
+	ds, err := dsClient.Create(ds)
+	if err != nil {
+		t.Fatalf("failed to create daemonset %q: %v", dsName, err)
+	}
+
+	// Create 2 nodes
+	addNodes(nodeClient, 0, 2, nil, t)
+
+	// Validate everything works correctly, include marking pods
+	// as ready and ensure they launch on every node
+	validateDaemonSetPodsAndMarkReady(podClient, podInformer, 2, t)
+	validateDaemonSetStatus(dsClient, ds.Name, ds.Namespace, 2, t)
+
+	// Manually update image of first pod to the new image
+	// Note: daemonset image update does not propagate to its pods
+	newImage := "non-existent-image"
+	pods := getPods(t, podClient, testLabels())
+	pod := updatePod(t, podClient, pods.Items[0].Name, func(pod *v1.Pod) {
+		pod.Spec.Containers[0].Image = newImage
+	})
+
+	// Ensure we are in the middle of a rollout by checking whether
+	// there is at least one pod with new image
+	checkAtLeastOnePodWithImage(podClient, newImage, t)
+	var existingPods, newPods []*v1.Pod
+	pods = getPods(t, podClient, testLabels())
+	for i := range pods.Items {
+		pod := pods.Items[i]
+		image := pod.Spec.Containers[0].Image
+		switch image {
+		case oldImage:
+			existingPods = append(existingPods, &pod)
+		case newImage:
+			newPods = append(newPods, &pod)
+		default:
+			t.Fatalf("unexpected pod image %q found", image)
+		}
+	}
+	if len(existingPods) == 0 {
+		t.Fatalf("expected at least one pod with old image exists, but found none")
+	}
+	if len(newPods) == 0 {
+		t.Fatalf("expected at least one pod with new image exists, but found none")
+	}
+
+	// Manually update image of first pod back to old image
+	updatePod(t, podClient, pod.Name, func(pod *v1.Pod) {
+		pod.Spec.Containers[0].Image = oldImage
+	})
+
+	// Ensure the rollback is complete
+	checkPodsImageAndAvailability(clientset, ds, oldImage, 1, podClient, t)
+
+	// Ensure pods are not restarted during rollback by comparing current and old pods
+	pods = getPods(t, podClient, testLabels())
+	m := map[string]bool{}
+	for _, pod := range pods.Items {
+		m[pod.Name] = true
+	}
+	for _, pod := range existingPods {
+		if _, ok := m[pod.Name]; !ok {
+			t.Fatalf("unexpected pod %q found due to pod restart", pod.Name)
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR converts failed pod recreation and rollback without unnecessary restarts daemonset e2e tests to integration tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
xref #TBA

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
