### PR TITLE
hack: fix godep license parsing for gopkg.in packages

### DIFF
--- a/hack/update-godep-licenses.sh
+++ b/hack/update-godep-licenses.sh
@@ -75,6 +75,14 @@ process_content () {
     go4.org/*)
      package_root=$(echo ${package} |awk -F/ '{ print $1 }')
      ;;
+    gopkg.in/*)
+     # Root of gopkg.in package always ends with '.v(number)' and my contain
+     # more than two path elements. For example:
+     # - gopkg.in/yaml.v2
+     # - gopkg.in/inf.v0
+     # - gopkg.in/square/go-jose.v2
+     package_root=$(echo ${package} |grep -oh '.*\.v[0-9]')
+     ;;
     *)
      package_root=$(echo ${package} |awk -F/ '{ print $1"/"$2 }')
      ;;


### PR DESCRIPTION
The script incorrectly thinks that `gopkg.in/square/go-jose.v2/cipher`
doesn't have a license because it parses `gopkg.in/square` as the
root of the repo, even though `gopkg.in/square/go-jose.v2` is the
root.

Add special handling for gopkg.in packages by grep'ing for the
version that gopkg.in appends to the package name.

Extracted from https://github.com/kubernetes/kubernetes/pull/56161

cc @thockin 

```release-note
NONE
```
