### PR TITLE
Add pod-level metric for CPU and memory stats

### DIFF
--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -86,6 +86,12 @@ type PodStats struct {
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	Containers []ContainerStats `json:"containers" patchStrategy:"merge" patchMergeKey:"name"`
+	// Stats pertaining to CPU resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	CPU *CPUStats `json:"cpu,omitempty"`
+	// Stats pertaining to memory (RAM) resources consumed by pod cgroup (which includes all containers' resource usage and pod overhead).
+	// +optional
+	Memory *MemoryStats `json:"memory,omitempty"`
 	// Stats pertaining to network resources.
 	// +optional
 	Network *NetworkStats `json:"network,omitempty"`

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -45,6 +45,8 @@ const (
 	libcontainerCgroupfs libcontainerCgroupManagerType = "cgroupfs"
 	// libcontainerSystemd means use libcontainer with systemd
 	libcontainerSystemd libcontainerCgroupManagerType = "systemd"
+	// systemdSuffix is the cgroup name suffix for systemd
+	systemdSuffix string = ".slice"
 )
 
 // hugePageSizeList is useful for converting to the hugetlb canonical unit
@@ -68,8 +70,8 @@ func ConvertCgroupNameToSystemd(cgroupName CgroupName, outputToCgroupFs bool) st
 			}
 			// detect if we are given a systemd style name.
 			// if so, we do not want to do double encoding.
