### PR TITLE
 pkg/volume: Improve CanMount checks 

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -65,15 +65,15 @@ var _ volume.Provisioner = &glusterfsVolumeProvisioner{}
 var _ volume.Deleter = &glusterfsVolumeDeleter{}
 
 const (
-	glusterfsPluginName            = "kubernetes.io/glusterfs"
-	volPrefix                      = "vol_"
-	dynamicEpSvcPrefix             = "glusterfs-dynamic-"
-	replicaCount                   = 3
-	durabilityType                 = "replicate"
-	secretKeyName                  = "key" // key name used in secret
-	gciLinuxGlusterMountBinaryPath = "/sbin/mount.glusterfs"
-	defaultGidMin                  = 2000
-	defaultGidMax                  = math.MaxInt32
+	glusterfsPluginName    = "kubernetes.io/glusterfs"
+	volPrefix              = "vol_"
+	dynamicEpSvcPrefix     = "glusterfs-dynamic-"
+	replicaCount           = 3
+	durabilityType         = "replicate"
+	secretKeyName          = "key" // key name used in secret
+	glusterMountBinaryPath = "/sbin/mount.glusterfs"
+	defaultGidMin          = 2000
+	defaultGidMax          = math.MaxInt32
 	// absoluteGidMin/Max are currently the same as the
 	// default values, but they play a different role and
 	// could take a different value. Only thing we need is:
@@ -242,8 +242,8 @@ func (b *glusterfsMounter) GetAttributes() volume.Attributes {
 func (b *glusterfsMounter) CanMount() error {
 	switch runtime.GOOS {
 	case "linux":
-		if _, err := os.Stat(gciLinuxGlusterMountBinaryPath); err != nil {
-			return fmt.Errorf("required binary %s not found: %v", gciLinuxGlusterMountBinaryPath, err)
+		if _, err := os.Stat(glusterMountBinaryPath); err != nil {
+			return fmt.Errorf("required binary %s not found: %v", glusterMountBinaryPath, err)
 		}
 	default:
 		return fmt.Errorf("unable to determine if glusterfs mounts are available on %s", runtime.GOOS)

--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -240,12 +240,13 @@ func (b *glusterfsMounter) GetAttributes() volume.Attributes {
 // to mount the volume are available on the underlying node.
 // If not, it returns an error
 func (b *glusterfsMounter) CanMount() error {
-	exe := b.plugin.host.GetExec(b.plugin.GetPluginName())
 	switch runtime.GOOS {
 	case "linux":
-		if _, err := exe.Run("/bin/ls", gciLinuxGlusterMountBinaryPath); err != nil {
-			return fmt.Errorf("Required binary %s is missing", gciLinuxGlusterMountBinaryPath)
+		if _, err := os.Stat(gciLinuxGlusterMountBinaryPath); err != nil {
+			return fmt.Errorf("required binary %s not found: %v", gciLinuxGlusterMountBinaryPath, err)
 		}
+	default:
+		return fmt.Errorf("unable to determine if glusterfs mounts are available on %s", runtime.GOOS)
 	}
 	return nil
 }

--- a/pkg/volume/quobyte/quobyte.go
+++ b/pkg/volume/quobyte/quobyte.go
@@ -102,13 +102,13 @@ func (plugin *quobytePlugin) CanSupport(spec *volume.Spec) bool {
 		glog.V(4).Infof("quobyte: Error: %v", err)
 	}
 
-	exec := plugin.host.GetExec(plugin.GetPluginName())
-	if out, err := exec.Run("ls", "/sbin/mount.quobyte"); err == nil {
-		glog.V(4).Infof("quobyte: can support: %s", string(out))
-		return true
+	stat, err := os.Stat("/sbin/mount.quobyte")
+	if err != nil {
+		glog.Warningf("quobyte support not available; could not find '/sbin/mount.quobyte': %v", err)
+		return false
 	}
-
-	return false
+	glog.V(4).Infof("quobyte: can support: %s", stat.Name())
+	return true
 }
 
 func (plugin *quobytePlugin) RequiresRemount() bool {


### PR DESCRIPTION
Go is able to stat files perfectly well without forking off 'ls'.

In addition, it was falling-through to return nil for unrecognized
GOOSs.

I also made a few minor logging and naming cleanups.

cc @rkouj since this is updating your code from #36280