### PR TITLE
CPU manager no-op policy is on by default.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -211,7 +211,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	TaintNodesByCondition:                       {Default: false, PreRelease: utilfeature.Alpha},
 	MountPropagation:                            {Default: false, PreRelease: utilfeature.Alpha},
 	ExpandPersistentVolumes:                     {Default: false, PreRelease: utilfeature.Alpha},
-	CPUManager:                                  {Default: false, PreRelease: utilfeature.Alpha},
+	CPUManager:                                  {Default: true, PreRelease: utilfeature.Beta},
 	ServiceNodeExclusion:                        {Default: false, PreRelease: utilfeature.Alpha},
 	MountContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
 	VolumeScheduling:                            {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
**What this PR does / why we need it**:

- Turn on the CPUManager feature gate by default.
- Mark CPU manager feature as beta.

Fixes #52031

**Special notes for your reviewer**:

/hold

Do not merge until:
- [ ] gating e2e tests are enabled in CI

**Release note**:
```release-note
Graduate CPU Manager feature from alpha to beta.
```