-			if strings.HasSuffix(part, ".slice") {
-				part = strings.TrimSuffix(part, ".slice")
+			if IsSystemdStyleName(part) {
+				part = strings.TrimSuffix(part, systemdSuffix)
 				separatorIndex := strings.LastIndex(part, "-")
 				if separatorIndex >= 0 && separatorIndex < len(part) {
 					part = part[separatorIndex+1:]
@@ -87,8 +89,8 @@ func ConvertCgroupNameToSystemd(cgroupName CgroupName, outputToCgroupFs bool) st
 		result = "-"
 	}
 	// always have a .slice suffix
-	if !strings.HasSuffix(result, ".slice") {
-		result = result + ".slice"
+	if !IsSystemdStyleName(result) {
+		result = result + systemdSuffix
 	}
 
 	// if the caller desired the result in cgroupfs format...
@@ -112,6 +114,13 @@ func ConvertCgroupFsNameToSystemd(cgroupfsName string) (string, error) {
 	// above and beyond the simple assumption here that the base of the path encodes the hierarchy
 	// per systemd convention.
 	return path.Base(cgroupfsName), nil
+}
+
+func IsSystemdStyleName(name string) bool {
+	if strings.HasSuffix(name, systemdSuffix) {
+		return true
+	}
+	return false
 }
 
 // libcontainerAdapter provides a simplified interface to libcontainer based on libcontainer type.
@@ -151,15 +160,18 @@ func (l *libcontainerAdapter) revertName(name string) CgroupName {
 	if l.cgroupManagerType != libcontainerSystemd {
 		return CgroupName(name)
 	}
+	return CgroupName(RevertFromSystemdToCgroupStyleName(name))
+}
 
+func RevertFromSystemdToCgroupStyleName(name string) string {
 	driverName, err := ConvertCgroupFsNameToSystemd(name)
 	if err != nil {
 		panic(err)
 	}
-	driverName = strings.TrimSuffix(driverName, ".slice")
+	driverName = strings.TrimSuffix(driverName, systemdSuffix)
 	driverName = strings.Replace(driverName, "-", "/", -1)
 	driverName = strings.Replace(driverName, "_", "-", -1)
-	return CgroupName(driverName)
+	return driverName
 }
 
 // adaptName converts a CgroupName identifier to a driver specific conversion value.

--- a/pkg/kubelet/cm/cgroup_manager_unsupported.go
+++ b/pkg/kubelet/cm/cgroup_manager_unsupported.go
@@ -77,3 +77,11 @@ func ConvertCgroupFsNameToSystemd(cgroupfsName string) (string, error) {
 func ConvertCgroupNameToSystemd(cgroupName CgroupName, outputToCgroupFs bool) string {
 	return ""
 }
+
+func RevertFromSystemdToCgroupStyleName(name string) string {
+	return ""
+}
+
+func IsSystemdStyleName(name string) bool {
+	return false
+}

--- a/pkg/kubelet/cm/helpers_linux.go
+++ b/pkg/kubelet/cm/helpers_linux.go
@@ -26,6 +26,7 @@ import (
 	libcontainercgroups "github.com/opencontainers/runc/libcontainer/cgroups"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/api/v1/resource"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	v1qos "k8s.io/kubernetes/pkg/apis/core/v1/helper/qos"
@@ -221,4 +222,9 @@ func getCgroupProcs(dir string) ([]int, error) {
 		}
 	}
 	return out, nil
+}
+
+// GetPodCgroupNameSuffix returns the last element of the pod CgroupName identifier
+func GetPodCgroupNameSuffix(podUID types.UID) string {
+	return podCgroupNamePrefix + string(podUID)
 }

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -18,7 +18,10 @@ limitations under the License.
 
 package cm
 
-import "k8s.io/api/core/v1"
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
 
 const (
 	MinShares     = 0
@@ -51,4 +54,9 @@ func GetCgroupSubsystems() (*CgroupSubsystems, error) {
 
 func getCgroupProcs(dir string) ([]int, error) {
 	return nil, nil
+}
+
+// GetPodCgroupNameSuffix returns the last element of the pod CgroupName identifier
+func GetPodCgroupNameSuffix(podUID types.UID) string {
+	return ""
 }

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -104,7 +104,7 @@ func (m *podContainerManagerImpl) GetPodContainerName(pod *v1.Pod) (CgroupName, 
 	case v1.PodQOSBestEffort:
 		parentContainer = m.qosContainersInfo.BestEffort
 	}
-	podContainer := podCgroupNamePrefix + string(pod.UID)
+	podContainer := GetPodCgroupNameSuffix(pod.UID)
 
 	// Get the absolute path of the cgroup
 	cgroupName := (CgroupName)(path.Join(parentContainer, podContainer))

--- a/pkg/kubelet/stats/BUILD
+++ b/pkg/kubelet/stats/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kubelet/apis/cri/v1alpha1/runtime:go_default_library",
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
+        "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/leaky:go_default_library",
         "//pkg/kubelet/network:go_default_library",

--- a/pkg/kubelet/stats/cadvisor_stats_provider_test.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider_test.go
@@ -134,8 +134,10 @@ func TestCadvisorListPodStats(t *testing.T) {
 		"/pod1-i":  getTestContainerInfo(seedPod1Infra, pName1, namespace0, leaky.PodInfraContainerName),
 		"/pod1-c0": getTestContainerInfo(seedPod1Container, pName1, namespace0, cName10),
 		// Pod2 - Namespace2
-		"/pod2-i":  getTestContainerInfo(seedPod2Infra, pName2, namespace2, leaky.PodInfraContainerName),
-		"/pod2-c0": getTestContainerInfo(seedPod2Container, pName2, namespace2, cName20),
+		"/pod2-i":                        getTestContainerInfo(seedPod2Infra, pName2, namespace2, leaky.PodInfraContainerName),
+		"/pod2-c0":                       getTestContainerInfo(seedPod2Container, pName2, namespace2, cName20),
+		"/kubepods/burstable/podUIDpod0": getTestContainerInfo(seedPod0Infra, pName0, namespace0, leaky.PodInfraContainerName),
+		"/kubepods/podUIDpod1":           getTestContainerInfo(seedPod1Infra, pName1, namespace0, leaky.PodInfraContainerName),
 	}
 
 	freeRootfsInodes := rootfsInodesFree
@@ -228,6 +230,8 @@ func TestCadvisorListPodStats(t *testing.T) {
 	assert.EqualValues(t, testTime(creationTime, seedPod0Infra).Unix(), ps.StartTime.Time.Unix())
 	checkNetworkStats(t, "Pod0", seedPod0Infra, ps.Network)
 	checkEphemeralStats(t, "Pod0", []int{seedPod0Container0, seedPod0Container1}, []int{seedEphemeralVolume1, seedEphemeralVolume2}, ps.EphemeralStorage)
+	checkCPUStats(t, "Pod0", seedPod0Infra, ps.CPU)
+	checkMemoryStats(t, "Pod0", seedPod0Infra, infos["/pod0-i"], ps.Memory)
 
 	// Validate Pod1 Results
 	ps, found = indexPods[prf1]

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -175,6 +175,20 @@ var _ = framework.KubeDescribe("Summary API", func() {
 					"TxBytes":  bounded(10, 10*framework.Mb),
 					"TxErrors": bounded(0, 1000),
 				}),
+				"CPU": ptrMatchAllFields(gstruct.Fields{
+					"Time":                 recent(maxStatsAge),
+					"UsageNanoCores":       bounded(100000, 1E9),
+					"UsageCoreNanoSeconds": bounded(10000000, 1E11),
+				}),
+				"Memory": ptrMatchAllFields(gstruct.Fields{
+					"Time":            recent(maxStatsAge),
+					"AvailableBytes":  bounded(1*framework.Kb, 10*framework.Mb),
+					"UsageBytes":      bounded(10*framework.Kb, 20*framework.Mb),
+					"WorkingSetBytes": bounded(10*framework.Kb, 20*framework.Mb),
+					"RSSBytes":        bounded(1*framework.Kb, framework.Mb),
+					"PageFaults":      bounded(0, 1000000),
+					"MajorPageFaults": bounded(0, 10),
+				}),
 				"VolumeStats": gstruct.MatchAllElements(summaryObjectID, gstruct.Elements{
 					"test-empty-dir": gstruct.MatchAllFields(gstruct.Fields{
 						"Name":   Equal("test-empty-dir"),


### PR DESCRIPTION
This PR adds the pod-level metrics for CPU and memory stats. cAdvisor
can get all pod cgroup information so we can add this pod-level CPU and
memory stats information from the corresponding pod cgroup
Address issue #55978

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add pod-level CPU and memory stats from pod cgroup information
```
