### PR TITLE
conversion-gen: check for nil pkg in getManualConversionFunctions

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -145,6 +145,10 @@ type conversionFuncMap map[conversionPair]*types.Type
 
 // Returns all manually-defined conversion functions in the package.
 func getManualConversionFunctions(context *generator.Context, pkg *types.Package, manualMap conversionFuncMap) {
+	if pkg == nil {
+		glog.Warningf("Skipping nil package passed to getManualConversionFunctions")
+		return
+	}
 	glog.V(5).Infof("Scanning for conversion functions in %v", pkg.Name)
 
 	scopeName := types.Ref(conversionPackagePath, "Scope").Name


### PR DESCRIPTION
**What this PR does / why we need it**:

Following https://github.com/kubernetes/kubernetes/pull/54394, this PR performs a check in getManualConversionFunctions for packages that are not found and prints a warning instead of panicking.

This should improve the UX of conversion-gen, and is also a narrower change than that proposed in #54394, so hopefully can be cherry picked into the release-1.8 etc. branches.

This would allow users to use conversion-gen via the generate-internal-groups.sh script without having to make a second call that 'blanks out' `--extra-peer-dirs`.

/cc @sttts

```release-note
NONE
```
