### PR TITLE
Create sig-autoscaling-maintainers alias

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -101,6 +101,12 @@ aliases:
   sig-apps-api-approvers:
     - erictune
     - smarterclayton
+  sig-autoscaling-maintainers:
+    - aleksandra-malinowska
+    - bskiba
+    - DirectXMan12
+    - MaciekPytel
+    - mwielgus
   milestone-maintainers:
     - lavalamp
     - deads2k

--- a/test/e2e/autoscaling/OWNERS
+++ b/test/e2e/autoscaling/OWNERS
@@ -1,14 +1,8 @@
 reviewers:
-  - aleksandra-malinowska
-  - bskiba
   - jszczepkowski
-  - MaciekPytel
-  - mwielgus
+  - sig-autoscaling-maintainers
   - wasylkowski
 approvers:
-  - aleksandra-malinowska
-  - bskiba
   - jszczepkowski
-  - MaciekPytel
-  - mwielgus
+  - sig-autoscaling-maintainers
   - wasylkowski


### PR DESCRIPTION
Create an alias group for sig-autoscaling.

This will be used by test/e2e/autoscaling/OWNERS.

```release-note
 NONE
```