### PR TITLE
WIP - Thought experiment - make clients not decode to internal or default

### DIFF
--- a/pkg/api/testapi/testapi.go
+++ b/pkg/api/testapi/testapi.go
@@ -360,10 +360,11 @@ func (g TestGroup) ExternalTypes() map[string]reflect.Type {
 // Codec returns the codec for the API version to test against, as set by the
 // KUBE_TEST_API_TYPE env var.
 func (g TestGroup) Codec() runtime.Codec {
-	if serializer.Serializer == nil {
-		return legacyscheme.Codecs.LegacyCodec(g.externalGroupVersion)
+	s := serializer.Serializer
+	if s == nil {
+		s = legacyscheme.Codecs.SupportedMediaTypes()[0].Serializer
 	}
-	return legacyscheme.Codecs.CodecForVersions(serializer.Serializer, legacyscheme.Codecs.UniversalDeserializer(), schema.GroupVersions{g.externalGroupVersion}, nil)
+	return legacyscheme.Codecs.CodecForVersions(false, s, legacyscheme.Codecs.UniversalDeserializer(), schema.GroupVersions{g.externalGroupVersion}, nil)
 }
 
 // NegotiatedSerializer returns the negotiated serializer for the server.
@@ -381,7 +382,7 @@ func (g TestGroup) StorageCodec() runtime.Codec {
 	s := storageSerializer.Serializer
 
 	if s == nil {
-		return legacyscheme.Codecs.LegacyCodec(g.externalGroupVersion)
+		s = legacyscheme.Codecs.SupportedMediaTypes()[0].Serializer
 	}
 
 	// etcd2 only supports string data - we must wrap any result before returning
@@ -391,7 +392,7 @@ func (g TestGroup) StorageCodec() runtime.Codec {
 	}
 	ds := recognizer.NewDecoder(s, legacyscheme.Codecs.UniversalDeserializer())
 
-	return legacyscheme.Codecs.CodecForVersions(s, ds, schema.GroupVersions{g.externalGroupVersion}, nil)
+	return legacyscheme.Codecs.CodecForVersions(true, s, ds, schema.GroupVersions{g.externalGroupVersion}, nil)
 }
 
 // Converter returns the legacyscheme.Scheme for the API version to test against, as set by the

--- a/pkg/kubectl/cmd/attach.go
+++ b/pkg/kubectl/cmd/attach.go
@@ -207,7 +207,7 @@ func (p *AttachOptions) Run() error {
 		if err != nil {
 			return err
 		}
-
+		fmt.Printf("DEBUG: Got pod %#v\n", pod)
 		if pod.Status.Phase == api.PodSucceeded || pod.Status.Phase == api.PodFailed {
 			return fmt.Errorf("cannot attach a container in a completed pod; current phase is %s", pod.Status.Phase)
 		}

--- a/pkg/kubectl/cmd/attach_test.go
+++ b/pkg/kubectl/cmd/attach_test.go
@@ -309,6 +309,7 @@ func TestAttachWarnings(t *testing.T) {
 			Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
 				switch p, m := req.URL.Path, req.Method; {
 				case p == test.podPath && m == "GET":
+					t.Logf("returning %#v\n%s", test.pod, runtime.EncodeOrDie(codec, test.pod))
 					body := objBody(codec, test.pod)
 					return &http.Response{StatusCode: 200, Header: defaultHeader(), Body: body}, nil
 				case p == test.fetchPodPath && m == "GET":

--- a/pkg/kubectl/cmd/set/set_env_test.go
+++ b/pkg/kubectl/cmd/set/set_env_test.go
@@ -434,7 +434,7 @@ func TestSetEnvRemote(t *testing.T) {
 		groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
 		testapi.Default = testapi.Groups[input.testAPIGroup]
 		f, tf, _, ns := cmdtesting.NewAPIFactory()
-		codec := scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
+		codec := scheme.Codecs.CodecForVersions(false, scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
 		tf.Printer = printers.NewVersionedPrinter(&printers.YAMLPrinter{}, testapi.Default.Converter(), *testapi.Default.GroupVersion())
 		tf.Namespace = "test"
 		tf.CategoryExpander = categories.LegacyCategoryExpander

--- a/pkg/kubectl/cmd/set/set_image_test.go
+++ b/pkg/kubectl/cmd/set/set_image_test.go
@@ -501,7 +501,7 @@ func TestSetImageRemote(t *testing.T) {
 		groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
 		testapi.Default = testapi.Groups[input.testAPIGroup]
 		f, tf, _, ns := cmdtesting.NewAPIFactory()
-		codec := scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
+		codec := scheme.Codecs.CodecForVersions(false, scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
 		tf.Printer = printers.NewVersionedPrinter(&printers.YAMLPrinter{}, testapi.Default.Converter(), *testapi.Default.GroupVersion())
 		tf.Namespace = "test"
 		tf.CategoryExpander = categories.LegacyCategoryExpander

--- a/pkg/kubectl/cmd/set/set_serviceaccount_test.go
+++ b/pkg/kubectl/cmd/set/set_serviceaccount_test.go
@@ -314,7 +314,7 @@ func TestSetServiceAccountRemote(t *testing.T) {
 		groupVersion := schema.GroupVersion{Group: input.apiGroup, Version: input.apiVersion}
 		testapi.Default = testapi.Groups[input.testAPIGroup]
 		f, tf, _, ns := cmdtesting.NewAPIFactory()
-		codec := scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
+		codec := scheme.Codecs.CodecForVersions(false, scheme.Codecs.LegacyCodec(groupVersion), scheme.Codecs.UniversalDecoder(groupVersion), groupVersion, groupVersion)
 		tf.Printer = printers.NewVersionedPrinter(&printers.YAMLPrinter{}, testapi.Default.Converter(), *testapi.Default.GroupVersion())
 		tf.Namespace = "test"
 		tf.CategoryExpander = categories.LegacyCategoryExpander

--- a/pkg/kubectl/resource/builder_test.go
+++ b/pkg/kubectl/resource/builder_test.go
@@ -51,7 +51,7 @@ import (
 
 var (
 	corev1GV     = schema.GroupVersion{Version: "v1"}
-	corev1Codec  = scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(corev1GV), scheme.Codecs.UniversalDecoder(corev1GV), corev1GV, corev1GV)
+	corev1Codec  = scheme.Codecs.CodecForVersions(false, scheme.Codecs.LegacyCodec(corev1GV), scheme.Codecs.UniversalDecoder(corev1GV), corev1GV, corev1GV)
 	metaAccessor = meta.NewAccessor()
 	restmapper   = scheme.Registry.RESTMapper()
 )

--- a/plugin/pkg/scheduler/util/testutil.go
+++ b/plugin/pkg/scheduler/util/testutil.go
@@ -98,7 +98,7 @@ func (g TestGroup) Codec() runtime.Codec {
 	if serializer.Serializer == nil {
 		return legacyscheme.Codecs.LegacyCodec(g.externalGroupVersion)
 	}
-	return legacyscheme.Codecs.CodecForVersions(serializer.Serializer, legacyscheme.Codecs.UniversalDeserializer(), schema.GroupVersions{g.externalGroupVersion}, nil)
+	return legacyscheme.Codecs.CodecForVersions(false, serializer.Serializer, legacyscheme.Codecs.UniversalDeserializer(), schema.GroupVersions{g.externalGroupVersion}, nil)
 }
 
 // SelfLink returns a self link that will appear to be for the version Version().

--- a/staging/src/k8s.io/apimachinery/pkg/api/testing/codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/testing/codec.go
@@ -40,7 +40,7 @@ func TestCodec(codecs runtimeserializer.CodecFactory, gvs ...schema.GroupVersion
 		if !ok {
 			panic(fmt.Sprintf("no serializer for %s", testCodecMediaType))
 		}
-		return codecs.CodecForVersions(serializerInfo.Serializer, codecs.UniversalDeserializer(), schema.GroupVersions(gvs), nil)
+		return codecs.CodecForVersions(false, serializerInfo.Serializer, codecs.UniversalDeserializer(), schema.GroupVersions(gvs), nil)
 	}
 	return codecs.LegacyCodec(gvs...)
 }
@@ -62,7 +62,7 @@ func TestStorageCodec(codecs runtimeserializer.CodecFactory, gvs ...schema.Group
 		}
 
 		decoder := recognizer.NewDecoder(serializer, codecs.UniversalDeserializer())
-		return codecs.CodecForVersions(serializer, decoder, schema.GroupVersions(gvs), nil)
+		return codecs.CodecForVersions(true, serializer, decoder, schema.GroupVersions(gvs), nil)
 
 	}
 	return codecs.LegacyCodec(gvs...)

--- a/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/testing/roundtrip/roundtrip.go
@@ -220,7 +220,7 @@ func roundTripToAllExternalVersions(t *testing.T, scheme *runtime.Scheme, codecF
 		// TODO remove this hack after we're past the intermediate steps
 		if !skipProtobuf && externalGVK.Group != "kubeadm.k8s.io" {
 			s := protobuf.NewSerializer(scheme, scheme, "application/arbitrary.content.type")
-			protobufCodec := codecFactory.CodecForVersions(s, s, externalGVK.GroupVersion(), nil)
+			protobufCodec := codecFactory.CodecForVersions(false, s, s, externalGVK.GroupVersion(), nil)
 			roundTrip(t, scheme, protobufCodec, object)
 		}
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -124,8 +124,13 @@ type NegotiatedSerializer interface {
 	// serializer are in the provided group version.
 	EncoderForVersion(serializer Encoder, gv GroupVersioner) Encoder
 	// DecoderForVersion returns a decoder that ensures objects being read by the provided
-	// serializer are in the provided group version by default.
+	// serializer are in the provided group version by default. It will not set defaults.
 	DecoderToVersion(serializer Decoder, gv GroupVersioner) Decoder
+	// DecoderForVersionWithDefaults returns a decoder that ensures objects being read by the provided
+	// serializer are in the provided group version by default. It also sets defaults prior to performing
+	// conversion.
+	// TODO: this method is deprecated and will be removed when the server splits out defaulting from decoding
+	DecoderToVersionWithDefaults(serializer Decoder, gv GroupVersioner) Decoder
 }
 
 // StorageSerializer is an interface used for obtaining encoders, decoders, and serializers
@@ -145,6 +150,11 @@ type StorageSerializer interface {
 	// DecoderForVersion returns a decoder that ensures objects being read by the provided
 	// serializer are in the provided group version by default.
 	DecoderToVersion(serializer Decoder, gv GroupVersioner) Decoder
+	// DecoderForVersionWithDefaults returns a decoder that ensures objects being read by the provided
+	// serializer are in the provided group version by default. It also sets defaults prior to performing
+	// conversion.
+	// TODO: this method is deprecated and will be removed when the server splits out defaulting from decoding
+	DecoderToVersionWithDefaults(serializer Decoder, gv GroupVersioner) Decoder
 }
 
 // NestedObjectEncoder is an optional interface that objects may implement to be given

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
@@ -149,7 +149,7 @@ func TestVersionedEncoding(t *testing.T) {
 	info, _ := runtime.SerializerInfoForMediaType(cf.SupportedMediaTypes(), runtime.ContentTypeJSON)
 	encoder := info.Serializer
 
-	codec := cf.CodecForVersions(encoder, nil, schema.GroupVersion{Version: "v2"}, nil)
+	codec := cf.CodecForVersions(false, encoder, nil, schema.GroupVersion{Version: "v2"}, nil)
 	out, err := runtime.Encode(codec, &serializertesting.TestType1{})
 	if err != nil {
 		t.Fatal(err)
@@ -158,14 +158,14 @@ func TestVersionedEncoding(t *testing.T) {
 		t.Fatal(string(out))
 	}
 
-	codec = cf.CodecForVersions(encoder, nil, schema.GroupVersion{Version: "v3"}, nil)
+	codec = cf.CodecForVersions(false, encoder, nil, schema.GroupVersion{Version: "v3"}, nil)
 	_, err = runtime.Encode(codec, &serializertesting.TestType1{})
 	if err == nil {
 		t.Fatal(err)
 	}
 
 	// unversioned encode with no versions is written directly to wire
-	codec = cf.CodecForVersions(encoder, nil, runtime.InternalGroupVersioner, nil)
+	codec = cf.CodecForVersions(false, encoder, nil, runtime.InternalGroupVersioner, nil)
 	out, err = runtime.Encode(codec, &serializertesting.TestType1{})
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/negotiated_codec.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/negotiated_codec.go
@@ -20,8 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// TODO: We should split negotiated serializers that we can change versions on from those we can change
-// serialization formats on
+// TODO: this interface needs to be removed and replaced with a concrete type.
 type negotiatedSerializerWrapper struct {
 	info runtime.SerializerInfo
 }
@@ -39,5 +38,9 @@ func (n *negotiatedSerializerWrapper) EncoderForVersion(e runtime.Encoder, _ run
 }
 
 func (n *negotiatedSerializerWrapper) DecoderToVersion(d runtime.Decoder, _gv runtime.GroupVersioner) runtime.Decoder {
+	return d
+}
+
+func (n *negotiatedSerializerWrapper) DecoderToVersionWithDefaults(d runtime.Decoder, _gv runtime.GroupVersioner) runtime.Decoder {
 	return d
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -66,7 +66,7 @@ func createHandler(r rest.NamedCreater, scope RequestScope, typer runtime.Object
 			scope.err(err, w, req)
 			return
 		}
-		decoder := scope.Serializer.DecoderToVersion(s.Serializer, schema.GroupVersion{Group: gv.Group, Version: runtime.APIVersionInternal})
+		decoder := scope.Serializer.DecoderToVersionWithDefaults(s.Serializer, schema.GroupVersion{Group: gv.Group, Version: runtime.APIVersionInternal})
 
 		body, err := readBody(req)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -64,7 +64,7 @@ func UpdateResource(r rest.Updater, scope RequestScope, typer runtime.ObjectType
 		defaultGVK := scope.Kind
 		original := r.New()
 		trace.Step("About to convert to expected version")
-		decoder := scope.Serializer.DecoderToVersion(s.Serializer, schema.GroupVersion{Group: defaultGVK.Group, Version: runtime.APIVersionInternal})
+		decoder := scope.Serializer.DecoderToVersionWithDefaults(s.Serializer, schema.GroupVersion{Group: defaultGVK.Group, Version: runtime.APIVersionInternal})
 		obj, gvk, err := decoder.Decode(body, &defaultGVK, original)
 		if err != nil {
 			err = transformDecodeError(typer, err, original, gvk, body)

--- a/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/storage/storage_codec.go
@@ -95,7 +95,7 @@ func NewStorageCodec(opts StorageCodecConfig) (runtime.Codec, error) {
 			schema.GroupKind{Group: opts.MemoryVersion.Group},
 		),
 	)
-	decoder := opts.StorageSerializer.DecoderToVersion(
+	decoder := opts.StorageSerializer.DecoderToVersionWithDefaults(
 		recognizer.NewDecoder(decoders...),
 		runtime.NewMultiGroupVersioner(
 			opts.MemoryVersion,

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -172,8 +172,11 @@ type ContentConfig struct {
 	ContentType string
 	// GroupVersion is the API version to talk to. Must be provided when initializing
 	// a RESTClient directly. When initializing a Client, will be set with the default
-	// code version.
+	// codec version. This field controls the version the object is written to.
 	GroupVersion *schema.GroupVersion
+	// DecodeToInternal supports translating the object (if the serializer supports it)
+	// to the internal version when retrieving objects. It defaults to false.
+	DecodeToInternal bool
 	// NegotiatedSerializer is used for obtaining encoders and decoders for multiple
 	// supported media types.
 	NegotiatedSerializer runtime.NegotiatedSerializer


### PR DESCRIPTION
Starts to help split decoding, conversion, and defaulting up into the necessary pieces.

Basically, server side we want to control the pipeline of how objects come in:

1. get off wire
2. perform defaulting
3. perform object meta defaulting
4. convert to internal
5. run admission control pipeline
6. pass to storage interfaces

We only need to apply defaulting when retrieving objects from stable storage or as part of a client api call:

1. from etcd
2. off the wire when an API handles it (above)
3. from a config file on disk for things like kubectl, kube-apiserver, etc
4. in test cases when priming data that appears to come from the server

For 1, the storage codec is created in one place and is easy to stack.  That code path could just do a wrapper defaulting (deserialize, default, then convert) and be ok.
For 2, we want to decompose the pipeline, and don't care about stacking
For 3, we can probably call defaulting directly, or have a simpler serializer wrapper (`DecodeAndDefault(..., object defaulter)`)
For 4, that's going to be ugly, but it's probably tractable

Everyone else either wants

1. unstructured (basic codec)
2. versioned types (scheme and serializer)
3. internal types (scheme, serializer, and converter)

The one wrinkle is encoding - a function of the codec is to set GVK based on two factors - the type the user passed, plus a preferred version.  Ideally we can just make this a simple wrapper (set GVK).  The other complex bits in versioned codecs can probably be dropped (things like runtime.VersionedObjects) as we have better solutions in place now.