### PR TITLE
deviceplugin: fix race when multiple plugins are registered

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/device_plugin_handler.go
+++ b/pkg/kubelet/cm/deviceplugin/device_plugin_handler.go
@@ -77,6 +77,10 @@ func NewHandlerImpl(updateCapacityFunc func(v1.ResourceList)) (*HandlerImpl, err
 	deviceManagerMonitorCallback := func(resourceName string, added, updated, deleted []pluginapi.Device) {
 		var capacity = v1.ResourceList{}
 		kept := append(updated, added...)
+
+		handler.Lock()
+		defer handler.Unlock()
+
 		if _, ok := handler.allDevices[resourceName]; !ok {
 			handler.allDevices[resourceName] = sets.NewString()
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
When registering multiple device plugins to Kubelet concurrently, there exists a race that crashes the Kubelet.

Consider two plugins: D1 and D2. The call order method is roughly

D1 -> manager.go:register -> endpoint.go:listAndWatch -> device_plugin_handler.go:(*D1).callback
D2 -> manager.go:register -> endpoint.go:listAndWatch -> device_plugin_handler.go:(*D2).callback

The callback function accesses HandlerImpl's allDevices map that maps (resourceName -> DeviceID). If both plugins reach these accesses at the same time, Kubelet crashes with "fatal error: concurrent map read and map write".

This can be solved by making sure handler is locked when allDevices are being updated. The functionality is needed to avoid Kubelet crashes when multiple device plugins are trying to register with Kubelet at the same moment. Occurs frequently when single binary tries to register itself as multiple plugins.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
