### PR TITLE
apiserver: remove unneeded scheme from registry tester

### DIFF
--- a/pkg/registry/apps/controllerrevision/storage/BUILD
+++ b/pkg/registry/apps/controllerrevision/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/apps/controllerrevision/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/apps/controllerrevision/storage/storage_test.go
+++ b/pkg/registry/apps/controllerrevision/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -36,7 +35,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	var (
 		valid       = stripObjectMeta(newControllerRevision("validname", metav1.NamespaceDefault, newObject(), 0))
 		badRevision = stripObjectMeta(newControllerRevision("validname", "validns", newObject(), -1))
@@ -60,7 +59,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 
 	addLabel := func(obj runtime.Object) runtime.Object {
 		rev := obj.(*apps.ControllerRevision)
@@ -95,7 +94,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(newControllerRevision("valid", metav1.NamespaceDefault, newObject(), 0))
 }
 
@@ -103,7 +102,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(newControllerRevision("valid", metav1.NamespaceDefault, newObject(), 0))
 }
 
@@ -111,7 +110,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(newControllerRevision("valid", metav1.NamespaceDefault, newObject(), 0))
 }
 
@@ -119,7 +118,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		newControllerRevision("valid", metav1.NamespaceDefault, newObject(), 0),
 		[]labels.Set{

--- a/pkg/registry/apps/statefulset/storage/BUILD
+++ b/pkg/registry/apps/statefulset/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",

--- a/pkg/registry/apps/statefulset/storage/storage_test.go
+++ b/pkg/registry/apps/statefulset/storage/storage_test.go
@@ -30,7 +30,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -95,7 +94,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.StatefulSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.StatefulSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.StatefulSet.Store)
 	ps := validNewStatefulSet()
 	ps.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -148,7 +147,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.StatefulSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.StatefulSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.StatefulSet.Store)
 	test.TestGet(validNewStatefulSet())
 }
 
@@ -156,7 +155,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.StatefulSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.StatefulSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.StatefulSet.Store)
 	test.TestList(validNewStatefulSet())
 }
 
@@ -164,7 +163,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.StatefulSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.StatefulSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.StatefulSet.Store)
 	test.TestDelete(validNewStatefulSet())
 }
 
@@ -172,7 +171,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.StatefulSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.StatefulSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.StatefulSet.Store)
 	test.TestWatch(
 		validNewStatefulSet(),
 		// matching labels

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/autoscaling/horizontalpodautoscaler/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	// Ensure that autoscaling/v1 package is initialized.
@@ -76,7 +75,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	autoscaler := validNewHorizontalPodAutoscaler("foo")
 	autoscaler.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -91,7 +90,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewHorizontalPodAutoscaler("foo"),
@@ -108,7 +107,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewHorizontalPodAutoscaler("foo"))
 }
 
@@ -116,7 +115,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewHorizontalPodAutoscaler("foo"))
 }
 
@@ -124,7 +123,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewHorizontalPodAutoscaler("foo"))
 }
 
@@ -132,7 +131,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewHorizontalPodAutoscaler("foo"),
 		// matching labels

--- a/pkg/registry/batch/cronjob/storage/BUILD
+++ b/pkg/registry/batch/cronjob/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/batch/cronjob/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/core:go_default_library",

--- a/pkg/registry/batch/cronjob/storage/storage_test.go
+++ b/pkg/registry/batch/cronjob/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -75,7 +74,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	validCronJob := validNewCronJob()
 	validCronJob.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -97,7 +96,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	schedule := "1 1 1 1 ?"
 	test.TestUpdate(
 		// valid
@@ -126,7 +125,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewCronJob())
 }
 
@@ -139,7 +138,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewCronJob())
 }
 
@@ -152,7 +151,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewCronJob())
 }
 
@@ -165,7 +164,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewCronJob(),
 		// matching labels

