### PR TITLE
Table printers and server generation should always copy ListMeta

### DIFF
--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -525,6 +525,16 @@ func (h *HumanReadablePrinter) PrintTable(obj runtime.Object, options PrintOptio
 		ColumnDefinitions: columns,
 		Rows:              results[0].Interface().([]metav1alpha1.TableRow),
 	}
+	if m, err := meta.ListAccessor(obj); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(obj); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
 	if err := DecorateTable(table, options); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
@@ -89,7 +89,7 @@ func ListAccessor(obj interface{}) (List, error) {
 		}
 		return nil, errNotList
 	default:
-		panic(fmt.Errorf("%T does not implement the List interface", obj))
+		return nil, errNotList
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1291,9 +1291,20 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 		t.Errorf("expected: %#v, got: %#v", objs, items)
 	}
 
+	m, err := meta.ListAccessor(listObj)
+	if err != nil {
+		t.Fatalf("list should support ListMeta %T: %v", listObj, err)
+	}
+	m.SetContinue("continuetoken")
+	m.SetResourceVersion("11")
+	m.SetSelfLink("/list/link")
+
 	table, err := t.storage.(rest.TableConvertor).ConvertToTable(ctx, listObj, nil)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+	if table.ResourceVersion != "11" || table.SelfLink != "/list/link" || table.Continue != "continuetoken" {
+		t.Errorf("printer lost list meta: %#v", table.ListMeta)
 	}
 	if len(table.Rows) != len(items) {
 		t.Errorf("unexpected number of rows: %v", len(table.Rows))

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -63,6 +63,16 @@ func (c defaultTableConvertor) ConvertToTable(ctx genericapirequest.Context, obj
 			return nil, err
 		}
 	}
+	if m, err := meta.ListAccessor(object); err == nil {
+		table.ResourceVersion = m.GetResourceVersion()
+		table.SelfLink = m.GetSelfLink()
+		table.Continue = m.GetContinue()
+	} else {
+		if m, err := meta.CommonAccessor(object); err == nil {
+			table.ResourceVersion = m.GetResourceVersion()
+			table.SelfLink = m.GetSelfLink()
+		}
+	}
 	table.ColumnDefinitions = []metav1alpha1.TableColumnDefinition{
 		{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
 		{Name: "Created At", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},

--- a/test/e2e/apimachinery/chunking.go
+++ b/test/e2e/apimachinery/chunking.go
@@ -72,6 +72,11 @@ var _ = SIGDescribe("Servers with support for API chunking", func() {
 				list, err := client.List(opts)
 				Expect(err).ToNot(HaveOccurred())
 				framework.Logf("Retrieved %d/%d results with rv %s and continue %s", len(list.Items), opts.Limit, list.ResourceVersion, list.Continue)
+				// TODO: kops PR job is still using etcd2, which prevents this feature from working. Remove this check when kops is upgraded to etcd3
+				if len(list.Items) > int(opts.Limit) {
+					framework.Skipf("ERROR: This cluster does not support chunking, which means it is running etcd2 and not supported.")
+				}
+				Expect(len(list.Items)).To(BeNumerically("<=", opts.Limit))
 
 				if len(lastRV) == 0 {
 					lastRV = list.ResourceVersion

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -98,6 +98,10 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 			SetHeader("Accept", "application/json;as=Table;v=v1alpha1;g=meta.k8s.io").
 			Do().Into(pagedTable)
 		Expect(err).NotTo(HaveOccurred())
+		// TODO: kops PR job is still using etcd2, which prevents this feature from working. Remove this check when kops is upgraded to etcd3
+		if len(pagedTable.Rows) > 2 {
+			framework.Skipf("ERROR: This cluster does not support chunking, which means it is running etcd2 and not supported.")
+		}
 		Expect(len(pagedTable.Rows)).To(Equal(2))
 		Expect(pagedTable.ResourceVersion).ToNot(Equal(""))
 		Expect(pagedTable.SelfLink).ToNot(Equal(""))

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1alpha1 "k8s.io/apimachinery/pkg/apis/meta/v1alpha1"
+	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/printers"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -63,6 +64,56 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		framework.Logf("Table:\n%s", out)
 	})
 
+	It("should return chunks of table results for list calls", func() {
+		ns := f.Namespace.Name
+		c := f.ClientSet
+		client := c.CoreV1().PodTemplates(ns)
+
+		By("creating a large number of resources")
+		workqueue.Parallelize(5, 20, func(i int) {
+			for tries := 3; tries >= 0; tries-- {
+				_, err := client.Create(&v1.PodTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: fmt.Sprintf("template-%04d", i),
+					},
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{Name: "test", Image: "test2"},
+							},
+						},
+					},
+				})
+				if err == nil {
+					return
+				}
+				framework.Logf("Got an error creating template %d: %v", i, err)
+			}
+			Fail("Unable to create template %d, exiting", i)
+		})
+
+		pagedTable := &metav1alpha1.Table{}
+		err := c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
+			VersionedParams(&metav1.ListOptions{Limit: 2}, metav1.ParameterCodec).
+			SetHeader("Accept", "application/json;as=Table;v=v1alpha1;g=meta.k8s.io").
+			Do().Into(pagedTable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(pagedTable.Rows)).To(Equal(2))
+		Expect(pagedTable.ResourceVersion).ToNot(Equal(""))
+		Expect(pagedTable.SelfLink).ToNot(Equal(""))
+		Expect(pagedTable.Continue).ToNot(Equal(""))
+		Expect(pagedTable.Rows[0].Cells[0]).To(Equal("template-0000"))
+		Expect(pagedTable.Rows[1].Cells[0]).To(Equal("template-0001"))
+
+		err = c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
+			VersionedParams(&metav1.ListOptions{Continue: pagedTable.Continue}, metav1.ParameterCodec).
+			SetHeader("Accept", "application/json;as=Table;v=v1alpha1;g=meta.k8s.io").
+			Do().Into(pagedTable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(pagedTable.Rows)).To(BeNumerically(">", 0))
+		Expect(pagedTable.Rows[0].Cells[0]).To(Equal("template-0002"))
+	})
+
 	It("should return generic metadata details across all namespaces for nodes", func() {
 		c := f.ClientSet
 
@@ -75,6 +126,8 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		Expect(len(table.Rows)).To(BeNumerically(">=", 1))
 		Expect(len(table.Rows[0].Cells)).To(Equal(len(table.ColumnDefinitions)))
 		Expect(table.ColumnDefinitions[0].Name).To(Equal("Name"))
+		Expect(table.ResourceVersion).ToNot(Equal(""))
+		Expect(table.SelfLink).ToNot(Equal(""))
 
 		out := printTable(table)
 		Expect(out).To(MatchRegexp("^NAME\\s"))


### PR DESCRIPTION
Tables should be a mapping from lists, so if the incoming object has these add them to the table. Paging over server side tables was broken without this. Add tests on the generic creater and on the resttest compatibility.


@deads2k