### PR TITLE
remove FilterFunc and use SelectionPredicate everywhere

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher.go
@@ -682,12 +682,16 @@ func forgetWatcher(c *Cacher, index int, triggerValue string, triggerSupported b
 }
 
 func filterFunction(key string, p SelectionPredicate) func(string, runtime.Object) bool {
-	f := SimpleFilter(p)
 	filterFunc := func(objKey string, obj runtime.Object) bool {
 		if !hasPathPrefix(objKey, key) {
 			return false
 		}
-		return f(obj)
+		matches, err := p.Matches(obj)
+		if err != nil {
+			glog.Errorf("invalid object for matching. Obj: %v. Err: %v", obj, err)
+			return false
+		}
+		return matches
 	}
 	return filterFunc
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_helper.go
@@ -240,7 +240,7 @@ func (h *etcdHelper) Watch(ctx context.Context, key string, resourceVersion stri
 		return nil, err
 	}
 	key = path.Join(h.pathPrefix, key)
-	w := newEtcdWatcher(false, h.quorum, nil, storage.SimpleFilter(pred), h.codec, h.versioner, nil, h.transformer, h)
+	w := newEtcdWatcher(false, h.quorum, nil, pred, h.codec, h.versioner, nil, h.transformer, h)
 	go w.etcdWatch(ctx, h.etcdKeysAPI, key, watchRV)
 	return w, nil
 }
@@ -255,7 +255,7 @@ func (h *etcdHelper) WatchList(ctx context.Context, key string, resourceVersion 
 		return nil, err
 	}
 	key = path.Join(h.pathPrefix, key)
-	w := newEtcdWatcher(true, h.quorum, exceptKey(key), storage.SimpleFilter(pred), h.codec, h.versioner, nil, h.transformer, h)
+	w := newEtcdWatcher(true, h.quorum, exceptKey(key), pred, h.codec, h.versioner, nil, h.transformer, h)
 	go w.etcdWatch(ctx, h.etcdKeysAPI, key, watchRV)
 	return w, nil
 }
