### PR TITLE
Add Json marshal/unmarshal methods for protobuf/jsonpb

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -55,6 +55,7 @@ go_library(
     deps = [
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
+        "//vendor/github.com/golang/protobuf/jsonpb:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/conversion:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_proto.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_proto.go
@@ -18,6 +18,8 @@ package v1
 
 import (
 	"time"
+
+	"github.com/golang/protobuf/jsonpb"
 )
 
 // Timestamp is a struct that is equivalent to Time, but intended for
@@ -89,4 +91,12 @@ func (m *Time) MarshalTo(data []byte) (int, error) {
 		return 0, nil
 	}
 	return m.ProtoTime().MarshalTo(data)
+}
+
+func (t Time) MarshalJSONPB(_ *jsonpb.Marshaler) ([]byte, error) {
+	return t.MarshalJSON()
+}
+
+func (t *Time) UnmarshalJSONPB(_ *jsonpb.Unmarshaler, jstr []byte) error {
+	return t.UnmarshalJSON(jstr)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/time_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
+	"github.com/golang/protobuf/jsonpb"
 )
 
 type TimeHolder struct {
@@ -193,5 +194,24 @@ func TestTimeEqual(t *testing.T) {
 				t.Errorf("Failed equality test for '%v', '%v': expected %+v, got %+v", c.x, c.y, c.result, result)
 			}
 		})
+	}
+}
+
+func TestTimeJsonPB(t *testing.T) {
+	in := NewTime(time.Now())
+
+	m := jsonpb.Marshaler{}
+	jstr, err := m.MarshalToString(&in)
+	if err != nil {
+		t.Fatalf("Failed to marshal output: '%v': %v", in, err)
+	}
+
+	var out Time
+	err = jsonpb.UnmarshalString(jstr, &out)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal output: '%v': %v", jstr, err)
+	}
+	if !reflect.DeepEqual(in, out) {
+		t.Errorf("Marshal->Unmarshal is not idempotent: '%v' vs '%v'", in, out)
 	}
 }


### PR DESCRIPTION
Why?
We are using protobufs generated from api objects to write a custom grpc server. We also use https://github.com/grpc-ecosystem/grpc-gateway to serve a JSON api. Without these methods, the marshaling fails.

ref:
https://godoc.org/github.com/golang/protobuf/jsonpb#JSONPBMarshaler