### PR TITLE
Add docker-logins config to kubernetes-worker charm

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/config.yaml
+++ b/cluster/juju/layers/kubernetes-worker/config.yaml
@@ -49,3 +49,12 @@ options:
         runtime-config=batch/v2alpha1=true profiling=true
       will result in kube-apiserver being run with the following options:
         --runtime-config=batch/v2alpha1=true --profiling=true
+  docker-logins:
+    type: string
+    default: "[]"
+    description: |
+      Docker login credentials. Setting this config allows Kubelet to pull images from
+      registries where auth is required.
+
+      The value for this config must be a JSON array of credential objects, like this:
+        [{"server": "my.registry", "username": "myUser", "password": "myPass"}]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds a `docker-logins` config option to the kubernetes-worker charm, which allows cluster operators to authenticate against docker registries so kubelet can pull containers from them.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added docker-logins config to kubernetes-worker charm
```
