### PR TITLE
Remove kubeadm fuzzer from api testing

### DIFF
--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -16,7 +16,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/api/testing",
     deps = [
-        "//cmd/kubeadm/app/apis/kubeadm/fuzzer:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/admissionregistration/fuzzer:go_default_library",
         "//pkg/apis/apps/fuzzer:go_default_library",

--- a/pkg/api/testing/fuzzer.go
+++ b/pkg/api/testing/fuzzer.go
@@ -27,7 +27,6 @@ import (
 	genericfuzzer "k8s.io/apimachinery/pkg/apis/meta/fuzzer"
 	"k8s.io/apimachinery/pkg/runtime"
 	runtimeserializer "k8s.io/apimachinery/pkg/runtime/serializer"
-	kubeadmfuzzer "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/fuzzer"
 	admissionregistrationfuzzer "k8s.io/kubernetes/pkg/apis/admissionregistration/fuzzer"
 	appsfuzzer "k8s.io/kubernetes/pkg/apis/apps/fuzzer"
 	autoscalingfuzzer "k8s.io/kubernetes/pkg/apis/autoscaling/fuzzer"
@@ -98,7 +97,6 @@ var FuzzerFuncs = fuzzer.MergeFuzzerFuncs(
 	batchfuzzer.Funcs,
 	autoscalingfuzzer.Funcs,
 	rbacfuzzer.Funcs,
-	kubeadmfuzzer.Funcs,
 	policyfuzzer.Funcs,
 	certificatesfuzzer.Funcs,
 	admissionregistrationfuzzer.Funcs,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
from @sttts https://github.com/kubernetes/kubernetes/pull/55961#discussion_r151926499
>Please only add fuzzer for apiserver types here, not for configs only used locally. Look for roundtrip_test.go files in the code-base. There are some more which have local fuzzers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
ref: https://github.com/kubernetes/kubernetes/pull/55961#discussion_r151926499

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
