### PR TITLE
Fix Heapster and Metrics Server configuration to enable overriding resource requirements.

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -20,6 +20,40 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: {{ base_metrics_cpu }}
+    cpuPerNode: {{ metrics_cpu_per_node }}m
+    baseMemory: {{ base_metrics_memory }}
+    memoryPerNode: {{ metrics_memory_per_node }}Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: 100m
+    cpuPerNode: 0m
+    baseMemory: {{ base_eventer_memory }}
+    memoryPerNode: {{ eventer_memory_per_node }}Ki
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,7 +98,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: heapster-nanny
           resources:
             limits:
@@ -73,6 +107,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountMath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -84,16 +121,13 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu={{ base_metrics_cpu }}
-            - --extra-cpu={{ metrics_cpu_per_node }}m
-            - --memory={{ base_metrics_memory }}
-            - --extra-memory={{metrics_memory_per_node}}Mi
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: eventer-nanny
           resources:
             limits:
@@ -111,17 +145,25 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: eventer-config-volume
+            mountMath: /etc/config
           command:
             - /pod_nanny
-            - --cpu=100m
-            - --extra-cpu=0m
-            - --memory={{base_eventer_memory}}
-            - --extra-memory={{eventer_memory_per_node}}Ki
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+      volumes:
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -20,6 +20,40 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: {{ base_metrics_cpu }}
+    cpuPerNode: {{ metrics_cpu_per_node }}m
+    baseMemory: {{ base_metrics_memory }}
+    memoryPerNode: {{ metrics_memory_per_node }}Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: 100m
+    cpuPerNode: 0m
+    baseMemory: {{ base_eventer_memory }}
+    memoryPerNode: {{ eventer_memory_per_node }}Ki
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -66,7 +100,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: heapster-nanny
           resources:
             limits:
@@ -75,6 +109,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -86,16 +123,13 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu={{ base_metrics_cpu }}
-            - --extra-cpu={{ metrics_cpu_per_node }}m
-            - --memory={{ base_metrics_memory }}
-            - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: eventer-nanny
           resources:
             limits:
@@ -104,6 +138,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: eventer-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -115,15 +152,19 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu=100m
-            - --extra-cpu=0m
-            - --memory={{ base_eventer_memory }}
-            - --extra-memory={{ eventer_memory_per_node }}Ki
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -20,6 +20,40 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: {{ base_metrics_cpu }}
+    cpuPerNode: {{ metrics_cpu_per_node }}m
+    baseMemory: {{ base_metrics_memory }}
+    memoryPerNode: {{ metrics_memory_per_node }}Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: 100m
+    cpuPerNode: 0m
+    baseMemory: {{ base_eventer_memory }}
+    memoryPerNode: {{ eventer_memory_per_node }}Ki
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,7 +98,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: heapster-nanny
           resources:
             limits:
@@ -82,18 +116,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
-            - --cpu={{ base_metrics_cpu }}
-            - --extra-cpu={{ metrics_cpu_per_node }}m
-            - --memory={{ base_metrics_memory }}
-            - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: eventer-nanny
           resources:
             limits:
@@ -111,17 +145,24 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: eventer-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
-            - --cpu=100m
-            - --extra-cpu=0m
-            - --memory={{ base_eventer_memory }}
-            - --extra-memory={{ eventer_memory_per_node }}Ki
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -18,6 +18,23 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: {{ base_metrics_cpu }}
+    cpuPerNode: {{ metrics_cpu_per_node }}m
+    baseMemory: {{ base_metrics_memory }}
+    memoryPerNode: {{ metrics_memory_per_node}}Mi
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -76,7 +93,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: heapster-nanny
           resources:
             limits:
@@ -85,6 +102,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -96,15 +116,16 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
-            - --cpu={{ base_metrics_cpu }}
-            - --extra-cpu={{ metrics_cpu_per_node }}m
-            - --memory={{ base_metrics_memory }}
-            - --extra-memory={{metrics_memory_per_node}}Mi
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -18,6 +18,23 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: {{ base_metrics_cpu }}
+    cpuPerNode: {{ metrics_cpu_per_node }}m
+    baseMemory: {{ base_metrics_memory }}
+    memoryPerNode: {{ metrics_memory_per_node }}Mi
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -55,7 +72,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.0
           name: heapster-nanny
           resources:
             limits:
@@ -73,17 +90,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
-            - --cpu={{ base_metrics_cpu }}
-            - --extra-cpu={{ metrics_cpu_per_node }}m
-            - --memory={{ base_metrics_memory }}
-            - --extra-memory={{ metrics_memory_per_node }}Mi
+            - --config-dir=/etc/config
             - --threshold=5
             - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -7,6 +7,23 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+    baseCPU: 40m
+    cpuPerNode: 0.5m
+    baseMemory: 140Mi
+    memoryPerNode: 4Mi
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -43,7 +60,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: gcr.io/google_containers/addon-resizer:1.7
+        image: gcr.io/google_containers/addon-resizer:1.8.0
         resources:
           limits:
             cpu: 100m
@@ -60,17 +77,21 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        volumeMounts:
+        - name: metrics-server-config-volume
+          mountPath: /etc/config
         command:
           - /pod_nanny
-          - --cpu=40m
-          - --extra-cpu=0.5m
-          - --memory=140Mi
-          - --extra-memory=4Mi
+          - --config-dir=/etc/config
           - --threshold=5
           - --deployment=metrics-server-v0.2.0
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential
+      volumes:
+        - name: metrics-server-config-volume
+          configMap:
+            name: metrics-server-config
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure resources for Heapster and Metrics Servier using Component Config. This will enable overriding default resource requirements for these components.

**Release note**:
```release-note
Fix Heapster configuration and Metrics Server configuration to enable overriding default resource requirements.
```