### PR TITLE
Updates kubenet CNI template for v0.3.1

### DIFF
--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -150,7 +150,7 @@ func (plugin *kubenetNetworkPlugin) Init(host network.Host, hairpinMode kubeletc
 	}
 
 	plugin.loConfig, err = libcni.ConfFromBytes([]byte(`{
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.3.1",
   "name": "kubenet-loopback",
   "type": "loopback"
 }`))
@@ -209,7 +209,7 @@ func findMinMTU() (*net.Interface, error) {
 }
 
 const NET_CONFIG_TEMPLATE = `{
-  "cniVersion": "0.1.0",
+  "cniVersion": "0.3.1",
   "name": "kubenet",
   "type": "bridge",
   "bridge": "%s",
@@ -220,10 +220,13 @@ const NET_CONFIG_TEMPLATE = `{
   "hairpinMode": %t,
   "ipam": {
     "type": "host-local",
-    "subnet": "%s",
-    "gateway": "%s",
-    "routes": [
-      { "dst": "0.0.0.0/0" }
+    "ranges": [
+      [
+        {
+          "subnet": "%s",
+          "gateway": "%s"
+        }
+      ]
     ]
   }
 }`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kubenet CNI template to use CNI v0.3.1.

**Which issue(s) this PR fixes**:
Fixes #52179

**Special notes for your reviewer**:
Since time is closing on v1.9 and I was unsure how to update #52180 from @rpothier, so this PR supersedes it. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
