### PR TITLE
make cadvisor's allow dynamic housekeeping option configurable

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -425,6 +425,7 @@ func AddKubeletConfigFlags(fs *pflag.FlagSet, c *kubeletconfig.KubeletConfigurat
 
 	fs.BoolVar(&c.EnableDebuggingHandlers, "enable-debugging-handlers", c.EnableDebuggingHandlers, "Enables server endpoints for log collection and local running of containers and commands")
 	fs.BoolVar(&c.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
+	fs.BoolVar(&c.CAdvisorAllowDynamicHousekeeping, "cadvisor-allow-dynamic-housekeeping", true, "Whether to allow cAdvisor's housekeeping interval to be dynamic")
 	fs.Int32Var(&c.CAdvisorPort, "cadvisor-port", c.CAdvisorPort, "The port of the localhost cAdvisor endpoint (set to 0 to disable)")
 	fs.Int32Var(&c.HealthzPort, "healthz-port", c.HealthzPort, "The port of the localhost healthz endpoint (set to 0 to disable)")
 	fs.Var(componentconfig.IPVar{Val: &c.HealthzBindAddress}, "healthz-bind-address", "The IP address for the healthz server to serve on. (set to 0.0.0.0 for all interfaces)")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -414,7 +414,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies) (err error) {
 
 	if kubeDeps.CAdvisorInterface == nil {
 		imageFsInfoProvider := cadvisor.NewImageFsInfoProvider(s.ContainerRuntime, s.RemoteRuntimeEndpoint)
-		kubeDeps.CAdvisorInterface, err = cadvisor.New(s.Address, uint(s.CAdvisorPort), imageFsInfoProvider, s.RootDirectory, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint))
+		kubeDeps.CAdvisorInterface, err = cadvisor.New(s.Address, uint(s.CAdvisorPort), imageFsInfoProvider, s.RootDirectory, cadvisor.UsingLegacyCadvisorStats(s.ContainerRuntime, s.RemoteRuntimeEndpoint), s.CAdvisorAllowDynamicHousekeeping)
 		if err != nil {
 			return err
 		}

--- a/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/kubeletconfig/fuzzer/fuzzer.go
@@ -45,6 +45,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.Authorization.Webhook.CacheUnauthorizedTTL = metav1.Duration{Duration: 30 * time.Second}
 			obj.Address = "0.0.0.0"
 			obj.CAdvisorPort = 4194
+			obj.CAdvisorAllowDynamicHousekeeping = true
 			obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}
 			obj.RuntimeRequestTimeout = metav1.Duration{Duration: 2 * time.Minute}
 			obj.CPUCFSQuota = true

--- a/pkg/kubelet/apis/kubeletconfig/helpers_test.go
+++ b/pkg/kubelet/apis/kubeletconfig/helpers_test.go
@@ -145,6 +145,7 @@ var (
 		"Authorization.Mode",
 		"Authorization.Webhook.CacheAuthorizedTTL.Duration",
 		"Authorization.Webhook.CacheUnauthorizedTTL.Duration",
+		"CAdvisorAllowDynamicHousekeeping",
 		"CAdvisorPort",
 		"CPUCFSQuota",
 		"CPUManagerPolicy",

--- a/pkg/kubelet/apis/kubeletconfig/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/types.go
@@ -121,6 +121,8 @@ type KubeletConfiguration struct {
 	EnableDebuggingHandlers bool
 	// enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
 	EnableContentionProfiling bool
+	// cAdvisorAllowDynamicHousekeeping allows housekeeping intervals to be dynamic.
+	CAdvisorAllowDynamicHousekeeping bool
 	// cAdvisorPort is the port of the localhost cAdvisor endpoint (set to 0 to disable)
 	CAdvisorPort int32
 	// healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/defaults.go
@@ -80,6 +80,9 @@ func SetDefaults_KubeletConfiguration(obj *KubeletConfiguration) {
 	if obj.CAdvisorPort == nil {
 		obj.CAdvisorPort = utilpointer.Int32Ptr(4194)
 	}
+	if obj.CAdvisorAllowDynamicHousekeeping == nil {
+		obj.CAdvisorAllowDynamicHousekeeping = boolVar(true)
+	}
 	if obj.VolumeStatsAggPeriod == zeroDuration {
 		obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}
 	}

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/types.go
@@ -121,6 +121,8 @@ type KubeletConfiguration struct {
 	EnableDebuggingHandlers *bool `json:"enableDebuggingHandlers"`
 	// enableContentionProfiling enables lock contention profiling, if enableDebuggingHandlers is true.
 	EnableContentionProfiling bool `json:"enableContentionProfiling"`
+	// cAdvisorAllowDynamicHousekeeping allows housekeeping intervals to be dynamic.
+	CAdvisorAllowDynamicHousekeeping *bool `json:"cAdvisorAllowDynamicHousekeeping"`
 	// cAdvisorPort is the port of the localhost cAdvisor endpoint (set to 0 to disable)
 	CAdvisorPort *int32 `json:"cAdvisorPort"`
 	// healthzPort is the port of the localhost healthz endpoint (set to 0 to disable)

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.conversion.go
@@ -181,6 +181,9 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_kubeletconfig_KubeletConfigura
 		return err
 	}
 	out.EnableContentionProfiling = in.EnableContentionProfiling
+	if err := v1.Convert_Pointer_bool_To_bool(&in.CAdvisorAllowDynamicHousekeeping, &out.CAdvisorAllowDynamicHousekeeping, s); err != nil {
+		return err
+	}
 	if err := v1.Convert_Pointer_int32_To_int32(&in.CAdvisorPort, &out.CAdvisorPort, s); err != nil {
 		return err
 	}
@@ -306,6 +309,9 @@ func autoConvert_kubeletconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigura
 		return err
 	}
 	out.EnableContentionProfiling = in.EnableContentionProfiling
+	if err := v1.Convert_bool_To_Pointer_bool(&in.CAdvisorAllowDynamicHousekeeping, &out.CAdvisorAllowDynamicHousekeeping, s); err != nil {
+		return err
+	}
 	if err := v1.Convert_int32_To_Pointer_int32(&in.CAdvisorPort, &out.CAdvisorPort, s); err != nil {
 		return err
 	}

--- a/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/kubeletconfig/v1alpha1/zz_generated.deepcopy.go
@@ -185,6 +185,15 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 			**out = **in
 		}
 	}
