### PR TITLE
Fix getting logs from daemonset

### DIFF
--- a/pkg/kubectl/cmd/util/factory_object_mapping.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping.go
@@ -248,6 +248,13 @@ func (f *ring1Factory) LogsForObject(object, options runtime.Object, timeout tim
 			return nil, fmt.Errorf("invalid label selector: %v", err)
 		}
 
+	case *extensions.DaemonSet:
+		namespace = t.Namespace
+		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label selector: %v", err)
+		}
+
 	case *batch.Job:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
@@ -340,6 +347,12 @@ func (f *ring1Factory) AttachablePodForObject(object runtime.Object, timeout tim
 		selector = labels.SelectorFromSet(t.Spec.Selector)
 
 	case *apps.StatefulSet:
+		namespace = t.Namespace
+		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
+		if err != nil {
+			return nil, fmt.Errorf("invalid label selector: %v", err)
+		}
+	case *extensions.DaemonSet:
 		namespace = t.Namespace
 		selector, err = metav1.LabelSelectorAsSelector(t.Spec.Selector)
 		if err != nil {


### PR DESCRIPTION
This PR fixes getting logs from DaemonSets. Currently:

```
→ kubectl logs ds/ds-test
error: cannot get the logs from apps/__internal, Kind=DaemonSet
```

```release-note
NONE
```