### PR TITLE
kubeadm-init: add --copy-credentials-for-user

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/phases:go_default_library",
+        "//cmd/kubeadm/app/cmd/platform:go_default_library",
         "//cmd/kubeadm/app/cmd/upgrade:go_default_library",
         "//cmd/kubeadm/app/cmd/util:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
@@ -115,6 +116,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//cmd/kubeadm/app/cmd/phases:all-srcs",
+        "//cmd/kubeadm/app/cmd/platform:all-srcs",
         "//cmd/kubeadm/app/cmd/upgrade:all-srcs",
         "//cmd/kubeadm/app/cmd/util:all-srcs",
     ],

--- a/cmd/kubeadm/app/cmd/platform/BUILD
+++ b/cmd/kubeadm/app/cmd/platform/BUILD
@@ -1,0 +1,59 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "init_shared.go",
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:dragonfly": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:freebsd": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:nacl": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:netbsd": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:openbsd": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:plan9": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:solaris": [
+            "init_unix.go",
+        ],
+        "@io_bazel_rules_go//go/platform:windows": [
+            "init_windows.go",
+        ],
+        "//conditions:default": [],
+    }),
+    importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd/platform",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/kubeadm/app/cmd/platform/init_shared.go
+++ b/cmd/kubeadm/app/cmd/platform/init_shared.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+// shared constants for init
+const (
+	InitErrorNoSuchUser               = "no such user %q: %v"
+	InitErrorUserIsRoot               = "user is root %q"
+	InitErrorNoHomeDir                = "cannot obtain the home directory for user %q"
+	InitErrorAtoiString               = "cannot Atoi() UID/GID string %q: %v"
+	InitErrorCannotCreateDir          = "cannot create %q: %v"
+	InitErrorCannotChown              = "cannot chown %q: %v"
+	InitErrorCannotOpenFileForReading = "cannot open file for reading %q: %v"
+	InitErrorCannotOpenFileForWriting = "cannot open file for writing %q: %v"
+	InitErrorCannotIoCopy             = "cannot io.Copy() the configuration: %v"
+
+	InitMessageCopyingCredentials = "[init] Copying administrator credentials to %q from %q\n"
+
+	InitPathKube   = "/.kube"
+	InitPathConfig = "/config"
+)

--- a/cmd/kubeadm/app/cmd/platform/init_unix.go
+++ b/cmd/kubeadm/app/cmd/platform/init_unix.go
@@ -1,0 +1,95 @@
+// +build !windows
+
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/user"
+	"strconv"
+)
+
+// InitCopyCredentialsForUser will copy the cluster admin credentials to the home path of a non-root user
+func InitCopyCredentialsForUser(copyCredentialsForUser string, adminKubeConfigPath string) error {
+
+	var err error
+	var uid, gid int
+	var usr *user.User
+	var src, dest *os.File
+	var kubeDir, configFilePath string
+
+	usr, err = user.Lookup(copyCredentialsForUser)
+	if err != nil {
+		return fmt.Errorf(InitErrorNoSuchUser, copyCredentialsForUser, err)
+	}
+
+	if usr.Gid == "0" {
+		return fmt.Errorf(InitErrorUserIsRoot, copyCredentialsForUser)
+	}
+
+	if usr.HomeDir == "" {
+		return fmt.Errorf(InitErrorNoHomeDir, copyCredentialsForUser)
+	}
+	kubeDir = usr.HomeDir + InitPathKube
+	configFilePath = kubeDir + InitPathConfig
+
+	fmt.Printf(InitMessageCopyingCredentials, configFilePath, adminKubeConfigPath)
+
+	uid, err = strconv.Atoi(usr.Uid)
+	if err != nil {
+		return fmt.Errorf(InitErrorAtoiString, usr.Uid, err)
+	}
+
+	gid, err = strconv.Atoi(usr.Gid)
+	if err != nil {
+		return fmt.Errorf(InitErrorAtoiString, usr.Gid, err)
+	}
+
+	if err := os.MkdirAll(kubeDir, 0700); err != nil {
+		return fmt.Errorf(InitErrorCannotCreateDir, kubeDir, err)
+	}
+
+	// Chown doesn't work on Windows
+	if err := os.Chown(kubeDir, uid, gid); err != nil {
+		return fmt.Errorf(InitErrorCannotChown, kubeDir, err)
+	}
+
+	src, err = os.Open(adminKubeConfigPath)
+	if err != nil {
+		return fmt.Errorf(InitErrorCannotOpenFileForReading, adminKubeConfigPath, err)
+	}
+	defer src.Close()
+
+	dest, err = os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, 0700)
+	if err != nil {
+		return fmt.Errorf(InitErrorCannotOpenFileForWriting, configFilePath, err)
+	}
+	defer dest.Close()
+
+	if _, err := io.Copy(dest, src); err != nil {
+		return fmt.Errorf(InitErrorCannotIoCopy, err)
+	}
+
+	if err := os.Chown(configFilePath, uid, gid); err != nil {
+		return fmt.Errorf(InitErrorCannotChown, configFilePath, err)
+	}
+
+	return nil
+}