+	if in.CAdvisorAllowDynamicHousekeeping != nil {
+		in, out := &in.CAdvisorAllowDynamicHousekeeping, &out.CAdvisorAllowDynamicHousekeeping
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(bool)
+			**out = **in
+		}
+	}
 	if in.CAdvisorPort != nil {
 		in, out := &in.CAdvisorPort, &out.CAdvisorPort
 		if *in == nil {

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -55,7 +55,6 @@ var _ Interface = new(cadvisorClient)
 const statsCacheDuration = 2 * time.Minute
 const maxHousekeepingInterval = 15 * time.Second
 const defaultHousekeepingInterval = 10 * time.Second
-const allowDynamicHousekeeping = true
 
 func init() {
 	// Override cAdvisor flag defaults.
@@ -105,7 +104,7 @@ func containerLabels(c *cadvisorapi.ContainerInfo) map[string]string {
 }
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool, allowDynamicHousekeeping bool) (Interface, error) {
 	sysFs := sysfs.NewRealSysFs()
 
 	ignoreMetrics := cadvisormetrics.MetricSet{cadvisormetrics.NetworkTcpUsageMetrics: struct{}{}, cadvisormetrics.NetworkUdpUsageMetrics: struct{}{}}

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -31,7 +31,7 @@ type cadvisorUnsupported struct {
 
 var _ Interface = new(cadvisorUnsupported)
 
-func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool, allowDynamicHousekeeping bool) (Interface, error) {
 	return &cadvisorUnsupported{}, nil
 }
 

--- a/pkg/kubelet/cadvisor/cadvisor_windows.go
+++ b/pkg/kubelet/cadvisor/cadvisor_windows.go
@@ -32,7 +32,7 @@ type cadvisorClient struct {
 var _ Interface = new(cadvisorClient)
 
 // New creates a cAdvisor and exports its API on the specified port if port > 0.
-func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool) (Interface, error) {
+func New(address string, port uint, imageFsInfoProvider ImageFsInfoProvider, rootPath string, usingLegacyStats bool, allowDynamicHousekeeping bool) (Interface, error) {
 	client, err := winstats.NewPerfCounterClient()
 	return &cadvisorClient{winStatsClient: client}, err
 }

--- a/test/e2e_node/environment/conformance.go
+++ b/test/e2e_node/environment/conformance.go
@@ -38,6 +38,8 @@ const failed = "\033[0;31mFAILED\033[0m"
 const notConfigured = "\033[0;34mNOT CONFIGURED\033[0m"
 const skipped = "\033[0;34mSKIPPED\033[0m"
 
+const allowDynamicHousekeeping = true
+
 var checkFlag = flag.String(
 	"check", "all", "what to check for conformance.  One or more of all,container-runtime,daemons,dns,firewall,kernel")
 
@@ -99,7 +101,7 @@ func containerRuntime() error {
 	}
 
 	// Setup cadvisor to check the container environment
-	c, err := cadvisor.New("", 0 /*don't start the http server*/, cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", false)
+	c, err := cadvisor.New("", 0 /*don't start the http server*/, cadvisor.NewImageFsInfoProvider("docker", ""), "/var/lib/kubelet", false, allowDynamicHousekeeping)
 	if err != nil {
 		return printError("Container Runtime Check: %s Could not start cadvisor %v", failed, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR introduces the missing option for kubelet:
```
--cadvisor-allow-dynamic-housekeeping Whether to allow cAdvisor's housekeeping interval to be dynamic (default true)
```

Without this flag housekeeping interval can be greater than 10s (`--housekeeping-interval` default or specified by user), and can be maximized up to 30sec because
housekeeping interval will be dynamically increased up to 15sec (`const maxHousekeepingInterval = 15 * time.Second`)

and then increased in `jitter` func up to 30sec: 
`duration + time.Duration(rand.Float64()*maxFactor*float64(duration))` 
(maxFactor = 1.0, rand.Float64() in [0.0, 1.0], duration = maxHousekeepingInterval = 15sec)

https://github.com/google/cadvisor/blob/49e0496/manager/container.go#L377-L380
https://github.com/google/cadvisor/blob/49e0496/manager/container.go#L90-L96

We run into the issue with lack of `memory/usage` metrics generated by heapster that collects it every 10 seconds, but kubelet's cadvisor produces metrics with intervals that greater than expected (10s).

With this option we can achieve expected for heapster behavior with maximum intervals up to 10 seconds without patching google/cadvisor (disabling jitter func) by disallowing dynamic changes in housekeeping interval and decreasing housekeeping interval itself up to 5 seconds.


**Special notes for your reviewer**:
This pull-request introduces new `--cadvisor-allow-dynamic-housekeeping` flag.

No additional action from users required.