### PR TITLE
Add balajismaniam and ConnorDoyle to node-e2e approvers.

### DIFF
--- a/test/e2e_node/OWNERS
+++ b/test/e2e_node/OWNERS
@@ -4,5 +4,7 @@ approvers:
 - vishh
 - derekwaynecarr
 - yujuhong
+- balajismaniam
+- ConnorDoyle
 reviewers:
 - sig-node-reviewers


### PR DESCRIPTION
**What this PR does / why we need it**:

- Add balajismaniam and ConnorDoyle to node-e2e approvers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
_Rationale:_ We are maintaining node e2e tests for the CPU manager component, and would also like to help with the rest of review load in this package. Both Balaji and I are approvers for the cpumanager and cpuset packages in the Kubelet container manager.

**Release note**:
```release-note
NONE
```