@@ -359,7 +359,7 @@ func (h *etcdHelper) GetToList(ctx context.Context, key string, resourceVersion 
 	nodes := make([]*etcd.Node, 0)
 	nodes = append(nodes, response.Node)
 
-	if err := h.decodeNodeList(nodes, storage.SimpleFilter(pred), listPtr); err != nil {
+	if err := h.decodeNodeList(nodes, pred, listPtr); err != nil {
 		return err
 	}
 	trace.Step("Object decoded")
@@ -370,7 +370,7 @@ func (h *etcdHelper) GetToList(ctx context.Context, key string, resourceVersion 
 }
 
 // decodeNodeList walks the tree of each node in the list and decodes into the specified object
-func (h *etcdHelper) decodeNodeList(nodes []*etcd.Node, filter storage.FilterFunc, slicePtr interface{}) error {
+func (h *etcdHelper) decodeNodeList(nodes []*etcd.Node, pred storage.SelectionPredicate, slicePtr interface{}) error {
 	trace := utiltrace.New("decodeNodeList " + getTypeName(slicePtr))
 	defer trace.LogIfLong(400 * time.Millisecond)
 	v, err := conversion.EnforcePtr(slicePtr)
@@ -383,13 +383,13 @@ func (h *etcdHelper) decodeNodeList(nodes []*etcd.Node, filter storage.FilterFun
 			// IMPORTANT: do not log each key as a discrete step in the trace log
 			// as it produces an immense amount of log spam when there is a large
 			// amount of content in the list.
-			if err := h.decodeNodeList(node.Nodes, filter, slicePtr); err != nil {
+			if err := h.decodeNodeList(node.Nodes, pred, slicePtr); err != nil {
 				return err
 			}
 			continue
 		}
-		if obj, found := h.getFromCache(node.ModifiedIndex, filter); found {
-			// obj != nil iff it matches the filter function.
+		if obj, found := h.getFromCache(node.ModifiedIndex, pred); found {
+			// obj != nil iff it matches the pred function.
 			if obj != nil {
 				v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 			}
@@ -407,7 +407,7 @@ func (h *etcdHelper) decodeNodeList(nodes []*etcd.Node, filter storage.FilterFun
 			}
 			// being unable to set the version does not prevent the object from being extracted
 			_ = h.versioner.UpdateObject(obj, node.ModifiedIndex)
-			if filter(obj) {
+			if matched, err := pred.Matches(obj); err == nil && matched {
 				v.Set(reflect.Append(v, reflect.ValueOf(obj).Elem()))
 			}
 			if node.ModifiedIndex != 0 {
@@ -439,7 +439,7 @@ func (h *etcdHelper) List(ctx context.Context, key string, resourceVersion strin
 	if err != nil {
 		return err
 	}
-	if err := h.decodeNodeList(nodes, storage.SimpleFilter(pred), listPtr); err != nil {
+	if err := h.decodeNodeList(nodes, pred, listPtr); err != nil {
 		return err
 	}
 	trace.Step("Node list decoded")
@@ -590,7 +590,7 @@ func (h *etcdHelper) GuaranteedUpdate(
 // their Node.ModifiedIndex, which is unique across all types.
 // All implementations must be thread-safe.
 type etcdCache interface {
-	getFromCache(index uint64, filter storage.FilterFunc) (runtime.Object, bool)
+	getFromCache(index uint64, pred storage.SelectionPredicate) (runtime.Object, bool)
 	addToCache(index uint64, obj runtime.Object)
 }
 
@@ -598,14 +598,14 @@ func getTypeName(obj interface{}) string {
 	return reflect.TypeOf(obj).String()
 }
 
-func (h *etcdHelper) getFromCache(index uint64, filter storage.FilterFunc) (runtime.Object, bool) {
+func (h *etcdHelper) getFromCache(index uint64, pred storage.SelectionPredicate) (runtime.Object, bool) {
 	startTime := time.Now()
 	defer func() {
 		metrics.ObserveGetCache(startTime)
 	}()
 	obj, found := h.cache.Get(index)
 	if found {
-		if !filter(obj.(runtime.Object)) {
+		if matched, err := pred.Matches(obj.(runtime.Object)); err != nil || !matched {
 			return nil, true
 		}
 		// We should not return the object itself to avoid polluting the cache if someone

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd/etcd_watcher.go
@@ -78,7 +78,7 @@ type etcdWatcher struct {
 	list    bool // If we're doing a recursive watch, should be true.
 	quorum  bool // If we enable quorum, shoule be true
 	include includeFunc
-	filter  storage.FilterFunc
+	pred    storage.SelectionPredicate
 
 	etcdIncoming  chan *etcd.Response
 	etcdError     chan error
@@ -105,11 +105,9 @@ const watchWaitDuration = 100 * time.Millisecond
 
 // newEtcdWatcher returns a new etcdWatcher; if list is true, watch sub-nodes.
 // The versioner must be able to handle the objects that transform creates.
-func newEtcdWatcher(
-	list bool, quorum bool, include includeFunc, filter storage.FilterFunc,
+func newEtcdWatcher(list bool, quorum bool, include includeFunc, pred storage.SelectionPredicate,
 	encoding runtime.Codec, versioner storage.Versioner, transform TransformFunc,
-	valueTransformer ValueTransformer,
-	cache etcdCache) *etcdWatcher {
+	valueTransformer ValueTransformer, cache etcdCache) *etcdWatcher {
 	w := &etcdWatcher{
 		encoding:         encoding,
 		versioner:        versioner,
@@ -119,7 +117,7 @@ func newEtcdWatcher(
 		list:    list,
 		quorum:  quorum,
 		include: include,
-		filter:  filter,
+		pred:    pred,
 		// Buffer this channel, so that the etcd client is not forced
 		// to context switch with every object it gets, and so that a
 		// long time spent decoding an object won't block the *next*
@@ -315,7 +313,7 @@ func (w *etcdWatcher) translate() {
 
 // decodeObject extracts an object from the provided etcd node or returns an error.
 func (w *etcdWatcher) decodeObject(node *etcd.Node) (runtime.Object, error) {
-	if obj, found := w.cache.getFromCache(node.ModifiedIndex, storage.SimpleFilter(storage.Everything)); found {
+	if obj, found := w.cache.getFromCache(node.ModifiedIndex, storage.Everything); found {
 		return obj, nil
 	}
 
@@ -365,7 +363,7 @@ func (w *etcdWatcher) sendAdd(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	if !w.filter(obj) {
+	if matched, err := w.pred.Matches(obj); err != nil || !matched {
 		return
 	}
 	action := watch.Added
@@ -391,7 +389,10 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	curObjPasses := w.filter(curObj)
+	curObjPasses := false
+	if matched, err := w.pred.Matches(curObj); err == nil && matched {
+		curObjPasses = true
+	}
 	oldObjPasses := false
 	var oldObj runtime.Object
 	if res.PrevNode != nil && res.PrevNode.Value != "" {
@@ -400,10 +401,12 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 			if err := w.versioner.UpdateObject(oldObj, res.Node.ModifiedIndex); err != nil {
 				utilruntime.HandleError(fmt.Errorf("failure to version api object (%d) %#v: %v", res.Node.ModifiedIndex, oldObj, err))
 			}
-			oldObjPasses = w.filter(oldObj)
+			if matched, err := w.pred.Matches(oldObj); err == nil && matched {
+				oldObjPasses = true
+			}
 		}
 	}
-	// Some changes to an object may cause it to start or stop matching a filter.
+	// Some changes to an object may cause it to start or stop matching a pred.
 	// We need to report those as adds/deletes. So we have to check both the previous
 	// and current value of the object.
 	switch {
@@ -423,7 +426,7 @@ func (w *etcdWatcher) sendModify(res *etcd.Response) {
 			Object: oldObj,
 		})
 	}
-	// Do nothing if neither new nor old object passed the filter.
+	// Do nothing if neither new nor old object passed the pred.
 }
 
 func (w *etcdWatcher) sendDelete(res *etcd.Response) {
@@ -449,7 +452,7 @@ func (w *etcdWatcher) sendDelete(res *etcd.Response) {
 		// the resourceVersion to resume will never be able to get past a bad value.
 		return
 	}
-	if !w.filter(obj) {
+	if matched, err := w.pred.Matches(obj); err != nil || !matched {
 		return
 	}
 	w.emit(watch.Event{

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -70,10 +70,6 @@ type MatchValue struct {
 // to that function.
 type TriggerPublisherFunc func(obj runtime.Object) []MatchValue
 
-// FilterFunc takes an API object and returns true if the object satisfies some requirements.
-// TODO: We will remove this type and use SelectionPredicate everywhere.
-type FilterFunc func(obj runtime.Object) bool
-
 // Everything accepts all objects.
 var Everything = SelectionPredicate{
 	Label: labels.Everything(),

--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -96,7 +96,7 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 	}
 	matched := s.Label.Matches(labels)
 	if matched && s.Field != nil {
-		matched = (matched && s.Field.Matches(fields))
+		matched = matched && s.Field.Matches(fields)
 	}
 	return matched, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/util.go
@@ -22,8 +22,6 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/golang/glog"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/validation/path"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -37,19 +35,6 @@ func SimpleUpdate(fn SimpleUpdateFunc) UpdateFunc {
 	return func(input runtime.Object, _ ResponseMeta) (runtime.Object, *uint64, error) {
 		out, err := fn(input)
 		return out, nil, err
-	}
-}
-
-// SimpleFilter converts a selection predicate into a FilterFunc.
-// It ignores any error from Matches().
-func SimpleFilter(p SelectionPredicate) FilterFunc {
-	return func(obj runtime.Object) bool {
-		matches, err := p.Matches(obj)
-		if err != nil {
-			glog.Errorf("invalid object for matching. Obj: %v. Err: %v", obj, err)
-			return false
-		}
-		return matches
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
> // FilterFunc takes an API object and returns true if the object satisfies some requirements.
// TODO: We will remove this type and use SelectionPredicate everywhere.
type FilterFunc func(obj runtime.Object) bool

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/assign @liggitt @wojtek-t 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
