### PR TITLE
Only attempt to construct GC informers for watchable resources

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -587,7 +587,7 @@ func (gc *GarbageCollector) GraphHasUID(UIDs []types.UID) bool {
 
 // GetDeletableResources returns all resources from discoveryClient that the
 // garbage collector should recognize and work with. More specifically, all
-// preferred resources which support the 'delete' verb.
+// preferred resources which support the 'delete', 'list', and 'watch' verbs.
 //
 // All discovery errors are considered temporary. Upon encountering any error,
 // GetDeletableResources will log and return any discovered resources it was
@@ -607,7 +607,7 @@ func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) m
 
 	// This is extracted from discovery.GroupVersionResources to allow tolerating
 	// failures on a per-resource basis.
-	deletableResources := discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"delete"}}, preferredResources)
+	deletableResources := discovery.FilteredBy(discovery.SupportsAllVerbs{Verbs: []string{"delete", "list", "watch"}}, preferredResources)
 	deletableGroupVersionResources := map[schema.GroupVersionResource]struct{}{}
 	for _, rl := range deletableResources {
 		gv, err := schema.ParseGroupVersion(rl.GroupVersion)

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -688,7 +688,7 @@ func TestGetDeletableResources(t *testing.T) {
 					// Valid GroupVersion
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
-						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete"}},
+						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete", "list", "watch"}},
 						{Name: "services", Namespaced: true, Kind: "Service"},
 					},
 				},
@@ -696,7 +696,14 @@ func TestGetDeletableResources(t *testing.T) {
 					// Invalid GroupVersion, should be ignored
 					GroupVersion: "foo//whatever",
 					APIResources: []metav1.APIResource{
-						{Name: "bars", Namespaced: true, Kind: "Bar", Verbs: metav1.Verbs{"delete"}},
+						{Name: "bars", Namespaced: true, Kind: "Bar", Verbs: metav1.Verbs{"delete", "list", "watch"}},
+					},
+				},
+				{
+					// Valid GroupVersion, missing required verbs, should be ignored
+					GroupVersion: "acme/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "widgets", Namespaced: true, Kind: "Widget", Verbs: metav1.Verbs{"delete"}},
 					},
 				},
 			},
@@ -710,7 +717,7 @@ func TestGetDeletableResources(t *testing.T) {
 				{
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
-						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete"}},
+						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete", "list", "watch"}},
 						{Name: "services", Namespaced: true, Kind: "Service"},
 					},
 				},
@@ -725,7 +732,7 @@ func TestGetDeletableResources(t *testing.T) {
 				{
 					GroupVersion: "apps/v1",
 					APIResources: []metav1.APIResource{
-						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete"}},
+						{Name: "pods", Namespaced: true, Kind: "Pod", Verbs: metav1.Verbs{"delete", "list", "watch"}},
 						{Name: "services", Namespaced: true, Kind: "Service"},
 					},
 				},

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -230,7 +230,7 @@ func (gb *GraphBuilder) syncMonitors(resources map[schema.GroupVersionResource]s
 	kept := 0
 	added := 0
 	for resource := range resources {
-		if _, ok := ignoredResources[resource.GroupResource()]; ok {
+		if _, ok := gb.ignoredResources[resource.GroupResource()]; ok {
 			continue
 		}
 		if m, ok := toRemove[resource]; ok {


### PR DESCRIPTION
A resource must support list/watch in addition to delete for an informer to be functional

Exclude resources that are not watchable from informer construction

Also fixes a bug with the graph builder not using the instance-configured list of ignored resources

/assign @ironcladlou

```release-note
NONE
```