### PR TITLE
No need to set GITHUB_USR environment if exist in git configuration

### DIFF
--- a/hack/cherry_pick_pull.sh
+++ b/hack/cherry_pick_pull.sh
@@ -33,10 +33,24 @@ REGENERATE_DOCS=${REGENERATE_DOCS:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
 FORK_REMOTE=${FORK_REMOTE:-origin}
 
+
+set +o errexit
+GIT_LOCAL_USER=$(git config --local --get user.name)
+GIT_GLOBAL_USER=$(git config --global --get user.name)
+set -o errexit
+
 if [[ -z ${GITHUB_USER:-} ]]; then
-  echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
-  exit 1
+  if [[ -n ${GIT_LOCAL_USER} ]]; then
+    GITHUB_USER=${GIT_LOCAL_USER}
+  elif [[ -n ${GIT_GLOBAL_USER} ]]; then
+   GITHUB_USER=${GIT_GLOBAL_USER}
+  else
+    echo "Please export GITHUB_USER=<your-user> (or GH organization, if that's where your fork lives)"
+    exit 1
+  fi
 fi
+
+
 
 if ! which hub > /dev/null; then
   echo "Can't find 'hub' tool in PATH, please install from https://github.com/github/hub"


### PR DESCRIPTION
**What this PR does / why we need it**:
When run  hack/cherry_pick_pull.sh to cherry pick commit, we have to set GITHUB_USR  environment, actually, we usual set this configuration in git configuration, so we could check/get this info from local configuration firstly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
` None`
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
