### PR TITLE
Fix TestForgivenessAdmission.

### DIFF
--- a/plugin/pkg/admission/defaulttolerationseconds/admission_test.go
+++ b/plugin/pkg/admission/defaulttolerationseconds/admission_test.go
@@ -267,8 +267,8 @@ func TestForgivenessAdmission(t *testing.T) {
 			t.Errorf("[%s]: unexpected error %v for pod %+v", test.description, err, test.requestedPod)
 		}
 
-		if !helper.Semantic.DeepEqual(test.expectedPod.Annotations, test.requestedPod.Annotations) {
-			t.Errorf("[%s]: expected %#v got %#v", test.description, test.expectedPod.Annotations, test.requestedPod.Annotations)
+		if !helper.Semantic.DeepEqual(test.expectedPod.Spec.Tolerations, test.requestedPod.Spec.Tolerations) {
+			t.Errorf("[%s]: expected %#v got %#v", test.description, test.expectedPod.Spec.Tolerations, test.requestedPod.Spec.Tolerations)
 		}
 	}
 }


### PR DESCRIPTION
This test would never fail because Annotations were empty in all cases!

This was missed when Tolerations were moved from Annotations to be part of Pod.Spec in #38957.

/kind bug
/sig scheduling

**Release note**:
```release-note
NONE
```
