### PR TITLE
apiserver:  pass a listener into genericapiserver bootstrapping 

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -355,6 +355,7 @@ func BuildGenericConfig(s *options.ServerRunOptions, proxyTransport *http.Transp
 	if err := s.GenericServerRunOptions.ApplyTo(genericConfig); err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
+
 	insecureServingOptions, err := s.InsecureServing.ApplyTo(genericConfig)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err

--- a/pkg/kubeapiserver/server/BUILD
+++ b/pkg/kubeapiserver/server/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/filters:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
     ],

--- a/pkg/kubeapiserver/server/insecure_handler.go
+++ b/pkg/kubeapiserver/server/insecure_handler.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apiserver/pkg/features"
 	"k8s.io/apiserver/pkg/server"
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/apiserver/pkg/server/options"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/rest"
 )
@@ -118,8 +119,11 @@ func serveInsecurely(insecureServingInfo *InsecureServingInfo, insecureHandler h
 		MaxHeaderBytes: 1 << 20,
 	}
 	glog.Infof("Serving insecurely on %s", insecureServingInfo.BindAddress)
-	var err error
-	_, err = server.RunServer(insecureServer, insecureServingInfo.BindNetwork, shutDownTimeout, stopCh)
+	ln, _, err := options.CreateListener(insecureServingInfo.BindNetwork, insecureServingInfo.BindAddress)
+	if err != nil {
+		return err
+	}
+	err = server.RunServer(insecureServer, ln, shutDownTimeout, stopCh)
 	return err
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -295,10 +295,6 @@
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
 		},
 		{
-			"ImportPath": "github.com/pkg/errors",
-			"Rev": "a22138067af1c4942683050411a841ade67fe1eb"
-		},
-		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 		},

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -519,10 +519,6 @@
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
 		},
 		{
-			"ImportPath": "github.com/pkg/errors",
-			"Rev": "a22138067af1c4942683050411a841ade67fe1eb"
-		},
-		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -71,7 +71,6 @@ go_library(
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
-        "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apimachinery/registered:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -203,11 +203,8 @@ type RecommendedConfig struct {
 }
 
 type SecureServingInfo struct {
-	// BindAddress is the ip:port to serve on
-	BindAddress string
-	// BindNetwork is the type of network to bind to - defaults to "tcp", accepts "tcp",
-	// "tcp4", and "tcp6".
-	BindNetwork string
+	// Listener is the secure server network listener.
+	Listener net.Listener
 
 	// Cert is the main server cert which is used if SNI does not match. Cert must be non-nil and is
 	// allowed to be in SNICerts.

--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient.go
@@ -32,7 +32,7 @@ func (s *SecureServingInfo) NewLoopbackClientConfig(token string, loopbackCert [
 		return nil, nil
 	}
 
-	host, port, err := LoopbackHostPort(s.BindAddress)
+	host, port, err := LoopbackHostPort(s.Listener.Addr().String())
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func LoopbackHostPort(bindAddress string) (string, string, error) {
 	}
 
 	// Value is expected to be an IP or DNS name, not "0.0.0.0".
-	if host == "0.0.0.0" {
+	if host == "0.0.0.0" || host == "::" {
 		host = "localhost"
 		// Get ip of local interface, but fall back to "localhost".
 		// Note that "localhost" is resolved with the external nameserver first with Go's stdlib.

--- a/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config_selfclient_test.go
@@ -43,4 +43,26 @@ func TestLoopbackHostPort(t *testing.T) {
 	if port != "443" {
 		t.Fatalf("expected 443 as port, got %q", port)
 	}
+
+	host, port, err = LoopbackHostPort("[ff06:0:0:0:0:0:0:c3]:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if host != "ff06:0:0:0:0:0:0:c3" {
+		t.Fatalf("expected ff06:0:0:0:0:0:0:c3 as host, got %q", host)
+	}
+	if port != "443" {
+		t.Fatalf("expected 443 as port, got %q", port)
+	}
+
+	host, port, err = LoopbackHostPort("[::]:443")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+		t.Fatalf("expected host to be loopback, got %q", host)
+	}
+	if port != "443" {
+		t.Fatalf("expected 443 as port, got %q", port)
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -100,9 +100,6 @@ type GenericAPIServer struct {
 
 	SecureServingInfo *SecureServingInfo
 
-	// numerical ports, set after listening
-	effectiveSecurePort int
-
 	// ExternalAddress is the address (hostname or IP and port) that should be used in
 	// external (public internet) URLs for this GenericAPIServer.
 	ExternalAddress string
@@ -336,11 +333,6 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	}
 
 	return nil
-}
-
-// EffectiveSecurePort returns the secure port we bound to.
-func (s *GenericAPIServer) EffectiveSecurePort() int {
-	return s.effectiveSecurePort
 }
 
 // installAPIResources is a private method for installing the REST storage backing each api groupversionresource

--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver_test.go
@@ -550,7 +550,15 @@ func TestGracefulShutdown(t *testing.T) {
 		Handler: s.Handler,
 	}
 	stopCh := make(chan struct{})
-	serverPort, err := RunServer(insecureServer, "tcp", 10*time.Second, stopCh)
+
+	ln, err := net.Listen("tcp", insecureServer.Addr)
+	if err != nil {
+		t.Errorf("failed to listen on %v: %v", insecureServer.Addr, err)
+	}
+
+	// get port
+	serverPort := ln.Addr().(*net.TCPAddr).Port
+	err = RunServer(insecureServer, ln, 10*time.Second, stopCh)
 	if err != nil {
 		t.Errorf("RunServer err: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving_test.go
@@ -47,6 +47,7 @@ import (
 	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/client-go/discovery"
 	restclient "k8s.io/client-go/rest"
+	"strconv"
 )
 
 func setUp(t *testing.T) Config {
@@ -481,6 +482,15 @@ NextTest:
 				},
 				SNICertKeys: namedCertKeys,
 			}
+			// use a random free port
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Errorf("failed to listen on 127.0.0.1:0")
+			}
+
+			secureOptions.Listener = ln
+			// get port
+			secureOptions.BindPort = ln.Addr().(*net.TCPAddr).Port
 			config.LoopbackClientConfig = &restclient.Config{}
 			if err := secureOptions.ApplyTo(&config); err != nil {
 				t.Errorf("%q - failed applying the SecureServingOptions: %v", title, err)
@@ -492,9 +502,6 @@ NextTest:
 				t.Errorf("%q - failed creating the server: %v", title, err)
 				return
 			}
-
-			// patch in a 0-port to enable auto port allocation
-			s.SecureServingInfo.BindAddress = "127.0.0.1:0"
 
 			// add poststart hook to know when the server is up.
 			startedCh := make(chan struct{})
@@ -517,9 +524,8 @@ NextTest:
 
 			<-startedCh
 
-			effectiveSecurePort := fmt.Sprintf("%d", preparedServer.EffectiveSecurePort())
 			// try to dial
-			addr := fmt.Sprintf("localhost:%s", effectiveSecurePort)
+			addr := fmt.Sprintf("localhost:%d", secureOptions.BindPort)
 			t.Logf("Dialing %s as %q", addr, test.ServerName)
 			conn, err := tls.Dial("tcp", addr, &tls.Config{
 				RootCAs:    roots,
@@ -547,7 +553,7 @@ NextTest:
 			if len(test.LoopbackClientBindAddressOverride) != 0 {
 				host = test.LoopbackClientBindAddressOverride
 			}
-			s.LoopbackClientConfig.Host = net.JoinHostPort(host, effectiveSecurePort)
+			s.LoopbackClientConfig.Host = net.JoinHostPort(host, strconv.Itoa(secureOptions.BindPort))
 			if test.ExpectLoopbackClientError {
 				if err == nil {
 					t.Errorf("%q - expected error creating loopback client config", title)

--- a/staging/src/k8s.io/apiserver/pkg/server/serve.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/serve.go
@@ -26,11 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
+
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
-
-	"github.com/golang/glog"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -41,8 +40,12 @@ const (
 // be loaded or the initial listen call fails. The actual server loop (stoppable by closing
 // stopCh) runs in a go routine, i.e. serveSecurely does not block.
 func (s *GenericAPIServer) serveSecurely(stopCh <-chan struct{}) error {
+	if s.SecureServingInfo.Listener == nil {
+		return fmt.Errorf("listener must not be nil")
+	}
+
 	secureServer := &http.Server{
-		Addr:           s.SecureServingInfo.BindAddress,
+		Addr:           s.SecureServingInfo.Listener.Addr().String(),
 		Handler:        s.Handler,
 		MaxHeaderBytes: 1 << 20,
 		TLSConfig: &tls.Config{
@@ -83,33 +86,22 @@ func (s *GenericAPIServer) serveSecurely(stopCh <-chan struct{}) error {
 		secureServer.TLSConfig.ClientCAs = s.SecureServingInfo.ClientCA
 	}
 
-	glog.Infof("Serving securely on %s", s.SecureServingInfo.BindAddress)
-	var err error
-	s.effectiveSecurePort, err = RunServer(secureServer, s.SecureServingInfo.BindNetwork, s.ShutdownTimeout, stopCh)
+	glog.Infof("Serving securely on %s", secureServer.Addr)
+	err := RunServer(secureServer, s.SecureServingInfo.Listener, s.ShutdownTimeout, stopCh)
 	return err
 }
 
-// RunServer listens on the given port, then spawns a go-routine continuously serving
-// until the stopCh is closed. The port is returned. This function does not block.
-func RunServer(server *http.Server, network string, shutDownTimeout time.Duration, stopCh <-chan struct{}) (int, error) {
-	if len(server.Addr) == 0 {
-		return 0, errors.New("address cannot be empty")
-	}
-
-	if len(network) == 0 {
-		network = "tcp"
-	}
-
-	ln, err := net.Listen(network, server.Addr)
-	if err != nil {
-		return 0, fmt.Errorf("failed to listen on %v: %v", server.Addr, err)
-	}
-
-	// get port
-	tcpAddr, ok := ln.Addr().(*net.TCPAddr)
-	if !ok {
-		ln.Close()
-		return 0, fmt.Errorf("invalid listen address: %q", ln.Addr().String())
+// RunServer listens on the given port if listener is not given,
+// then spawns a go-routine continuously serving
+// until the stopCh is closed. This function does not block.
+func RunServer(
+	server *http.Server,
+	ln net.Listener,
+	shutDownTimeout time.Duration,
+	stopCh <-chan struct{},
+) error {
+	if ln == nil {
+		return fmt.Errorf("listener must not be nil")
 	}
 
 	// Shutdown server gracefully.
@@ -131,7 +123,7 @@ func RunServer(server *http.Server, network string, shutDownTimeout time.Duratio
 
 		err := server.Serve(listener)
 
-		msg := fmt.Sprintf("Stopped listening on %s", tcpAddr.String())
+		msg := fmt.Sprintf("Stopped listening on %s", ln.Addr().String())
 		select {
 		case <-stopCh:
 			glog.Info(msg)
@@ -140,7 +132,7 @@ func RunServer(server *http.Server, network string, shutDownTimeout time.Duratio
 		}
 	}()
 
-	return tcpAddr.Port, nil
+	return nil
 }
 
 type NamedTLSCert struct {

--- a/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
+++ b/staging/src/k8s.io/kube-aggregator/Godeps/Godeps.json
@@ -275,10 +275,6 @@
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
 		},
 		{
-			"ImportPath": "github.com/pkg/errors",
-			"Rev": "a22138067af1c4942683050411a841ade67fe1eb"
-		},
-		{
 			"ImportPath": "github.com/pmezard/go-difflib/difflib",
 			"Rev": "d8ed2627bdf02c080bf22230dbb337003b7aba2d"
 		},

--- a/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/sample-apiserver/Godeps/Godeps.json
@@ -267,10 +267,6 @@
 			"Rev": "5f041e8faa004a95c88a202771f4cc3e991971e6"
 		},
 		{
-			"ImportPath": "github.com/pkg/errors",
-			"Rev": "a22138067af1c4942683050411a841ade67fe1eb"
-		},
-		{
 			"ImportPath": "github.com/prometheus/client_golang/prometheus",
 			"Rev": "e7e903064f5e9eb5da98208bae10b475d4db0f8c"
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

>At the moment we pass a port via the options into the config. A zero port does not work because the loopback clients created during apiserver initialization need to know the port before. Passing a listener into the server instead would allow us to use a zero port beforehand and bootstrapping order should be fine.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55784

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