--- a/pkg/registry/batch/job/storage/BUILD
+++ b/pkg/registry/batch/job/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/batch/job/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/batch/job/storage/storage_test.go
+++ b/pkg/registry/batch/job/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -84,7 +83,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	validJob := validNewJob()
 	validJob.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -105,7 +104,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	two := int32(2)
 	test.TestUpdate(
 		// valid
@@ -134,7 +133,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	test.TestDelete(validNewJob())
 }
 
@@ -142,7 +141,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	test.TestGet(validNewJob())
 }
 
@@ -150,7 +149,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	test.TestList(validNewJob())
 }
 
@@ -158,7 +157,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Job.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Job.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Job.Store)
 	test.TestWatch(
 		validNewJob(),
 		// matching labels

--- a/pkg/registry/core/configmap/storage/BUILD
+++ b/pkg/registry/core/configmap/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/configmap/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/configmap/storage/storage_test.go
+++ b/pkg/registry/core/configmap/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -62,7 +61,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 
 	validConfigMap := validNewConfigMap()
 	validConfigMap.ObjectMeta = metav1.ObjectMeta{
@@ -90,7 +89,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewConfigMap(),
@@ -113,7 +112,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewConfigMap())
 }
 
@@ -121,7 +120,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewConfigMap())
 }
 
@@ -129,7 +128,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewConfigMap())
 }
 
@@ -137,7 +136,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewConfigMap(),
 		// matching labels

--- a/pkg/registry/core/endpoint/storage/BUILD
+++ b/pkg/registry/core/endpoint/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/endpoint/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/endpoint/storage/storage_test.go
+++ b/pkg/registry/core/endpoint/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -69,7 +68,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	endpoints := validNewEndpoints()
 	endpoints.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -86,7 +85,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestUpdate(
 		// valid
 		validNewEndpoints(),
@@ -106,7 +105,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewEndpoints())
 }
 
@@ -114,7 +113,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewEndpoints())
 }
 
@@ -122,7 +121,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewEndpoints())
 }
 
@@ -130,7 +129,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewEndpoints(),
 		// matching labels

--- a/pkg/registry/core/event/storage/BUILD
+++ b/pkg/registry/core/event/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/event/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/event/storage/storage_test.go
+++ b/pkg/registry/core/event/storage/storage_test.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -60,7 +59,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	event := validNewEvent(test.TestNamespace())
 	event.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -75,7 +74,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestUpdate(
 		// valid
 		validNewEvent(test.TestNamespace()),
@@ -98,7 +97,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewEvent(test.TestNamespace()))
 }
 

--- a/pkg/registry/core/limitrange/storage/BUILD
+++ b/pkg/registry/core/limitrange/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/limitrange/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/registry/core/limitrange/storage/storage_test.go
+++ b/pkg/registry/core/limitrange/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -71,7 +70,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).GeneratesName()
+	test := genericregistrytest.New(t, storage.Store).GeneratesName()
 	validLimitRange := validNewLimitRange()
 	validLimitRange.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -88,7 +87,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestUpdate(
 		// valid
 		validNewLimitRange(),
@@ -117,7 +116,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewLimitRange())
 }
 
@@ -125,7 +124,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewLimitRange())
 }
 
@@ -133,7 +132,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewLimitRange())
 }
 
@@ -141,7 +140,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewLimitRange(),
 		// matching labels

--- a/pkg/registry/core/namespace/storage/BUILD
+++ b/pkg/registry/core/namespace/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/namespace/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/namespace/storage/storage_test.go
+++ b/pkg/registry/core/namespace/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -51,7 +50,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.store).ClusterScope()
 	namespace := validNewNamespace()
 	namespace.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
 	test.TestCreate(
@@ -95,7 +94,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.store, legacyscheme.Scheme).ClusterScope().ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.store).ClusterScope().ReturnDeletedObject()
 	test.TestDelete(validNewNamespace())
 }
 
@@ -103,7 +102,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.store).ClusterScope()
 	test.TestGet(validNewNamespace())
 }
 
@@ -111,7 +110,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.store).ClusterScope()
 	test.TestList(validNewNamespace())
 }
 
