### PR TITLE
improved error message

### DIFF
--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -88,18 +88,11 @@ var (
 	errFileCannotBeEmpty         = errors.New("Filepath can not be empty")
 	errTar126					 = errors.New("Tar command invoked but could not execute. Might be a permission problem or command is not an executable")
 	errTar127 					 = errors.New("Tar command not found, please install tar before using kubectl cp")
-	errTar2 					 = errors.New("Could be a permission problem or missing command arguments and keywords")
-	//errTarGeneric 				 = errors.New("The cp command failed")
 )
 
 const (
-	// errTar126					 = "Tar command invoked but could not execute. Might be a permission problem or command is not an executable"
-	// errTar127 					 = "Tar command not found, please install tar before using kubectl cp"
-	// errTar2 					 = "Could be a permission problem or missing command arguments and keywords"
-	// errTarGeneric				 = "The cp command failed"
 	exitCode126 				 = "command terminated with exit code 126"
 	exitCode127 				 = "command terminated with exit code 127"
-	exitCode2 					 = "command terminated with exit code 2"
 )
 
 func extractFileSpec(arg string) (fileSpec, error) {
@@ -221,22 +214,16 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 			return errTar126
 		} else if err.Error() == exitCode127 {
 			return errTar127 
-		} else if err.Error() == exitCode2 {
-			return errTar2
 		} else {
 			return err
 		}
 	}
-
-	// fmt.Println("Error before go func")
 
 	go func() {
 		defer writer.Close()
 		err := makeTar(src.File, dest.File, writer)
 		cmdutil.CheckErr(err)
 	}()
-
-	// fmt.Println("Error after go func")
 
 	cmdArr := []string{"tar", "xf", "-"}
 	destDir := path.Dir(dest.File)
@@ -258,9 +245,6 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 		Command:  cmdArr,
 		Executor: &DefaultRemoteExecutor{},
 	}
-
-	// fmt.Println("Should not get here")
-
 	return execute(f, cmd, options)
 }
 
@@ -276,8 +260,6 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 			return errTar126
 		} else if err.Error() == exitCode127 {
 			return errTar127 
-		} else if err.Error() == exitCode2 {
-			return errTar2
 		} else {
 			return err
 		}

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -89,7 +89,7 @@ var (
 	errTar126					 = errors.New("Tar command invoked but could not execute. Might be a permission problem or command is not an executable")
 	errTar127 					 = errors.New("Tar command not found, please install tar before using kubectl cp")
 	errTar2 					 = errors.New("Could be a permission problem or missing command arguments and keywords")
-	errTarGeneric 				 = errors.New("The cp command failed")
+	//errTarGeneric 				 = errors.New("The cp command failed")
 )
 
 const (
@@ -224,11 +224,11 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 		} else if err.Error() == exitCode2 {
 			return errTar2
 		} else {
-			return errTarGeneric
+			return err
 		}
 	}
 
-	fmt.Println("Error before go func")
+	// fmt.Println("Error before go func")
 
 	go func() {
 		defer writer.Close()
@@ -236,7 +236,7 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 		cmdutil.CheckErr(err)
 	}()
 
-	fmt.Println("Error after go func")
+	// fmt.Println("Error after go func")
 
 	cmdArr := []string{"tar", "xf", "-"}
 	destDir := path.Dir(dest.File)
@@ -259,8 +259,8 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 		Executor: &DefaultRemoteExecutor{},
 	}
 
-	fmt.Println("Should not get here")
-	
+	// fmt.Println("Should not get here")
+
 	return execute(f, cmd, options)
 }
 
@@ -269,19 +269,19 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 		return errFileCannotBeEmpty
 	}
 
