### PR TITLE
apiextensions: fix object keys in fuzzer to exclude escape characters

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/fuzzer/fuzzer.go
@@ -58,8 +58,24 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 					case reflect.Interface, reflect.Map, reflect.Slice, reflect.Ptr:
 						isValue = false
 					}
-					if isValue || c.Intn(5) == 0 {
+					if isValue || c.Intn(10) == 0 {
 						c.Fuzz(vobj.Field(i).Addr().Interface())
+
+						// JSON keys must not contain escape char with our JSON codec (jsoniter)
+						// TODO: remove this when/if we moved from jsoniter.ConfigFastest to ConfigCompatibleWithStandardLibrary
+						if field.Type.Kind() == reflect.Map {
+							keys := append([]reflect.Value(nil), vobj.Field(i).MapKeys()...)
+							for _, k := range keys {
+								stripped := toJSONString(k.String())
+								if stripped == k.String() {
+									continue
+								}
+								// set new key
+								vobj.Field(i).SetMapIndex(reflect.ValueOf(stripped), vobj.Field(i).MapIndex(k))
+								// remove old
+								vobj.Field(i).SetMapIndex(k, reflect.Value{})
+							}
+						}
 					}
 				}
 			}
@@ -108,4 +124,14 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 		},
 	}
+}
+
+func toJSONString(s string) string {
+	return strings.Map(func(r rune) rune {
+		// replace chars which are not supported in keys by jsoniter.ConfigFastest
+		if r == '\\' || r == '"' {
+			return 'x'
+		}
+		return r
+	}, s)
 }


### PR DESCRIPTION
Jsoniter in ConfigFastest mode does not support escape characters in object keys. Hence, we have to fix this after the fuzzer chose invalid keys.

This might be only an intermediate fix if we decide to accept arbitrary object keys again. But for now, with the choice of `ConfigFastest` (https://github.com/json-iterator/go/blob/f1258b01aa14930fff5c6b9b09fe9b4614359472/feature_config.go#L66) this change is necessary.