@@ -119,7 +118,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.store).ClusterScope()
 	test.TestWatch(
 		validNewNamespace(),
 		// matching labels

--- a/pkg/registry/core/node/storage/BUILD
+++ b/pkg/registry/core/node/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/node/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/core/node/storage/storage_test.go
+++ b/pkg/registry/core/node/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	kubeletclient "k8s.io/kubernetes/pkg/kubelet/client"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -72,7 +71,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	node := validNewNode()
 	node.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
 	test.TestCreate(
@@ -89,7 +88,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewNode(),
@@ -106,7 +105,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestDelete(validNewNode())
 }
 
@@ -114,7 +113,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewNode())
 }
 
@@ -122,7 +121,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewNode())
 }
 
@@ -130,7 +129,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewNode(),
 		// matching labels

--- a/pkg/registry/core/persistentvolume/storage/BUILD
+++ b/pkg/registry/core/persistentvolume/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/persistentvolume/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/core/persistentvolume/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolume/storage/storage_test.go
@@ -31,7 +31,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -87,7 +86,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	pv := validNewPersistentVolume("foo")
 	pv.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
 	test.TestCreate(
@@ -104,7 +103,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewPersistentVolume("foo"),
@@ -123,7 +122,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope().ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope().ReturnDeletedObject()
 	test.TestDelete(validNewPersistentVolume("foo"))
 }
 
@@ -131,7 +130,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewPersistentVolume("foo"))
 }
 
@@ -139,7 +138,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewPersistentVolume("foo"))
 }
 
@@ -147,7 +146,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewPersistentVolume("foo"),
 		// matching labels

--- a/pkg/registry/core/persistentvolumeclaim/storage/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/persistentvolumeclaim/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
@@ -31,7 +31,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -73,7 +72,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	pv := validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault)
 	pv.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -90,7 +89,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault),
@@ -107,7 +106,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ReturnDeletedObject()
 	test.TestDelete(validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault))
 }
 
@@ -115,7 +114,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault))
 }
 
@@ -123,7 +122,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault))
 }
 
@@ -131,7 +130,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault),
 		// matching labels

--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/pod/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//pkg/securitycontext:go_default_library",

--- a/pkg/registry/core/pod/storage/storage_test.go
+++ b/pkg/registry/core/pod/storage/storage_test.go
@@ -41,7 +41,6 @@ import (
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utilfeaturetesting "k8s.io/apiserver/pkg/util/feature/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 	"k8s.io/kubernetes/pkg/securitycontext"
@@ -100,7 +99,7 @@ func TestCreate(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	pod := validNewPod()
 	pod.ObjectMeta = metav1.ObjectMeta{}
 	// Make an invalid pod with an an incorrect label.
@@ -127,7 +126,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewPod(),
@@ -144,7 +143,7 @@ func TestDelete(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ReturnDeletedObject()
 	test.TestDelete(validNewPod())
 
 	scheduledPod := validNewPod()
@@ -368,7 +367,7 @@ func TestGet(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewPod())
 }
 
@@ -376,7 +375,7 @@ func TestList(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewPod())
 }
 
@@ -384,7 +383,7 @@ func TestWatch(t *testing.T) {
 	storage, _, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewPod(),
 		// matching labels

--- a/pkg/registry/core/podtemplate/storage/BUILD
+++ b/pkg/registry/core/podtemplate/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/podtemplate/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/podtemplate/storage/storage_test.go
+++ b/pkg/registry/core/podtemplate/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -74,7 +73,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	pod := validNewPodTemplate("foo")
 	pod.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -91,7 +90,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		//valid
 		validNewPodTemplate("foo"),
@@ -108,7 +107,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ReturnDeletedObject()
 	test.TestDelete(validNewPodTemplate("foo"))
 }
 
@@ -116,7 +115,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewPodTemplate("foo"))
 }
 
@@ -124,7 +123,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewPodTemplate("foo"))
 }
 
@@ -132,7 +131,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewPodTemplate("foo"),
 		// matching labels