-	// // check if tar command exists in the container
-	// if err := testTar(f, cmd, dest); err != nil {
+	// check if tar command exists in the container
+	if err := testTar(f, cmd, dest); err != nil {
 
-	// 	if err.Error() == exitCode126 {
-	// 		return errTar126
-	// 	} else if err.Error() == exitCode127 {
-	// 		return errTar127 
-	// 	} else if err.Error() == exitCode2 {
-	// 		return errTar2
-	// 	} else {
-	// 		return errTarGeneric
-	// 	}
-	// }
+		if err.Error() == exitCode126 {
+			return errTar126
+		} else if err.Error() == exitCode127 {
+			return errTar127 
+		} else if err.Error() == exitCode2 {
+			return errTar2
+		} else {
+			return err
+		}
+	}
 
 	reader, outStream := io.Pipe()
 	options := &ExecOptions{
@@ -404,7 +404,7 @@ func untarAll(reader io.Reader, destFile, prefix string) error {
 			if err := os.MkdirAll(outFileName, 0755); err != nil {
 				return err
 			}
-			continue
+			break
 		}
 
 		// handle coping remote file into local directory

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -86,6 +86,8 @@ type fileSpec struct {
 var (
 	errFileSpecDoesntMatchFormat = errors.New("Filespec must match the canonical format: [[namespace/]pod:]file/path")
 	errFileCannotBeEmpty         = errors.New("Filepath can not be empty")
+	errTar126					 = errors.New("Tar command invoked but could not execute. Might be a permission problem or command is not an executable")
+	errTar127 					 = errors.New("Tar command not found, please install tar before using kubectl cp")
 )
 
 func extractFileSpec(arg string) (fileSpec, error) {
@@ -160,6 +162,36 @@ func checkDestinationIsDir(dest fileSpec, f cmdutil.Factory, cmd *cobra.Command)
 	return execute(f, cmd, options)
 }
 
+
+// testTar receives information about the destination container 
+// and determines if the command tar is present in the containe.
+// If the command does not exist or permission was denied, an 
+// error will be returned along with the exit code received 
+func testTar(f cmdutil.Factory, cmd *cobra.Command, dest fileSpec) error {
+	
+	cmdArr := []string{"tar"}
+
+	reader, _ := io.Pipe()
+
+	options := &ExecOptions{
+		StreamOptions: StreamOptions{
+			In:    reader,
+			Out:   bytes.NewBuffer([]byte{}),
+			Err:   bytes.NewBuffer([]byte{}),
+			Stdin: true,
+
+			Namespace: dest.PodNamespace,
+			PodName:   dest.PodName,
+		},
+
+		Command:  cmdArr,
+		Executor: &DefaultRemoteExecutor{},
+	}
+	
+	return execute(f, cmd, options)
+
+}
+
 func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, src, dest fileSpec) error {
 	if len(src.File) == 0 {
 		return errFileCannotBeEmpty
@@ -184,6 +216,20 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 	}()
 
 	// TODO: Improve error messages by first testing if 'tar' is present in the container?
+	if err := testTar(f, cmd, dest); err != nil {
+
+		exitCode126 := "command terminated with exit code 126"
+		exitCode127 := "command terminated with exit code 127"
+
+		if err.Error() == exitCode126 {
+			return errTar126
+		} else if err.Error() == exitCode127 {
+			return errTar127 
+		} else {
+			return err
+		}
+	}
+
 	cmdArr := []string{"tar", "xf", "-"}
 	destDir := path.Dir(dest.File)
 	if len(destDir) > 0 {
@@ -210,6 +256,21 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, dest fileSpec) error {
 	if len(src.File) == 0 {
 		return errFileCannotBeEmpty
+	}
+
+	// check if tar command exists in the container
+	if err := testTar(f, cmd, dest); err != nil {
+
+		exitCode126 := "command terminated with exit code 126"
+		exitCode127 := "command terminated with exit code 127"
+
+		if err.Error() == exitCode126 {
+			return errTar126
+		} else if err.Error() == exitCode127 {
+			return errTar127 
+		} else {
+			return err
+		}
 	}
 
 	reader, outStream := io.Pipe()

--- a/pkg/kubectl/cmd/cp.go
+++ b/pkg/kubectl/cmd/cp.go
@@ -86,14 +86,14 @@ type fileSpec struct {
 var (
 	errFileSpecDoesntMatchFormat = errors.New("Filespec must match the canonical format: [[namespace/]pod:]file/path")
 	errFileCannotBeEmpty         = errors.New("Filepath can not be empty")
-	errTar126					 = errors.New("Tar command invoked but could not execute. Might be a permission problem or command is not an executable")
-	errTar127 					 = errors.New("Tar command not found, please install tar before using kubectl cp")
+	// errTar126					 = errors.New("Tar command invoked but could not execute. Might be a permission problem or command is not an executable")
+	// errTar127 					 = errors.New("Tar command not found, please install tar before using kubectl cp")
 )
 
-const (
-	exitCode126 				 = "command terminated with exit code 126"
-	exitCode127 				 = "command terminated with exit code 127"
-)
+// const (
+// 	exitCode126 				 = "command terminated with exit code 126"
+// 	exitCode127 				 = "command terminated with exit code 127"
+// )
 
 func extractFileSpec(arg string) (fileSpec, error) {
 	pieces := strings.Split(arg, ":")
@@ -172,24 +172,24 @@ func checkDestinationIsDir(dest fileSpec, f cmdutil.Factory, cmd *cobra.Command)
 // and determines if the command tar is present in the container.
 // If the command does not exist or permission was denied, an 
 // error will be returned along with the exit code received 
-func testTar(f cmdutil.Factory, cmd *cobra.Command, dest fileSpec) error {
+// func testTar(f cmdutil.Factory, cmd *cobra.Command, dest fileSpec) error {
 
-	options := &ExecOptions{
-		StreamOptions: StreamOptions{
-			Out:   bytes.NewBuffer([]byte{}),
-			Err:   bytes.NewBuffer([]byte{}),
+// 	options := &ExecOptions{
+// 		StreamOptions: StreamOptions{
+// 			Out:   bytes.NewBuffer([]byte{}),
+// 			Err:   bytes.NewBuffer([]byte{}),
 
-			Namespace: dest.PodNamespace,
-			PodName:   dest.PodName,
-		},
+// 			Namespace: dest.PodNamespace,
+// 			PodName:   dest.PodName,
+// 		},
 
-		Command:  []string{"tar"},
-		Executor: &DefaultRemoteExecutor{},
-	}
+// 		Command:  []string{"tar"},
+// 		Executor: &DefaultRemoteExecutor{},
+// 	}
 	
-	return execute(f, cmd, options)
+// 	return execute(f, cmd, options)
 
-}
+// }
 
 func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, src, dest fileSpec) error {
 	if len(src.File) == 0 {
@@ -208,16 +208,16 @@ func copyToPod(f cmdutil.Factory, cmd *cobra.Command, stdout, stderr io.Writer, 
 		dest.File = dest.File + "/" + path.Base(src.File)
 	}
 
-	if err := testTar(f, cmd, dest); err != nil {
+	// if err := testTar(f, cmd, dest); err != nil {
 
-		if err.Error() == exitCode126 {
-			return errTar126
-		} else if err.Error() == exitCode127 {
-			return errTar127 
-		} else {
-			return err
-		}
-	}
+	// 	if err.Error() == exitCode126 {
+	// 		return errTar126
+	// 	} else if err.Error() == exitCode127 {
+	// 		return errTar127 
+	// 	} else {
+	// 		return err
+	// 	}
+	// }
 
 	go func() {
 		defer writer.Close()
@@ -253,17 +253,17 @@ func copyFromPod(f cmdutil.Factory, cmd *cobra.Command, cmderr io.Writer, src, d
 		return errFileCannotBeEmpty
 	}
 
-	// check if tar command exists in the container
-	if err := testTar(f, cmd, dest); err != nil {
+	// // check if tar command exists in the container
+	// if err := testTar(f, cmd, dest); err != nil {
 
-		if err.Error() == exitCode126 {
-			return errTar126
-		} else if err.Error() == exitCode127 {
-			return errTar127 
-		} else {
-			return err
-		}
-	}
+	// 	if err.Error() == exitCode126 {
+	// 		return errTar126
+	// 	} else if err.Error() == exitCode127 {
+	// 		return errTar127 
+	// 	} else {
+	// 		return err
+	// 	}
+	// }
 
 	reader, outStream := io.Pipe()
 	options := &ExecOptions{

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -133,8 +133,10 @@ func checkErr(err error, handleErr func(string, int)) {
 
 	switch {
 	case err == ErrExit:
+		fmt.Println("Case 1")
 		handleErr("", DefaultErrorExitCode)
 	case kerrors.IsInvalid(err):
+		fmt.Println("Case 2")
 		details := err.(*kerrors.StatusError).Status().Details
 		s := fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
 		if len(details.Causes) > 0 {
@@ -144,25 +146,33 @@ func checkErr(err error, handleErr func(string, int)) {
 			handleErr(s, DefaultErrorExitCode)
 		}
 	case clientcmd.IsConfigurationInvalid(err):
+		fmt.Println("Case 3")
 		handleErr(MultilineError("Error in configuration: ", err), DefaultErrorExitCode)
 	default:
 		switch err := err.(type) {
 		case *meta.NoResourceMatchError:
 			switch {
 			case len(err.PartialResource.Group) > 0 && len(err.PartialResource.Version) > 0:
+				fmt.Println("Case 4")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q and version %q", err.PartialResource.Resource, err.PartialResource.Group, err.PartialResource.Version), DefaultErrorExitCode)
 			case len(err.PartialResource.Group) > 0:
+				fmt.Println("Case 5")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q", err.PartialResource.Resource, err.PartialResource.Group), DefaultErrorExitCode)
 			case len(err.PartialResource.Version) > 0:
+				fmt.Println("Case 6")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in version %q", err.PartialResource.Resource, err.PartialResource.Version), DefaultErrorExitCode)
 			default:
+				fmt.Println("Case 7")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q", err.PartialResource.Resource), DefaultErrorExitCode)
 			}
 		case utilerrors.Aggregate:
+			fmt.Println("Case 8")
 			handleErr(MultipleErrors(``, err.Errors()), DefaultErrorExitCode)
 		case utilexec.ExitError:
+			fmt.Println("Case 9")
 			handleErr(err.Error(), err.ExitStatus())
 		default: // for any other error type
+			fmt.Println("Case 10")
 			msg, ok := StandardErrorMessage(err)
 			if !ok {
 				msg = err.Error()

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -133,10 +133,8 @@ func checkErr(err error, handleErr func(string, int)) {
 
 	switch {
 	case err == ErrExit:
-		// fmt.Println("Case 1")
 		handleErr("", DefaultErrorExitCode)
 	case kerrors.IsInvalid(err):
-		// fmt.Println("Case 2")
 		details := err.(*kerrors.StatusError).Status().Details
 		s := fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
 		if len(details.Causes) > 0 {
@@ -146,33 +144,25 @@ func checkErr(err error, handleErr func(string, int)) {
 			handleErr(s, DefaultErrorExitCode)
 		}
 	case clientcmd.IsConfigurationInvalid(err):
-		// fmt.Println("Case 3")
 		handleErr(MultilineError("Error in configuration: ", err), DefaultErrorExitCode)
 	default:
 		switch err := err.(type) {
 		case *meta.NoResourceMatchError:
 			switch {
 			case len(err.PartialResource.Group) > 0 && len(err.PartialResource.Version) > 0:
-				// fmt.Println("Case 4")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q and version %q", err.PartialResource.Resource, err.PartialResource.Group, err.PartialResource.Version), DefaultErrorExitCode)
 			case len(err.PartialResource.Group) > 0:
-				// fmt.Println("Case 5")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q", err.PartialResource.Resource, err.PartialResource.Group), DefaultErrorExitCode)
 			case len(err.PartialResource.Version) > 0:
-				// fmt.Println("Case 6")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in version %q", err.PartialResource.Resource, err.PartialResource.Version), DefaultErrorExitCode)
 			default:
-				// fmt.Println("Case 7")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q", err.PartialResource.Resource), DefaultErrorExitCode)
 			}
 		case utilerrors.Aggregate:
-			// fmt.Println("Case 8")
 			handleErr(MultipleErrors(``, err.Errors()), DefaultErrorExitCode)
 		case utilexec.ExitError:
-			// fmt.Println("Case 9")
 			handleErr(err.Error(), err.ExitStatus())
 		default: // for any other error type
-			// fmt.Println("Case 10")
 			msg, ok := StandardErrorMessage(err)
 			if !ok {
 				msg = err.Error()

--- a/pkg/kubectl/cmd/util/helpers.go
+++ b/pkg/kubectl/cmd/util/helpers.go
@@ -133,10 +133,10 @@ func checkErr(err error, handleErr func(string, int)) {
 
 	switch {
 	case err == ErrExit:
-		fmt.Println("Case 1")
+		// fmt.Println("Case 1")
 		handleErr("", DefaultErrorExitCode)
 	case kerrors.IsInvalid(err):
-		fmt.Println("Case 2")
+		// fmt.Println("Case 2")
 		details := err.(*kerrors.StatusError).Status().Details
 		s := fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
 		if len(details.Causes) > 0 {
@@ -146,33 +146,33 @@ func checkErr(err error, handleErr func(string, int)) {
 			handleErr(s, DefaultErrorExitCode)
 		}
 	case clientcmd.IsConfigurationInvalid(err):
-		fmt.Println("Case 3")
+		// fmt.Println("Case 3")
 		handleErr(MultilineError("Error in configuration: ", err), DefaultErrorExitCode)
 	default:
 		switch err := err.(type) {
 		case *meta.NoResourceMatchError:
 			switch {
 			case len(err.PartialResource.Group) > 0 && len(err.PartialResource.Version) > 0:
-				fmt.Println("Case 4")
+				// fmt.Println("Case 4")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q and version %q", err.PartialResource.Resource, err.PartialResource.Group, err.PartialResource.Version), DefaultErrorExitCode)
 			case len(err.PartialResource.Group) > 0:
-				fmt.Println("Case 5")
+				// fmt.Println("Case 5")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in group %q", err.PartialResource.Resource, err.PartialResource.Group), DefaultErrorExitCode)
 			case len(err.PartialResource.Version) > 0:
-				fmt.Println("Case 6")
+				// fmt.Println("Case 6")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q in version %q", err.PartialResource.Resource, err.PartialResource.Version), DefaultErrorExitCode)
 			default:
-				fmt.Println("Case 7")
+				// fmt.Println("Case 7")
 				handleErr(fmt.Sprintf("the server doesn't have a resource type %q", err.PartialResource.Resource), DefaultErrorExitCode)
 			}
 		case utilerrors.Aggregate:
-			fmt.Println("Case 8")
+			// fmt.Println("Case 8")
 			handleErr(MultipleErrors(``, err.Errors()), DefaultErrorExitCode)
 		case utilexec.ExitError:
-			fmt.Println("Case 9")
+			// fmt.Println("Case 9")
 			handleErr(err.Error(), err.ExitStatus())
 		default: // for any other error type
-			fmt.Println("Case 10")
+			// fmt.Println("Case 10")
 			msg, ok := StandardErrorMessage(err)
 			if !ok {
 				msg = err.Error()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Improves kubectl cp error message by checking if the tar command is present in the container first before actually executing and triggering the copy mechanics. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
