### PR TITLE
WaitForCacheSync fail should return for service controller

### DIFF
--- a/pkg/controller/service/service_controller_test.go
+++ b/pkg/controller/service/service_controller_test.go
@@ -506,7 +506,7 @@ func TestProcessServiceDeletion(t *testing.T) {
 			},
 			expectedFn: func(svcErr error, retryDuration time.Duration) error {
 
-				expectedError := "Service external-balancer not in cache even though the watcher thought it was. Ignoring the deletion."
+				expectedError := "service external-balancer not in cache even though the watcher thought it was. Ignoring the deletion"
 				if svcErr == nil || svcErr.Error() != expectedError {
 					//cannot be nil or Wrong error message
 					return fmt.Errorf("Expected=%v Obtained=%v", expectedError, svcErr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

1. WaitForCacheSync fail should return for service controller as other controller
2. remove unused function
3. fix several weak error follow up #54280 according to https://github.com/golang/go/wiki/CodeReviewComments#error-strings

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
