### PR TITLE
kubeadm: Fix a small bug in the self-hosting code

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting.go
@@ -141,6 +141,9 @@ func BuildDaemonSet(name string, podSpec *v1.PodSpec, mutators map[string][]PodS
 			Labels:    BuildSelfhostedComponentLabels(name),
 		},
 		Spec: apps.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: BuildSelfhostedComponentLabels(name),
+			},
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: BuildSelfhostedComponentLabels(name),

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -113,6 +113,9 @@ metadata:
   name: self-hosted-kube-apiserver
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: self-hosted-kube-apiserver
   template:
     metadata:
       creationTimestamp: null
@@ -271,6 +274,9 @@ metadata:
   name: self-hosted-kube-controller-manager
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: self-hosted-kube-controller-manager
   template:
     metadata:
       creationTimestamp: null
@@ -398,6 +404,9 @@ metadata:
   name: self-hosted-kube-scheduler
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: self-hosted-kube-scheduler
   template:
     metadata:
       creationTimestamp: null


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`apps/v1beta2` requires that `DaemonSet.spec.selector.matchLabels` equals `DaemonSet.spec.template.metadata.labels`. Without this change, the API server rejects the DaemonSet in the validation stage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews @xiangpengzhao 