### PR TITLE
Move audit logs e2e to the default test suite.

### DIFF
--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -50,8 +50,11 @@ var (
 	patch, _     = json.Marshal(jsonpatch.Patch{})
 )
 
-var _ = SIGDescribe("Advanced Audit [Feature:Audit]", func() {
+var _ = SIGDescribe("Advanced Audit", func() {
 	f := framework.NewDefaultFramework("audit")
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("gce", "gke")
+	})
 
 	It("should audit API calls", func() {
 		namespace := f.Namespace.Name


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/56235

```release-note
NONE
```
