### PR TITLE
InternalDetermineEffectiveSecurityContext: remove unused function

### DIFF
--- a/pkg/securitycontext/util.go
+++ b/pkg/securitycontext/util.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"k8s.io/api/core/v1"
-	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 // HasPrivilegedRequest returns the value of SecurityContext.Privileged, taking into account
@@ -150,83 +149,6 @@ func securityContextFromPodSecurityContext(pod *v1.Pod) *v1.SecurityContext {
 
 	if pod.Spec.SecurityContext.SELinuxOptions != nil {
 		synthesized.SELinuxOptions = &v1.SELinuxOptions{}
-		*synthesized.SELinuxOptions = *pod.Spec.SecurityContext.SELinuxOptions
-	}
-	if pod.Spec.SecurityContext.RunAsUser != nil {
-		synthesized.RunAsUser = new(int64)
-		*synthesized.RunAsUser = *pod.Spec.SecurityContext.RunAsUser
-	}
-
-	if pod.Spec.SecurityContext.RunAsNonRoot != nil {
-		synthesized.RunAsNonRoot = new(bool)
-		*synthesized.RunAsNonRoot = *pod.Spec.SecurityContext.RunAsNonRoot
-	}
-
-	return synthesized
-}
-
-// TODO: remove the duplicate code
-func InternalDetermineEffectiveSecurityContext(pod *api.Pod, container *api.Container) *api.SecurityContext {
-	effectiveSc := internalSecurityContextFromPodSecurityContext(pod)
-	containerSc := container.SecurityContext
-
-	if effectiveSc == nil && containerSc == nil {
-		return nil
-	}
-	if effectiveSc != nil && containerSc == nil {
-		return effectiveSc
-	}
-	if effectiveSc == nil && containerSc != nil {
-		return containerSc
-	}
-
-	if containerSc.SELinuxOptions != nil {
-		effectiveSc.SELinuxOptions = new(api.SELinuxOptions)
-		*effectiveSc.SELinuxOptions = *containerSc.SELinuxOptions
-	}
-
-	if containerSc.Capabilities != nil {
-		effectiveSc.Capabilities = new(api.Capabilities)
-		*effectiveSc.Capabilities = *containerSc.Capabilities
-	}
-
-	if containerSc.Privileged != nil {
-		effectiveSc.Privileged = new(bool)
-		*effectiveSc.Privileged = *containerSc.Privileged
-	}
-
-	if containerSc.RunAsUser != nil {
-		effectiveSc.RunAsUser = new(int64)
-		*effectiveSc.RunAsUser = *containerSc.RunAsUser
-	}
-
-	if containerSc.RunAsNonRoot != nil {
-		effectiveSc.RunAsNonRoot = new(bool)
-		*effectiveSc.RunAsNonRoot = *containerSc.RunAsNonRoot
-	}
-
-	if containerSc.ReadOnlyRootFilesystem != nil {
-		effectiveSc.ReadOnlyRootFilesystem = new(bool)
-		*effectiveSc.ReadOnlyRootFilesystem = *containerSc.ReadOnlyRootFilesystem
-	}
-
-	if containerSc.AllowPrivilegeEscalation != nil {
-		effectiveSc.AllowPrivilegeEscalation = new(bool)
-		*effectiveSc.AllowPrivilegeEscalation = *containerSc.AllowPrivilegeEscalation
-	}
-
-	return effectiveSc
-}
-
-func internalSecurityContextFromPodSecurityContext(pod *api.Pod) *api.SecurityContext {
-	if pod.Spec.SecurityContext == nil {
-		return nil
-	}
-
-	synthesized := &api.SecurityContext{}
-
-	if pod.Spec.SecurityContext.SELinuxOptions != nil {
-		synthesized.SELinuxOptions = &api.SELinuxOptions{}
 		*synthesized.SELinuxOptions = *pod.Spec.SecurityContext.SELinuxOptions
 	}
 	if pod.Spec.SecurityContext.RunAsUser != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes unused `InternalDetermineEffectiveSecurityContext` and `internalSecurityContextFromPodSecurityContext` functions.

We stopped using it in the following commit: https://github.com/kubernetes/kubernetes/pull/52849/files#diff-291b8dd7d08cc034975ddb3925dbb08fL205

**Release note**:
```release-note
NONE
```

PTAL @liggitt 
CC @simo5 