### PR TITLE
Cluster Autoscaler 1.0.3

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.2",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.0.3",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cluster Autoscaler 1.0.3 fixes problems around scaling node groups with GPUs. It also makes possible for users to mark some non-replicated pods as good for eviction.

```release-note
Cluster Autoscaler 1.0.3
```
