### PR TITLE
Add new test job for the CPU Manager node e2e serial tests.

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -410,7 +410,7 @@ func runCPUManagerTests(f *framework.Framework) {
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = framework.KubeDescribe("CPU Manager [Serial]", func() {
+var _ = framework.KubeDescribe("CPU Manager [Feature:CPUManager] [Serial]", func() {
 	f := framework.NewDefaultFramework("cpu-manager-test")
 
 	Context("With kubeconfig updated with static CPU Manager policy run the CPU Manager tests", func() {

--- a/test/e2e_node/jenkins/image-config-serial-cpu-manager.yaml
+++ b/test/e2e_node/jenkins/image-config-serial-cpu-manager.yaml
@@ -1,0 +1,15 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    project: ubuntu-os-gke-cloud
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4
+  cos-stable1:
+    image_regex: cos-stable-60-9592-84-0 # docker 1.13.1
+    project: cos-cloud
+    metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
+    # Using `n1-standard-4` to enable CPU manager node e2e tests.
+    machine: n1-standard-4

--- a/test/e2e_node/jenkins/jenkins-serial-cpu-manager.properties
+++ b/test/e2e_node/jenkins/jenkins-serial-cpu-manager.properties
@@ -1,0 +1,10 @@
+GCE_HOSTS=
+GCE_IMAGE_CONFIG_PATH=test/e2e_node/jenkins/image-config-serial-cpu-manager.yaml
+GCE_ZONE=us-west1-b
+GCE_PROJECT=k8s-jkns-ci-node-e2e
+CLEANUP=true
+GINKGO_FLAGS='--focus="\[Feature:CPUManager\]" --skip="\[Flaky\]|\[Benchmark\]"'
+TEST_ARGS='--feature-gates=DynamicKubeletConfig=true'
+KUBELET_ARGS='--cgroups-per-qos=true --cgroup-root=/'
+PARALLELISM=1
+TIMEOUT=3h


### PR DESCRIPTION
**What this PR does / why we need it**: This change allows the node e2e tests for the CPU manager feature to run. The CPU manager requires at least 3 cores to run all the tests ( i.e., `cpu.allocatable` >= 2). Note: By default, the CPU manager feature expects the `kube-reserved+system-reserved > 0` for cpus.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #55980 