### PR TITLE
Allow resource.Builder to modify requests per client

### DIFF
--- a/pkg/kubectl/resource/BUILD
+++ b/pkg/kubectl/resource/BUILD
@@ -73,6 +73,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/rest/fake:go_default_library",
         "//vendor/k8s.io/client-go/rest/watch:go_default_library",
         "//vendor/k8s.io/client-go/util/testing:go_default_library",

--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -58,6 +58,7 @@ type Builder struct {
 	selectAll            bool
 	includeUninitialized bool
 	limitChunks          int64
+	requestTransforms    []RequestTransform
 
 	resources []string
 
@@ -351,6 +352,13 @@ func (b *Builder) RequireNamespace() *Builder {
 // no chunking.
 func (b *Builder) RequestChunksOf(chunkSize int64) *Builder {
 	b.limitChunks = chunkSize
+	return b
+}
+
+// TransformRequests alters API calls made by clients requested from this builder. Pass
+// an empty list to clear modifiers.
+func (b *Builder) TransformRequests(opts ...RequestTransform) *Builder {
+	b.requestTransforms = opts
 	return b
 }
 
@@ -656,6 +664,7 @@ func (b *Builder) visitBySelector() *Result {
 			result.err = err
 			return result
 		}
+		client = NewClientWithOptions(client, b.requestTransforms...)
 		selectorNamespace := b.namespace
 		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			selectorNamespace = ""
@@ -705,6 +714,7 @@ func (b *Builder) visitByResource() *Result {
 			result.err = err
 			return result
 		}
+		client = NewClientWithOptions(client, b.requestTransforms...)
 		clients[s] = client
 	}
 


### PR DESCRIPTION
Gives the builder a hook point to add settings to each request. These
settings are applied before the request is created and so are unable to
view the request. Intended to set controls on a per request basis.

Prereq for server-side `kubectl get`

@enj as requested @kubernetes/sig-cli-api-reviews