--- a/pkg/registry/core/replicationcontroller/storage/BUILD
+++ b/pkg/registry/core/replicationcontroller/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/replicationcontroller/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/core/replicationcontroller/storage/storage_test.go
+++ b/pkg/registry/core/replicationcontroller/storage/storage_test.go
@@ -31,7 +31,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -100,7 +99,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	controller := validNewController()
 	controller.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -121,7 +120,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	test.TestUpdate(
 		// valid
 		validNewController(),
@@ -149,7 +148,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	test.TestDelete(validNewController())
 }
 
@@ -208,7 +207,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	test.TestGet(validNewController())
 }
 
@@ -216,7 +215,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	test.TestList(validNewController())
 }
 
@@ -224,7 +223,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Controller.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Controller.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Controller.Store)
 	test.TestWatch(
 		validController,
 		// matching labels

--- a/pkg/registry/core/resourcequota/storage/BUILD
+++ b/pkg/registry/core/resourcequota/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/resourcequota/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/registry/core/resourcequota/storage/storage_test.go
+++ b/pkg/registry/core/resourcequota/storage/storage_test.go
@@ -30,7 +30,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -70,7 +69,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	resourcequota := validNewResourceQuota()
 	resourcequota.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -111,7 +110,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ReturnDeletedObject()
 	test.TestDelete(validNewResourceQuota())
 }
 
@@ -119,7 +118,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewResourceQuota())
 }
 
@@ -127,7 +126,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewResourceQuota())
 }
 
@@ -135,7 +134,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewResourceQuota(),
 		// matching labels

--- a/pkg/registry/core/secret/storage/BUILD
+++ b/pkg/registry/core/secret/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/secret/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/secret/storage/storage_test.go
+++ b/pkg/registry/core/secret/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -58,7 +57,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	secret := validNewSecret("foo")
 	secret.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
 	test.TestCreate(
@@ -81,7 +80,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewSecret("foo"),
@@ -98,7 +97,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewSecret("foo"))
 }
 
@@ -106,7 +105,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewSecret("foo"))
 }
 
@@ -114,7 +113,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewSecret("foo"))
 }
 
@@ -122,7 +121,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewSecret("foo"),
 		// matching labels

--- a/pkg/registry/core/service/storage/BUILD
+++ b/pkg/registry/core/service/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/service/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/service/storage/storage_test.go
+++ b/pkg/registry/core/service/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -68,7 +67,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	validService := validService()
 	validService.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -99,7 +98,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestUpdate(
 		// valid
 		validService(),
@@ -126,7 +125,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestDelete(validService())
 }
 
@@ -134,7 +133,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestGet(validService())
 }
 
@@ -142,7 +141,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).AllowCreateOnUpdate()
+	test := genericregistrytest.New(t, storage.Store).AllowCreateOnUpdate()
 	test.TestList(validService())
 }
 
@@ -150,7 +149,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validService(),
 		// matching labels

--- a/pkg/registry/core/serviceaccount/storage/BUILD
+++ b/pkg/registry/core/serviceaccount/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/core/serviceaccount/storage/storage_test.go
+++ b/pkg/registry/core/serviceaccount/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -56,7 +55,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	serviceAccount := validNewServiceAccount("foo")
 	serviceAccount.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
 	test.TestCreate(
@@ -74,7 +73,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewServiceAccount("foo"),
@@ -91,7 +90,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ReturnDeletedObject()
 	test.TestDelete(validNewServiceAccount("foo"))
 }
 
@@ -99,7 +98,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewServiceAccount("foo"))
 }
 
@@ -107,7 +106,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewServiceAccount("foo"))
 }
 
@@ -115,7 +114,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewServiceAccount("foo"),
 		// matching labels

--- a/pkg/registry/extensions/daemonset/storage/BUILD
+++ b/pkg/registry/extensions/daemonset/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/extensions/daemonset/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/extensions/daemonset/storage/storage_test.go
+++ b/pkg/registry/extensions/daemonset/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -82,7 +81,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	ds := newValidDaemonSet()
 	ds.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -109,7 +108,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		newValidDaemonSet(),
@@ -138,7 +137,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(newValidDaemonSet())
 }
 
