### PR TITLE
e2e_node: small fixes to setup_host.sh for Ubuntu Trusty

### DIFF
--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -59,11 +59,11 @@ if [ $? -eq 0 ]; then
      echo "Do not find nsenter. Install it."
      NSENTER_BUILD_DIR=$(mktemp -d /tmp/nsenter-build-XXXXXX)
      cd $NSENTER_BUILD_DIR
-     curl https://www.kernel.org/pub/linux/utils/util-linux/v2.24/util-linux-2.24.tar.gz | tar -zxf-
+     curl https://www.kernel.org/pub/linux/utils/util-linux/v2.31/util-linux-2.31.tar.gz | tar -zxf-
      sudo apt-get update
      sudo apt-get --yes install make
      sudo apt-get --yes install gcc
-     cd util-linux-2.24
+     cd util-linux-2.31
      ./configure --without-ncurses
      make nsenter
      sudo cp nsenter /usr/local/bin

--- a/test/e2e_node/environment/setup_host.sh
+++ b/test/e2e_node/environment/setup_host.sh
@@ -57,8 +57,8 @@ cat /etc/*-release | grep "ID=ubuntu"
 if [ $? -eq 0 ]; then
   if ! which nsenter > /dev/null; then
      echo "Do not find nsenter. Install it."
-     mkdir -p /tmp/nsenter-install
-     cd /tmp/nsenter-install
+     NSENTER_BUILD_DIR=$(mktemp -d /tmp/nsenter-build-XXXXXX)
+     cd $NSENTER_BUILD_DIR
      curl https://www.kernel.org/pub/linux/utils/util-linux/v2.24/util-linux-2.24.tar.gz | tar -zxf-
      sudo apt-get update
      sudo apt-get --yes install make
@@ -67,7 +67,7 @@ if [ $? -eq 0 ]; then
      ./configure --without-ncurses
      make nsenter
      sudo cp nsenter /usr/local/bin
-     rm -rf /tmp/nsenter-install
+     rm -rf $NSENTER_BUILD_DIR
    fi
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Two small fixes for how nsenter is built from source and installed on Ubuntu Trusty:
1. Use mktemp for the creating the build directory instead of a hard coded name
2. Use current (2.31) util-linux instead of 3+ year old version

**Which issue(s) this PR fixes**:

Fixes #56106 

**Special notes for your reviewer**:

See https://github.com/kubernetes/kubernetes/issues/56106 for some thoughts on other ways to address this.  My patch for util-linux 2.31 may just be a band-aid?

**Release note**:
```release-note
NONE
```
