### PR TITLE
[WIP] Add script to verify build tags

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -36,6 +36,7 @@ QUICK_PATTERNS+=(
   "verify-api-groups.sh"
   "verify-bazel.sh"
   "verify-boilerplate.sh"
+  "verify-build-tags.sh"
   "verify-generated-files-remake"
   "verify-godep-licenses.sh"
   "verify-gofmt.sh"
@@ -147,7 +148,7 @@ run-checks "${KUBE_ROOT}/hack/verify-*.sh" bash
 run-checks "${KUBE_ROOT}/hack/verify-*.py" python
 
 if [[ ${ret} -eq 1 ]]; then
-    print-failed-tests 
+    print-failed-tests
 fi
 exit ${ret}
 

--- a/hack/verify-build-tags.sh
+++ b/hack/verify-build-tags.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify whether files containing build tags are named with a platform specific
+# suffix. This is needed to ensure that the cross build is run when a file with
+# build tags changed.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+# Excluded files and directories
+EXCLUDED_FILES=(
+  "vendor/*"
+  "**/zz_generated*.go"
+)
+
+# File extensions that are permitted to have build tags
+SUPPORTED_EXTENSIONS=(
+  "linux"
+  "osx"
+  "solaris"
+  "unix"
+  "unsupported"
+  "windows"
+)
+
+FILTER_PATTERNS=()
+for i in "${EXCLUDED_FILES[@]}"; do
+    FILTER_PATTERNS+=(":(exclude)${i}")
+    FILTER_PATTERNS+=(":(exclude)${i}")
+done
+for i in "${SUPPORTED_EXTENSIONS[@]}"; do
+    FILTER_PATTERNS+=(":(exclude)**/*_${i}.go")
+    FILTER_PATTERNS+=(":(exclude)**/*_${i}_test.go")
+done
+
+cd "${KUBE_ROOT}"
+if git --no-pager grep -E $'^(// \+build) .*$' -- '**/*.go' "${FILTER_PATTERNS[@]}"; then
+  kube::log::error "Build tags are present in files that don't match a support build extension"
+  exit 1
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a script to verify build tags are only present in files with a proper extension.

This doesn't yet fix all the files that are non-conformant, and is a work in progress.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55750

**Release note**:
```release-note
NONE
```