### PR TITLE
Fix setting resources in fluentd-gcp plugin

### DIFF
--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds-sa.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds-sa.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd-gcp
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: fluentd-gcp
-  namespace: kube-system
-  labels:
-    kubernetes.io/cluster-service: "true"
-    addonmanager.kubernetes.io/mode: Reconcile
----
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:


### PR DESCRIPTION
Currently if some of the variables are not set, scripts prints error, which is not critical, since the function is executed in a separate process, but it leads to the wrong resulting values

```release-note
fluentd-gcp addon: Fix fluentd deployment on GCP when custom resources are set.
```

/cc @piosz @x13n 
/assign @roberthbailey @mikedanese 
Could you please approve?