@@ -146,7 +145,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(newValidDaemonSet())
 }
 
@@ -154,7 +153,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(newValidDaemonSet())
 }
 
@@ -162,7 +161,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validDaemonSet,
 		// matching labels

--- a/pkg/registry/extensions/deployment/storage/BUILD
+++ b/pkg/registry/extensions/deployment/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/extensions/deployment/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",

--- a/pkg/registry/extensions/deployment/storage/storage_test.go
+++ b/pkg/registry/extensions/deployment/storage/storage_test.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	storeerr "k8s.io/apiserver/pkg/storage/errors"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -100,7 +99,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	deployment := validNewDeployment()
 	deployment.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -120,7 +119,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	test.TestUpdate(
 		// valid
 		validNewDeployment(),
@@ -153,7 +152,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	test.TestDelete(validNewDeployment())
 }
 
@@ -161,7 +160,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	test.TestGet(validNewDeployment())
 }
 
@@ -169,7 +168,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	test.TestList(validNewDeployment())
 }
 
@@ -177,7 +176,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Deployment.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Deployment.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Deployment.Store)
 	test.TestWatch(
 		validNewDeployment(),
 		// matching labels

--- a/pkg/registry/extensions/ingress/storage/BUILD
+++ b/pkg/registry/extensions/ingress/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/extensions/ingress/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/extensions/ingress/storage/storage_test.go
+++ b/pkg/registry/extensions/ingress/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -124,7 +123,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	ingress := validIngress()
 	noDefaultBackendAndRules := validIngress()
 	noDefaultBackendAndRules.Spec.Backend = &extensions.IngressBackend{}
@@ -144,7 +143,7 @@ func TestUpdate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validIngress(),
@@ -180,7 +179,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validIngress())
 }
 
@@ -188,7 +187,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validIngress())
 }
 
@@ -196,7 +195,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validIngress())
 }
 
@@ -204,7 +203,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validIngress(),
 		// matching labels

--- a/pkg/registry/extensions/podsecuritypolicy/storage/BUILD
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/extensions/podsecuritypolicy/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",

--- a/pkg/registry/extensions/podsecuritypolicy/storage/storage_test.go
+++ b/pkg/registry/extensions/podsecuritypolicy/storage/storage_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	// Ensure that extensions/v1beta1 package is initialized.
 	_ "k8s.io/api/extensions/v1beta1"
@@ -70,7 +69,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	psp := validNewPodSecurityPolicy()
 	psp.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
 	test.TestCreate(
@@ -87,7 +86,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewPodSecurityPolicy(),
@@ -104,7 +103,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope().ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope().ReturnDeletedObject()
 	test.TestDelete(validNewPodSecurityPolicy())
 }
 
@@ -112,7 +111,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewPodSecurityPolicy())
 }
 
@@ -120,7 +119,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewPodSecurityPolicy())
 }
 
@@ -128,7 +127,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewPodSecurityPolicy(),
 		// matching labels

--- a/pkg/registry/extensions/replicaset/storage/BUILD
+++ b/pkg/registry/extensions/replicaset/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/extensions/replicaset/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/extensions:go_default_library",

--- a/pkg/registry/extensions/replicaset/storage/storage_test.go
+++ b/pkg/registry/extensions/replicaset/storage/storage_test.go
@@ -31,7 +31,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/autoscaling"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -97,7 +96,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	rs := validNewReplicaSet()
 	rs.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -118,7 +117,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	test.TestUpdate(
 		// valid
 		validNewReplicaSet(),
@@ -146,7 +145,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	test.TestDelete(validNewReplicaSet())
 }
 
@@ -205,7 +204,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	test.TestGet(validNewReplicaSet())
 }
 
@@ -213,7 +212,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	test.TestList(validNewReplicaSet())
 }
 
