### PR TITLE
Support passing a generic admission webhooks kubeconfig file in gce-gci

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -134,6 +134,12 @@
 {% set admission_controller_config_volume = "" -%}
 {% set image_policy_webhook_config_mount = "" -%}
 {% set image_policy_webhook_config_volume = "" -%}
+{% set image_policy_webhook_plugin_config_mount = "" -%}
+{% set image_policy_webhook_plugin_config_volume = "" -%}
+{% set validating_admission_webhook_config_mount = "" -%}
+{% set validating_admission_webhook_config_volume = "" -%}
+{% set mutating_admission_webhook_config_mount = "" -%}
+{% set mutating_admission_webhook_config_volume = "" -%}
 {% if grains.image_review_config is defined -%}
   {% set image_review_config = " --admission-control-config-file=" + grains.image_review_config -%}
   {% set admission_controller_config_mount = "{\"name\": \"admissioncontrollerconfigmount\",\"mountPath\": \"" + grains.image_review_config + "\", \"readOnly\": false}," -%}
@@ -260,6 +266,9 @@
         {{audit_webhook_config_mount}}
         {{admission_controller_config_mount}}
         {{image_policy_webhook_config_mount}}
+        {{image_policy_webhook_plugin_config_mount}}
+        {{validating_admission_webhook_config_mount}}
+        {{mutating_admission_webhook_config_mount}}
         { "name": "srvkube",
         "mountPath": "{{srv_kube_path}}",
         "readOnly": true},
@@ -299,6 +308,9 @@
   {{audit_webhook_config_volume}}
   {{admission_controller_config_volume}}
   {{image_policy_webhook_config_volume}}
+  {{image_policy_webhook_plugin_config_volume}}
+  {{validating_admission_webhook_config_volume}}
+  {{mutating_admission_webhook_config_volume}}
   { "name": "srvkube",
     "hostPath": {
         "path": "{{srv_kube_path}}"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
e2e test for generic admission webhooks needs to be able to test different types of authentication, so the cluster start up needs to be able to pass this config to the apiserver

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Part of fixing #54709

**Special notes for your reviewer**:
Really just a duplication of the way imagepolicy webhook config is passed, but since they share the flag --admission-control-config-file some logic has to be done if either is being sent
Based on top of #56822

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Plumbing for passing admission webhook configuration in gce-gci
```
