### PR TITLE
Add RequestTimeoutQuery to configure API timeout

### DIFF
--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -120,6 +120,9 @@ type Config struct {
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
+
+	// The "timeout" query parameter to include in API server requests.
+	RequestTimeoutQuery time.Duration
 }
 
 // ImpersonationConfig has all the available impersonation options
@@ -217,7 +220,14 @@ func RESTClientFor(config *Config) (*RESTClient, error) {
 		}
 	}
 
-	return NewRESTClient(baseURL, versionedAPIPath, config.ContentConfig, qps, burst, config.RateLimiter, httpClient)
+	client, err := NewRESTClient(baseURL, versionedAPIPath, config.ContentConfig, qps, burst, config.RateLimiter, httpClient)
+	if err != nil {
+		return nil, err
+	}
+	if config.RequestTimeoutQuery > 0 {
+		client.WithRequestTimeoutQuery(config.RequestTimeoutQuery)
+	}
+	return client, nil
 }
 
 // UnversionedRESTClientFor is the same as RESTClientFor, except that it allows
@@ -413,14 +423,15 @@ func AnonymousClientConfig(config *Config) *Config {
 			CAFile:     config.TLSClientConfig.CAFile,
 			CAData:     config.TLSClientConfig.CAData,
 		},
-		RateLimiter:   config.RateLimiter,
-		UserAgent:     config.UserAgent,
-		Transport:     config.Transport,
-		WrapTransport: config.WrapTransport,
-		QPS:           config.QPS,
-		Burst:         config.Burst,
-		Timeout:       config.Timeout,
-		Dial:          config.Dial,
+		RateLimiter:         config.RateLimiter,
+		UserAgent:           config.UserAgent,
+		Transport:           config.Transport,
+		WrapTransport:       config.WrapTransport,
+		QPS:                 config.QPS,
+		Burst:               config.Burst,
+		Timeout:             config.Timeout,
+		Dial:                config.Dial,
+		RequestTimeoutQuery: config.RequestTimeoutQuery,
 	}
 }
 
@@ -452,13 +463,14 @@ func CopyConfig(config *Config) *Config {
 			KeyData:    config.TLSClientConfig.KeyData,
 			CAData:     config.TLSClientConfig.CAData,
 		},
-		UserAgent:     config.UserAgent,
-		Transport:     config.Transport,
-		WrapTransport: config.WrapTransport,
-		QPS:           config.QPS,
-		Burst:         config.Burst,
-		RateLimiter:   config.RateLimiter,
-		Timeout:       config.Timeout,
-		Dial:          config.Dial,
+		UserAgent:           config.UserAgent,
+		Transport:           config.Transport,
+		WrapTransport:       config.WrapTransport,
+		QPS:                 config.QPS,
+		Burst:               config.Burst,
+		RateLimiter:         config.RateLimiter,
+		Timeout:             config.Timeout,
+		Dial:                config.Dial,
+		RequestTimeoutQuery: config.RequestTimeoutQuery,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Added `RequestTimeoutQuery` to configure a default "timeout" query included
in HTTP API server requests. Currently it is difficult to enable the timeout query through a client and/or clientset but is useful for K8S processes that may be slower than normal. As an example, a developer setup using minikube can often take longer to respond to create and delete requests than a production setup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
I was unsure about the right interface naming format to follow but I choose to use a fluent API style for setting the `requestTimeoutQuery`. The reason for this was because I viewed this as as an exceptional variable (it'll only be used in specific circumstances) so I didn't want to expose it via the New method and in future any other exceptional variables could then be set by chaining calls together in the fluent style. The getter is also different from the `GetRateLimiter()` API exposed on the RESTClient interface as the word `Get` is omited. I did this because I tend to follow these [conventions](https://golang.org/doc/effective_go.html#Getters). I'm not particularly precious about the naming but wanted to explain my thought process.
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added ability to set "timeout" query on RESTClient via configuration using the `RequestTimeoutQuery` field. Valid settings for this field are > 0 else it is ignored.
```
