### PR TITLE
require webhook admission kubeconfigfile to be absolute

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/errors:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/kubeconfig.go
@@ -17,13 +17,14 @@ limitations under the License.
 package config
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
-
-	"fmt"
+	"path"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/config/apis/webhookadmission/v1alpha1"
 )
@@ -55,6 +56,10 @@ func LoadConfig(configFile io.Reader) (string, error) {
 		config, ok := decodedObj.(*webhookadmission.WebhookAdmission)
 		if !ok {
 			return "", fmt.Errorf("unexpected type: %T", decodedObj)
+		}
+
+		if !path.IsAbs(config.KubeConfigFile) {
+			return "", field.Invalid(field.NewPath("kubeConfigFile"), config.KubeConfigFile, "must be an absolute file path")
 		}
 
 		kubeconfigFile = config.KubeConfigFile


### PR DESCRIPTION
Minimal change to enforce absolute file paths when using webhook admission config.

Eventually we should resolve the local file paths relative to the original configuration file, but that requires fairly significant plumbing.

@caesarxuchao @sttts @liggitt 

If this is not fixed, then inconsistent, seemingly random file resolution will happen and may pin this API to bad behavior that we will later have to break.