### PR TITLE
Kubectl explain with aggregated resources

### DIFF
--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -79,7 +79,6 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 
 	recursive := cmdutil.GetFlagBool(cmd, "recursive")
 	apiVersionString := cmdutil.GetFlagString(cmd, "api-version")
-	apiVersion := schema.GroupVersion{}
 
 	mapper, _ := f.Object()
 	// TODO: After we figured out the new syntax to separate group and resource, allow
@@ -103,15 +102,13 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 		}
 	}
 
-	if len(apiVersionString) == 0 {
-		apiVersion = gvk.GroupVersion()
-	} else {
-		apiVersion, err = schema.ParseGroupVersion(apiVersionString)
+	if len(apiVersionString) != 0 {
+		apiVersion, err := schema.ParseGroupVersion(apiVersionString)
 		if err != nil {
 			return err
 		}
+		gvk = apiVersion.WithKind(gvk.Kind)
 	}
-	gvk = apiVersion.WithKind(gvk.Kind)
 
 	resources, err := f.OpenAPISchema()
 	if err != nil {

--- a/pkg/kubectl/cmd/explain.go
+++ b/pkg/kubectl/cmd/explain.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	"k8s.io/kubernetes/pkg/kubectl/explain"
-	"k8s.io/kubernetes/pkg/kubectl/scheme"
 	"k8s.io/kubernetes/pkg/kubectl/util/i18n"
 )
 
@@ -105,12 +104,7 @@ func RunExplain(f cmdutil.Factory, out, cmdErr io.Writer, cmd *cobra.Command, ar
 	}
 
 	if len(apiVersionString) == 0 {
-		groupMeta, err := scheme.Registry.Group(gvk.Group)
-		if err != nil {
-			return err
-		}
-		apiVersion = groupMeta.GroupVersion
-
+		apiVersion = gvk.GroupVersion()
 	} else {
 		apiVersion, err = schema.ParseGroupVersion(apiVersionString)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, it's not possible to do "kubectl explain" on resources from aggregated API servers (such as the Service Catalog API server, for example):
```
$ kubectl explain clusterservicebroker
error: group servicecatalog.k8s.io has not been registered
```

This PR addresses this problem by removing kubectl explain's unnecessary lookup into `scheme.Registry`, which only contains resource types registered in the kubectl client itself. 

Explaining clusterservicebrokers now works:
```
$ _output/bin/kubectl explain clusterservicebroker
DESCRIPTION:
     ClusterServiceBroker represents an entity that provides
     ClusterServiceClasses for use in the service catalog.

FIELDS:
   apiVersion	<string>
   ...
```

**Which issue(s) this PR fixes** 
There was no existing issue and I did not file one. Should I?

**Release note**:
```release-note
kubectl explain can now be used with resources from aggregated API servers
```
