### PR TITLE
Automated cherry pick of #51034

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -132,7 +132,7 @@ func Run(s *options.CMServer) error {
 		}
 		var clientBuilder controller.ControllerClientBuilder
 		if s.UseServiceAccountCredentials {
-			if len(s.ServiceAccountKeyFile) > 0 {
+			if len(s.ServiceAccountKeyFile) == 0 {
 				// It's possible another controller process is creating the tokens for us.
 				// If one isn't, we'll timeout and exit when our client builder is unable to create the tokens.
 				glog.Warningf("--use-service-account-credentials was specified without providing a --service-account-private-key-file")


### PR DESCRIPTION
Cherry pick of #51034 on release-1.8.

#51034: fix conditional for warning while starting KCM without secret

```release-note
Fix wrong warning when --service-account-private-key-file is specified.
```