### PR TITLE
Rename generic webhook

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -321,7 +321,7 @@ if [[ -z "${KUBE_ADMISSION_CONTROL:-}" ]]; then
     ADMISSION_CONTROL="${ADMISSION_CONTROL},PodSecurityPolicy"
   fi
   # ResourceQuota must come last, or a creation is recorded, but the pod may be forbidden.
-  ADMISSION_CONTROL="${ADMISSION_CONTROL},GenericAdmissionWebhook,ResourceQuota"
+  ADMISSION_CONTROL="${ADMISSION_CONTROL},ValidatingAdmissionWebhook,ResourceQuota"
 else
   ADMISSION_CONTROL=${KUBE_ADMISSION_CONTROL}
 fi

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -104,8 +104,8 @@ func TestAddFlags(t *testing.T) {
 			MinRequestTimeout:           1800,
 		},
 		Admission: &apiserveroptions.AdmissionOptions{
-			RecommendedPluginOrder: []string{"MutatingAdmissionWebhook", "NamespaceLifecycle", "Initializers", "GenericAdmissionWebhook"},
-			DefaultOffPlugins:      []string{"MutatingAdmissionWebhook", "Initializers", "GenericAdmissionWebhook"},
+			RecommendedPluginOrder: []string{"MutatingAdmissionWebhook", "NamespaceLifecycle", "Initializers", "ValidatingAdmissionWebhook"},
+			DefaultOffPlugins:      []string{"MutatingAdmissionWebhook", "Initializers", "ValidatingAdmissionWebhook"},
 			PluginNames:            []string{"AlwaysDeny"},
 			ConfigFile:             "/admission-control-config",
 			Plugins:                s.Admission.Plugins,

--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -419,7 +419,7 @@ function start_apiserver {
     fi
 
     # Admission Controllers to invoke prior to persisting objects in cluster
-    ADMISSION_CONTROL=MutatingAdmissionWebhook,Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount${security_admission},DefaultStorageClass,DefaultTolerationSeconds,GenericAdmissionWebhook,ResourceQuota
+    ADMISSION_CONTROL=MutatingAdmissionWebhook,Initializers,NamespaceLifecycle,LimitRanger,ServiceAccount${security_admission},DefaultStorageClass,DefaultTolerationSeconds,ValidatingAdmissionWebhook,ResourceQuota
     # This is the default dir and filename where the apiserver will generate a self-signed cert
     # which should be able to be used as the CA to verify itself
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission_test.go
@@ -116,7 +116,7 @@ func (c urlConfigGenerator) ccfgURL(urlPath string) registrationv1alpha1.Webhook
 	}
 }
 
-// TestAdmit tests that GenericAdmissionWebhook#Admit works as expected
+// TestAdmit tests that ValidatingAdmissionWebhook#Admit works as expected
 func TestAdmit(t *testing.T) {
 	scheme := runtime.NewScheme()
 	v1alpha1.AddToScheme(scheme)
@@ -129,7 +129,7 @@ func TestAdmit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("this should never happen? %v", err)
 	}
-	wh, err := NewGenericAdmissionWebhook(nil)
+	wh, err := NewValidatingAdmissionWebhook(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -410,7 +410,7 @@ func TestAdmit(t *testing.T) {
 	}
 }
 
-// TestAdmitCachedClient tests that GenericAdmissionWebhook#Admit should cache restClient
+// TestAdmitCachedClient tests that ValidatingAdmissionWebhook#Admit should cache restClient
 func TestAdmitCachedClient(t *testing.T) {
 	scheme := runtime.NewScheme()
 	v1alpha1.AddToScheme(scheme)
@@ -423,7 +423,7 @@ func TestAdmitCachedClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("this should never happen? %v", err)
 	}
-	wh, err := NewGenericAdmissionWebhook(nil)
+	wh, err := NewValidatingAdmissionWebhook(nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ref #https://github.com/kubernetes/features/issues/492

A pure gred & sed change. The `GenericAdmissionWebhook` is renamed as `ValidatingAdmissionWebhook`.

```release-note
The `GenericAdmissionWebhook` is renamed as `ValidatingAdmissionWebhook`. Please update you apiserver configuration file to use the new name to pass to the apiserver's `--admission-control` flag.
```