### PR TITLE
[WIP]: Started Quota monitor after cache sync.

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -274,11 +274,11 @@ func (rq *ResourceQuotaController) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Starting resource quota controller")
 	defer glog.Infof("Shutting down resource quota controller")
 
-	go rq.quotaMonitor.Run(stopCh)
-
 	if !controller.WaitForCacheSync("resource quota", stopCh, rq.informerSyncedFuncs...) {
 		return
 	}
+
+	go rq.quotaMonitor.Run(stopCh)
 
 	// the workers that chug through the quota calculation backlog
 	for i := 0; i < workers; i++ {


### PR DESCRIPTION
**What this PR does / why we need it**:
The quota monitor should be started after informer cache sync.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #51454

**Release note**:
```release-note
None
```