### PR TITLE
Adding etcd version for kubeadm upgrade plan

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -56,8 +56,10 @@ func RunPlan(parentFlags *cmdUpgradeFlags) error {
 		return err
 	}
 
+	// Define Local Etcd cluster to be able to retrieve information
+	etcdCluster := kubeadmutil.LocalEtcdCluster{}
 	// Compute which upgrade possibilities there are
-	availUpgrades, err := upgrade.GetAvailableUpgrades(upgradeVars.versionGetter, parentFlags.allowExperimentalUpgrades, parentFlags.allowRCUpgrades)
+	availUpgrades, err := upgrade.GetAvailableUpgrades(upgradeVars.versionGetter, parentFlags.allowExperimentalUpgrades, parentFlags.allowRCUpgrades, etcdCluster)
 	if err != nil {
 		return fmt.Errorf("[upgrade/versions] FATAL: %v", err)
 	}
@@ -112,6 +114,7 @@ func printAvailableUpgrades(upgrades []upgrade.Upgrade, w io.Writer) {
 		fmt.Fprintf(tabw, "Scheduler\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
 		fmt.Fprintf(tabw, "Kube Proxy\t%s\t%s\n", upgrade.Before.KubeVersion, upgrade.After.KubeVersion)
 		fmt.Fprintf(tabw, "Kube DNS\t%s\t%s\n", upgrade.Before.DNSVersion, upgrade.After.DNSVersion)
+		fmt.Fprintf(tabw, "Etcd\t%s\t%s\n", upgrade.Before.EtcdVersion, upgrade.After.EtcdVersion)
 
 		// The tabwriter should be flushed at this stage as we have now put in all the required content for this time. This is required for the tabs' size to be correct.
 		tabw.Flush()

--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -73,40 +73,43 @@ func TestPrintAvailableUpgrades(t *testing.T) {
 		{
 			upgrades: []upgrade.Upgrade{
 				{
-					Description: "version in the v1.7 series",
+					Description: "version in the v1.8 series",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.1",
+						KubeVersion: "v1.8.1",
 						KubeletVersions: map[string]uint16{
-							"v1.7.1": 1,
+							"v1.8.1": 1,
 						},
-						KubeadmVersion: "v1.7.2",
+						KubeadmVersion: "v1.8.2",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.7.3",
-						KubeadmVersion: "v1.7.3",
+						KubeVersion:    "v1.8.3",
+						KubeadmVersion: "v1.8.3",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.1   v1.7.3
+Kubelet     1 x v1.8.1   v1.8.3
 
-Upgrade to the latest version in the v1.7 series:
+Upgrade to the latest version in the v1.8 series:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.1    v1.7.3
-Controller Manager   v1.7.1    v1.7.3
-Scheduler            v1.7.1    v1.7.3
-Kube Proxy           v1.7.1    v1.7.3
+API Server           v1.8.1    v1.8.3
+Controller Manager   v1.8.1    v1.8.3
+Scheduler            v1.8.1    v1.8.3
+Kube Proxy           v1.8.1    v1.8.3
 Kube DNS             1.14.5    1.14.5
+Etcd                 3.0.17    3.0.17
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.7.3
+	kubeadm upgrade apply v1.8.3
 
-Note: Before you can perform this upgrade, you have to update kubeadm to v1.7.3.
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.8.3.
 
 _____________________________________________________________________
 
@@ -117,36 +120,39 @@ _____________________________________________________________________
 				{
 					Description: "stable version",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.3",
+						KubeVersion: "v1.8.3",
 						KubeletVersions: map[string]uint16{
-							"v1.7.3": 1,
+							"v1.8.3": 1,
 						},
-						KubeadmVersion: "v1.8.0",
+						KubeadmVersion: "v1.9.0",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.8.0",
-						KubeadmVersion: "v1.8.0",
-						DNSVersion:     "1.14.5",
+						KubeVersion:    "v1.9.0",
+						KubeadmVersion: "v1.9.0",
+						DNSVersion:     "1.14.7",
+						EtcdVersion:    "3.1.10",
 					},
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.3   v1.8.0
+Kubelet     1 x v1.8.3   v1.9.0
 
 Upgrade to the latest stable version:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.3    v1.8.0
-Controller Manager   v1.7.3    v1.8.0
-Scheduler            v1.7.3    v1.8.0
-Kube Proxy           v1.7.3    v1.8.0
-Kube DNS             1.14.5    1.14.5
+API Server           v1.8.3    v1.9.0
+Controller Manager   v1.8.3    v1.9.0
+Scheduler            v1.8.3    v1.9.0
+Kube Proxy           v1.8.3    v1.9.0
+Kube DNS             1.14.5    1.14.7
+Etcd                 3.0.17    3.1.10
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.8.0
+	kubeadm upgrade apply v1.9.0
 
 _____________________________________________________________________
 
@@ -155,75 +161,81 @@ _____________________________________________________________________
 		{
 			upgrades: []upgrade.Upgrade{
 				{
-					Description: "version in the v1.7 series",
+					Description: "version in the v1.8 series",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.3",
+						KubeVersion: "v1.8.3",
 						KubeletVersions: map[string]uint16{
-							"v1.7.3": 1,
+							"v1.8.3": 1,
 						},
-						KubeadmVersion: "v1.8.1",
+						KubeadmVersion: "v1.8.3",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.7.5",
-						KubeadmVersion: "v1.8.1",
+						KubeVersion:    "v1.8.5",
+						KubeadmVersion: "v1.8.3",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 				},
 				{
 					Description: "stable version",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.3",
+						KubeVersion: "v1.8.3",
 						KubeletVersions: map[string]uint16{
-							"v1.7.3": 1,
+							"v1.8.3": 1,
 						},
-						KubeadmVersion: "v1.8.1",
+						KubeadmVersion: "v1.8.3",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.8.2",
-						KubeadmVersion: "v1.8.2",
-						DNSVersion:     "1.14.5",
+						KubeVersion:    "v1.9.0",
+						KubeadmVersion: "v1.9.0",
+						DNSVersion:     "1.14.7",
+						EtcdVersion:    "3.1.10",
 					},
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.3   v1.7.5
+Kubelet     1 x v1.8.3   v1.8.5
 
-Upgrade to the latest version in the v1.7 series:
+Upgrade to the latest version in the v1.8 series:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.3    v1.7.5
-Controller Manager   v1.7.3    v1.7.5
-Scheduler            v1.7.3    v1.7.5
-Kube Proxy           v1.7.3    v1.7.5
+API Server           v1.8.3    v1.8.5
+Controller Manager   v1.8.3    v1.8.5
+Scheduler            v1.8.3    v1.8.5
+Kube Proxy           v1.8.3    v1.8.5
 Kube DNS             1.14.5    1.14.5
+Etcd                 3.0.17    3.0.17
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.7.5
+	kubeadm upgrade apply v1.8.5
 
 _____________________________________________________________________
 
 Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.3   v1.8.2
+Kubelet     1 x v1.8.3   v1.9.0
 
 Upgrade to the latest stable version:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.3    v1.8.2
-Controller Manager   v1.7.3    v1.8.2
-Scheduler            v1.7.3    v1.8.2
-Kube Proxy           v1.7.3    v1.8.2
-Kube DNS             1.14.5    1.14.5
+API Server           v1.8.3    v1.9.0
+Controller Manager   v1.8.3    v1.9.0
+Scheduler            v1.8.3    v1.9.0
+Kube Proxy           v1.8.3    v1.9.0
+Kube DNS             1.14.5    1.14.7
+Etcd                 3.0.17    3.1.10
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.8.2
+	kubeadm upgrade apply v1.9.0
 
-Note: Before you can perform this upgrade, you have to update kubeadm to v1.8.2.
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.0.
 
 _____________________________________________________________________
 
@@ -234,38 +246,41 @@ _____________________________________________________________________
 				{
 					Description: "experimental version",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.5",
+						KubeVersion: "v1.8.5",
 						KubeletVersions: map[string]uint16{
-							"v1.7.5": 1,
+							"v1.8.5": 1,
 						},
-						KubeadmVersion: "v1.7.5",
+						KubeadmVersion: "v1.8.5",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.8.0-beta.1",
-						KubeadmVersion: "v1.8.0-beta.1",
-						DNSVersion:     "1.14.5",
+						KubeVersion:    "v1.9.0-beta.1",
+						KubeadmVersion: "v1.9.0-beta.1",
+						DNSVersion:     "1.14.7",
+						EtcdVersion:    "3.1.10",
 					},
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.5   v1.8.0-beta.1
+Kubelet     1 x v1.8.5   v1.9.0-beta.1
 
 Upgrade to the latest experimental version:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.5    v1.8.0-beta.1
-Controller Manager   v1.7.5    v1.8.0-beta.1
-Scheduler            v1.7.5    v1.8.0-beta.1
-Kube Proxy           v1.7.5    v1.8.0-beta.1
-Kube DNS             1.14.5    1.14.5
+API Server           v1.8.5    v1.9.0-beta.1
+Controller Manager   v1.8.5    v1.9.0-beta.1
+Scheduler            v1.8.5    v1.9.0-beta.1
+Kube Proxy           v1.8.5    v1.9.0-beta.1
+Kube DNS             1.14.5    1.14.7
+Etcd                 3.0.17    3.1.10
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.8.0-beta.1
+	kubeadm upgrade apply v1.9.0-beta.1
 
-Note: Before you can perform this upgrade, you have to update kubeadm to v1.8.0-beta.1.
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.0-beta.1.
 
 _____________________________________________________________________
 
@@ -276,38 +291,41 @@ _____________________________________________________________________
 				{
 					Description: "release candidate version",
 					Before: upgrade.ClusterState{
-						KubeVersion: "v1.7.5",
+						KubeVersion: "v1.8.5",
 						KubeletVersions: map[string]uint16{
-							"v1.7.5": 1,
+							"v1.8.5": 1,
 						},
-						KubeadmVersion: "v1.7.5",
+						KubeadmVersion: "v1.8.5",
 						DNSVersion:     "1.14.5",
+						EtcdVersion:    "3.0.17",
 					},
 					After: upgrade.ClusterState{
-						KubeVersion:    "v1.8.0-rc.1",
-						KubeadmVersion: "v1.8.0-rc.1",
-						DNSVersion:     "1.14.5",
+						KubeVersion:    "v1.9.0-rc.1",
+						KubeadmVersion: "v1.9.0-rc.1",
+						DNSVersion:     "1.14.7",
+						EtcdVersion:    "3.1.10",
 					},
 				},
 			},
 			expectedBytes: []byte(`Components that must be upgraded manually after you have upgraded the control plane with 'kubeadm upgrade apply':
 COMPONENT   CURRENT      AVAILABLE
-Kubelet     1 x v1.7.5   v1.8.0-rc.1
+Kubelet     1 x v1.8.5   v1.9.0-rc.1
 
 Upgrade to the latest release candidate version:
 
 COMPONENT            CURRENT   AVAILABLE
-API Server           v1.7.5    v1.8.0-rc.1
-Controller Manager   v1.7.5    v1.8.0-rc.1
-Scheduler            v1.7.5    v1.8.0-rc.1
-Kube Proxy           v1.7.5    v1.8.0-rc.1
-Kube DNS             1.14.5    1.14.5
+API Server           v1.8.5    v1.9.0-rc.1
+Controller Manager   v1.8.5    v1.9.0-rc.1
+Scheduler            v1.8.5    v1.9.0-rc.1
+Kube Proxy           v1.8.5    v1.9.0-rc.1
+Kube DNS             1.14.5    1.14.7
+Etcd                 3.0.17    3.1.10
 
 You can now apply the upgrade by executing the following command:
 
-	kubeadm upgrade apply v1.8.0-rc.1
+	kubeadm upgrade apply v1.9.0-rc.1
 
-Note: Before you can perform this upgrade, you have to update kubeadm to v1.8.0-rc.1.
+Note: Before you can perform this upgrade, you have to update kubeadm to v1.9.0-rc.1.
 
 _____________________________________________________________________
 

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -226,8 +226,9 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		8: "3.0.17",
-		9: "3.1.10",
+		8:  "3.0.17",
+		9:  "3.1.10",
+		10: "3.1.11",
 	}
 )
 

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -137,8 +137,8 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		},
 		{
 			kubernetesVersion: "1.10.0",
-			expectedVersion:   nil,
-			expectedError:     fmt.Errorf("Unsupported or unknown kubernetes version"),
+			expectedVersion:   version.MustParseSemantic("3.1.11"),
+			expectedError:     nil,
 		},
 		{
 			kubernetesVersion: "1.8.6",

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -78,6 +78,7 @@ go_test(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/version:go_default_library",
+        "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -175,7 +175,8 @@ func performEtcdStaticPodUpgrade(waiter apiclient.Waiter, pathMgr StaticPodPathM
 		return false, fmt.Errorf("external etcd cannot be upgraded with kubeadm")
 	}
 	// Checking health state of etcd before proceeding with the upgrtade
-	etcdStatus, err := util.GetEtcdClusterStatus()
+	etcdCluster := util.LocalEtcdCluster{}
+	etcdStatus, err := etcdCluster.GetEtcdClusterStatus()
 	if err != nil {
 		return true, fmt.Errorf("etcd cluster is not healthy: %v", err)
 	}
@@ -222,7 +223,7 @@ func performEtcdStaticPodUpgrade(waiter apiclient.Waiter, pathMgr StaticPodPathM
 	}
 
 	// Checking health state of etcd after the upgrade
-	etcdStatus, err = util.GetEtcdClusterStatus()
+	etcdStatus, err = etcdCluster.GetEtcdClusterStatus()
 	if err != nil {
 		return true, rollbackEtcdData(cfg, fmt.Errorf("etcd cluster is not healthy after upgrade: %v rolling back", err), pathMgr)
 	}

--- a/cmd/kubeadm/app/util/etcd.go
+++ b/cmd/kubeadm/app/util/etcd.go
@@ -22,8 +22,16 @@ import (
 	"time"
 )
 
+// EtcdCluster is an interface to get etcd cluster related information
+type EtcdCluster interface {
+	GetEtcdClusterStatus() (*clientv3.StatusResponse, error)
+}
+
+// LocalEtcdCluster represents an instance of a local etcd cluster
+type LocalEtcdCluster struct{}
+
 // GetEtcdClusterStatus returns nil for status Up or error for status Down
-func GetEtcdClusterStatus() (*clientv3.StatusResponse, error) {
+func (cluster LocalEtcdCluster) GetEtcdClusterStatus() (*clientv3.StatusResponse, error) {
 	ep := []string{"localhost:2379"}
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   ep,


### PR DESCRIPTION
Adding etcd version display to kubeadm upgrade plan subcommand
```release-note
Adding etcd version display to kubeadm upgrade plan subcommand
```
Closes https://github.com/kubernetes/kubeadm/issues/531
