### PR TITLE
Kubelet: --node-ip should support loopback and link-local addresses

### DIFF
--- a/pkg/kubelet/kubelet_network_test.go
+++ b/pkg/kubelet/kubelet_network_test.go
@@ -108,12 +108,12 @@ func TestNodeIPParam(t *testing.T) {
 		},
 		{
 			nodeIP:   "127.0.0.1",
-			success:  false,
+			success:  true,
 			testName: "IPv4 loopback address",
 		},
 		{
 			nodeIP:   "::1",
-			success:  false,
+			success:  true,
 			testName: "IPv6 loopback address",
 		},
 		{
@@ -128,12 +128,12 @@ func TestNodeIPParam(t *testing.T) {
 		},
 		{
 			nodeIP:   "169.254.0.1",
-			success:  false,
+			success:  true,
 			testName: "IPv4 link-local unicast address",
 		},
 		{
 			nodeIP:   "fe80::0202:b3ff:fe1e:8329",
-			success:  false,
+			success:  true,
 			testName: "IPv6 link-local unicast address",
 		},
 		{

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -1002,14 +1002,8 @@ func validateNodeIP(nodeIP net.IP) error {
 	if nodeIP.To4() == nil && nodeIP.To16() == nil {
 		return fmt.Errorf("nodeIP must be a valid IP address")
 	}
-	if nodeIP.IsLoopback() {
-		return fmt.Errorf("nodeIP can't be loopback address")
-	}
 	if nodeIP.IsMulticast() {
 		return fmt.Errorf("nodeIP can't be a multicast address")
-	}
-	if nodeIP.IsLinkLocalUnicast() {
-		return fmt.Errorf("nodeIP can't be a link-local unicast address")
 	}
 	if nodeIP.IsUnspecified() {
 		return fmt.Errorf("nodeIP can't be an all zeros address")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I didn't see any reason to apply these restrictions to `--node-ip`
parameter of Kubelet. Loopback addresses are useful for all-in-one
deployment.

Removal of these restrictions could provide a unified interface to
users, which is very useful to automated tools.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
