### PR TITLE
Bump Heapster version to v1.5.0-beta.2

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.0-beta.1
+  name: heapster-v1.5.0-beta.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.0-beta.1
+    version: v1.5.0-beta.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.0-beta.1
+      version: v1.5.0-beta.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.0-beta.1
+        version: v1.5.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=gcm
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: eventer
           command:
             - /eventer
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -118,7 +118,7 @@ spec:
             - --memory={{base_eventer_memory}}
             - --extra-memory={{eventer_memory_per_node}}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.0-beta.1
+  name: heapster-v1.5.0-beta.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.0-beta.1
+    version: v1.5.0-beta.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.0-beta.1
+      version: v1.5.0-beta.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.0-beta.1
+        version: v1.5.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
 
           name: heapster
           livenessProbe:
@@ -60,7 +60,7 @@ spec:
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
             - --sink=gcm:?metrics=autoscaling
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: eventer
           command:
             - /eventer
@@ -91,7 +91,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -120,7 +120,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -23,29 +23,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.0-beta.1
+  name: heapster-v1.5.0-beta.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.0-beta.1
+    version: v1.5.0-beta.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.0-beta.1
+      version: v1.5.0-beta.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.0-beta.1
+        version: v1.5.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: heapster
           livenessProbe:
             httpGet:
@@ -58,7 +58,7 @@ spec:
             - /heapster
             - --source=kubernetes.summary_api:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: eventer
           command:
             - /eventer
@@ -89,7 +89,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
@@ -118,7 +118,7 @@ spec:
             - --memory={{ base_eventer_memory }}
             - --extra-memory={{ eventer_memory_per_node }}Ki
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.0-beta.1
+  name: heapster-v1.5.0-beta.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.0-beta.1
+    version: v1.5.0-beta.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.0-beta.1
+      version: v1.5.0-beta.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.0-beta.1
+        version: v1.5.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: heapster
           livenessProbe:
             httpGet:
@@ -101,7 +101,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{metrics_memory_per_node}}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -21,29 +21,29 @@ metadata:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: heapster-v1.5.0-beta.1
+  name: heapster-v1.5.0-beta.2
   namespace: kube-system
   labels:
     k8s-app: heapster
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.5.0-beta.1
+    version: v1.5.0-beta.2
 spec:
   replicas: 1
   selector:
     matchLabels:
       k8s-app: heapster
-      version: v1.5.0-beta.1
+      version: v1.5.0-beta.2
   template:
     metadata:
       labels:
         k8s-app: heapster
-        version: v1.5.0-beta.1
+        version: v1.5.0-beta.2
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       containers:
-        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.1
+        - image: gcr.io/google_containers/heapster-amd64:v1.5.0-beta.2
           name: heapster
           livenessProbe:
             httpGet:
@@ -80,7 +80,7 @@ spec:
             - --memory={{ base_metrics_memory }}
             - --extra-memory={{ metrics_memory_per_node }}Mi
             - --threshold=5
-            - --deployment=heapster-v1.5.0-beta.1
+            - --deployment=heapster-v1.5.0-beta.2
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump Heapster version to v1.5.0-beta.2

**Release note**:

```release-note
NONE
```
