### PR TITLE
oidc auth: fix prefix flag plumbing

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -294,8 +294,10 @@ func (s *BuiltInAuthenticationOptions) ToAuthenticationConfig() authenticator.Au
 		ret.OIDCCAFile = s.OIDC.CAFile
 		ret.OIDCClientID = s.OIDC.ClientID
 		ret.OIDCGroupsClaim = s.OIDC.GroupsClaim
+		ret.OIDCGroupsPrefix = s.OIDC.GroupsPrefix
 		ret.OIDCIssuerURL = s.OIDC.IssuerURL
 		ret.OIDCUsernameClaim = s.OIDC.UsernameClaim
+		ret.OIDCUsernamePrefix = s.OIDC.UsernamePrefix
 	}
 
 	if s.PasswordFile != nil {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/56169

Tested this with an full API server against Google. It works now.

:(

cc @kubernetes/sig-auth-bugs 

```release-note
kube-apiserver: fixed --oidc-username-prefix and --oidc-group-prefix flags which previously weren't correctly enabled
```

/assign @liggitt @deads2k 

Probably worth a cherry pick.