### PR TITLE
Test device plugin re-registration with new device id

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -83,7 +83,12 @@ func TestDevicePluginReRegistration(t *testing.T) {
 	devices := m.Devices()
 	require.Equal(t, 2, len(devices[testResourceName]), "Devices are not updated.")
 
-	p2 := NewDevicePluginStub(devs, pluginSocketName+".new")
+	devs2 := []*pluginapi.Device{
+		{ID: "Dev3", Health: pluginapi.Healthy},
+		{ID: "Dev4", Health: pluginapi.Healthy},
+	}
+
+	p2 := NewDevicePluginStub(devs2, pluginSocketName+".new")
 	err := p2.Start()
 	require.NoError(t, err)
 	p2.Register(socketName, testResourceName)
@@ -91,14 +96,14 @@ func TestDevicePluginReRegistration(t *testing.T) {
 	<-callbackChan
 
 	devices2 := m.Devices()
-	require.Equal(t, 2, len(devices2[testResourceName]), "Devices shouldn't change.")
+	require.Equal(t, 2, len(devices2[testResourceName]), "Devices' capacity shouldn't change.")
 
 	// Test the scenario that a plugin re-registers with different devices.
 	p3 := NewDevicePluginStub(devsForRegistration, pluginSocketName+".third")
 	err = p3.Start()
 	require.NoError(t, err)
 	p3.Register(socketName, testResourceName)
-	// Wait for the second callback to be issued.
+	// Wait for the third callback to be issued.
 	<-callbackChan
 
 	devices3 := m.Devices()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

UT try to reproduce https://github.com/kubernetes/kubernetes/issues/55179

**Which issue(s) this PR fixes**

**Special notes for your reviewer**:

@jiayingz @lichuqiang PTAL.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
/sig node