### PR TITLE
Skip pods that refer to PVCs that are being deleted

### DIFF
--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -117,6 +117,12 @@ type ReplicaSetLister interface {
 	GetPodReplicaSets(*v1.Pod) ([]*extensions.ReplicaSet, error)
 }
 
+// PersistentVolumeClaimLister interface represents anything that can list PVCs for a scheduler.
+type PersistentVolumeClaimLister interface {
+	// Gets given PVC
+	Get(namespace, name string) (*v1.PersistentVolumeClaim, error)
+}
+
 var _ ControllerLister = &EmptyControllerLister{}
 
 // EmptyControllerLister implements ControllerLister on []v1.ReplicationController returning empty data

--- a/plugin/pkg/scheduler/algorithm/types.go
+++ b/plugin/pkg/scheduler/algorithm/types.go
@@ -117,12 +117,6 @@ type ReplicaSetLister interface {
 	GetPodReplicaSets(*v1.Pod) ([]*extensions.ReplicaSet, error)
 }
 
-// PersistentVolumeClaimLister interface represents anything that can list PVCs for a scheduler.
-type PersistentVolumeClaimLister interface {
-	// Gets given PVC
-	Get(namespace, name string) (*v1.PersistentVolumeClaim, error)
-}
-
 var _ ControllerLister = &EmptyControllerLister{}
 
 // EmptyControllerLister implements ControllerLister on []v1.ReplicationController returning empty data

--- a/plugin/pkg/scheduler/core/BUILD
+++ b/plugin/pkg/scheduler/core/BUILD
@@ -64,6 +64,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/trace:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",

--- a/plugin/pkg/scheduler/core/extender_test.go
+++ b/plugin/pkg/scheduler/core/extender_test.go
@@ -317,7 +317,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		}
 		queue := NewSchedulingQueue()
 		scheduler := NewGenericScheduler(
-			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil)
+			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{})
 		podIgnored := &v1.Pod{}
 		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -903,7 +903,7 @@ func (f *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 		glog.Info("Created equivalence class cache")
 	}
 
-	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder)
+	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder, &pvcLister{f.pVCLister})
 
 	podBackoff := util.CreateDefaultPodBackoff()
 	return &scheduler.Config{
@@ -933,6 +933,14 @@ type nodeLister struct {
 
 func (n *nodeLister) List() ([]*v1.Node, error) {
 	return n.NodeLister.List(labels.Everything())
+}
+
+type pvcLister struct {
+	corelisters.PersistentVolumeClaimLister
+}
+
+func (p *pvcLister) Get(namespace, name string) (*v1.PersistentVolumeClaim, error) {
+	return p.PersistentVolumeClaimLister.PersistentVolumeClaims(namespace).Get(name)
 }
 
 func (f *configFactory) GetPriorityFunctionConfigs(priorityKeys sets.String) ([]algorithm.PriorityConfig, error) {

--- a/plugin/pkg/scheduler/factory/factory.go
+++ b/plugin/pkg/scheduler/factory/factory.go
@@ -903,7 +903,7 @@ func (f *configFactory) CreateFromKeys(predicateKeys, priorityKeys sets.String, 
 		glog.Info("Created equivalence class cache")
 	}
 
-	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder, &pvcLister{f.pVCLister})
+	algo := core.NewGenericScheduler(f.schedulerCache, f.equivalencePodCache, f.podQueue, predicateFuncs, predicateMetaProducer, priorityConfigs, priorityMetaProducer, extenders, f.volumeBinder, f.pVCLister)
 
 	podBackoff := util.CreateDefaultPodBackoff()
 	return &scheduler.Config{
@@ -933,14 +933,6 @@ type nodeLister struct {
 
 func (n *nodeLister) List() ([]*v1.Node, error) {
 	return n.NodeLister.List(labels.Everything())
-}
-
-type pvcLister struct {
-	corelisters.PersistentVolumeClaimLister
-}
-
-func (p *pvcLister) Get(namespace, name string) (*v1.PersistentVolumeClaim, error) {
-	return p.PersistentVolumeClaimLister.PersistentVolumeClaims(namespace).Get(name)
 }
 
 func (f *configFactory) GetPriorityFunctionConfigs(priorityKeys sets.String) ([]algorithm.PriorityConfig, error) {

--- a/plugin/pkg/scheduler/scheduler_test.go
+++ b/plugin/pkg/scheduler/scheduler_test.go
@@ -532,7 +532,8 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
-		nil)
+		nil,
+		schedulertesting.FakePersistentVolumeClaimLister{})
 	bindingChan := make(chan *v1.Binding, 1)
 	errChan := make(chan error, 1)
 	configurator := &FakeConfigurator{
@@ -575,7 +576,8 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		[]algorithm.PriorityConfig{},
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
-		nil)
+		nil,
+		schedulertesting.FakePersistentVolumeClaimLister{})
 	bindingChan := make(chan *v1.Binding, 2)
 	configurator := &FakeConfigurator{
 		Config: &Config{

--- a/plugin/pkg/scheduler/testing/BUILD
+++ b/plugin/pkg/scheduler/testing/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/api/policy/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],
 )
 

--- a/plugin/pkg/scheduler/testing/fake_lister.go
+++ b/plugin/pkg/scheduler/testing/fake_lister.go
@@ -176,3 +176,18 @@ func (f FakeStatefulSetLister) GetPodStatefulSets(pod *v1.Pod) (sss []*apps.Stat
 	}
 	return
 }
+
+// FakePersistentVolumeClaimLister implements PersistentVolumeClaimLister on []*v1.PersistentVolumeClaim for test purposes.
+type FakePersistentVolumeClaimLister []*v1.PersistentVolumeClaim
+
+var _ PersistentVolumeClaimLister = FakePersistentVolumeClaimLister{}
+
+// List returns nodes as a []string.
+func (f FakePersistentVolumeClaimLister) Get(namespace, name string) (*v1.PersistentVolumeClaim, error) {
+	for _, pvc := range f {
+		if pvc.Name == name && pvc.Namespace == namespace {
+			return pvc, nil
+		}
+	}
+	return nil, fmt.Errorf("persistentvolumeclaim %q not found", name)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

New check was added to `Schedule()` to make sure that a scheduled pod refers to existing PVCs that are not being deleted.

In 1.9 we plan to add a new feature that uses finalizers on PVC to protect PVCs that are used by a running pod from being deleted. This finalizer will be removed when all pods that use a PVC are finished or deleted. See https://github.com/kubernetes/community/blob/master/contributors/design-proposals/storage/postpone-pvc-deletion-if-used-in-a-pod.md for details.

I needed to pass `pvcLister` to `GenericScheduler`.

UX:

```
$ kubectl describe pod
...
  Type     Reason            Age              From               Message
  ----     ------            ----             ----               -------
  Warning  FailedScheduling  5s (x4 over 8s)  default-scheduler  persistentvolumeclaim "myclaim" is being deleted
  Warning  FailedScheduling  1s (x2 over 1s)  default-scheduler  persistentvolumeclaim "myclaim" not found

```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Scheduler skips pods that use a PVC that either does not exist or is being deleted.
```

/sig scheduling
/kind feature