### PR TITLE
Implement individual control for kubeadm preflight checks

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//pkg/registry/core/service/ipallocator:go_default_library",
         "//pkg/util/node:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],

--- a/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
+++ b/cmd/kubeadm/app/apis/kubeadm/validation/validation.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/pflag"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -289,7 +290,7 @@ func ValidateMixedArguments(flag *pflag.FlagSet) error {
 
 	mixedInvalidFlags := []string{}
 	flag.Visit(func(f *pflag.Flag) {
-		if f.Name == "config" || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" {
+		if f.Name == "config" || strings.HasPrefix(f.Name, "ignore-checks-") || strings.HasPrefix(f.Name, "skip-") || f.Name == "dry-run" || f.Name == "kubeconfig" {
 			// "--skip-*" flags or other whitelisted flags can be set with --config
 			return
 		}
@@ -327,4 +328,28 @@ func ValidateAPIEndpoint(c *kubeadm.MasterConfiguration, fldPath *field.Path) fi
 		allErrs = append(allErrs, field.Invalid(fldPath, endpoint, "Invalid API Endpoint"))
 	}
 	return allErrs
+}
+
+// ValidateIgnoreChecksErrors validates duplicates in ignore-checks-errors flag.
+func ValidateIgnoreChecksErrors(ignoreChecksErrors []string, skipPreflightChecks bool) (sets.String, error) {
+	ignoreErrors := sets.NewString()
+	allErrs := field.ErrorList{}
+
+	for _, item := range ignoreChecksErrors {
+		ignoreErrors.Insert(strings.ToLower(item)) // parameters are case insensitive
+	}
+
+	// TODO: remove once deprecated flag --skip-preflight-checks is removed.
+	if skipPreflightChecks {
+		if ignoreErrors.Has("all") {
+			allErrs = append(allErrs, field.Invalid(field.NewPath("ignore-checks-errors"), strings.Join(ignoreErrors.List(), ","), "'all' is used together with deprecated flag --skip-preflight-checks. Remove deprecated flag"))
+		}
+		ignoreErrors.Insert("all")
+	}
+
+	if ignoreErrors.Has("all") && ignoreErrors.Len() > 1 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("ignore-checks-errors"), strings.Join(ignoreErrors.List(), ","), "don't specify individual checks if 'all' is used"))
+	}
+
+	return ignoreErrors, allErrs.ToAggregate()
 }

--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -29,6 +29,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	certutil "k8s.io/client-go/util/cert"
@@ -110,6 +111,7 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 	var cfgPath string
 	var criSocket string
 	var featureGatesString string
+	var ignoreChecksErrors []string
 
 	cmd := &cobra.Command{
 		Use:   "join [flags]",
@@ -127,7 +129,10 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 			internalcfg := &kubeadmapi.NodeConfiguration{}
 			legacyscheme.Scheme.Convert(cfg, internalcfg, nil)
 
-			j, err := NewJoin(cfgPath, args, internalcfg, skipPreFlight, criSocket)
+			ignoreChecksErrorsSet, err := validation.ValidateIgnoreChecksErrors(ignoreChecksErrors, skipPreFlight)
+			kubeadmutil.CheckErr(err)
+
+			j, err := NewJoin(cfgPath, args, internalcfg, ignoreChecksErrorsSet, criSocket)
 			kubeadmutil.CheckErr(err)
 			kubeadmutil.CheckErr(j.Validate(cmd))
 			kubeadmutil.CheckErr(j.Run(out))
@@ -135,7 +140,7 @@ func NewCmdJoin(out io.Writer) *cobra.Command {
 	}
 
 	AddJoinConfigFlags(cmd.PersistentFlags(), cfg, &featureGatesString)
-	AddJoinOtherFlags(cmd.PersistentFlags(), &cfgPath, &skipPreFlight, &criSocket)
+	AddJoinOtherFlags(cmd.PersistentFlags(), &cfgPath, &skipPreFlight, &criSocket, &ignoreChecksErrors)
 
 	return cmd
 }
@@ -170,15 +175,20 @@ func AddJoinConfigFlags(flagSet *flag.FlagSet, cfg *kubeadmapiext.NodeConfigurat
 }
 
 // AddJoinOtherFlags adds join flags that are not bound to a configuration file to the given flagset
