### PR TITLE
Automatically opt into dependent feature gates when using kubeadm

### DIFF
--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -155,5 +155,22 @@ func NewFeatureGate(f *FeatureList, value string) (map[string]bool, error) {
 		featureGate[k] = boolValue
 	}
 
+	ResolveFeatureGateDependencies(featureGate)
+
 	return featureGate, nil
+}
+
+// ResolveFeatureGateDependencies resolve dependencies between feature gates
+func ResolveFeatureGateDependencies(featureGate map[string]bool) {
+
+	// if StoreCertsInSecrets enabled, SelfHosting should enabled
+	if Enabled(featureGate, StoreCertsInSecrets) {
+		featureGate[SelfHosting] = true
+	}
+
+	// if HighAvailability enabled, both StoreCertsInSecrets and SelfHosting should enabled
+	if Enabled(featureGate, HighAvailability) && !Enabled(featureGate, StoreCertsInSecrets) {
+		featureGate[SelfHosting] = true
+		featureGate[StoreCertsInSecrets] = true
+	}
 }

--- a/cmd/kubeadm/app/features/features_test.go
+++ b/cmd/kubeadm/app/features/features_test.go
@@ -156,3 +156,36 @@ func TestValidateVersion(t *testing.T) {
 		}
 	}
 }
+
+func TestResolveFeatureGateDependencies(t *testing.T) {
+
+	var tests = []struct {
+		inputFeatures    map[string]bool
+		expectedFeatures map[string]bool
+	}{
+		{ // no flags
+			inputFeatures:    map[string]bool{},
+			expectedFeatures: map[string]bool{},
+		},
+		{ // others flags
+			inputFeatures:    map[string]bool{"SupportIPVSProxyMode": true},
+			expectedFeatures: map[string]bool{"SupportIPVSProxyMode": true},
+		},
+		{ // just StoreCertsInSecrets flags
+			inputFeatures:    map[string]bool{"StoreCertsInSecrets": true},
+			expectedFeatures: map[string]bool{"StoreCertsInSecrets": true, "SelfHosting": true},
+		},
+		{ // just HighAvailability flags
+			inputFeatures:    map[string]bool{"HighAvailability": true},
+			expectedFeatures: map[string]bool{"HighAvailability": true, "StoreCertsInSecrets": true, "SelfHosting": true},
+		},
+	}
+
+	for _, test := range tests {
+		ResolveFeatureGateDependencies(test.inputFeatures)
+		if !reflect.DeepEqual(test.inputFeatures, test.expectedFeatures) {
+			t.Errorf("ResolveFeatureGateDependencies failed, expected: %v, got: %v", test.inputFeatures, test.expectedFeatures)
+
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
There will be a dependency chain between  feature gates.  kubeadm needs to automatically opt into dependent feature gates of a chosen one.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # [https://github.com/kubernetes/kubeadm/issues/554](https://github.com/kubernetes/kubeadm/issues/554)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
