### PR TITLE
Add Feature tag to CPU Manager node e2e test.

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -415,7 +415,7 @@ func runCPUManagerTests(f *framework.Framework) {
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = framework.KubeDescribe("CPU Manager [Serial]", func() {
+var _ = framework.KubeDescribe("CPU Manager [Feature:CPUManager]", func() {
 	f := framework.NewDefaultFramework("cpu-manager-test")
 
 	Context("With kubeconfig updated with static CPU Manager policy run the CPU Manager tests", func() {


### PR DESCRIPTION
**What this PR does / why we need it**: Adds a `Feature` tag to the CPU manager node e2e tests.

CC @ConnorDoyle 