### PR TITLE
Remove incorrect dead code.

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -493,37 +493,6 @@ func AddOrUpdateTolerationInPod(pod *core.Pod, toleration *core.Toleration) bool
 	return true
 }
 
-// TolerationToleratesTaint checks if the toleration tolerates the taint.
-func TolerationToleratesTaint(toleration *core.Toleration, taint *core.Taint) bool {
-	if len(toleration.Effect) != 0 && toleration.Effect != taint.Effect {
-		return false
-	}
-
-	if toleration.Key != taint.Key {
-		return false
-	}
-	// TODO: Use proper defaulting when Toleration becomes a field of PodSpec
-	if (len(toleration.Operator) == 0 || toleration.Operator == core.TolerationOpEqual) && toleration.Value == taint.Value {
-		return true
-	}
-	if toleration.Operator == core.TolerationOpExists {
-		return true
-	}
-	return false
-}
-
-// TaintToleratedByTolerations checks if taint is tolerated by any of the tolerations.
-func TaintToleratedByTolerations(taint *core.Taint, tolerations []core.Toleration) bool {
-	tolerated := false
-	for i := range tolerations {
-		if TolerationToleratesTaint(&tolerations[i], taint) {
-			tolerated = true
-			break
-		}
-	}
-	return tolerated
-}
-
 // GetTaintsFromNodeAnnotations gets the json serialized taints data from Pod.Annotations
 // and converts it to the []Taint type in core.
 func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]core.Taint, error) {


### PR DESCRIPTION
TolerationToleratesTaint was incorrect: if the toleration.Key is empty and
taint is non-empty, it should not return false. It was also not used anywhere.

The correct implementations are in staging/src/k8s.io/api/core/v1/toleration.go
and pkg/apis/core/v1/helper/helpers.go

**Release note**:
```release-note
NONE
```

/sig scheduling
/sig api-machinery
/kind bug