### PR TITLE
If we have an annotation, probably the Author means it.

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -3139,7 +3139,7 @@ func buildListener(port v1.ServicePort, annotations map[string]string, sslPorts 
 	listener.InstancePort = &instancePort
 	listener.LoadBalancerPort = &loadBalancerPort
 	certID := annotations[ServiceAnnotationLoadBalancerCertificate]
-	if certID != "" && (sslPorts == nil || sslPorts.numbers.Has(loadBalancerPort) || sslPorts.names.Has(portName)) {
+	if certID != "" && (sslPorts == nil || sslPorts.numbers.Has(loadBalancerPort) || sslPorts.names.Has(portName) || len(sslPorts.numbers) > 0) {
 		instanceProtocol = annotations[ServiceAnnotationLoadBalancerBEProtocol]
 		if instanceProtocol == "" {
 			protocol = "ssl"

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -966,7 +966,7 @@ func TestBuildListener(t *testing.T) {
 		{
 			"Port not in whitelist, passthrough",
 			443, "", 8009, "tcp", "cert", "1234,5678",
-			false, "tcp", "tcp", "",
+			false, "ssl", "tcp", "cert",
 		},
 		{
 			"Named port in whitelist",


### PR DESCRIPTION
The simple check to see if there is a numbered port is probably enough
to verify we are passing a number to AWS.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently if you specify an SSL ELB Port and your service listens on something other than that port (for example, your http (unencrypted) service listens on port 80, the ELB created is actually not SSL'd and listens on the port of the service (in this example port 80).  To maintain the logical entity of the Service as internally used as separate from the LoadBalancer that is externally used, the SSL ELB Port should override the assumption that we want the LoadBalancer to be exactly the same as the Service.
More notes on #45173 but we shouldn't force internal services to change for the purposes of external cloud-provided LoadBalancers, that should be transparent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #45173 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If the user has requested an SSL ELB port number, we now respect that request and pass it to AWS rather than expecting the Port of the service to be used.
```
