### PR TITLE
Expose single annotation/label via downward API

### DIFF
--- a/hack/import-restrictions.yaml
+++ b/hack/import-restrictions.yaml
@@ -4,6 +4,7 @@
   - k8s.io/apiserver/pkg/util/feature
   - k8s.io/kubernetes/pkg/apis/core
   - k8s.io/kubernetes/pkg/features
+  - k8s.io/kubernetes/pkg/fieldpath
   - k8s.io/kubernetes/pkg/util
   - k8s.io/api/core/v1
 

--- a/pkg/apis/core/BUILD
+++ b/pkg/apis/core/BUILD
@@ -51,6 +51,7 @@ filegroup(
         "//pkg/apis/core/fuzzer:all-srcs",
         "//pkg/apis/core/helper:all-srcs",
         "//pkg/apis/core/install:all-srcs",
+        "//pkg/apis/core/pods:all-srcs",
         "//pkg/apis/core/v1:all-srcs",
         "//pkg/apis/core/validation:all-srcs",
     ],

--- a/pkg/apis/core/pods/BUILD
+++ b/pkg/apis/core/pods/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["helpers.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/pods",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/fieldpath:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["helpers_test.go"],
+    importpath = "k8s.io/kubernetes/pkg/apis/core/pods",
+    library = ":go_default_library",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/apis/core/pods/helpers.go
+++ b/pkg/apis/core/pods/helpers.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/fieldpath"
+)
+
+func ConvertDownwardAPIFieldLabel(version, label, value string) (string, string, error) {
+	if version != "v1" {
+		return "", "", fmt.Errorf("unsupported pod version: %s", version)
+	}
+
+	path, _ := fieldpath.SplitMaybeSubscriptedPath(label)
+	switch path {
+	case "metadata.annotations",
+		"metadata.labels",
+		"metadata.name",
+		"metadata.namespace",
+		"metadata.uid",
+		"spec.nodeName",
+		"spec.restartPolicy",
+		"spec.serviceAccountName",
+		"spec.schedulerName",
+		"status.phase",
+		"status.hostIP",
+		"status.podIP":
+		return label, value, nil
+	// This is for backwards compatibility with old v1 clients which send spec.host
+	case "spec.host":
+		return "spec.nodeName", value, nil
+	default:
+		return "", "", fmt.Errorf("field label not supported: %s", label)
+	}
+}

--- a/pkg/apis/core/pods/helpers_test.go
+++ b/pkg/apis/core/pods/helpers_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pods
+
+import (
+	"testing"
+)
+
+func TestConvertDownwardAPIFieldLabel(t *testing.T) {
+	testCases := []struct {
+		version       string
+		label         string
+		value         string
+		expectedErr   bool
+		expectedLabel string
+		expectedValue string
+	}{
+		{
+			version:     "v2",
+			label:       "metadata.name",
+			value:       "test-pod",
+			expectedErr: true,
+		},
+		{
+			version:     "v1",
+			label:       "invalid-label",
+			value:       "value",
+			expectedErr: true,
+		},
+		{
+			version:       "v1",
+			label:         "metadata.name",
+			value:         "test-pod",
+			expectedLabel: "metadata.name",
+			expectedValue: "test-pod",
+		},
+		{
+			version:       "v1",
+			label:         "metadata.annotations",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations",
+			expectedValue: "myValue",
+		},
+		{
+			version:       "v1",
+			label:         "metadata.annotations['myKey']",
+			value:         "myValue",
+			expectedLabel: "metadata.annotations['myKey']",
+			expectedValue: "myValue",
+		},
+		{
+			version:       "v1",
+			label:         "spec.host",
+			value:         "127.0.0.1",
+			expectedLabel: "spec.nodeName",
+			expectedValue: "127.0.0.1",
+		},
+	}
+	for _, tc := range testCases {
+		label, value, err := ConvertDownwardAPIFieldLabel(tc.version, tc.label, tc.value)
+		if err != nil {
+			if tc.expectedErr {
+				continue
+			}
+			t.Errorf("ConvertDownwardAPIFieldLabel(%s, %s, %s) failed: %s",
+				tc.version, tc.label, tc.value, err)
+		}
+		if tc.expectedLabel != label || tc.expectedValue != value {
+			t.Errorf("ConvertDownwardAPIFieldLabel(%s, %s, %s) = (%s, %s, nil), expected (%s, %s, nil)",
+				tc.version, tc.label, tc.value, label, value, tc.expectedLabel, tc.expectedValue)
+		}
+	}
+}

