### PR TITLE
auth/gcp: capture stderr from gcloud config-helper

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -228,9 +228,11 @@ func newCmdTokenSource(cmd string, args []string, tokenKey, expiryKey, timeFmt s
 func (c *commandTokenSource) Token() (*oauth2.Token, error) {
 	fullCmd := strings.Join(append([]string{c.cmd}, c.args...), " ")
 	cmd := execCommand(c.cmd, c.args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("error executing access token command %q: err=%v output=%s", fullCmd, err, output)
+		return nil, fmt.Errorf("error executing access token command %q: err=%v output=%s stderr=%s", fullCmd, err, output, string(stderr.Bytes()))
 	}
 	token, err := c.parseTokenCmdOutput(output)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/client-go/issues/327

Currently we're not capturing stderr when shelling out to "gcloud config
config-helper --format=json" fails. This patch is capturing the stderr in the
error message returned.

This gcloud command sometimes returns an upgrade reminder (in stderr) so using
`cmd.CombinedOutput()` is not an option here. Maybe we should also add an unit
test in gcp_test.go capturing this situation, too, in case someone decides to
replace this with CombinedOutput someday.


/assign @cjcullen