### PR TITLE
Delete unused code in gce/ensureInternalBackendService

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
+++ b/pkg/cloudprovider/providers/gce/gce_loadbalancer_internal.go
@@ -525,11 +525,6 @@ func (gce *GCECloud) ensureInternalBackendService(name, description string, affi
 		glog.V(2).Infof("ensureInternalBackendService: created backend service %v successfully", name)
 		return nil
 	}
-	// Check existing backend service
-	existingIGLinks := sets.NewString()
-	for _, be := range bs.Backends {
-		existingIGLinks.Insert(be.Group)
-	}
 
 	if backendSvcEqual(expectedBS, bs) {
 		return nil


### PR DESCRIPTION
existingIGLinks is not used after initialization,  because instance groups are compared in backendSvcEqual()

**Release note**:
```release-note
NONE
```

/area cloudprovider
/area platform/gce
/sig gcp