### PR TITLE
[advance auditing] introduce buffered backend

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/BUILD
@@ -22,6 +22,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/log:all-srcs",
         "//staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook:all-srcs",
     ],

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/BUILD
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/BUILD
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "buffered.go",
+        "doc.go",
+    ],
+    importpath = "k8s.io/apiserver/plugin/pkg/audit/buffered",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
+        "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["buffered_test.go"],
+    embed = [":go_default_library"],
+    importpath = "k8s.io/apiserver/plugin/pkg/audit/buffered",
+    deps = [
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/apis/audit:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/audit:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package buffered provides an implementation for the audit.Backend interface
+// that batches incoming audit events and sends batches to the delegate audit.Backend.
+package buffered
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+	"k8s.io/client-go/util/flowcontrol"
+)
+
+// The plugin name reported in error metrics.
+const pluginName = "buffered"
+
+const (
+	// Default configuration values for ModeBatch.
+	defaultBatchBufferSize = 10000            // Buffer up to 10000 events before starting discarding.
+	defaultBatchMaxSize    = 400              // Only send up to 400 events at a time.
+	defaultBatchMaxWait    = 30 * time.Second // Send events at least twice a minute.
+	defaultInitialBackoff  = 10 * time.Second // Wait at least 10 seconds before retrying.
+
+	defaultBatchThrottleQPS   = 10 // Limit the send rate by 10 QPS.
+	defaultBatchThrottleBurst = 15 // Allow up to 15 QPS burst.
+)
+
+// BatchConfig represents batching delegate audit backend configuration.
+type BatchConfig struct {
+	// BufferSize defines a size of the buffering queue.
+	BufferSize int
+	// MaxBatchSize defines maximum size of a batch.
+	MaxBatchSize int
+	// MaxBatchWait indicates the maximum interval between two batches.
+	MaxBatchWait time.Duration
+	// InitialBackoff defines the amount of time to wait before retrying the requests
+	// to the webhook for the first time.
+	InitialBackoff time.Duration
+
+	// ThrottleQPS defines the allowed rate of batches per second sent to the delegate backend.
+	ThrottleQPS float32
+	// ThrottleBurst defines the maximum rate of batches per second sent to the delegate backend in case
+	// the capacity defined by ThrottleQPS was not utilized.
+	ThrottleBurst int
+}
+
+// NewDefaultBatchConfig returns new Config objects populated by default values.
+func NewDefaultBatchConfig() BatchConfig {
+	return BatchConfig{
+		BufferSize:   defaultBatchBufferSize,
+		MaxBatchSize: defaultBatchMaxSize,
+		MaxBatchWait: defaultBatchMaxWait,
+
+		ThrottleQPS:   defaultBatchThrottleQPS,
+		ThrottleBurst: defaultBatchThrottleBurst,
+
+		InitialBackoff: defaultInitialBackoff,
+	}
+}
+
+type bufferedBackend struct {
+	// The delegate backend that actually exports events.
+	delegateBackend audit.Backend
+
+	// Channel to buffer events before sending to the delegate backend.
+	buffer chan *auditinternal.Event
+	// Maximum number of events in a batch sent to the delegate backend.
+	maxBatchSize int
+	// Amount of time to wait after sending a batch to the delegate backend before sending another one.
+	//
+	// Receiving maxBatchSize events will always trigger sending a batch, regardless of the amount of time passed.
+	maxBatchWait time.Duration
+
+	// Channel to signal that the batching routine has processed all remaining events and exited.
+	// Once `shutdownCh` is closed no new events will be sent to the delegate backend.
+	shutdownCh chan struct{}
+
+	// WaitGroup to control the concurrency of sending batches to the delegate backend.
+	// Worker routine calls Add before sending a batch and
+	// then spawns a routine that calls Done after batch was processed by the delegate backend.
+	// This WaitGroup is also used to wait for all sending routines to finish before shutting down audit backend.
+	wg sync.WaitGroup
+
+	// Limits the number of batches sent to the delegate backend per second.
+	throttle flowcontrol.RateLimiter
+}
+
+var _ audit.Backend = &bufferedBackend{}
+
+// NewBackend returns a buffered audit backend wraps delegate backend.
+func NewBackend(backend audit.Backend, config BatchConfig) audit.Backend {
+	return &bufferedBackend{
+		delegateBackend: backend,
+		buffer:          make(chan *auditinternal.Event, config.BufferSize),
+		maxBatchSize:    config.MaxBatchSize,
+		maxBatchWait:    config.MaxBatchWait,
+		shutdownCh:      make(chan struct{}),
+		wg:              sync.WaitGroup{},
+		throttle:        flowcontrol.NewTokenBucketRateLimiter(config.ThrottleQPS, config.ThrottleBurst),
+	}
+}
+
+func (b *bufferedBackend) Run(stopCh <-chan struct{}) error {
+	go func() {
+		// Signal that the working routine has exited.
+		defer close(b.shutdownCh)
+
+		b.processIncomingEvents(stopCh)
+
+		// Handle the events that were received after the last buffer
+		// scraping and before this line. Since the buffer is closed, no new
+		// events will come through.
+		allEventsProcessed := false
+		timer := make(chan time.Time)
+		for {
+			if !allEventsProcessed {
+				allEventsProcessed = func() bool {
+					// Recover from any panic in order to try to process all remaining events.
+					// Note, that in case of a panic, the return value will be false and
+					// the loop execution will continue.
+					defer runtime.HandleCrash()
+
+					events := b.collectEvents(timer, wait.NeverStop)
+					b.processEvents(events)
+					return len(events) == 0
+				}()
+			} else {
+				break
+			}
+		}
+	}()
+	return nil
+}
+
+func (b *bufferedBackend) Shutdown() {
+	<-b.shutdownCh
+
+	// Wait blocks here until all sending routines exit.
+	b.wg.Wait()
+}
+
+// processIncomingEvents runs a loop that collects events from the buffer. When
+// b.stopCh is closed, processIncomingEvents stops and closes the buffer.
+func (b *bufferedBackend) processIncomingEvents(stopCh <-chan struct{}) {
+	defer close(b.buffer)
+	t := time.NewTimer(b.maxBatchWait)
+	defer t.Stop()
+
+	for {
+		func() {
+			// Recover from any panics caused by this function so a panic in the
+			// goroutine can't bring down the main routine.
+			defer runtime.HandleCrash()
+
+			t.Reset(b.maxBatchWait)
+			b.processEvents(b.collectEvents(t.C, stopCh))
+		}()
+
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+	}
+}
+
+// collectEvents attempts to collect some number of events in a batch.
+//
+// The following things can cause collectEvents to stop and return the list
+// of events:
+//
+//   * Maximum number of events for a batch.
+//   * Timer has passed.
+//   * Buffer channel is closed and empty.
+//   * stopCh is closed.
+func (b *bufferedBackend) collectEvents(timer <-chan time.Time, stopCh <-chan struct{}) []*auditinternal.Event {
+	var events []*auditinternal.Event
+
+L:
+	for i := 0; i < b.maxBatchSize; i++ {
+		select {
+		case ev, ok := <-b.buffer:
+			// Buffer channel was closed and no new events will follow.
+			if !ok {
+				break L
+			}
+			events = append(events, ev)
+		case <-timer:
+			// Timer has expired. Send currently accumulated batch.
+			break L
+		case <-stopCh:
+			// Backend has been stopped. Send currently accumulated batch.
+			break L
+		}
+	}
+
+	return events
+}
+
+// processEvents process the batch events in a goroutine using the
+// real delegateBackend interface's ProcessEvents.
+func (b *bufferedBackend) processEvents(events []*auditinternal.Event) {
+	if len(events) == 0 {
+		return
+	}
+
+	// TODO(audit): Should control the number of active goroutines
+	// if one goroutine takes 5 seconds to finish, the number of goroutines can be 5 * defaultBatchThrottleQPS
+	if b.throttle != nil {
+		b.throttle.Accept()
+	}
+
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		defer runtime.HandleCrash()
+
+		// Execute the real processing in a goroutine to keep it from blocking.
+		// This lets the batching routine continue draining the queue immediately.
+		b.delegateBackend.ProcessEvents(events...)
+	}()
+}
+
+func (b *bufferedBackend) ProcessEvents(ev ...*auditinternal.Event) {
+	// The following mechanism is in place to support the situation when audit
+	// events are still coming after the backend was stopped.
+	var sendErr error
+	var evIndex int
+
+	// If the delegateBackend was shutdown and the buffer channel was closed, an
+	// attempt to add an event to it will result in panic that we should
+	// recover from.
+	defer func() {
+		if err := recover(); err != nil {
+			sendErr = fmt.Errorf("panic when processing events: %v", err)
+		}
+		if sendErr != nil {
+			audit.HandlePluginError(pluginName, sendErr, ev[evIndex:]...)
+		}
+	}()
+
+	for i, e := range ev {
+		evIndex = i
+		// Per the audit.Backend interface these events are reused after being
+		// sent to the Sink. Deep copy and send the copy to the queue.
+		event := e.DeepCopy()
+
+		select {
+		case b.buffer <- event:
+		default:
+			sendErr = fmt.Errorf("audit buffer queue blocked")
+			return
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/buffered_test.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package buffered
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	auditinternal "k8s.io/apiserver/pkg/apis/audit"
+	"k8s.io/apiserver/pkg/audit"
+)
+
+type options struct {
+	withWaitGroup bool
+	withChannel   bool
+}
+
+func newBufferedBackend(opts options) (*bufferedBackend, *fakeBackend) {
+	fakeBackend := &fakeBackend{}
+	switch {
+	case opts.withChannel == true:
+		fakeBackend.ch = make(chan struct{})
+	case opts.withWaitGroup == true:
+		fakeBackend.wg = new(sync.WaitGroup)
+	default:
+	}
+
+	config := NewDefaultBatchConfig()
+	backend := NewBackend(fakeBackend, config)
+	return backend.(*bufferedBackend), fakeBackend
+}
+
+func newEvents(number int) []*auditinternal.Event {
+	events := make([]*auditinternal.Event, number)
+	for i := range events {
+		events[i] = &auditinternal.Event{}
+	}
+
+	return events
+}
+
+// waitForEmptyBuffer indicates when the sendBatchEvents method has read from the
+// existing buffer. This lets test coordinate closing a timer and stop channel
+// until the for loop has read from the buffer.
+func waitForEmptyBuffer(b *bufferedBackend) {
+	for len(b.buffer) != 0 {
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestBufferedBackendBatchMaxEvents(t *testing.T) {
+	stopCh := make(chan struct{})
+	timer := make(chan time.Time)
+
+	backend, delegateBackend := newBufferedBackend(options{})
+
+	events := newEvents(backend.maxBatchSize + 1) // greater than max size.
+
+	backend.ProcessEvents(events...)
+
+	delegateBackend.ProcessEvents(backend.collectEvents(timer, stopCh)...)
+	require.Equal(t, 1, int(atomic.LoadInt32(&delegateBackend.got)), "did not get batch max size")
+
+	go func() {
+		waitForEmptyBuffer(backend) // wait for the buffer to empty
+		close(timer)                // Trigger the wait timeout
+	}()
+
+	delegateBackend.ProcessEvents(backend.collectEvents(timer, stopCh)...)
+	require.Equal(t, 2, int(atomic.LoadInt32(&delegateBackend.got)), "failed to get the rest of the events")
+}
+
+func TestBufferedBackendStopCh(t *testing.T) {
+	events := newEvents(1) // less than max size.
+	stopCh := make(chan struct{})
+	timer := make(chan time.Time)
+
+	backend, delegateBackend := newBufferedBackend(options{})
+
+	backend.ProcessEvents(events...)
+
+	go func() {
+		waitForEmptyBuffer(backend)
+		close(stopCh) // stop channel has stopped
+	}()
+
+	delegateBackend.ProcessEvents(backend.collectEvents(timer, stopCh)...)
+	require.Equal(t, 1, int(atomic.LoadInt32(&delegateBackend.got)), "get queued events after timer expires")
+}
+
+func TestBufferedBackendProcessEventsAfterStop(t *testing.T) {
+	events := newEvents(1) // less than max size.
+
+	backend, _ := newBufferedBackend(options{})
+	stopCh := make(chan struct{})
+
+	backend.Run(stopCh)
+	close(stopCh)
+	<-backend.shutdownCh
+	backend.ProcessEvents(events...)
+	assert.Equal(t, 0, len(backend.buffer), "processed events after the backed has been stopped")
+}
+
+func TestBufferedBackendShutdown(t *testing.T) {
+	shutdownCh := make(chan struct{})
+	backend, delegateBackend := newBufferedBackend(options{withChannel: true})
+	events := newEvents(1)
+	backend.ProcessEvents(events...)
+
+	go func() {
+		// Assume stopCh was closed.
+		close(backend.buffer)
+		backend.processEvents(backend.collectEvents(make(chan time.Time), make(chan struct{})))
+	}()
+
+	for atomic.LoadInt32(&delegateBackend.got) == 0 {
+		time.Sleep(time.Millisecond)
+	}
+
+	go func() {
+		close(backend.shutdownCh)
+		backend.Shutdown()
+		close(shutdownCh)
+	}()
+
+	// Wait for some time in case there's a bug that allows for the Shutdown
+	// method to exit before all requests has been completed.
+	time.Sleep(1 * time.Second)
+	select {
+	case <-shutdownCh:
+		t.Fatal("Backend shut down before all requests finished")
+	default:
+		// Continue.
+	}
+
+	close(delegateBackend.ch)
+	<-shutdownCh
+}
+
+func TestBufferedBackendEmptyBuffer(t *testing.T) {
+	events := newEvents(1) // less than max size.
+	stopCh := make(chan struct{})
+	timer := make(chan time.Time, 1)
+
+	backend, delegateBackend := newBufferedBackend(options{})
+
+	timer <- time.Now() // Timer is done.
+
+	// Buffer is empty, no events have been queued. This should exit but send no events.
+	backend.processEvents(backend.collectEvents(timer, stopCh))
+
+	// Send additional events after the sendBatchEvents has been called.
+	backend.ProcessEvents(events...)
+	go func() {
+		waitForEmptyBuffer(backend)
+		timer <- time.Now()
+	}()
+
+	delegateBackend.ProcessEvents(backend.collectEvents(timer, stopCh)...)
+
+	require.Equal(t, 1, int(atomic.LoadInt32(&delegateBackend.got)), "expected one batch")
+}
+
+func TestBufferedBackendBufferFull(t *testing.T) {
+	backend, _ := newBufferedBackend(options{})
+	events := newEvents(len(backend.buffer) + 1) // More than buffered size
+
+	// Make sure this doesn't block.
+	backend.ProcessEvents(events...)
+}
+
+// Test BufferedBackend.Run
+func TestBufferedBackendRun(t *testing.T) {
+	done := make(chan struct{})
+	backend, delegateBackend := newBufferedBackend(options{withWaitGroup: true})
+	events := newEvents(backend.maxBatchSize * 3)
+	want := 3
+
+	delegateBackend.wg.Add(want)
+
+	go func() {
+		delegateBackend.wg.Wait()
+		// When the expected number of events have been received, close the channel.
+		close(done)
+	}()
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	// Test the Run codepath. E.g. that the spawned goroutines behave correctly.
+	backend.Run(stopCh)
+
+	backend.ProcessEvents(events...)
+
+	select {
+	case <-done:
+		// Received all the events.
+	case <-time.After(2 * time.Minute):
+		t.Errorf("expected %d batch events got %d", want, atomic.LoadInt32(&delegateBackend.got))
+	}
+}
+
+// Test concurrently processing events
+func TestBufferedBackendConcurrentRequests(t *testing.T) {
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	backend, delegateBackend := newBufferedBackend(options{withWaitGroup: true})
+	events := newEvents(len(backend.buffer))
+
+	delegateBackend.wg.Add(len(events) / backend.maxBatchSize)
+
+	backend.Run(stopCh)
+
+	go backend.ProcessEvents(events[:len(events)/2]...)
+	go backend.ProcessEvents(events[len(events)/2:]...)
+	// Wait for the underlying backend to receive all events.
+	delegateBackend.wg.Wait()
+}
+
+type fakeBackend struct {
+	wg  *sync.WaitGroup
+	got int32
+	ch  chan struct{} // used for test shutdown
+}
+
+var _ audit.Backend = &fakeBackend{}
+
+func (b *fakeBackend) Run(stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (b *fakeBackend) Shutdown() {
+	// nothing to do here
+	return
+}
+
+func (b *fakeBackend) ProcessEvents(ev ...*auditinternal.Event) {
+	atomic.AddInt32(&b.got, 1)
+	if b.wg != nil {
+		b.wg.Done()
+	}
+	if b.ch != nil {
+		<-b.ch
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/doc.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/buffered/doc.go
@@ -1,0 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package buffered provides an implementation for the audit.Backend interface
+// that batches incoming audit events and sends batches to the delegate audit.Backend.
+package buffered // import "k8s.io/apiserver/plugin/pkg/audit/buffered"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

To facilitate review， I split pr #53105 into three according @crassirostris [suggestion](https://github.com/kubernetes/kubernetes/pull/53105#issuecomment-345748344)

1. introduce new buffered backend implementation.

2.  use the new buffered backend.

3. remove old buffered webhook.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
partially Fixes #53006 

**Special notes for your reviewer**:

This pr mechanically copy from pr #53105

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
introduce audit buffered backend.
```
