### PR TITLE
Add initial Virtual Machine Scale Sets (VMSS) support in Azure

### DIFF
--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -23,6 +23,7 @@ go_library(
         "azure_storage.go",
         "azure_storageaccount.go",
         "azure_util.go",
+        "azure_util_vmss.go",
         "azure_wrap.go",
         "azure_zones.go",
     ],
@@ -57,7 +58,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["azure_test.go"],
+    srcs = [
+        "azure_test.go",
+        "azure_util_test.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
     library = ":go_default_library",
     deps = [
@@ -66,6 +70,7 @@ go_test(
         "//vendor/github.com/Azure/azure-sdk-for-go/arm/compute:go_default_library",
         "//vendor/github.com/Azure/azure-sdk-for-go/arm/network:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/cloudprovider/providers/azure/azure_fakes.go
+++ b/pkg/cloudprovider/providers/azure/azure_fakes.go
@@ -339,6 +339,10 @@ func (fIC fakeAzureInterfacesClient) Get(resourceGroupName string, networkInterf
 	}
 }
 
+func (fIC fakeAzureInterfacesClient) GetVirtualMachineScaleSetNetworkInterface(resourceGroupName string, virtualMachineScaleSetName string, virtualmachineIndex string, networkInterfaceName string, expand string) (result network.Interface, err error) {
+	return result, nil
+}
+
 type fakeAzureVirtualMachinesClient struct {
 	mutex     *sync.Mutex
 	FakeStore map[string]map[string]compute.VirtualMachine

--- a/pkg/cloudprovider/providers/azure/azure_util.go
+++ b/pkg/cloudprovider/providers/azure/azure_util.go
@@ -402,6 +402,19 @@ outer:
 }
 
 func (az *Cloud) getIPForMachine(nodeName types.NodeName) (string, error) {
+	if az.Config.VMType == vmTypeVMSS {
+		ip, err := az.getIPForVmssMachine(nodeName)
+		if err == cloudprovider.InstanceNotFound || err == ErrorNotVmssInstance {
+			return az.getIPForStandardMachine(nodeName)
+		}
+
+		return ip, err
+	}
+
+	return az.getIPForStandardMachine(nodeName)
+}
+
+func (az *Cloud) getIPForStandardMachine(nodeName types.NodeName) (string, error) {
 	az.operationPollRateLimiter.Accept()
 	machine, exists, err := az.getVirtualMachine(nodeName)
 	if !exists {

--- a/pkg/cloudprovider/providers/azure/azure_util_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_util_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVmssInstanceID(t *testing.T) {
+	tests := []struct {
+		msg                string
+		machineName        string
+		expectError        bool
+		expectedInstanceID string
+	}{{
+		msg:         "invalid vmss instance name",
+		machineName: "vmvm",
+		expectError: true,
+	},
+		{
+			msg:                "valid vmss instance name",
+			machineName:        "vm00000Z",
+			expectError:        false,
+			expectedInstanceID: "35",
+		},
+	}
+
+	for i, test := range tests {
+		instanceID, err := getVmssInstanceID(test.machineName)
+		if test.expectError {
+			assert.Error(t, err, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+		} else {
+			assert.Equal(t, test.expectedInstanceID, instanceID, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+		}
+	}
+}

--- a/pkg/cloudprovider/providers/azure/azure_util_vmss.go
+++ b/pkg/cloudprovider/providers/azure/azure_util_vmss.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
+	"github.com/golang/glog"
+
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+)
+
+func (az *Cloud) getIPForVmssMachine(nodeName types.NodeName) (string, error) {
+	az.operationPollRateLimiter.Accept()
+	machine, exists, err := az.getVmssVirtualMachine(nodeName)
+	if !exists {
+		return "", cloudprovider.InstanceNotFound
+	}
+	if err != nil {
+		glog.Errorf("error: az.getIPForVmssMachine(%s), az.getVmssVirtualMachine(%s), err=%v", nodeName, nodeName, err)
+		return "", err
+	}
+
+	nicID, err := getPrimaryInterfaceIDForVmssMachine(machine)
+	if err != nil {
+		glog.Errorf("error: az.getIPForVmssMachine(%s), getPrimaryInterfaceID(%v), err=%v", nodeName, machine, err)
+		return "", err
+	}
+
+	nicName, err := getLastSegment(nicID)
+	if err != nil {
+		glog.Errorf("error: az.getIPForVmssMachine(%s), getLastSegment(%s), err=%v", nodeName, nicID, err)
+		return "", err
+	}
+
+	az.operationPollRateLimiter.Accept()
+	glog.V(10).Infof("InterfacesClient.Get(%q): start", nicName)
+	nic, err := az.InterfacesClient.GetVirtualMachineScaleSetNetworkInterface(az.ResourceGroup, az.Config.PrimaryScaleSetName, *machine.InstanceID, nicName, "")
+	glog.V(10).Infof("InterfacesClient.Get(%q): end", nicName)
+	if err != nil {
+		glog.Errorf("error: az.getIPForVmssMachine(%s), az.GetVirtualMachineScaleSetNetworkInterface.Get(%s, %s, %s), err=%v", nodeName, az.ResourceGroup, nicName, "", err)
+		return "", err
+	}
+
+	ipConfig, err := getPrimaryIPConfig(nic)
+	if err != nil {
+		glog.Errorf("error: az.getIPForVmssMachine(%s), getPrimaryIPConfig(%v), err=%v", nodeName, nic, err)
+		return "", err
+	}
+
+	targetIP := *ipConfig.PrivateIPAddress
+	return targetIP, nil
+}
+
+// This returns the full identifier of the primary NIC for the given VM.
+func getPrimaryInterfaceIDForVmssMachine(machine compute.VirtualMachineScaleSetVM) (string, error) {
+	if len(*machine.NetworkProfile.NetworkInterfaces) == 1 {
+		return *(*machine.NetworkProfile.NetworkInterfaces)[0].ID, nil
+	}
+
+	for _, ref := range *machine.NetworkProfile.NetworkInterfaces {
+		if *ref.Primary {
+			return *ref.ID, nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to find a primary nic for the vm. vmname=%q", *machine.Name)
+}
+
+// machineName is composed of computerNamePrefix and 36-based instanceID.
+// And instanceID part if in fixed length of 6 characters.
+// Refer https://msftstack.wordpress.com/2017/05/10/figuring-out-azure-vm-scale-set-machine-names/.
+func getVmssInstanceID(machineName string) (string, error) {
+	nameLength := len(machineName)
+	if nameLength < 6 {
+		return "", ErrorNotVmssInstance
+	}
+
+	instanceID, err := strconv.ParseUint(machineName[nameLength-6:], 36, 64)
+	if err != nil {
+		return "", ErrorNotVmssInstance
+	}
+
+	return fmt.Sprintf("%d", instanceID), nil
+}

--- a/pkg/cloudprovider/providers/azure/azure_wrap.go
+++ b/pkg/cloudprovider/providers/azure/azure_wrap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package azure
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/arm/compute"
@@ -24,6 +25,11 @@ import (
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/golang/glog"
 	"k8s.io/apimachinery/pkg/types"
+)
+
+var (
+	// ErrorNotVmssInstance indicates an instance is not belongint to any vmss.
+	ErrorNotVmssInstance = errors.New("not a vmss instance")
 )
 
 // checkExistsFromError inspects an error and returns a true if err is nil,
@@ -61,6 +67,32 @@ func (az *Cloud) getVirtualMachine(nodeName types.NodeName) (vm compute.VirtualM
 	glog.V(10).Infof("VirtualMachinesClient.Get(%s): start", vmName)
 	vm, err = az.VirtualMachinesClient.Get(az.ResourceGroup, vmName, "")
 	glog.V(10).Infof("VirtualMachinesClient.Get(%s): end", vmName)
+
+	exists, realErr = checkResourceExistsFromError(err)
+	if realErr != nil {
+		return vm, false, realErr
+	}
+
+	if !exists {
+		return vm, false, nil
+	}
+
+	return vm, exists, err
+}
+
+func (az *Cloud) getVmssVirtualMachine(nodeName types.NodeName) (vm compute.VirtualMachineScaleSetVM, exists bool, err error) {
+	var realErr error
+
+	vmName := string(nodeName)
+	instanceID, err := getVmssInstanceID(vmName)
+	if err != nil {
+		return vm, false, err
+	}
+
+	az.operationPollRateLimiter.Accept()
+	glog.V(10).Infof("VirtualMachineScaleSetVMsClient.Get(%s): start", vmName)
+	vm, err = az.VirtualMachineScaleSetVMsClient.Get(az.ResourceGroup, az.PrimaryScaleSetName, instanceID)
+	glog.V(10).Infof("VirtualMachineScaleSetVMsClient.Get(%s): end", vmName)
 
 	exists, realErr = checkResourceExistsFromError(err)
 	if realErr != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This is the first step of adding Virtual Machine Scale Sets (VMSS) support in Azure, it

- Adds  vmType params to support both vmss and standard in Azure
- Adds initial InstanceID/InstanceType/IP/Routes support for vmss instances
- Master nodes may not belong to any scale sets, so it falls back to VirtualMachinesClient for such instances

Have validated that nodes could be registered and pods could be scheduled and run correctly.

Still more work to do to fully support Azure VMSS. And next steps are tracking at #43287.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Part of #43287.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
