### PR TITLE
test enhance for logs from daemonset

### DIFF
--- a/pkg/kubectl/cmd/util/factory_object_mapping_test.go
+++ b/pkg/kubectl/cmd/util/factory_object_mapping_test.go
@@ -116,6 +116,20 @@ func TestLogsForObject(t *testing.T) {
 			},
 		},
 		{
+			name: "daemonset logs",
+			obj: &extensions.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},
+				Spec: extensions.DaemonSetSpec{
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}},
+				},
+			},
+			pods: []runtime.Object{testPod()},
+			actions: []testclient.Action{
+				testclient.NewListAction(podsResource, podsKind, "test", metav1.ListOptions{LabelSelector: "foo=bar"}),
+				getLogsAction("test", nil),
+			},
+		},
+		{
 			name: "job logs",
 			obj: &batch.Job{
 				ObjectMeta: metav1.ObjectMeta{Name: "hello", Namespace: "test"},


### PR DESCRIPTION
Follow up pr of https://github.com/kubernetes/kubernetes/pull/56045, will pass if preceding pr got merged.

```release-note
NONE
```
