### PR TITLE
Avoid frequently type casting

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -222,10 +222,11 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 
 	// calculate final priority score for each node
 	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
+	maxPriorityFloat64 := float64(schedulerapi.MaxPriority)
 	for _, node := range nodes {
 		fScore := float64(0)
 		if (maxCount - minCount) > 0 {
-			fScore = float64(schedulerapi.MaxPriority) * ((pm.counts[node.Name] - minCount) / (maxCount - minCount))
+			fScore = maxPriorityFloat64 * ((pm.counts[node.Name] - minCount) / (maxCount - minCount))
 		}
 		result = append(result, schedulerapi.HostPriority{Host: node.Name, Score: int(fScore)})
 		if glog.V(10) {

--- a/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/selector_spreading.go
@@ -236,13 +236,15 @@ func (s *ServiceAntiAffinity) CalculateAntiAffinityPriority(pod *v1.Pod, nodeNam
 	}
 	numServicePods := len(nsServicePods)
 	result := []schedulerapi.HostPriority{}
+	maxPriorityFloat64 := float64(schedulerapi.MaxPriority)
+	numServicePodsFloat64 := float64(numServicePods)
 	//score int - scale of 0-maxPriority
 	// 0 being the lowest priority and maxPriority being the highest
 	for node := range labeledNodes {
 		// initializing to the default/max node score of maxPriority
 		fScore := float64(schedulerapi.MaxPriority)
 		if numServicePods > 0 {
-			fScore = float64(schedulerapi.MaxPriority) * (float64(numServicePods-podCounts[labeledNodes[node]]) / float64(numServicePods))
+			fScore = maxPriorityFloat64 * (float64(numServicePods-podCounts[labeledNodes[node]]) / numServicePodsFloat64)
 		}
 		result = append(result, schedulerapi.HostPriority{Host: node, Score: int(fScore)})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Avoid frequently type casting in our priority functions, i thinks it's benefit to kube-scheduler when scheduling in a large scale cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
