### PR TITLE
Sort keys before calculating diff.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/diff/diff.go
@@ -71,7 +71,7 @@ func ObjectDiff(a, b interface{}) string {
 // can't figure out why reflect.DeepEqual is returning false and nothing is
 // showing you differences. This will.
 func ObjectGoPrintDiff(a, b interface{}) string {
-	s := spew.ConfigState{DisableMethods: true}
+	s := spew.ConfigState{DisableMethods: true, SortKeys: true, SpewKeys: true}
 	return StringDiff(
 		s.Sprintf("%#v", a),
 		s.Sprintf("%#v", b),


### PR DESCRIPTION
Due to random order of map keys sometime ObjectGoPrintDiff output not
correct diffs.

E.G if you if you have struct with map fields it will start diff
from first map (due to keys order) and not from actual problem.

And this happens randomly, e.g on some runs you can get
actual distinction and map keys diff on others.


**Release note**:
```release-note
NONE
```
