### PR TITLE
pkg/controller/garbagecollector/garbagecollector.go: fix string format

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -596,9 +596,9 @@ func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) m
 	preferredResources, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		if discovery.IsGroupDiscoveryFailedError(err) {
-			glog.Warning("failed to discover some groups: %v", err.(*discovery.ErrGroupDiscoveryFailed).Groups)
+			glog.Warningf("failed to discover some groups: %v", err.(*discovery.ErrGroupDiscoveryFailed).Groups)
 		} else {
-			glog.Warning("failed to discover preferred resources: %v", err)
+			glog.Warningf("failed to discover preferred resources: %v", err)
 		}
 	}
 	if preferredResources == nil {
@@ -612,7 +612,7 @@ func GetDeletableResources(discoveryClient discovery.ServerResourcesInterface) m
 	for _, rl := range deletableResources {
 		gv, err := schema.ParseGroupVersion(rl.GroupVersion)
 		if err != nil {
-			glog.Warning("ignoring invalid discovered resource %q: %v", rl.GroupVersion, err)
+			glog.Warningf("ignoring invalid discovered resource %q: %v", rl.GroupVersion, err)
 			continue
 		}
 		for i := range rl.APIResources {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes broken formatting in the warning message by using appropriate function:
> W1121 13:13:39.359283   19160 garbagecollector.go:601] failed to discover preferred resources: %vGet https://127.0.0.1:37983/api: dial tcp 127.0.0.1:37983: getsockopt: connection refused

**Special notes for your reviewer**:
This change was introduced in #55259

**Release note**:
```release-note
NONE
```

PTAL @ironcladlou 
CC @simo5 