--- a/cmd/kubeadm/app/cmd/platform/init_windows.go
+++ b/cmd/kubeadm/app/cmd/platform/init_windows.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package platform
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/user"
+	"strings"
+)
+
+// InitCopyCredentialsForUser will copy the cluster admin credentials to the home path of a non-root user
+func InitCopyCredentialsForUser(copyCredentialsForUser string, adminKubeConfigPath string) error {
+	var err error
+	var usr *user.User
+	var src, dest *os.File
+	var kubeDir, configFilePath string
+
+	usr, err = user.Lookup(copyCredentialsForUser)
+	if err != nil {
+		return fmt.Errorf(InitErrorNoSuchUser, copyCredentialsForUser, err)
+	}
+	// check if the given user is an admin.
+	// if the list of users returned by `net localgroup administrators`
+	// contains the username then the user is an administrator.
+	// the list is separated by \r\n, also user names are case insensitive on Windows.
+	out, err := exec.Command("net", "localgroup", "administrators").Output()
+	if err != nil {
+		return fmt.Errorf("failed to run 'net' command: %v", err)
+	}
+	outLower := strings.ToLower(string(out))
+	if strings.Index(outLower, "\r\n"+strings.ToLower(copyCredentialsForUser)+"\r\n") != -1 {
+		return fmt.Errorf(InitErrorUserIsRoot, copyCredentialsForUser)
+	}
+
+	// User.HomeDir don't work on Windows
+	usr.HomeDir = ""
+	out, err = exec.Command("cmd", "/c", "reg", "query", "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\ProfileList\\"+usr.Uid, "/v", "ProfileImagePath").Output()
+	if err != nil {
+		return fmt.Errorf("no registry key for the home path of user %q: %v", copyCredentialsForUser, err)
+	}
+	usr.HomeDir = strings.Fields(string(out))[4]
+	if usr.HomeDir == "" {
+		return fmt.Errorf(InitErrorNoHomeDir, copyCredentialsForUser)
+	}
+	kubeDir = usr.HomeDir + InitPathKube
+	configFilePath = kubeDir + InitPathConfig
+
+	fmt.Printf(InitMessageCopyingCredentials, configFilePath, adminKubeConfigPath)
+
+	if err := os.MkdirAll(kubeDir, 0700); err != nil {
+		return fmt.Errorf(InitErrorCannotCreateDir, kubeDir, err)
+	}
+
+	// Chown() doesn't work on Windows. Attempt to use 'icacls' but if it's missing try 'cacls'.
+	if _, err := exec.Command("icacls", kubeDir, "/e", "/g", copyCredentialsForUser+":f").Output(); err != nil {
+		if _, err := exec.Command("cacls", kubeDir, "/e", "/g", copyCredentialsForUser+":f").Output(); err != nil {
+			return fmt.Errorf(InitErrorCannotChown, kubeDir, err)
+		}
+	}
+
+	src, err = os.Open(adminKubeConfigPath)
+	if err != nil {
+		return fmt.Errorf(InitErrorCannotOpenFileForReading, adminKubeConfigPath, err)
+	}
+	defer src.Close()
+
+	dest, err = os.OpenFile(configFilePath, os.O_RDWR|os.O_CREATE, 0700)
+	if err != nil {
+		return fmt.Errorf(InitErrorCannotOpenFileForWriting, configFilePath, err)
+	}
+	defer dest.Close()
+
+	if _, err := io.Copy(dest, src); err != nil {
+		return fmt.Errorf(InitErrorCannotIoCopy, err)
+	}
+
+	if _, err := exec.Command("icacls", configFilePath, "/e", "/g", copyCredentialsForUser+":f").Output(); err != nil {
+		if _, err := exec.Command("cacls", configFilePath, "/e", "/g", copyCredentialsForUser+":f").Output(); err != nil {
+			return fmt.Errorf(InitErrorCannotChown, kubeDir, err)
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Using this new parameter the administrator's credentials
for the cluster will be copied to the specified
user's home directory.

WARNING: existing files will be overwritten.

Usage:
    kubeadm init --copy-credentials-for-user=<someuser>

It automates a step that the user needs to perform either manually each time or by scripting. If the flag is not set the old behavior is preserved - i.e. show info how / where to copy the config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Related to #235
Fixes https://github.com/kubernetes/kubeadm/issues/416

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--copy-credentials-for-user` to `kubeadm init`. The flag can be used to automatically copy the administrator's credentials to the specified user's home directory.
```