--- a/pkg/apis/core/v1/BUILD
+++ b/pkg/apis/core/v1/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/features:go_default_library",
+        "//pkg/fieldpath:go_default_library",
         "//pkg/util/parsers:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/core/v1/BUILD
+++ b/pkg/apis/core/v1/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/features:go_default_library",
-        "//pkg/fieldpath:go_default_library",
         "//pkg/util/parsers:go_default_library",
         "//pkg/util/pointer:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
-	"k8s.io/kubernetes/pkg/fieldpath"
 )
 
 // This is a "fast-path" that avoids reflection for common types. It focuses on the objects that are
@@ -157,8 +156,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	// Add field conversion funcs.
 	err = scheme.AddFieldLabelConversionFunc("v1", "Pod",
 		func(label, value string) (string, string, error) {
-			path, _ := fieldpath.SplitMaybeSubscriptedPath(label)
-			switch path {
+			switch label {
 			case "metadata.name",
 				"metadata.namespace",
 				"spec.nodeName",

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -159,17 +159,12 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 		func(label, value string) (string, string, error) {
 			path, _ := fieldpath.SplitMaybeSubscriptedPath(label)
 			switch path {
-			case "metadata.annotations",
-				"metadata.labels",
-				"metadata.name",
+			case "metadata.name",
 				"metadata.namespace",
-				"metadata.uid",
 				"spec.nodeName",
 				"spec.restartPolicy",
-				"spec.serviceAccountName",
 				"spec.schedulerName",
 				"status.phase",
-				"status.hostIP",
 				"status.podIP":
 				return label, value, nil
 			// This is for backwards compatibility with old v1 clients which send spec.host

--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
+	"k8s.io/kubernetes/pkg/fieldpath"
 )
 
 // This is a "fast-path" that avoids reflection for common types. It focuses on the objects that are
@@ -156,7 +157,8 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	// Add field conversion funcs.
 	err = scheme.AddFieldLabelConversionFunc("v1", "Pod",
 		func(label, value string) (string, string, error) {
-			switch label {
+			path, _ := fieldpath.SplitMaybeSubscriptedPath(label)
+			switch path {
 			case "metadata.annotations",
 				"metadata.labels",
 				"metadata.name",
@@ -170,7 +172,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 				"status.hostIP",
 				"status.podIP":
 				return label, value, nil
-				// This is for backwards compatibility with old v1 clients which send spec.host
+			// This is for backwards compatibility with old v1 clients which send spec.host
 			case "spec.host":
 				return "spec.nodeName", value, nil
 			default:

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/capabilities:go_default_library",
         "//pkg/features:go_default_library",
+        "//pkg/fieldpath:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/api/service:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/helper:go_default_library",
+        "//pkg/apis/core/pods:go_default_library",
         "//pkg/apis/core/v1:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/capabilities:go_default_library",

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -42,10 +42,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	apiservice "k8s.io/kubernetes/pkg/api/service"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
+	podshelper "k8s.io/kubernetes/pkg/apis/core/pods"
 	corev1 "k8s.io/kubernetes/pkg/apis/core/v1"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/capabilities"
@@ -1964,7 +1964,7 @@ func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets
 		return allErrs
 	}
 
-	internalFieldPath, _, err := legacyscheme.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+	internalFieldPath, _, err := podshelper.ConvertDownwardAPIFieldLabel(fs.APIVersion, fs.FieldPath, "")
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldPath"), fs.FieldPath, fmt.Sprintf("error converting fieldPath: %v", err)))
 		return allErrs

--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -50,6 +50,7 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/capabilities"
 	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/pkg/fieldpath"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 )
 
@@ -960,11 +961,13 @@ func validateFlockerVolumeSource(flocker *core.FlockerVolumeSource, fldPath *fie
 	return allErrs
 }
 
-var validDownwardAPIFieldPathExpressions = sets.NewString(
+var validVolumeDownwardAPIFieldPathExpressions = sets.NewString(
 	"metadata.name",
 	"metadata.namespace",
 	"metadata.labels",
+	"metadata.labels[]", // represents "metadata.labels" with an arbitary subscript
 	"metadata.annotations",
+	"metadata.annotations[]", // represents "metadata.annotations" with an arbitary subscript
 	"metadata.uid")
 
 func validateDownwardAPIVolumeFile(file *core.DownwardAPIVolumeFile, fldPath *field.Path) field.ErrorList {
@@ -975,7 +978,7 @@ func validateDownwardAPIVolumeFile(file *core.DownwardAPIVolumeFile, fldPath *fi
 	}
 	allErrs = append(allErrs, validateLocalNonReservedPath(file.Path, fldPath.Child("path"))...)
 	if file.FieldRef != nil {
-		allErrs = append(allErrs, validateObjectFieldSelector(file.FieldRef, &validDownwardAPIFieldPathExpressions, fldPath.Child("fieldRef"))...)
+		allErrs = append(allErrs, validateObjectFieldSelector(file.FieldRef, &validVolumeDownwardAPIFieldPathExpressions, fldPath.Child("fieldRef"))...)
 		if file.ResourceFieldRef != nil {
 			allErrs = append(allErrs, field.Invalid(fldPath, "resource", "fieldRef and resourceFieldRef can not be specified simultaneously"))
 		}
@@ -1898,7 +1901,16 @@ func ValidateEnv(vars []core.EnvVar, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-var validFieldPathExpressionsEnv = sets.NewString("metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP")
+var validEnvDownwardAPIFieldPathExpressions = sets.NewString(
+	"metadata.annotations[]", // represents "metadata.annotations" with an arbitary subscript
+	"metadata.labels[]",      // represents "metadata.labels" with an arbitary subscript
+	"metadata.name",
+	"metadata.namespace",
+	"metadata.uid",
+	"spec.nodeName",
+	"spec.serviceAccountName",
+	"status.hostIP",
+	"status.podIP")
 var validContainerResourceFieldPathExpressions = sets.NewString("limits.cpu", "limits.memory", "limits.ephemeral-storage", "requests.cpu", "requests.memory", "requests.ephemeral-storage")
 
 func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path) field.ErrorList {
@@ -1912,7 +1924,7 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path) field.ErrorLis
 
 	if ev.ValueFrom.FieldRef != nil {
 		numSources++
-		allErrs = append(allErrs, validateObjectFieldSelector(ev.ValueFrom.FieldRef, &validFieldPathExpressionsEnv, fldPath.Child("fieldRef"))...)
+		allErrs = append(allErrs, validateObjectFieldSelector(ev.ValueFrom.FieldRef, &validEnvDownwardAPIFieldPathExpressions, fldPath.Child("fieldRef"))...)
 	}
 	if ev.ValueFrom.ResourceFieldRef != nil {
 		numSources++
@@ -1945,14 +1957,32 @@ func validateObjectFieldSelector(fs *core.ObjectFieldSelector, expressions *sets
 
 	if len(fs.APIVersion) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("apiVersion"), ""))
-	} else if len(fs.FieldPath) == 0 {
+		return allErrs
+	}
+	if len(fs.FieldPath) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("fieldPath"), ""))
-	} else {
-		internalFieldPath, _, err := legacyscheme.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldPath"), fs.FieldPath, fmt.Sprintf("error converting fieldPath: %v", err)))
-		} else if !expressions.Has(internalFieldPath) {
-			allErrs = append(allErrs, field.NotSupported(fldPath.Child("fieldPath"), internalFieldPath, expressions.List()))
+		return allErrs
+	}
+
+	internalFieldPath, _, err := legacyscheme.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+	if err != nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("fieldPath"), fs.FieldPath, fmt.Sprintf("error converting fieldPath: %v", err)))
+		return allErrs
+	}
+
+	path, subscript := fieldpath.SplitMaybeSubscriptedPath(internalFieldPath)
+	if len(subscript) > 0 {
+		// This is to indicate that the internalFieldPath has a subscript, so
+		// that we can compare the path against the allowed path set easily.
+		path += "[]"
+	}
+	if !expressions.Has(path) {
+		allErrs = append(allErrs, field.NotSupported(fldPath.Child("fieldPath"), path, expressions.List()))
+		return allErrs
+	}
+	if len(subscript) > 0 {
+		for _, msg := range validation.IsQualifiedName(subscript) {
+			allErrs = append(allErrs, field.Invalid(fldPath, subscript, msg))
 		}
 	}
 

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -2629,10 +2629,24 @@ func TestValidateVolumes(t *testing.T) {
 								},
 							},
 							{
+								Path: "labels with subscript",
+								FieldRef: &core.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "metadata.labels['key']",
+								},
+							},
+							{
 								Path: "annotations",
 								FieldRef: &core.ObjectFieldSelector{
 									APIVersion: "v1",
 									FieldPath:  "metadata.annotations",
+								},
+							},
+							{
+								Path: "annotations with subscript",
+								FieldRef: &core.ObjectFieldSelector{
+									APIVersion: "v1",
+									FieldPath:  "metadata.annotations['key']",
 								},
 							},
 							{
@@ -3829,6 +3843,24 @@ func TestValidateEnv(t *testing.T) {
 			ValueFrom: &core.EnvVarSource{
 				FieldRef: &core.ObjectFieldSelector{
 					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
+					FieldPath:  "metadata.annotations['key']",
+				},
+			},
+		},
+		{
+			Name: "abc",
+			ValueFrom: &core.EnvVarSource{
+				FieldRef: &core.ObjectFieldSelector{
+					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
+					FieldPath:  "metadata.labels['key']",
+				},
+			},
+		},
+		{
+			Name: "abc",
+			ValueFrom: &core.EnvVarSource{
+				FieldRef: &core.ObjectFieldSelector{
+					APIVersion: legacyscheme.Registry.GroupOrDie(core.GroupName).GroupVersion.String(),
 					FieldPath:  "metadata.name",
 				},
 			},
@@ -4095,7 +4127,20 @@ func TestValidateEnv(t *testing.T) {
 			expectedError: `[0].valueFrom.fieldRef.fieldPath: Invalid value: "metadata.whoops": error converting fieldPath`,
 		},
 		{
-			name: "invalid fieldPath labels",
+			name: "metadata.name with subscript",
+			envs: []core.EnvVar{{
+				Name: "labels",
+				ValueFrom: &core.EnvVarSource{
+					FieldRef: &core.ObjectFieldSelector{
+						FieldPath:  "metadata.name['key']",
+						APIVersion: "v1",
+					},
+				},
+			}},
+			expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.name[]": supported values: "metadata.annotations[]", "metadata.labels[]", "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
+		},
+		{
+			name: "metadata.labels without subscript",
 			envs: []core.EnvVar{{
 				Name: "labels",
 				ValueFrom: &core.EnvVarSource{
@@ -4105,10 +4150,10 @@ func TestValidateEnv(t *testing.T) {
 					},
 				},
 			}},
-			expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
+			expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.labels": supported values: "metadata.annotations[]", "metadata.labels[]", "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
 		},
 		{
-			name: "invalid fieldPath annotations",
+			name: "metadata.annotations without subscript",
 			envs: []core.EnvVar{{
 				Name: "abc",
 				ValueFrom: &core.EnvVarSource{
@@ -4118,7 +4163,7 @@ func TestValidateEnv(t *testing.T) {
 					},
 				},
 			}},
-			expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
+			expectedError: `[0].valueFrom.fieldRef.fieldPath: Unsupported value: "metadata.annotations": supported values: "metadata.annotations[]", "metadata.labels[]", "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
 		},
 		{
 			name: "unsupported fieldPath",
@@ -4131,7 +4176,7 @@ func TestValidateEnv(t *testing.T) {
 					},
 				},
 			}},
-			expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
+			expectedError: `valueFrom.fieldRef.fieldPath: Unsupported value: "status.phase": supported values: "metadata.annotations[]", "metadata.labels[]", "metadata.name", "metadata.namespace", "metadata.uid", "spec.nodeName", "spec.serviceAccountName", "status.hostIP", "status.podIP"`,
 		},
 	}
 	for _, tc := range errorCases {

--- a/pkg/fieldpath/BUILD
+++ b/pkg/fieldpath/BUILD
@@ -13,7 +13,10 @@ go_library(
         "fieldpath.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/fieldpath",
-    deps = ["//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
+    ],
 )
 
 go_test(

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // FormatMap formats map[string]string to a string.
@@ -42,20 +43,24 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 		return "", nil
 	}
 
-	path, subscript := SplitMaybeSubscriptedPath(fieldPath)
-
-	if len(subscript) > 0 {
+	if path, subscript, ok := SplitMaybeSubscriptedPath(fieldPath); ok {
 		switch path {
 		case "metadata.annotations":
+			if errs := validation.IsQualifiedName(strings.ToLower(subscript)); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
 			return accessor.GetAnnotations()[subscript], nil
 		case "metadata.labels":
+			if errs := validation.IsQualifiedName(subscript); len(errs) != 0 {
+				return "", fmt.Errorf("invalid key subscript in %s: %s", fieldPath, strings.Join(errs, ";"))
+			}
 			return accessor.GetLabels()[subscript], nil
 		default:
 			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
 		}
 	}
 
-	switch path {
+	switch fieldPath {
 	case "metadata.annotations":
 		return FormatMap(accessor.GetAnnotations()), nil
 	case "metadata.labels":
@@ -74,25 +79,25 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 // SplitMaybeSubscriptedPath checks whether the specified fieldPath is
 // subscripted, and
 //  - if yes, this function splits the fieldPath into path and subscript, and
-//    returns (path, subscript).
-//  - if no, this function returns (fieldPath, "").
+//    returns (path, subscript, true).
+//  - if no, this function returns (fieldPath, "", false).
 //
 // Example inputs and outputs:
-//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey")
-//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c")
-//  - "metadata.labels"               --> ("metadata.labels", "")
-//  - "metadata.labels['']"           --> ("metadata.labels", "")
-func SplitMaybeSubscriptedPath(fieldPath string) (string, string) {
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey", true)
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c", true)
+//  - "metadata.labels['']"           --> ("metadata.labels", "", true)
+//  - "metadata.labels"               --> ("metadata.labels", "", false)
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string, bool) {
 	if !strings.HasSuffix(fieldPath, "']") {
-		return fieldPath, ""
+		return fieldPath, "", false
 	}
 	s := strings.TrimSuffix(fieldPath, "']")
 	parts := strings.SplitN(s, "['", 2)
 	if len(parts) < 2 {
-		return fieldPath, ""
+		return fieldPath, "", false
 	}
-	if len(parts[0]) == 0 || len(parts[1]) == 0 {
-		return fieldPath, ""
+	if len(parts[0]) == 0 {
+		return fieldPath, "", false
 	}
-	return parts[0], parts[1]
+	return parts[0], parts[1], true
 }

--- a/pkg/fieldpath/fieldpath.go
+++ b/pkg/fieldpath/fieldpath.go
@@ -42,7 +42,20 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 		return "", nil
 	}
 
-	switch fieldPath {
+	path, subscript := SplitMaybeSubscriptedPath(fieldPath)
+
+	if len(subscript) > 0 {
+		switch path {
+		case "metadata.annotations":
+			return accessor.GetAnnotations()[subscript], nil
+		case "metadata.labels":
+			return accessor.GetLabels()[subscript], nil
+		default:
+			return "", fmt.Errorf("fieldPath %q does not support subscript", fieldPath)
+		}
+	}
+
+	switch path {
 	case "metadata.annotations":
 		return FormatMap(accessor.GetAnnotations()), nil
 	case "metadata.labels":
@@ -56,4 +69,30 @@ func ExtractFieldPathAsString(obj interface{}, fieldPath string) (string, error)
 	}
 
 	return "", fmt.Errorf("unsupported fieldPath: %v", fieldPath)
+}
+
+// SplitMaybeSubscriptedPath checks whether the specified fieldPath is
+// subscripted, and
+//  - if yes, this function splits the fieldPath into path and subscript, and
+//    returns (path, subscript).
+//  - if no, this function returns (fieldPath, "").
+//
+// Example inputs and outputs:
+//  - "metadata.annotations['myKey']" --> ("metadata.annotations", "myKey")
+//  - "metadata.annotations['a[b]c']" --> ("metadata.annotations", "a[b]c")
+//  - "metadata.labels"               --> ("metadata.labels", "")
+//  - "metadata.labels['']"           --> ("metadata.labels", "")
+func SplitMaybeSubscriptedPath(fieldPath string) (string, string) {
+	if !strings.HasSuffix(fieldPath, "']") {
+		return fieldPath, ""
+	}
+	s := strings.TrimSuffix(fieldPath, "']")
+	parts := strings.SplitN(s, "['", 2)
+	if len(parts) < 2 {
+		return fieldPath, ""
+	}
+	if len(parts[0]) == 0 || len(parts[1]) == 0 {
+		return fieldPath, ""
+	}
+	return parts[0], parts[1]
 }

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -29,10 +29,10 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/kubelet",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/api/v1/resource:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/pods:go_default_library",
         "//pkg/apis/core/v1:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/apis/core/v1/helper/qos:go_default_library",

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -43,9 +43,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/tools/remotecommand"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
+	podshelper "k8s.io/kubernetes/pkg/apis/core/pods"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
 	"k8s.io/kubernetes/pkg/apis/core/v1/validation"
@@ -733,7 +733,7 @@ func (kl *Kubelet) makeEnvironmentVariables(pod *v1.Pod, container *v1.Container
 // podFieldSelectorRuntimeValue returns the runtime value of the given
 // selector for a pod.
 func (kl *Kubelet) podFieldSelectorRuntimeValue(fs *v1.ObjectFieldSelector, pod *v1.Pod, podIP string) (string, error) {
-	internalFieldPath, _, err := legacyscheme.Scheme.ConvertFieldLabel(fs.APIVersion, "Pod", fs.FieldPath, "")
+	internalFieldPath, _, err := podshelper.ConvertDownwardAPIFieldLabel(fs.APIVersion, fs.FieldPath, "")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -545,6 +545,48 @@ func TestCollectDataWithDownwardAPI(t *testing.T) {
 		success    bool
 	}{
 		{
+			name: "annotation",
+			volumeFile: []v1.DownwardAPIVolumeFile{
+				{Path: "annotation", FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.annotations['a1']"}}},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						"a1": "value1",
+						"a2": "value2",
+					},
+					UID: testPodUID},
+			},
+			mode: 0644,
+			payload: map[string]util.FileProjection{
+				"annotation": {Data: []byte("value1"), Mode: 0644},
+			},
+			success: true,
+		},
+		{
+			name: "annotation-error",
+			volumeFile: []v1.DownwardAPIVolumeFile{
+				{Path: "annotation", FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.annotations['']"}}},
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testPodName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						"a1": "value1",
+						"a2": "value2",
+					},
+					UID: testPodUID},
+			},
+			mode: 0644,
+			payload: map[string]util.FileProjection{
+				"annotation": {Data: []byte("does-not-matter-because-this-test-case-will-fail-anyway"), Mode: 0644},
+			},
+			success: false,
+		},
+		{
 			name: "labels",
 			volumeFile: []v1.DownwardAPIVolumeFile{
 				{Path: "labels", FieldRef: &v1.ObjectFieldSelector{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/annotations-downward-api.md

Support exposing single annotation via both env and volume downward API using the following syntax:

```
metadata.annotations['key']
metadata.labels['key']
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

#31218

**Special notes for your reviewer**:

This PR takes over the work in https://github.com/kubernetes/kubernetes/pull/41648.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
A single value in metadata.annotations/metadata.labels can be passed into the containers via Downward API
```

/assign @thockin @vishh 