### PR TITLE
Allow constructing spdy executor from existing transports

### DIFF
--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -256,7 +256,12 @@ func TestStream(t *testing.T) {
 			conf := &restclient.Config{
 				Host: server.URL,
 			}
-			e, err := remoteclient.NewSPDYExecutorForProtocols(conf, "POST", req.URL(), testCase.ClientProtocols...)
+			transport, upgradeTransport, err := spdy.RoundTripperFor(conf)
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", name, err)
+				continue
+			}
+			e, err := remoteclient.NewSPDYExecutorForProtocols(transport, upgradeTransport, "POST", req.URL(), testCase.ClientProtocols...)
 			if err != nil {
 				t.Errorf("%s: unexpected error: %v", name, err)
 				continue

--- a/staging/src/k8s.io/client-go/tools/remotecommand/BUILD
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/BUILD
@@ -42,7 +42,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/remotecommand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
-        "//vendor/k8s.io/client-go/transport:go_default_library",
         "//vendor/k8s.io/client-go/transport/spdy:go_default_library",
         "//vendor/k8s.io/client-go/util/exec:go_default_library",
     ],


### PR DESCRIPTION
If you already have an existing transport, it is not always possible to reconstruct a client config from it.

Allow constructing a spdy executor, given a connection/upgrade transport

```release-note
NONE
```