### PR TITLE
Enhance kubeadm markmaster

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/markmaster.go
+++ b/cmd/kubeadm/app/cmd/phases/markmaster.go
@@ -19,31 +19,70 @@ package phases
 import (
 	"github.com/spf13/cobra"
 
+	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	markmasterphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markmaster"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+	configutil "k8s.io/kubernetes/cmd/kubeadm/app/util/config"
 	kubeconfigutil "k8s.io/kubernetes/cmd/kubeadm/app/util/kubeconfig"
+	"k8s.io/kubernetes/pkg/api/legacyscheme"
+	"k8s.io/kubernetes/pkg/util/normalizer"
+)
+
+var (
+	markMasterLongDesc = normalizer.LongDesc(`
+		Applies a label that specifies that a node is a master and a taint that forces workloads to be deployed accordingly.
+		` + cmdutil.AlphaDisclaimer)
+
+	markMasterExample = normalizer.Examples(`
+		# Applies master label and taint to the current node, functionally equivalent to what executed by kubeadm init.
+		kubeadm alpha phase mark-master
+
+		# Applies master label and taint to a specific node
+		kubeadm alpha phase mark-master --node-name myNode
+		`)
 )
 
 // NewCmdMarkMaster returns the Cobra command for running the mark-master phase
 func NewCmdMarkMaster() *cobra.Command {
-	var kubeConfigFile string
+
+	cfg := &kubeadmapiext.MasterConfiguration{
+		// KubernetesVersion is not used by mark master, but we set this explicitly to avoid
+		// the lookup of the version from the internet when executing ConfigFileAndDefaultsToInternalConfig
+		KubernetesVersion: "v1.9.0",
+	}
+
+	// Default values for the cobra help text
+	legacyscheme.Scheme.Default(cfg)
+
+	var cfgPath, kubeConfigFile string
 	cmd := &cobra.Command{
-		Use:     "mark-master <node-name>",
-		Short:   "Mark a node as master.",
+		Use:     "mark-master",
+		Short:   "Mark a node as master",
+		Long:    markMasterLongDesc,
+		Example: markMasterExample,
 		Aliases: []string{"markmaster"},
-		RunE: func(_ *cobra.Command, args []string) error {
-			err := cmdutil.ValidateExactArgNumber(args, []string{"node-name"})
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := validation.ValidateMixedArguments(cmd.Flags()); err != nil {
+				kubeadmutil.CheckErr(err)
+			}
+
+			// This call returns the ready-to-use configuration based on the configuration file that might or might not exist and the default cfg populated by flags
+			internalcfg, err := configutil.ConfigFileAndDefaultsToInternalConfig(cfgPath, cfg)
 			kubeadmutil.CheckErr(err)
 
 			client, err := kubeconfigutil.ClientSetFromFile(kubeConfigFile)
 			kubeadmutil.CheckErr(err)
 
-			nodeName := args[0]
-			return markmasterphase.MarkMaster(client, nodeName)
+			err = markmasterphase.MarkMaster(client, internalcfg.NodeName)
+			kubeadmutil.CheckErr(err)
 		},
 	}
 
 	cmd.Flags().StringVar(&kubeConfigFile, "kubeconfig", "/etc/kubernetes/admin.conf", "The KubeConfig file to use when talking to the cluster")
+	cmd.Flags().StringVar(&cfgPath, "config", cfgPath, "Path to kubeadm config file (WARNING: Usage of a configuration file is experimental)")
+	cmd.Flags().StringVar(&cfg.NodeName, "node-name", cfg.NodeName, `The node name to which label and taints should apply`)
+
 	return cmd
 }

--- a/cmd/kubeadm/app/cmd/util/documentation.go
+++ b/cmd/kubeadm/app/cmd/util/documentation.go
@@ -23,7 +23,7 @@ import (
 var (
 	// AlphaDisclaimer to be places at the end of description of commands in alpha release
 	AlphaDisclaimer = `
-		Alpha Disclaimer: this command is currently alpha but, please try it out and give us feedback!
+		Alpha Disclaimer: this command is currently alpha.
 	`
 
 	// MacroCommandLongDescription provide a standard description for "macro" commands


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is part of the effort for improving kubeadm phases, and more specifically improves `mark-master` phase by implementing a behaviour similar to `kubeadm init`, that is:
- dynamically initialise node name if not provided 
- allow to override with `--node-name` flag or with `--config` 

Also reference doc for `mark-master` was improved.

**Which issue(s) this PR fixes** 
part of the effort for [#454](https://github.com/kubernetes/kubeadm/issues/454)
part of the effort for [#265](https://github.com/kubernetes/kubeadm/issues/265)

**Special notes for your reviewer**:
Alpha disclaimer aligned to change requested on the website.

**Release note**:
```release-note
NONE
```