-func AddJoinOtherFlags(flagSet *flag.FlagSet, cfgPath *string, skipPreFlight *bool, criSocket *string) {
+func AddJoinOtherFlags(flagSet *flag.FlagSet, cfgPath *string, skipPreFlight *bool, criSocket *string, ignoreChecksErrors *[]string) {
 	flagSet.StringVar(
 		cfgPath, "config", *cfgPath,
 		"Path to kubeadm config file.")
 
+	flagSet.StringSliceVar(
+		ignoreChecksErrors, "ignore-checks-errors", *ignoreChecksErrors,
+		"A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.",
+	)
 	flagSet.BoolVar(
 		skipPreFlight, "skip-preflight-checks", false,
 		"Skip preflight checks which normally run before modifying the system.",
 	)
+	flagSet.MarkDeprecated("skip-preflight-checks", "it is now equivalent to --ignore-checks-errors=all")
 	flagSet.StringVar(
 		criSocket, "cri-socket", "/var/run/dockershim.sock",
 		`Specify the CRI socket to connect to.`,
@@ -191,7 +201,7 @@ type Join struct {
 }
 
 // NewJoin instantiates Join struct with given arguments
-func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, skipPreFlight bool, criSocket string) (*Join, error) {
+func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, ignoreChecksErrors sets.String, criSocket string) (*Join, error) {
 	fmt.Println("[kubeadm] WARNING: kubeadm is currently in beta")
 
 	if cfg.NodeName == "" {
@@ -208,19 +218,15 @@ func NewJoin(cfgPath string, args []string, cfg *kubeadmapi.NodeConfiguration, s
 		}
 	}
 
-	if !skipPreFlight {
-		fmt.Println("[preflight] Running pre-flight checks.")
+	fmt.Println("[preflight] Running pre-flight checks.")
 
-		// Then continue with the others...
-		if err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, criSocket); err != nil {
-			return nil, err
-		}
-
-		// Try to start the kubelet service in case it's inactive
-		preflight.TryStartKubelet()
-	} else {
-		fmt.Println("[preflight] Skipping pre-flight checks.")
+	// Then continue with the others...
+	if err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, criSocket, ignoreChecksErrors); err != nil {
+		return nil, err
 	}
+
+	// Try to start the kubelet service in case it's inactive
+	preflight.TryStartKubelet(ignoreChecksErrors)
 
 	return &Join{cfg: cfg}, nil
 }

--- a/cmd/kubeadm/app/cmd/phases/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/normalizer:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/cmd/kubeadm/app/cmd/phases/preflight.go
+++ b/cmd/kubeadm/app/cmd/phases/preflight.go
@@ -19,6 +19,7 @@ package phases
 import (
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/preflight"
@@ -70,7 +71,7 @@ func NewCmdPreFlightMaster() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := &kubeadmapi.MasterConfiguration{}
 			criSocket := ""
-			err := preflight.RunInitMasterChecks(utilsexec.New(), cfg, criSocket)
+			err := preflight.RunInitMasterChecks(utilsexec.New(), cfg, criSocket, sets.NewString())
 			kubeadmutil.CheckErr(err)
 		},
 	}
@@ -88,7 +89,7 @@ func NewCmdPreFlightNode() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := &kubeadmapi.NodeConfiguration{}
 			criSocket := ""
-			err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, criSocket)
+			err := preflight.RunJoinNodeChecks(utilsexec.New(), cfg, criSocket, sets.NewString())
 			kubeadmutil.CheckErr(err)
 		},
 	}

--- a/cmd/kubeadm/app/cmd/reset_test.go
+++ b/cmd/kubeadm/app/cmd/reset_test.go
@@ -195,6 +195,10 @@ func (c *fakeDockerChecker) Check() (warnings, errors []error) {
 	return c.warnings, c.errors
 }
 
+func (c *fakeDockerChecker) Name() string {
+	return "FakeDocker"
+}
+
 func newFakeDockerChecker(warnings, errors []error) preflight.Checker {
 	return &fakeDockerChecker{warnings: warnings, errors: errors}
 }

--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/apis/kubeadm/v1alpha1:go_default_library",
+        "//cmd/kubeadm/app/apis/kubeadm/validation:go_default_library",
         "//cmd/kubeadm/app/cmd/util:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/controlplane:go_default_library",
@@ -27,6 +28,7 @@ go_library(
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/ghodss/yaml:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],

