### PR TITLE
ensure that network policy can be GC'd

### DIFF
--- a/pkg/apis/extensions/validation/validation.go
+++ b/pkg/apis/extensions/validation/validation.go
@@ -19,7 +19,6 @@ package validation
 import (
 	"fmt"
 	"net"
-	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -998,7 +997,7 @@ func ValidateNetworkPolicy(np *extensions.NetworkPolicy) field.ErrorList {
 func ValidateNetworkPolicyUpdate(update, old *extensions.NetworkPolicy) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
-	if !reflect.DeepEqual(update.Spec, old.Spec) {
+	if !apiequality.Semantic.DeepEqual(update.Spec, old.Spec) {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec"), "updates to networkpolicy spec are forbidden."))
 	}
 	return allErrs


### PR DESCRIPTION
Updates validation to use semantic equality when comparing different specs.  This prevents errors like: 

`failed with NetworkPolicy.networking.k8s.io "allow-all" is invalid: spec: Forbidden: updates to networkpolicy spec are forbidden.`

```release-note
Fix validation of NetworkPolicy
```