### PR TITLE
kubeadm: set kube-apiserver advertise address using downward API

### DIFF
--- a/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
+++ b/cmd/kubeadm/app/phases/selfhosting/podspec_mutation.go
@@ -18,6 +18,7 @@ package selfhosting
 
 import (
 	"path/filepath"
+	"strings"
 
 	"k8s.io/api/core/v1"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
@@ -42,6 +43,7 @@ func GetDefaultMutators() map[string][]PodSpecMutatorFunc {
 			addNodeSelectorToPodSpec,
 			setMasterTolerationOnPodSpec,
 			setRightDNSPolicyOnPodSpec,
+			setHostIPOnPodSpec,
 		},
 		kubeadmconstants.KubeControllerManager: {
 			addNodeSelectorToPodSpec,
@@ -99,6 +101,26 @@ func setMasterTolerationOnPodSpec(podSpec *v1.PodSpec) {
 	}
 
 	podSpec.Tolerations = append(podSpec.Tolerations, kubeadmconstants.MasterToleration)
+}
+
+// setHostIPOnPodSpec sets the environment variable HOST_IP using downward API
+func setHostIPOnPodSpec(podSpec *v1.PodSpec) {
+	envVar := v1.EnvVar{
+		Name: "HOST_IP",
+		ValueFrom: &v1.EnvVarSource{
+			FieldRef: &v1.ObjectFieldSelector{
+				FieldPath: "status.hostIP",
+			},
+		},
+	}
+
+	podSpec.Containers[0].Env = append(podSpec.Containers[0].Env, envVar)
+
+	for i := range podSpec.Containers[0].Command {
+		if strings.Contains(podSpec.Containers[0].Command[i], "advertise-address") {
+			podSpec.Containers[0].Command[i] = "--advertise-address=$(HOST_IP)"
+		}
+	}
 }
 
 // setRightDNSPolicyOnPodSpec makes sure the self-hosted components can look up things via kube-dns if necessary

--- a/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
+++ b/cmd/kubeadm/app/phases/selfhosting/selfhosting_test.go
@@ -134,7 +134,7 @@ spec:
         - --service-cluster-ip-range=10.96.0.0/12
         - --tls-cert-file=/etc/kubernetes/pki/apiserver.crt
         - --kubelet-client-certificate=/etc/kubernetes/pki/apiserver-kubelet-client.crt
-        - --advertise-address=192.168.1.115
+        - --advertise-address=$(HOST_IP)
         - --requestheader-client-ca-file=/etc/kubernetes/pki/front-proxy-ca.crt
         - --insecure-port=0
         - --experimental-bootstrap-token-auth=true
@@ -148,6 +148,11 @@ spec:
         - --proxy-client-key-file=/etc/kubernetes/pki/front-proxy-client.key
         - --authorization-mode=Node,RBAC
         - --etcd-servers=http://127.0.0.1:2379
+        env:
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         image: gcr.io/google_containers/kube-apiserver-amd64:v1.7.4
         livenessProbe:
           failureThreshold: 8


### PR DESCRIPTION
**What this PR does / why we need it**:
Sets kube-apiserver --advertise-address using downward API for self-hosted Kubernetes with kubeadm. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubernetes/kubeadm/issues/400

**Special notes for your reviewer**:
@luxas mentioned something about losing the ability to customize advertise address via kubeadm, didn't really take that into consideration yet but I can definitely make the necessary changes if needed. 

**Release note**:
```release-note
kubeadm: set kube-apiserver advertise address using downward API
```
