### PR TITLE
make quick-verify: show script names without full paths

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -92,24 +92,26 @@ function run-checks {
   local -r pattern=$1
   local -r runner=$2
 
+  local t
   for t in $(ls ${pattern})
   do
+    local check_name="$(basename "${t}")"
     if is-excluded "${t}" ; then
-      echo "Skipping ${t}"
+      echo "Skipping ${check_name}"
       continue
     fi
     if ${QUICK} && ! is-quick "${t}" ; then
-      echo "Skipping ${t} in quick mode"
+      echo "Skipping ${check_name} in quick mode"
       continue
     fi
-    echo -e "Verifying ${t}"
+    echo -e "Verifying ${check_name}"
     local start=$(date +%s)
     run-cmd "${runner}" "${t}" && tr=$? || tr=$?
     local elapsed=$(($(date +%s) - ${start}))
     if [[ ${tr} -eq 0 ]]; then
-      echo -e "${color_green}SUCCESS${color_norm}  ${t}\t${elapsed}s"
+      echo -e "${color_green}SUCCESS${color_norm}  ${check_name}\t${elapsed}s"
     else
-      echo -e "${color_red}FAILED${color_norm}   ${t}\t${elapsed}s"
+      echo -e "${color_red}FAILED${color_norm}   ${check_name}\t${elapsed}s"
       ret=1
       FAILED_TESTS+=(${t})
     fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the output of `make quick-verify` by showing script names without full paths. This simplifies reading its output during debugging session.

Before:
```
FAILED   hack/make-rules/../../hack/verify-boilerplate.sh	1s
Skipping hack/make-rules/../../hack/verify-cli-conventions.sh in quick mode
Skipping hack/make-rules/../../hack/verify-codegen.sh in quick mode
Skipping hack/make-rules/../../hack/verify-description.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-device-plugin.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-docs.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-files-remake.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-protobuf.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-runtime.sh in quick mode
Skipping hack/make-rules/../../hack/verify-generated-swagger-docs.sh in quick mode
Verifying hack/make-rules/../../hack/verify-godep-licenses.sh
Checking for 'Godeps/' changes against 'upstream/master'
SUCCESS  hack/make-rules/../../hack/verify-godep-licenses.sh	14s
```

After:
```
FAILED   verify-boilerplate.sh	1s
Skipping verify-cli-conventions.sh in quick mode
Skipping verify-codegen.sh in quick mode
Skipping verify-description.sh in quick mode
Skipping verify-generated-device-plugin.sh in quick mode
Skipping verify-generated-docs.sh in quick mode
Skipping verify-generated-files-remake.sh in quick mode
Skipping verify-generated-protobuf.sh in quick mode
Skipping verify-generated-runtime.sh in quick mode
Skipping verify-generated-swagger-docs.sh in quick mode
Verifying verify-godep-licenses.sh
Checking for 'Godeps/' changes against 'upstream/master'
SUCCESS  verify-godep-licenses.sh	14s
```

**Release note**:
```release-note
NONE
```

CC @simo5 