### PR TITLE
kubeadm: add `--print-join-command` flag for token create.

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -74,6 +74,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/version:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//vendor/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],


### PR DESCRIPTION
**What this PR does / why we need it**: This change adds a new flag `kubeadm token create --print-join-command`. When this flag is passed, kubeadm prints the full `kubeadm join [...]` command, including the CA certificate hash which is otherwise annoying to calculate.

**Which issue(s) this PR fixes** fixes https://github.com/kubernetes/kubeadm/issues/519

**Special notes for your reviewer**:

### Example Output
```
$ kubeadm token create --print-join-command
kubeadm join --token 447067.20b55955bd6abe6c 192.168.99.100:8443 --discovery-token-ca-cert-hash sha256:17023a5c90b996e50c514e63e161e46f78be216fd48c0c3df3be67e008b28889
$ kubeadm token create -h
[...]
      --print-join-command   Instead of printing only the token, print the full 'kubeadm join' flag needed to join the cluster using the token.
[...]
```

I ended up not using the approach suggested by @xiangpengzhao in https://github.com/kubernetes/kubernetes/pull/56025 (and also by @fabriziopandini) of reusing the `bootstrap-token` phase code, since that code assumes it can load the CA certificates from `/etc/kubernetes`, but that is only true if kubeadm is run on an already-joined node.

Instead, I wrote code to pull the CA certificates and server endpoint from the kubeconfig that `kubeadm token create` is called with, since that also contains the data and is available even if, e.g., kubeadm is being run from outside the cluster.

**Release note**:
```release-note
kubeadm: added `--print-join-command` flag for `kubeadm token create`.
```

/sig cluster-lifecycle

/cc @fabriziopandini @xiangpengzhao @luxas