### PR TITLE
Don't call f.BeforeEach() again in ingress suite

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -49,7 +49,6 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 	f := framework.NewDefaultFramework("ingress")
 
 	BeforeEach(func() {
-		f.BeforeEach()
 		jig = framework.NewIngressTestJig(f.ClientSet)
 		ns = f.Namespace.Name
 		cloudConfig = framework.TestContext.CloudConfig


### PR DESCRIPTION
**What this PR does / why we need it**: Calling f.BeforeEach() explicitly in ingress suite is causing test panics. See #56089.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes (hopefully) #56089

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
