### PR TITLE
Avoid wrong filling of  glusterfs Volume Spec at ConstructVolumeSpec()

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -197,16 +197,11 @@ func (plugin *glusterfsPlugin) newUnmounterInternal(volName string, podUID types
 }
 
 func (plugin *glusterfsPlugin) ConstructVolumeSpec(volumeName, mountPath string) (*volume.Spec, error) {
-	glusterfsVolume := &v1.Volume{
-		Name: volumeName,
-		VolumeSource: v1.VolumeSource{
-			Glusterfs: &v1.GlusterfsVolumeSource{
-				EndpointsName: volumeName,
-				Path:          volumeName,
-			},
-		},
-	}
-	return volume.NewSpecFromVolume(glusterfsVolume), nil
+
+	// To reconstrcut volume spec we need endpoint where fetching endpoint from mount
+	// string looks to be impossible, so returning error.
+
+	return nil, fmt.Errorf("impossible to reconstruct glusterfs volume spec from volume mountpath")
 }
 
 // Glusterfs volumes represent a bare host file or directory mount of an Glusterfs export.


### PR DESCRIPTION
Issue#https://github.com/kubernetes/kubernetes/issues/37625, https://github.com/kubernetes/kubernetes/issues/49108

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

