### PR TITLE
Do not add new field in fluentd CRI log format.

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -99,7 +99,7 @@ data:
     # Json Log Example:
     # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
     # CRI Log Example:
-    # 2016-02-17T00:04:05.931087621Z stdout [info:2016-02-16T16:04:05.930-08:00] Some log text here
+    # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
     <source>
       type tail
       path /var/log/containers/*.log
@@ -114,7 +114,7 @@ data:
         time_format %Y-%m-%dT%H:%M:%S.%NZ
       </pattern>
       <pattern>
-        format /^(?<time>.+) (?<stream>stdout|stderr) (?<tag>.*) (?<log>.*)$/
+        format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
         time_format %Y-%m-%dT%H:%M:%S.%N%:z
       </pattern>
     </source>

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml
@@ -44,7 +44,7 @@ data:
     # Json Log Example:
     # {"log":"[info:2016-02-16T16:04:05.930-08:00] Some log text here\n","stream":"stdout","time":"2016-02-17T00:04:05.931087621Z"}
     # CRI Log Example:
-    # 2016-02-17T00:04:05.931087621Z stdout [info:2016-02-16T16:04:05.930-08:00] Some log text here
+    # 2016-02-17T00:04:05.931087621Z stdout F [info:2016-02-16T16:04:05.930-08:00] Some log text here
     <source>
       type tail
       path /var/log/containers/*.log
@@ -58,7 +58,7 @@ data:
         time_format %Y-%m-%dT%H:%M:%S.%NZ
       </pattern>
       <pattern>
-        format /^(?<time>.+) (?<stream>stdout|stderr) (?<tag>.*) (?<log>.*)$/
+        format /^(?<time>.+) (?<stream>stdout|stderr) [^ ]* (?<log>.*)$/
         time_format %Y-%m-%dT%H:%M:%S.%N%:z
       </pattern>
     </source>


### PR DESCRIPTION
After https://github.com/kubernetes/kubernetes/pull/55922 is merged, the test `Cluster level logging implemented by Stackdriver should ingest logs` starts to fail in cri-containerd cluster e2e test.
https://k8s-testgrid.appspot.com/sig-node-containerd#e2e-gci

I believe the reason is that the GCP fluentd plugin assumes that there are only `timestamp`, `severity`, `stream` and `log|message|msg` fields in the log entry.

If there is any other fields, GCP fluentd plugin will not try to convert the payload to json, even if the log content is json. The plugin deletes `stream`, `timestamp` and `severity`, then assumes that there is only one field left https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/blob/e13c89a1b6e0c33bac35435fe8e41d566ce52687/lib/fluent/plugin/out_google_cloud.rb#L495.

This PR removes the tag field. With this, fluentd GCP plugin should work again.

@yujuhong @crassirostris 
/cc @kubernetes/sig-node-bugs @kubernetes/sig-instrumentation-bugs 
/cc @derekwaynecarr for milestone approve. Thanks!

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