--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -25,6 +25,7 @@ import (
 
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/controlplane"
@@ -70,8 +71,12 @@ func NewCmdApply(parentFlags *cmdUpgradeFlags) *cobra.Command {
 		Use:   "apply [version]",
 		Short: "Upgrade your Kubernetes cluster to the specified version.",
 		Run: func(cmd *cobra.Command, args []string) {
+			var err error
+			flags.parent.ignoreChecksErrorsSet, err = validation.ValidateIgnoreChecksErrors(flags.parent.ignoreChecksErrors, flags.parent.skipPreFlight)
+			kubeadmutil.CheckErr(err)
+
 			// Ensure the user is root
-			err := runPreflightChecks(flags.parent.skipPreFlight)
+			err = runPreflightChecks(flags.parent.ignoreChecksErrorsSet)
 			kubeadmutil.CheckErr(err)
 
 			err = cmdutil.ValidateExactArgNumber(args, []string{"version"})

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ghodss/yaml"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapiext "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1alpha1"
@@ -97,14 +98,9 @@ func printConfiguration(cfg *kubeadmapiext.MasterConfiguration, w io.Writer) {
 }
 
 // runPreflightChecks runs the root preflight check
-func runPreflightChecks(skipPreFlight bool) error {
-	if skipPreFlight {
-		fmt.Println("[preflight] Skipping pre-flight checks.")
-		return nil
-	}
-
+func runPreflightChecks(ignoreChecksErrors sets.String) error {
 	fmt.Println("[preflight] Running pre-flight checks.")
-	return preflight.RunRootCheckOnly()
+	return preflight.RunRootCheckOnly(ignoreChecksErrors)
 }
 
 // getClient gets a real or fake client depending on whether the user is dry-running or not

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/validation"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/upgrade"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
@@ -35,8 +36,11 @@ func NewCmdPlan(parentFlags *cmdUpgradeFlags) *cobra.Command {
 		Use:   "plan",
 		Short: "Check which versions are available to upgrade to and validate whether your current cluster is upgradeable.",
 		Run: func(_ *cobra.Command, _ []string) {
+			var err error
+			parentFlags.ignoreChecksErrorsSet, err = validation.ValidateIgnoreChecksErrors(parentFlags.ignoreChecksErrors, parentFlags.skipPreFlight)
+			kubeadmutil.CheckErr(err)
 			// Ensure the user is root
-			err := runPreflightChecks(parentFlags.skipPreFlight)
+			err = runPreflightChecks(parentFlags.ignoreChecksErrorsSet)
 			kubeadmutil.CheckErr(err)
 
 			err = RunPlan(parentFlags)

--- a/cmd/kubeadm/app/cmd/upgrade/upgrade.go
+++ b/cmd/kubeadm/app/cmd/upgrade/upgrade.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/sets"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 )
 
@@ -31,6 +32,8 @@ type cmdUpgradeFlags struct {
 	allowRCUpgrades           bool
 	printConfig               bool
 	skipPreFlight             bool
+	ignoreChecksErrors        []string
+	ignoreChecksErrorsSet     sets.String
 }
 
 // NewCmdUpgrade returns the cobra command for `kubeadm upgrade`
@@ -42,6 +45,7 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 		allowRCUpgrades:           false,
 		printConfig:               false,
 		skipPreFlight:             false,
+		ignoreChecksErrorsSet:     sets.NewString(),
 	}
 
 	cmd := &cobra.Command{
@@ -55,7 +59,9 @@ func NewCmdUpgrade(out io.Writer) *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&flags.allowExperimentalUpgrades, "allow-experimental-upgrades", flags.allowExperimentalUpgrades, "Show unstable versions of Kubernetes as an upgrade alternative and allow upgrading to an alpha/beta/release candidate versions of Kubernetes.")
 	cmd.PersistentFlags().BoolVar(&flags.allowRCUpgrades, "allow-release-candidate-upgrades", flags.allowRCUpgrades, "Show release candidate versions of Kubernetes as an upgrade alternative and allow upgrading to a release candidate versions of Kubernetes.")
 	cmd.PersistentFlags().BoolVar(&flags.printConfig, "print-config", flags.printConfig, "Specifies whether the configuration file that will be used in the upgrade should be printed or not.")
+	cmd.PersistentFlags().StringSliceVar(&flags.ignoreChecksErrors, "ignore-checks-errors", flags.ignoreChecksErrors, "A list of checks whose errors will be shown as warnings. Example: 'IsPrivilegedUser,Swap'. Value 'all' ignores errors from all checks.")
 	cmd.PersistentFlags().BoolVar(&flags.skipPreFlight, "skip-preflight-checks", flags.skipPreFlight, "Skip preflight checks that normally run before modifying the system.")
+	cmd.PersistentFlags().MarkDeprecated("skip-preflight-checks", "it is now equivalent to --ignore-checks-errors=all")
 
 	cmd.AddCommand(NewCmdApply(flags))
 	cmd.AddCommand(NewCmdPlan(flags))

--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )
@@ -51,6 +52,7 @@ go_test(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//vendor/github.com/renstrom/dedent:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
With new flag `--ignore-preflight-errors` user is able to
decrease severity of each individual check error to warning.

Old flag `--skip-preflight-checks` now acts as `--ignore-preflight-errors=all` and will produce warnings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubeadm#480

**Special notes for your reviewer**:
/area kubeadm 
/sig cluster-lifecycle

cc @luxas 

**Release note**:
```release-note
New kubeadm flag `--ignore-preflight-errors` that enables to decrease severity of each individual error to warning.
Old flag `--skip-preflight-checks` is marked as deprecated and acts as `--ignore-preflight-errors=all`
```