@@ -221,7 +220,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.ReplicaSet.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.ReplicaSet.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.ReplicaSet.Store)
 	test.TestWatch(
 		validNewReplicaSet(),
 		// matching labels

--- a/pkg/registry/networking/networkpolicy/storage/BUILD
+++ b/pkg/registry/networking/networkpolicy/storage/BUILD
@@ -39,7 +39,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/networking/networkpolicy/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/networking:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/networking/networkpolicy/storage/storage_test.go
+++ b/pkg/registry/networking/networkpolicy/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/networking"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -73,7 +72,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	np := validNetworkPolicy()
 	np.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo-"}
 	test.TestCreate(
@@ -91,7 +90,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNetworkPolicy(),
@@ -134,7 +133,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNetworkPolicy())
 }
 
@@ -142,7 +141,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNetworkPolicy())
 }
 
@@ -150,7 +149,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNetworkPolicy())
 }
 
@@ -158,7 +157,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNetworkPolicy(),
 		// matching labels

--- a/pkg/registry/policy/poddisruptionbudget/storage/BUILD
+++ b/pkg/registry/policy/poddisruptionbudget/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/policy/poddisruptionbudget/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/policy:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
+++ b/pkg/registry/policy/poddisruptionbudget/storage/storage_test.go
@@ -28,7 +28,6 @@ import (
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	"k8s.io/apiserver/pkg/registry/rest"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/policy"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -71,7 +70,7 @@ func TestCreate(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	pdb := validNewPodDisruptionBudget()
 	pdb.ObjectMeta = metav1.ObjectMeta{}
 	test.TestCreate(
@@ -132,7 +131,7 @@ func TestGet(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewPodDisruptionBudget())
 }
 
@@ -140,7 +139,7 @@ func TestList(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewPodDisruptionBudget())
 }
 
@@ -148,7 +147,7 @@ func TestDelete(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewPodDisruptionBudget())
 }
 
@@ -156,7 +155,7 @@ func TestWatch(t *testing.T) {
 	storage, _, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewPodDisruptionBudget(),
 		// matching labels

--- a/pkg/registry/scheduling/priorityclass/storage/BUILD
+++ b/pkg/registry/scheduling/priorityclass/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/scheduling/priorityclass/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/scheduling:go_default_library",
         "//pkg/registry/registrytest:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/registry/scheduling/priorityclass/storage/storage_test.go
+++ b/pkg/registry/scheduling/priorityclass/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
 )
@@ -57,7 +56,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestCreate(
 		validNewPriorityClass(),
 		// invalid cases
@@ -76,7 +75,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewPriorityClass(),
@@ -102,7 +101,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestDelete(validNewPriorityClass())
 }
 
@@ -110,7 +109,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewPriorityClass())
 }
 
@@ -118,7 +117,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewPriorityClass())
 }
 
@@ -126,7 +125,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewPriorityClass(),
 		// matching labels

--- a/pkg/registry/settings/podpreset/storage/BUILD
+++ b/pkg/registry/settings/podpreset/storage/BUILD
@@ -38,7 +38,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/settings/podpreset/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/settings:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/settings/podpreset/storage/storage_test.go
+++ b/pkg/registry/settings/podpreset/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/settings"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -104,7 +103,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	invalidPodPreset := validNewPodPreset(test.TestNamespace())
 	invalidPodPreset.Spec.VolumeMounts[0].Name = "/cache/VolumeMounts"
 	test.TestCreate(
@@ -118,7 +117,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestUpdate(
 		// valid
 		validNewPodPreset(test.TestNamespace()),
@@ -135,7 +134,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestDelete(validNewPodPreset(test.TestNamespace()))
 }
 
@@ -143,7 +142,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestGet(validNewPodPreset(test.TestNamespace()))
 }
 
@@ -151,7 +150,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestList(validNewPodPreset(test.TestNamespace()))
 }
 
