### PR TITLE
Fix client-gen for groups that no types requiring clients

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -41,13 +41,19 @@ type genGroup struct {
 	imports          namer.ImportTracker
 	inputPackage     string
 	clientsetPackage string
+	// If the genGroup has been called. This generator should only execute once.
+	called bool
 }
 
 var _ generator.Generator = &genGroup{}
 
 // We only want to call GenerateType() once per group.
 func (g *genGroup) Filter(c *generator.Context, t *types.Type) bool {
-	return len(g.types) == 0 || t == g.types[0]
+	if !g.called {
+		g.called = true
+		return true
+	}
+	return false
 }
 
 func (g *genGroup) Namers(c *generator.Context) namer.NameSystems {


### PR DESCRIPTION
If the group has no type with the `+genClient` tag, the group client is generated multiple times because the `Filter` function always returns true, resulting in bad output like https://gist.github.com/gmarek/9a11d5a305a52b193889684e56c103e4.

unblock #49112 
cc @gmarek 