### PR TITLE
Use extensions client with explicit version

### DIFF
--- a/pkg/controller/replication/conversion.go
+++ b/pkg/controller/replication/conversion.go
@@ -187,7 +187,7 @@ func (c clientsetAdapter) ExtensionsV1beta1() extensionsv1beta1client.Extensions
 }
 
 func (c clientsetAdapter) Extensions() extensionsv1beta1client.ExtensionsV1beta1Interface {
-	return conversionExtensionsClient{c.Interface, c.Interface.Extensions()}
+	return conversionExtensionsClient{c.Interface, c.Interface.ExtensionsV1beta1()}
 }
 
 func (c clientsetAdapter) AppsV1beta2() appsv1beta2.AppsV1beta2Interface {

--- a/pkg/kubectl/cmd/drain.go
+++ b/pkg/kubectl/cmd/drain.go
@@ -333,11 +333,11 @@ func (o *DrainOptions) getController(namespace string, controllerRef *metav1.Own
 	case "ReplicationController":
 		return o.client.Core().ReplicationControllers(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	case "DaemonSet":
-		return o.client.Extensions().DaemonSets(namespace).Get(controllerRef.Name, metav1.GetOptions{})
+		return o.client.ExtensionsV1beta1().DaemonSets(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	case "Job":
 		return o.client.Batch().Jobs(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	case "ReplicaSet":
-		return o.client.Extensions().ReplicaSets(namespace).Get(controllerRef.Name, metav1.GetOptions{})
+		return o.client.ExtensionsV1beta1().ReplicaSets(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	case "StatefulSet":
 		return o.client.AppsV1beta1().StatefulSets(namespace).Get(controllerRef.Name, metav1.GetOptions{})
 	}
@@ -404,7 +404,7 @@ func (o *DrainOptions) daemonsetFilter(pod corev1.Pod) (bool, *warning, *fatal) 
 	if controllerRef == nil || controllerRef.Kind != "DaemonSet" {
 		return true, nil, nil
 	}
-	if _, err := o.client.Extensions().DaemonSets(pod.Namespace).Get(controllerRef.Name, metav1.GetOptions{}); err != nil {
+	if _, err := o.client.ExtensionsV1beta1().DaemonSets(pod.Namespace).Get(controllerRef.Name, metav1.GetOptions{}); err != nil {
 		return false, nil, &fatal{err.Error()}
 	}
 	if !o.IgnoreDaemonsets {

--- a/pkg/kubectl/rollout_status.go
+++ b/pkg/kubectl/rollout_status.go
@@ -38,9 +38,9 @@ type StatusViewer interface {
 func StatusViewerFor(kind schema.GroupKind, c kubernetes.Interface) (StatusViewer, error) {
 	switch kind {
 	case extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(), apps.Kind("Deployment"):
-		return &DeploymentStatusViewer{c.Extensions()}, nil
+		return &DeploymentStatusViewer{c.ExtensionsV1beta1()}, nil
 	case extensionsv1beta1.SchemeGroupVersion.WithKind("DaemonSet").GroupKind(), apps.Kind("DaemonSet"):
-		return &DaemonSetStatusViewer{c.Extensions()}, nil
+		return &DaemonSetStatusViewer{c.ExtensionsV1beta1()}, nil
 	case apps.Kind("StatefulSet"):
 		return &StatefulSetStatusViewer{c.AppsV1beta1()}, nil
 	}

--- a/test/e2e/apimachinery/initializers.go
+++ b/test/e2e/apimachinery/initializers.go
@@ -405,7 +405,7 @@ func cleanupInitializer(c clientset.Interface, initializerConfigName, initialize
 // waits till the RS status.observedGeneration matches metadata.generation.
 func waitForRSObservedGeneration(c clientset.Interface, ns, name string, generation int64) error {
 	return wait.PollImmediate(1*time.Second, 1*time.Minute, func() (bool, error) {
-		rs, err := c.Extensions().ReplicaSets(ns).Get(name, metav1.GetOptions{})
+		rs, err := c.ExtensionsV1beta1().ReplicaSets(ns).Get(name, metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -330,6 +330,6 @@ func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclu
 		},
 	}
 
-	_, err := cs.Extensions().ReplicaSets(ns).Create(rs)
+	_, err := cs.ExtensionsV1beta1().ReplicaSets(ns).Create(rs)
 	framework.ExpectNoError(err, "Creating replica set %q in namespace %q", rs.Name, ns)
 }

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -199,27 +199,27 @@ var _ = SIGDescribe("Advanced Audit [Feature:Audit]", func() {
 					podLabels := map[string]string{"name": "audit-deployment-pod"}
 					d := framework.NewDeployment("audit-deployment", int32(1), podLabels, "redis", imageutils.GetE2EImage(imageutils.Redis), extensions.RecreateDeploymentStrategyType)
 
-					_, err := f.ClientSet.Extensions().Deployments(namespace).Create(d)
+					_, err := f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Create(d)
 					framework.ExpectNoError(err, "failed to create audit-deployment")
 
-					_, err = f.ClientSet.Extensions().Deployments(namespace).Get(d.Name, metav1.GetOptions{})
+					_, err = f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Get(d.Name, metav1.GetOptions{})
 					framework.ExpectNoError(err, "failed to get audit-deployment")
 
-					deploymentChan, err := f.ClientSet.Extensions().Deployments(namespace).Watch(watchOptions)
+					deploymentChan, err := f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Watch(watchOptions)
 					framework.ExpectNoError(err, "failed to create watch for deployments")
 					for range deploymentChan.ResultChan() {
 					}
 
-					_, err = f.ClientSet.Extensions().Deployments(namespace).Update(d)
+					_, err = f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Update(d)
 					framework.ExpectNoError(err, "failed to update audit-deployment")
 
-					_, err = f.ClientSet.Extensions().Deployments(namespace).Patch(d.Name, types.JSONPatchType, patch)
+					_, err = f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Patch(d.Name, types.JSONPatchType, patch)
 					framework.ExpectNoError(err, "failed to patch deployment")
 
-					_, err = f.ClientSet.Extensions().Deployments(namespace).List(metav1.ListOptions{})
+					_, err = f.ClientSet.ExtensionsV1beta1().Deployments(namespace).List(metav1.ListOptions{})
 					framework.ExpectNoError(err, "failed to create list deployments")
 
-					err = f.ClientSet.Extensions().Deployments(namespace).Delete("audit-deployment", &metav1.DeleteOptions{})
+					err = f.ClientSet.ExtensionsV1beta1().Deployments(namespace).Delete("audit-deployment", &metav1.DeleteOptions{})
 					framework.ExpectNoError(err, "failed to delete deployments")
 				},
 				[]auditEvent{

--- a/test/e2e/autoscaling/custom_metrics_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_autoscaling.go
@@ -113,7 +113,7 @@ func testHPA(f *framework.Framework, kubeClient clientset.Interface) {
 }
 
 func createDeploymentsToScale(f *framework.Framework, cs clientset.Interface) error {
-	_, err := cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Create(monitoring.StackdriverExporterDeployment(stackdriverExporterDeployment, f.Namespace.Name, 2, 100))
+	_, err := cs.ExtensionsV1beta1().Deployments(f.Namespace.ObjectMeta.Name).Create(monitoring.StackdriverExporterDeployment(stackdriverExporterDeployment, f.Namespace.Name, 2, 100))
 	if err != nil {
 		return err
 	}
@@ -121,14 +121,14 @@ func createDeploymentsToScale(f *framework.Framework, cs clientset.Interface) er
 	if err != nil {
 		return err
 	}
-	_, err = cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Create(monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.Name, 2, 100))
+	_, err = cs.ExtensionsV1beta1().Deployments(f.Namespace.ObjectMeta.Name).Create(monitoring.StackdriverExporterDeployment(dummyDeploymentName, f.Namespace.Name, 2, 100))
 	return err
 }
 
 func cleanupDeploymentsToScale(f *framework.Framework, cs clientset.Interface) {
-	_ = cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Delete(stackdriverExporterDeployment, &metav1.DeleteOptions{})
+	_ = cs.ExtensionsV1beta1().Deployments(f.Namespace.ObjectMeta.Name).Delete(stackdriverExporterDeployment, &metav1.DeleteOptions{})
 	_ = cs.CoreV1().Pods(f.Namespace.ObjectMeta.Name).Delete(stackdriverExporterPod, &metav1.DeleteOptions{})
-	_ = cs.Extensions().Deployments(f.Namespace.ObjectMeta.Name).Delete(dummyDeploymentName, &metav1.DeleteOptions{})
+	_ = cs.ExtensionsV1beta1().Deployments(f.Namespace.ObjectMeta.Name).Delete(dummyDeploymentName, &metav1.DeleteOptions{})
 }
 
 func createPodsHPA(f *framework.Framework, cs clientset.Interface) error {
@@ -196,7 +196,7 @@ func createObjectHPA(f *framework.Framework, cs clientset.Interface) error {
 func waitForReplicas(deploymentName, namespace string, cs clientset.Interface, timeout time.Duration, desiredReplicas int) {
 	interval := 20 * time.Second
 	err := wait.PollImmediate(interval, timeout, func() (bool, error) {
-		deployment, err := cs.Extensions().Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
+		deployment, err := cs.ExtensionsV1beta1().Deployments(namespace).Get(deploymentName, metav1.GetOptions{})
 		if err != nil {
 			framework.Failf("Failed to get replication controller %s: %v", deployment, err)
 		}

--- a/test/e2e/framework/deployment_util.go
+++ b/test/e2e/framework/deployment_util.go
@@ -215,7 +215,7 @@ func CheckDeploymentRevisionAndImage(c clientset.Interface, ns, deploymentName, 
 
 func CreateDeployment(client clientset.Interface, replicas int32, podLabels map[string]string, namespace string, pvclaims []*v1.PersistentVolumeClaim, command string) (*extensions.Deployment, error) {
 	deploymentSpec := MakeDeployment(replicas, podLabels, namespace, pvclaims, false, command)
-	deployment, err := client.Extensions().Deployments(namespace).Create(deploymentSpec)
+	deployment, err := client.ExtensionsV1beta1().Deployments(namespace).Create(deploymentSpec)
 	if err != nil {
 		return nil, fmt.Errorf("deployment %q Create API error: %v", deploymentSpec.Name, err)
 	}

--- a/test/e2e/scheduling/resource_quota.go
+++ b/test/e2e/scheduling/resource_quota.go
@@ -503,7 +503,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 
 		By("Creating a ReplicaSet")
 		replicaSet := newTestReplicaSetForQuota("test-rs", "nginx", 0)
-		replicaSet, err = f.ClientSet.Extensions().ReplicaSets(f.Namespace.Name).Create(replicaSet)
+		replicaSet, err = f.ClientSet.ExtensionsV1beta1().ReplicaSets(f.Namespace.Name).Create(replicaSet)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring resource quota status captures replicaset creation")
@@ -513,7 +513,7 @@ var _ = SIGDescribe("ResourceQuota", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Deleting a ReplicaSet")
-		err = f.ClientSet.Extensions().ReplicaSets(f.Namespace.Name).Delete(replicaSet.Name, nil)
+		err = f.ClientSet.ExtensionsV1beta1().ReplicaSets(f.Namespace.Name).Delete(replicaSet.Name, nil)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Ensuring resource quota status released usage")

--- a/test/e2e/storage/vsphere_volume_node_poweroff.go
+++ b/test/e2e/storage/vsphere_volume_node_poweroff.go
@@ -103,7 +103,7 @@ var _ = SIGDescribe("Node Poweroff [Feature:vsphere] [Slow] [Disruptive]", func(
 
 		By("Creating a Deployment")
 		deployment, err := framework.CreateDeployment(client, int32(1), map[string]string{"test": "app"}, namespace, pvclaims, "")
-		defer client.Extensions().Deployments(namespace).Delete(deployment.Name, &metav1.DeleteOptions{})
+		defer client.ExtensionsV1beta1().Deployments(namespace).Delete(deployment.Name, &metav1.DeleteOptions{})
 
 		By("Get pod from the deployement")
 		podList, err := framework.GetPodsForDeployment(client, deployment)

--- a/test/e2e/upgrades/apps/replicasets.go
+++ b/test/e2e/upgrades/apps/replicasets.go
@@ -54,7 +54,7 @@ func (r *ReplicaSetUpgradeTest) Setup(f *framework.Framework) {
 
 	By(fmt.Sprintf("Creating replicaset %s in namespace %s", rsName, ns))
 	replicaSet := framework.NewReplicaSet(rsName, ns, 1, map[string]string{"test": "upgrade"}, "nginx", nginxImage)
-	rs, err := c.Extensions().ReplicaSets(ns).Create(replicaSet)
+	rs, err := c.ExtensionsV1beta1().ReplicaSets(ns).Create(replicaSet)
 	framework.ExpectNoError(err)
 
 	By(fmt.Sprintf("Waiting for replicaset %s to have all of its replicas ready", rsName))
@@ -67,7 +67,7 @@ func (r *ReplicaSetUpgradeTest) Setup(f *framework.Framework) {
 func (r *ReplicaSetUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade upgrades.UpgradeType) {
 	c := f.ClientSet
 	ns := f.Namespace.Name
-	rsClient := c.Extensions().ReplicaSets(ns)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(ns)
 
 	// Block until upgrade is done
 	By(fmt.Sprintf("Waiting for upgrade to finish before checking replicaset %s", rsName))

--- a/test/e2e/upgrades/kube_proxy_migration.go
+++ b/test/e2e/upgrades/kube_proxy_migration.go
@@ -216,5 +216,5 @@ func getKubeProxyStaticPods(c clientset.Interface) (*v1.PodList, error) {
 func getKubeProxyDaemonSet(c clientset.Interface) (*extensions.DaemonSetList, error) {
 	label := labels.SelectorFromSet(labels.Set(map[string]string{clusterAddonLabelKey: kubeProxyLabelName}))
 	listOpts := metav1.ListOptions{LabelSelector: label.String()}
-	return c.Extensions().DaemonSets(metav1.NamespaceSystem).List(listOpts)
+	return c.ExtensionsV1beta1().DaemonSets(metav1.NamespaceSystem).List(listOpts)
 }

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -123,7 +123,7 @@ func Test202StatusCode(t *testing.T) {
 	ns := framework.CreateTestingNamespace("status-code", s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
 
-	rsClient := clientSet.Extensions().ReplicaSets(ns.Name)
+	rsClient := clientSet.ExtensionsV1beta1().ReplicaSets(ns.Name)
 
 	// 1. Create the resource without any finalizer and then delete it without setting DeleteOptions.
 	// Verify that server returns 200 in this case.
@@ -173,7 +173,7 @@ func TestAPIListChunking(t *testing.T) {
 	ns := framework.CreateTestingNamespace("list-paging", s, t)
 	defer framework.DeleteTestingNamespace(ns, s, t)
 
-	rsClient := clientSet.Extensions().ReplicaSets(ns.Name)
+	rsClient := clientSet.ExtensionsV1beta1().ReplicaSets(ns.Name)
 
 	for i := 0; i < 4; i++ {
 		rs := newRS(ns.Name)

--- a/test/integration/replicaset/replicaset_test.go
+++ b/test/integration/replicaset/replicaset_test.go
@@ -115,7 +115,7 @@ func newMatchingPod(podName, namespace string) *v1.Pod {
 // sets and pods are rsNum and podNum. It returns error if the
 // communication with the API server fails.
 func verifyRemainingObjects(t *testing.T, clientSet clientset.Interface, namespace string, rsNum, podNum int) (bool, error) {
-	rsClient := clientSet.Extensions().ReplicaSets(namespace)
+	rsClient := clientSet.ExtensionsV1beta1().ReplicaSets(namespace)
 	podClient := clientSet.CoreV1().Pods(namespace)
 	pods, err := podClient.List(metav1.ListOptions{})
 	if err != nil {
@@ -199,7 +199,7 @@ func createRSsPods(t *testing.T, clientSet clientset.Interface, rss []*v1beta1.R
 	var createdRSs []*v1beta1.ReplicaSet
 	var createdPods []*v1.Pod
 	for _, rs := range rss {
-		createdRS, err := clientSet.Extensions().ReplicaSets(rs.Namespace).Create(rs)
+		createdRS, err := clientSet.ExtensionsV1beta1().ReplicaSets(rs.Namespace).Create(rs)
 		if err != nil {
 			t.Fatalf("Failed to create replica set %s: %v", rs.Name, err)
 		}
@@ -225,7 +225,7 @@ func waitRSStable(t *testing.T, clientSet clientset.Interface, rs *v1beta1.Repli
 
 // Update .Spec.Replicas to replicas and verify .Status.Replicas is changed accordingly
 func scaleRS(t *testing.T, c clientset.Interface, rs *v1beta1.ReplicaSet, replicas int32) {
-	rsClient := c.Extensions().ReplicaSets(rs.Namespace)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(rs.Namespace)
 	rs = updateRS(t, rsClient, rs.Name, func(rs *v1beta1.ReplicaSet) {
 		*rs.Spec.Replicas = replicas
 	})
@@ -360,7 +360,7 @@ func setPodsReadyCondition(t *testing.T, clientSet clientset.Interface, pods *v1
 
 func testScalingUsingScaleSubresource(t *testing.T, c clientset.Interface, rs *v1beta1.ReplicaSet, replicas int32) {
 	ns := rs.Namespace
-	rsClient := c.Extensions().ReplicaSets(ns)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(ns)
 	newRS, err := rsClient.Get(rs.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Failed to obtain rs %s: %v", rs.Name, err)
@@ -453,7 +453,7 @@ func TestAdoption(t *testing.T) {
 			ns := framework.CreateTestingNamespace(fmt.Sprintf("rs-adoption-%d", i), s, t)
 			defer framework.DeleteTestingNamespace(ns, s, t)
 
-			rsClient := clientSet.Extensions().ReplicaSets(ns.Name)
+			rsClient := clientSet.ExtensionsV1beta1().ReplicaSets(ns.Name)
 			podClient := clientSet.CoreV1().Pods(ns.Name)
 			const rsName = "rs"
 			rs, err := rsClient.Create(newRS(rsName, ns.Name, 1))
@@ -548,7 +548,7 @@ func TestSpecReplicasChange(t *testing.T) {
 
 	// Add a template annotation change to test RS's status does update
 	// without .Spec.Replicas change
-	rsClient := c.Extensions().ReplicaSets(ns.Name)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(ns.Name)
 	var oldGeneration int64
 	newRS := updateRS(t, rsClient, rs.Name, func(rs *v1beta1.ReplicaSet) {
 		oldGeneration = rs.Generation
@@ -818,7 +818,7 @@ func TestReadyAndAvailableReplicas(t *testing.T) {
 	// by setting LastTransitionTime to more than 3600 seconds ago
 	setPodsReadyCondition(t, c, thirdPodList, v1.ConditionTrue, time.Now().Add(-120*time.Minute))
 
-	rsClient := c.Extensions().ReplicaSets(ns.Name)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(ns.Name)
 	if err := wait.PollImmediate(interval, timeout, func() (bool, error) {
 		newRS, err := rsClient.Get(rs.Name, metav1.GetOptions{})
 		if err != nil {
@@ -897,7 +897,7 @@ func TestFullyLabeledReplicas(t *testing.T) {
 	waitRSStable(t, c, rs)
 
 	// Change RS's template labels to have extra labels, but not its selector
-	rsClient := c.Extensions().ReplicaSets(ns.Name)
+	rsClient := c.ExtensionsV1beta1().ReplicaSets(ns.Name)
 	updateRS(t, rsClient, rs.Name, func(rs *v1beta1.ReplicaSet) {
 		rs.Spec.Template.Labels = extraLabelMap
 	})

--- a/test/utils/deployment.go
+++ b/test/utils/deployment.go
@@ -259,12 +259,12 @@ func UpdateDeploymentWithRetries(c clientset.Interface, namespace, name string, 
 	var updateErr error
 	pollErr := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		var err error
-		if deployment, err = c.Extensions().Deployments(namespace).Get(name, metav1.GetOptions{}); err != nil {
+		if deployment, err = c.ExtensionsV1beta1().Deployments(namespace).Get(name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(deployment)
-		if deployment, err = c.Extensions().Deployments(namespace).Update(deployment); err == nil {
+		if deployment, err = c.ExtensionsV1beta1().Deployments(namespace).Update(deployment); err == nil {
 			logf("Updating deployment %s", name)
 			return true, nil
 		}
@@ -279,7 +279,7 @@ func UpdateDeploymentWithRetries(c clientset.Interface, namespace, name string, 
 
 func WaitForObservedDeployment(c clientset.Interface, ns, deploymentName string, desiredGeneration int64) error {
 	return deploymentutil.WaitForObservedDeployment(func() (*extensions.Deployment, error) {
-		return c.Extensions().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
+		return c.ExtensionsV1beta1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
 	}, desiredGeneration, 2*time.Second, 1*time.Minute)
 }
 

--- a/test/utils/replicaset.go
+++ b/test/utils/replicaset.go
@@ -34,12 +34,12 @@ func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, 
 	var updateErr error
 	pollErr := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
 		var err error
-		if rs, err = c.Extensions().ReplicaSets(namespace).Get(name, metav1.GetOptions{}); err != nil {
+		if rs, err = c.ExtensionsV1beta1().ReplicaSets(namespace).Get(name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(rs)
-		if rs, err = c.Extensions().ReplicaSets(namespace).Update(rs); err == nil {
+		if rs, err = c.ExtensionsV1beta1().ReplicaSets(namespace).Update(rs); err == nil {
 			logf("Updating replica set %q", name)
 			return true, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Extensions client without explicit version has been deprecated, change them to the one with explicit version.

**Which issue(s) this PR fixes**:
Fixes partially #55993

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```