### PR TITLE
Fixes Issue 55816: Removes unneeded IPPart error

### DIFF
--- a/pkg/proxy/util/endpoints.go
+++ b/pkg/proxy/util/endpoints.go
@@ -39,8 +39,9 @@ func IPPart(s string) string {
 	}
 	// Check if host string is a valid IP address
 	if ip := net.ParseIP(host); ip != nil {
+		return ip.String()
+	} else {
 		glog.Errorf("invalid IP part '%s'", host)
-		return host
 	}
 	return ""
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Previously proxy was incorrectly logging an error message for the IPPart function. The PR fixes this logging behavior to only log `invalid IP part` for invalid IP:Port combinations.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/55816

**Special notes for your reviewer**:
None

**Release note**:
```
none
```
