### PR TITLE
KubeletConfiguration.BaseConfig.ClusterDNS defaults to the tenth address of MasterConfiguration.Networking.ServiceSubnet

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	kubeletconfigv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1alpha1"
 	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
@@ -163,7 +162,7 @@ func SetDefaults_KubeletConfiguration(obj *MasterConfiguration) {
 		obj.KubeletConfiguration.BaseConfig.AllowPrivileged = utilpointer.BoolPtr(true)
 	}
 	if obj.KubeletConfiguration.BaseConfig.ClusterDNS == nil {
-		dnsIP, err := dns.GetDNSIP(obj.Networking.ServiceSubnet)
+		dnsIP, err := constants.GetDNSIP(obj.Networking.ServiceSubnet)
 		if err != nil {
 			obj.KubeletConfiguration.BaseConfig.ClusterDNS = []string{DefaultClusterDNSIP}
 		} else {

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	"k8s.io/kubernetes/cmd/kubeadm/app/phases/addons/dns"
 	kubeletconfigv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1alpha1"
 	utilpointer "k8s.io/kubernetes/pkg/util/pointer"
 )
@@ -162,7 +163,12 @@ func SetDefaults_KubeletConfiguration(obj *MasterConfiguration) {
 		obj.KubeletConfiguration.BaseConfig.AllowPrivileged = utilpointer.BoolPtr(true)
 	}
 	if obj.KubeletConfiguration.BaseConfig.ClusterDNS == nil {
-		obj.KubeletConfiguration.BaseConfig.ClusterDNS = []string{DefaultClusterDNSIP}
+		dnsIP, err := dns.GetDNSIP(obj.Networking.ServiceSubnet)
+		if err != nil {
+			obj.KubeletConfiguration.BaseConfig.ClusterDNS = []string{DefaultClusterDNSIP}
+		} else {
+			obj.KubeletConfiguration.BaseConfig.ClusterDNS = []string{dnsIP.String()}
+		}
 	}
 	if obj.KubeletConfiguration.BaseConfig.ClusterDomain == "" {
 		obj.KubeletConfiguration.BaseConfig.ClusterDomain = DefaultServiceDNSDomain

--- a/cmd/kubeadm/app/constants/BUILD
+++ b/cmd/kubeadm/app/constants/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = ["constants.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/constants",
     deps = [
+        "//pkg/registry/core/service/ipallocator:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/addons/dns/BUILD
+++ b/cmd/kubeadm/app/phases/addons/dns/BUILD
@@ -41,7 +41,6 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/registry/core/service/ipallocator:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -18,7 +18,6 @@ package dns
 
 import (
 	"fmt"
-	"net"
 	"runtime"
 
 	apps "k8s.io/api/apps/v1beta2"
@@ -34,7 +33,6 @@ import (
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
-	"k8s.io/kubernetes/pkg/registry/core/service/ipallocator"
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
@@ -60,7 +58,7 @@ func kubeDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interfac
 		return err
 	}
 
-	dnsip, err := GetDNSIP(cfg.Networking.ServiceSubnet)
+	dnsip, err := kubeadmconstants.GetDNSIP(cfg.Networking.ServiceSubnet)
 	if err != nil {
 		return err
 	}
@@ -149,7 +147,7 @@ func coreDNSAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Interfac
 		return fmt.Errorf("error when parsing CoreDNS configMap template: %v", err)
 	}
 
-	dnsip, err := GetDNSIP(cfg.Networking.ServiceSubnet)
+	dnsip, err := kubeadmconstants.GetDNSIP(cfg.Networking.ServiceSubnet)
 	if err != nil {
 		return err
 	}
@@ -243,22 +241,4 @@ func createDNSService(dnsService *v1.Service, serviceBytes []byte, client client
 		}
 	}
 	return nil
-}
-
-// GetDNSIP returns a dnsIP, which is 10th IP in svcSubnet CIDR range
-func GetDNSIP(svcSubnet string) (net.IP, error) {
-
-	// Get the service subnet CIDR
-	_, svcSubnetCIDR, err := net.ParseCIDR(svcSubnet)
-	if err != nil {
-		return nil, fmt.Errorf("couldn't parse service subnet CIDR %q: %v", svcSubnet, err)
-	}
-
-	// Selects the 10th IP in service subnet CIDR range as dnsIP
-	dnsIP, err := ipallocator.GetIndexedIP(svcSubnetCIDR, 10)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get tenth IP address from service subnet CIDR %s: %v", svcSubnetCIDR.String(), err)
-	}
-
-	return dnsIP, nil
 }

--- a/cmd/kubeadm/app/phases/addons/dns/dns_test.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
+	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -159,7 +160,7 @@ func TestGetDNSIP(t *testing.T) {
 		},
 	}
 	for _, rt := range tests {
-		dnsIP, err := GetDNSIP(rt.svcSubnet)
+		dnsIP, err := kubeadmconstants.GetDNSIP(rt.svcSubnet)
 		if err != nil {
 			t.Fatalf("couldn't get dnsIP : %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If can get DNS IP from MasterConfiguration.Networking.ServiceSubnet, defaults to it. Otherwise defaults to DefaultClusterDNSIP

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref: https://github.com/kubernetes/kubeadm/issues/28#issuecomment-345502933

**Special notes for your reviewer**:
/cc @luxas 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
