### PR TITLE
probeAttachedVolume improvement in Cinder

### DIFF
--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -44,7 +44,7 @@ var _ volume.Attacher = &cinderDiskAttacher{}
 var _ volume.AttachableVolumePlugin = &cinderPlugin{}
 
 const (
-	checkSleepDuration       = 1 * time.Second
+	checkSleepDuration       = 5 * time.Second
 	operationFinishInitDealy = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -241,8 +241,7 @@ func (attacher *cinderDiskAttacher) waitProbeVolume(devicePath, volumeID string)
 		if exists && err == nil {
 			glog.Infof("Successfully found attached Cinder disk %q at %v.", volumeID, devicePath)
 			return devicePath, nil
-		}
-		else {
+		} else {
 			// Log an error, and continue checking periodically
 			glog.Errorf("Error: could not find attached Cinder disk %q (path: %q): %v", volumeID, devicePath, err)
 		}

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -44,7 +44,9 @@ var _ volume.Attacher = &cinderDiskAttacher{}
 var _ volume.AttachableVolumePlugin = &cinderPlugin{}
 
 const (
-	checkSleepDuration       = 5 * time.Second
+	probeVolumeInitDealy     = 1 * time.Second
+	probeVolumeFactor        = 2.0
+	probeVolumeSteps         = 10
 	operationFinishInitDealy = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
@@ -221,6 +223,38 @@ func (attacher *cinderDiskAttacher) VolumesAreAttached(specs []*volume.Spec, nod
 	return volumesAttachedCheck, nil
 }
 
+func (attacher *cinderDiskAttacher) waitProbeVolume(devicePath, volumeID string) (string, error) {
+	backoff := wait.Backoff{
+		Duration: probeVolumeInitDealy,
+		Factor:   probeVolumeFactor,
+		Steps:    probeVolumeSteps,
+	}
+
+	err := wait.ExponentialBackoff(backoff, func() (string, error) {
+		glog.V(5).Infof("Checking Cinder disk %q is attached.", volumeID)
+		probeAttachedVolume()
+		if !attacher.cinderProvider.ShouldTrustDevicePath() {
+			// Using the Cinder volume ID, find the real device path (See Issue #33128)
+			devicePath = attacher.cinderProvider.GetDevicePath(volumeID)
+		}
+		exists, err := volumeutil.PathExists(devicePath)
+		if exists && err == nil {
+			glog.Infof("Successfully found attached Cinder disk %q at %v.", volumeID, devicePath)
+			return devicePath, nil
+		}
+		else {
+			// Log an error, and continue checking periodically
+			glog.Errorf("Error: could not find attached Cinder disk %q (path: %q): %v", volumeID, devicePath, err)
+		}
+	})
+
+	if err == wait.ErrWaitTimeout {
+		err = fmt.Errorf("Volume %q failed to be probed within the alloted time", volumeID)
+	}
+
+	return "", err
+}
+
 func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath string, _ *v1.Pod, timeout time.Duration) (string, error) {
 	// NOTE: devicePath is is path as reported by Cinder, which may be incorrect and should not be used. See Issue #33128
 	volumeSource, _, err := getVolumeSource(spec)
@@ -234,32 +268,8 @@ func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath 
 		return "", fmt.Errorf("WaitForAttach failed for Cinder disk %q: devicePath is empty.", volumeID)
 	}
 
-	ticker := time.NewTicker(checkSleepDuration)
-	defer ticker.Stop()
-	timer := time.NewTimer(timeout)
-	defer timer.Stop()
-
-	for {
-		select {
-		case <-ticker.C:
-			glog.V(5).Infof("Checking Cinder disk %q is attached.", volumeID)
-			probeAttachedVolume()
-			if !attacher.cinderProvider.ShouldTrustDevicePath() {
-				// Using the Cinder volume ID, find the real device path (See Issue #33128)
-				devicePath = attacher.cinderProvider.GetDevicePath(volumeID)
-			}
-			exists, err := volumeutil.PathExists(devicePath)
-			if exists && err == nil {
-				glog.Infof("Successfully found attached Cinder disk %q at %v.", volumeID, devicePath)
-				return devicePath, nil
-			} else {
-				// Log an error, and continue checking periodically
-				glog.Errorf("Error: could not find attached Cinder disk %q (path: %q): %v", volumeID, devicePath, err)
-			}
-		case <-timer.C:
-			return "", fmt.Errorf("Could not find attached Cinder disk %q. Timeout waiting for mount paths to be created.", volumeID)
-		}
-	}
+	// Using exponential backoff instead of linear
+	return attacher.waitProbeVolume(devicePath, volumeID)
 }
 
 func (attacher *cinderDiskAttacher) GetDeviceMountPath(

--- a/pkg/volume/cinder/attacher.go
+++ b/pkg/volume/cinder/attacher.go
@@ -44,15 +44,15 @@ var _ volume.Attacher = &cinderDiskAttacher{}
 var _ volume.AttachableVolumePlugin = &cinderPlugin{}
 
 const (
-	probeVolumeInitDealy     = 1 * time.Second
+	probeVolumeInitDelay     = 1 * time.Second
 	probeVolumeFactor        = 2.0
-	operationFinishInitDealy = 1 * time.Second
+	operationFinishInitDelay = 1 * time.Second
 	operationFinishFactor    = 1.1
 	operationFinishSteps     = 10
-	diskAttachInitDealy      = 1 * time.Second
+	diskAttachInitDelay      = 1 * time.Second
 	diskAttachFactor         = 1.2
 	diskAttachSteps          = 15
-	diskDetachInitDealy      = 1 * time.Second
+	diskDetachInitDelay      = 1 * time.Second
 	diskDetachFactor         = 1.2
 	diskDetachSteps          = 13
 )
@@ -75,7 +75,7 @@ func (plugin *cinderPlugin) GetDeviceMountRefs(deviceMountPath string) ([]string
 
 func (attacher *cinderDiskAttacher) waitOperationFinished(volumeID string) error {
 	backoff := wait.Backoff{
-		Duration: operationFinishInitDealy,
+		Duration: operationFinishInitDelay,
 		Factor:   operationFinishFactor,
 		Steps:    operationFinishSteps,
 	}
@@ -100,7 +100,7 @@ func (attacher *cinderDiskAttacher) waitOperationFinished(volumeID string) error
 
 func (attacher *cinderDiskAttacher) waitDiskAttached(instanceID, volumeID string) error {
 	backoff := wait.Backoff{
-		Duration: diskAttachInitDealy,
+		Duration: diskAttachInitDelay,
 		Factor:   diskAttachFactor,
 		Steps:    diskAttachSteps,
 	}
@@ -235,12 +235,12 @@ func (attacher *cinderDiskAttacher) WaitForAttach(spec *volume.Spec, devicePath 
 		return "", fmt.Errorf("WaitForAttach failed for Cinder disk %q: devicePath is empty.", volumeID)
 	}
 
-	ticker := time.NewTicker(probeVolumeInitDealy)
+	ticker := time.NewTicker(probeVolumeInitDelay)
 	defer ticker.Stop()
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 
-	duration := probeVolumeInitDealy
+	duration := probeVolumeInitDelay
 	for {
 		select {
 		case <-ticker.C:
@@ -334,7 +334,7 @@ func (plugin *cinderPlugin) NewDetacher() (volume.Detacher, error) {
 
 func (detacher *cinderDiskDetacher) waitOperationFinished(volumeID string) error {
 	backoff := wait.Backoff{
-		Duration: operationFinishInitDealy,
+		Duration: operationFinishInitDelay,
 		Factor:   operationFinishFactor,
 		Steps:    operationFinishSteps,
 	}
@@ -359,7 +359,7 @@ func (detacher *cinderDiskDetacher) waitOperationFinished(volumeID string) error
 
 func (detacher *cinderDiskDetacher) waitDiskDetached(instanceID, volumeID string) error {
 	backoff := wait.Backoff{
-		Duration: diskDetachInitDealy,
+		Duration: diskDetachInitDelay,
 		Factor:   diskDetachFactor,
 		Steps:    diskDetachSteps,
 	}

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -224,6 +224,18 @@ func probeAttachedVolume() error {
 	scsiHostRescan()
 
 	executor := exec.New()
+
+        // udevadm settle waits for udevd to process the device creation
+        // events for all hardware devices, thus ensuring that any device
+        // nodes have been created successfully before proceeding.
+	argsSettle := []string{"settle", "--timeout=1"}
+	cmdSettle := executor.Command("udevadm", argsSettle...)
+	_, errSettle := cmdSettle.CombinedOutput()
+	if errSettle != nil {
+		glog.Errorf("error running udevadm settle %v\n", errSettle)
+		return errSettle
+	}
+
 	args := []string{"trigger"}
 	cmd := executor.Command("udevadm", args...)
 	_, err := cmd.CombinedOutput()

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -228,12 +228,11 @@ func probeAttachedVolume() error {
 	// udevadm settle waits for udevd to process the device creation
 	// events for all hardware devices, thus ensuring that any device
 	// nodes have been created successfully before proceeding.
-	argsSettle := []string{"settle", "--timeout=1"}
+	argsSettle := []string{"settle"}
 	cmdSettle := executor.Command("udevadm", argsSettle...)
 	_, errSettle := cmdSettle.CombinedOutput()
 	if errSettle != nil {
 		glog.Errorf("error running udevadm settle %v\n", errSettle)
-		return errSettle
 	}
 
 	args := []string{"trigger"}

--- a/pkg/volume/cinder/cinder_util.go
+++ b/pkg/volume/cinder/cinder_util.go
@@ -225,9 +225,9 @@ func probeAttachedVolume() error {
 
 	executor := exec.New()
 
-        // udevadm settle waits for udevd to process the device creation
-        // events for all hardware devices, thus ensuring that any device
-        // nodes have been created successfully before proceeding.
+	// udevadm settle waits for udevd to process the device creation
+	// events for all hardware devices, thus ensuring that any device
+	// nodes have been created successfully before proceeding.
 	argsSettle := []string{"settle", "--timeout=1"}
 	cmdSettle := executor.Command("udevadm", argsSettle...)
 	_, errSettle := cmdSettle.CombinedOutput()


### PR DESCRIPTION
What this PR does / why we need it:

During OpenStack Cinder volume attachment, kubelet creates too many udev "change" events.
If volume attachement takes long, then udev event queue gets full,therefore
udev does not answer requests from docker, and makes Kubernetes node unhealthy.

This patch will extend the udevadm trigger period,
and use the udevadm settle to ensure that any device nodes
have been created successfully before proceeding.

Fixes #55007

Release note:

```release-note
None
```

/cc @dims @kabakaev
