### PR TITLE
Fix potential unexpected object mutation that can lead to data races

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -411,7 +411,8 @@ func (c *unstructuredConverter) ToUnstructured(obj interface{}) (map[string]inte
 	var u map[string]interface{}
 	var err error
 	if unstr, ok := obj.(Unstructured); ok {
-		u = DeepCopyJSON(unstr.UnstructuredContent())
+		// UnstructuredContent() mutates the object so we need to make a copy first
+		u = unstr.DeepCopyObject().(Unstructured).UnstructuredContent()
 	} else {
 		t := reflect.TypeOf(obj)
 		value := reflect.ValueOf(obj)

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -919,8 +919,8 @@ var _ = SIGDescribe("Garbage collector", func() {
 				"kind":       definition.Spec.Names.Kind,
 				"metadata": map[string]interface{}{
 					"name": dependentName,
-					"ownerReferences": []map[string]string{
-						{
+					"ownerReferences": []interface{}{
+						map[string]interface{}{
 							"uid":        string(persistedOwner.GetUID()),
 							"apiVersion": apiVersion,
 							"kind":       definition.Spec.Names.Kind,


### PR DESCRIPTION
**What this PR does / why we need it**:
In #51526 I introduced an optimization - do a deep copy instead of to and from JSON roundtrip to convert anything that implements `runtime.Unstructured`. I just discovered that the method that is used there `UnstructuredContent()` in both `Unstructured` and `UnstructuredList` may mutate the original object.
https://github.com/kubernetes/kubernetes/blob/200875039812d1559555727da74596dc925cfa77/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go#L87-L92
https://github.com/kubernetes/kubernetes/blob/7c10cbc642b47a8f11a74d5178ebbe76a9588cb6/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list.go#L58-L75
This is problematic because previously (before #51526) there was no mutation and because this is unexpected and may lead to data races - it is bad behaviour to mutate original object when you just want a copy of it.
This PR fixes the issue.

Without the fix the tests I've added are failing because when comparison is done original object is not the same:
```
converter_test.go:154: Object changed, diff: 
object.Object[items]:
  a: []interface {}{}
  b: <nil>
converter_test.go:154: Object changed, diff: 
object.Object[items]:
  a: []interface {}{map[string]interface {}{"kind":"Pod"}}
  b: <nil>
```

However the underlying issue is not fixed here - `UnstructuredContent()` is brittle and dangerous. Method name does not imply that it mutates data when you call it. And godoc does not mention that either:
https://github.com/kubernetes/kubernetes/blob/509df603b18d356777176953e5d160b6f3d0bba9/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go#L233-L249
Something needs to be done about it IMO.
Also `UnstructuredContent()` implementation in `UnstructuredList` does not implement the behaviour required by godoc in `runtime.Unstructured`.

**Release note**:
```release-note
NONE
```
/kind bug
/sig api-machinery
/assign @sttts 