### PR TITLE
Azure Load Balancer reconciliation should consider all Kubernetes-controlled properties of a LB NSG

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -1207,9 +1207,33 @@ func findRule(rules []network.LoadBalancingRule, rule network.LoadBalancingRule)
 
 func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) bool {
 	for _, existingRule := range rules {
-		if strings.EqualFold(*existingRule.Name, *rule.Name) {
-			return true
+		if !strings.EqualFold(*existingRule.Name, *rule.Name) {
+			continue
 		}
+		if existingRule.Protocol != rule.Protocol {
+			continue
+		}
+		if !strings.EqualFold(*existingRule.SourcePortRange, *rule.SourcePortRange) {
+			continue
+		}
+		if !strings.EqualFold(*existingRule.DestinationPortRange, *rule.DestinationPortRange) {
+			continue
+		}
+		if !strings.EqualFold(*existingRule.SourceAddressPrefix, *rule.SourceAddressPrefix) {
+			continue
+		}
+		if !allowsConsolidation(existingRule) && !allowsConsolidation(rule) {
+			if !strings.EqualFold(*existingRule.DestinationAddressPrefix, *rule.DestinationAddressPrefix) {
+				continue
+			}
+		}
+		if existingRule.Access != rule.Access {
+			continue
+		}
+		if existingRule.Direction != rule.Direction {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -1205,6 +1205,10 @@ func findRule(rules []network.LoadBalancingRule, rule network.LoadBalancingRule)
 	return false
 }
 
+// This compares rule's Name, Protocol, SourcePortRange, DestinationPortRange, SourceAddressPrefix, Access, and Direction.
+// Note that it compares rule's DestinationAddressPrefix only when it's not consolidated rule as such rule does not have DestinationAddressPrefix defined.
+// We intentionally do not compare DestinationAddressPrefixes in consolidated case because reconcileSecurityRule has to consider the two rules equal,
+// despite different DestinationAddressPrefixes, in order to give it a chance to consolidate the two rules.
 func findSecurityRule(rules []network.SecurityRule, rule network.SecurityRule) bool {
 	for _, existingRule := range rules {
 		if !strings.EqualFold(*existingRule.Name, *rule.Name) {

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -398,7 +398,7 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 	svc1.Spec.LoadBalancerIP = "192.168.0.0"
 	sg := getTestSecurityGroup(az)
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
-	sg,err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(""), true)
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(""), true)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}

--- a/pkg/cloudprovider/providers/azure/azure_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_test.go
@@ -392,6 +392,36 @@ func TestReconcileLoadBalancerAddServiceOnInternalSubnet(t *testing.T) {
 	validateLoadBalancer(t, lb, svc)
 }
 
+func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t *testing.T) {
+	az := getTestCloud()
+	svc1 := getTestService("serviceea", v1.ProtocolTCP, 80)
+	svc1.Spec.LoadBalancerIP = "192.168.0.0"
+	sg := getTestSecurityGroup(az)
+	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
+	sg,err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(""), true)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+	sg, err = az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(svc1.Spec.LoadBalancerIP), true)
+	if err != nil {
+		t.Errorf("Unexpected error: %q", err)
+	}
+	validateSecurityGroup(t, sg, svc1)
+}
+
+func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
+	az := getTestCloud()
+	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1.Spec.LoadBalancerIP = ""
+	sg := getTestSecurityGroup(az)
+	dynamicallyAssignedIP := "192.168.0.0"
+	sg, err := az.reconcileSecurityGroup(testClusterName, &svc1, to.StringPtr(dynamicallyAssignedIP), true)
+	if err != nil {
+		t.Errorf("unexpected error: %q", err)
+	}
+	validateSecurityGroup(t, sg, svc1)
+}
+
 // Test addition of services on an internal LB using both default and explicit subnets.
 func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	az := getTestCloud()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR refers to issue #55733 
With this PR, Kubernetes will update Azure nsg rules based on not just name, but also based on other properties such as destination port range and destination ip address.
We need it because right now Kubernetes will detect the difference and update only if there is difference in Name of nsg rule. It's been working fine for changing destination port range and source IP address because these two are part of the Name. (which external users should not assume) Basically right now, Kubernetes won't detect the difference if I go ahead and change any part of nsg rule using port UI. 
This PR will let Kubernetes detect the difference and always try to reconcile nsg rules with service definition.

**Which issue(s) this PR fixes** :
Fixes #55733 

**Special notes for your reviewer**: None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Kubernetes update Azure nsg rules based on not just difference in Name, but also in Protocol, SourcePortRange, DestinationPortRange, SourceAddressPrefix, DestinationAddressPrefix, Access, and Direction.
```