@@ -159,7 +158,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme)
+	test := genericregistrytest.New(t, storage.Store)
 	test.TestWatch(
 		validNewPodPreset(test.TestNamespace()),
 		// matching labels

--- a/pkg/registry/storage/storageclass/storage/BUILD
+++ b/pkg/registry/storage/storageclass/storage/BUILD
@@ -12,7 +12,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/storage/storageclass/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/storage:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/storage/storageclass/storage/storage_test.go
+++ b/pkg/registry/storage/storageclass/storage/storage_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	storageapi "k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -66,7 +65,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	storageClass := validNewStorageClass("foo")
 	storageClass.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
 	deleteReclaimPolicy := api.PersistentVolumeReclaimDelete
@@ -85,7 +84,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewStorageClass("foo"),
@@ -109,7 +108,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope().ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope().ReturnDeletedObject()
 	test.TestDelete(validNewStorageClass("foo"))
 }
 
@@ -117,7 +116,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewStorageClass("foo"))
 }
 
@@ -125,7 +124,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewStorageClass("foo"))
 }
 
@@ -133,7 +132,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewStorageClass("foo"),
 		// matching labels

--- a/pkg/registry/storage/volumeattachment/storage/BUILD
+++ b/pkg/registry/storage/volumeattachment/storage/BUILD
@@ -20,7 +20,6 @@ go_test(
     importpath = "k8s.io/kubernetes/pkg/registry/storage/volumeattachment/storage",
     library = ":go_default_library",
     deps = [
-        "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/testapi:go_default_library",
         "//pkg/apis/storage:go_default_library",
         "//pkg/registry/registrytest:go_default_library",

--- a/pkg/registry/storage/volumeattachment/storage/storage_test.go
+++ b/pkg/registry/storage/volumeattachment/storage/storage_test.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistrytest "k8s.io/apiserver/pkg/registry/generic/testing"
 	etcdtesting "k8s.io/apiserver/pkg/storage/etcd/testing"
-	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/testapi"
 	storageapi "k8s.io/kubernetes/pkg/apis/storage"
 	"k8s.io/kubernetes/pkg/registry/registrytest"
@@ -74,7 +73,7 @@ func TestCreate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	volumeAttachment := validNewVolumeAttachment("foo")
 	volumeAttachment.ObjectMeta = metav1.ObjectMeta{GenerateName: "foo"}
 	pvName := "foo"
@@ -104,7 +103,7 @@ func TestUpdate(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestUpdate(
 		// valid
 		validNewVolumeAttachment("foo"),
@@ -132,7 +131,7 @@ func TestDelete(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope().ReturnDeletedObject()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope().ReturnDeletedObject()
 	test.TestDelete(validNewVolumeAttachment("foo"))
 }
 
@@ -145,7 +144,7 @@ func TestGet(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestGet(validNewVolumeAttachment("foo"))
 }
 
@@ -158,7 +157,7 @@ func TestList(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestList(validNewVolumeAttachment("foo"))
 }
 
@@ -171,7 +170,7 @@ func TestWatch(t *testing.T) {
 	storage, server := newStorage(t)
 	defer server.Terminate(t)
 	defer storage.Store.DestroyFunc()
-	test := genericregistrytest.New(t, storage.Store, legacyscheme.Scheme).ClusterScope()
+	test := genericregistrytest.New(t, storage.Store).ClusterScope()
 	test.TestWatch(
 		validNewVolumeAttachment("foo"),
 		// matching labels

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/testing/tester.go
@@ -39,9 +39,9 @@ type Tester struct {
 }
 type UpdateFunc func(runtime.Object) runtime.Object
 
-func New(t *testing.T, storage *genericregistry.Store, scheme *runtime.Scheme) *Tester {
+func New(t *testing.T, storage *genericregistry.Store) *Tester {
 	return &Tester{
-		tester:  resttest.New(t, storage, scheme),
+		tester:  resttest.New(t, storage),
 		storage: storage,
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -47,15 +47,13 @@ type Tester struct {
 	generatesName       bool
 	returnDeletedObject bool
 	namer               func(int) string
-	scheme              *runtime.Scheme
 }
 
-func New(t *testing.T, storage rest.Storage, scheme *runtime.Scheme) *Tester {
+func New(t *testing.T, storage rest.Storage) *Tester {
 	return &Tester{
 		T:       t,
 		storage: storage,
 		namer:   defaultNamer,
-		scheme:  scheme,
 	}
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/55622, removing an unused scheme.