### PR TITLE
[addons] Add PodDisruptionBudget for kube-dns pods

### DIFF
--- a/cluster/addons/dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns.yaml.base
@@ -56,6 +56,19 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/cluster/addons/dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns.yaml.in
@@ -56,6 +56,19 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/cluster/addons/dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns.yaml.sed
@@ -56,6 +56,19 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 ---
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: kube-dns
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:


### PR DESCRIPTION
### What this PR does / why we need it**:

####

When scaling in a node pool, the `cluster-autoscaler` can potentially remove all nodes on which `kube-dns` pods reside... at once. 

It happened in one of our clusters this morning and resulted in a 1-2 minutes downtime (only thanks to Kubernetes' ability to reschedule these pods on other nodes really fast), but it's something we'd love to avoid in the future :)

##### Details
We're deploying `kubernetes` atop AWS with `kops`. One of our instance groups is dedicated to asynchronous batch jobs and is scaled in&out pretty often. If all `kube-dns` pods are relocated to this instance group, they might end up being deleted at the same time, which happened for us. 

Adding taints to all our "batch" nodes (and tolerations to all pods supposed to run on it) to prevent `kube-dns` pods from landing here would work as well but is sort of cumbersome. 

In addition, this little improvement should also prevent `kube-dns` from becoming unavailable when upgrading an instance group in a rolling-upgrade fashion (providing that the rolling upgrade process drains nodes before deleting them ofc.).

### How this PR addresses the issue

Since Kubernetes 1.6, the `cluster-autoscaler` [is supposed to support](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#does-ca-work-with-poddisruptionbudget-in-scale-down) `PodDisruptionBudget`s when scaling down. Therefore, adding such a PDB for `kube-dns` felt like a good idea: `kube-dns` is typically the kind of service Kubernetes users  expect to be available :)

##### Drawbacks
If only one `kube-dns` pod exist, `kubectl drain`ing the node on which it resides will wait forever (actually not forever, but it will be required that the user manually evicts the `kube-dns` pod. I don't think it's a big issue:
 * Most people deploy at least 2 `kube-dns` replicas on production clusters
 * Having `kubectl drain` be stalled until the administrator deletes the `kube-dns` pod manually isn't as problematic as having unexpected downtime, in my opinion :)

### Release note:
```release-note
[addons][kube-dns] Add PodDisruptionBudget on kube-dns pods to prevent kube-dns downtime
```

Thanks for the review :)