### PR TITLE
Update webhook test image to use mutual TLS

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -134,6 +134,12 @@
 {% set admission_controller_config_volume = "" -%}
 {% set image_policy_webhook_config_mount = "" -%}
 {% set image_policy_webhook_config_volume = "" -%}
+{% set image_policy_webhook_plugin_config_mount = "" -%}
+{% set image_policy_webhook_plugin_config_volume = "" -%}
+{% set validating_admission_webhook_config_mount = "" -%}
+{% set validating_admission_webhook_config_volume = "" -%}
+{% set mutating_admission_webhook_config_mount = "" -%}
+{% set mutating_admission_webhook_config_volume = "" -%}
 {% if grains.image_review_config is defined -%}
   {% set image_review_config = " --admission-control-config-file=" + grains.image_review_config -%}
   {% set admission_controller_config_mount = "{\"name\": \"admissioncontrollerconfigmount\",\"mountPath\": \"" + grains.image_review_config + "\", \"readOnly\": false}," -%}
@@ -260,6 +266,9 @@
         {{audit_webhook_config_mount}}
         {{admission_controller_config_mount}}
         {{image_policy_webhook_config_mount}}
+        {{image_policy_webhook_plugin_config_mount}}
+        {{validating_admission_webhook_config_mount}}
+        {{mutating_admission_webhook_config_mount}}
         { "name": "srvkube",
         "mountPath": "{{srv_kube_path}}",
         "readOnly": true},
@@ -299,6 +308,9 @@
   {{audit_webhook_config_volume}}
   {{admission_controller_config_volume}}
   {{image_policy_webhook_config_volume}}
+  {{image_policy_webhook_plugin_config_volume}}
+  {{validating_admission_webhook_config_volume}}
+  {{mutating_admission_webhook_config_volume}}
   { "name": "srvkube",
     "hostPath": {
         "path": "{{srv_kube_path}}"}

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v2 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v1
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.9v2

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -45,10 +45,16 @@ const (
 	]`
 )
 
-// Config contains the server (the webhook) cert and key.
+// Config contains the values of the flags passed to this webhook
 type Config struct {
+	// cert presented by the server (the webhook) to prove
+	// its identity to the client (the apiserver)
 	CertFile string
 	KeyFile  string
+
+	// CA to trust when verifying the identity of the client (the apiserver)
+	// If left blank then the client's identitiy will not be verified
+	ClientCAFile string
 }
 
 func (c *Config) addFlags() {
@@ -57,6 +63,10 @@ func (c *Config) addFlags() {
 		"after server cert).")
 	flag.StringVar(&c.KeyFile, "tls-private-key-file", c.KeyFile, ""+
 		"File containing the default x509 private key matching --tls-cert-file.")
+	flag.StringVar(&c.ClientCAFile, "client-ca-file", c.ClientCAFile, ""+
+		"If set, any request presenting a client certificate signed by one of "+
+		"the authorities in the client-ca-file is authenticated with an identity "+
+		"corresponding to the CommonName of the client certificate.")
 }
 
 func toAdmissionResponse(err error) *v1beta1.AdmissionResponse {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -48,7 +48,7 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.9v1", true}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.9v2", true}
 	APIServer                = ImageConfig{e2eRegistry, "k8s-aggregator-sample-apiserver", "1.7v2", true}
 	AppArmorLoader           = ImageConfig{gcRegistry, "apparmor-loader", "0.1", false}
 	BusyBox                  = ImageConfig{gcRegistry, "busybox", "1.24", false}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update webhook test image source to authenticate client certs, using client-ca-file as its certificate authority

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
fixes #54709

**Special notes for your reviewer**:
Based on top of #55907 so the apiserver will present a client cert to the webhook.
Also on top of #56822 because it also makes changes to the test image.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update webhook test image to use mutual TLS
```
