### PR TITLE
Add [sig-node] to some unowned e2e_node tests

### DIFF
--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -12,6 +12,7 @@ go_library(
         "container.go",
         "doc.go",
         "docker_util.go",
+        "framework.go",
         "gpu_device_plugin.go",
         "gpus.go",
         "image_list.go",

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -415,7 +415,7 @@ func runCPUManagerTests(f *framework.Framework) {
 }
 
 // Serial because the test updates kubelet configuration.
-var _ = framework.KubeDescribe("CPU Manager [Feature:CPUManager]", func() {
+var _ = SIGDescribe("CPU Manager [Feature:CPUManager]", func() {
 	f := framework.NewDefaultFramework("cpu-manager-test")
 
 	Context("With kubeconfig updated with static CPU Manager policy run the CPU Manager tests", func() {

--- a/test/e2e_node/dockershim_checkpoint_test.go
+++ b/test/e2e_node/dockershim_checkpoint_test.go
@@ -42,7 +42,7 @@ const (
 	testCheckpointContent = `{"version":"v1","name":"fluentd-gcp-v2.0-vmnqx","namespace":"kube-system","data":{},"checksum":1799154314}`
 )
 
-var _ = framework.KubeDescribe("Dockershim [Serial] [Disruptive] [Feature:Docker]", func() {
+var _ = SIGDescribe("Dockershim [Serial] [Disruptive] [Feature:Docker]", func() {
 	f := framework.NewDefaultFramework("dockerhism-checkpoint-test")
 
 	It("should clean up pod sandbox checkpoint after pod deletion", func() {

--- a/test/e2e_node/framework.go
+++ b/test/e2e_node/framework.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_node
+
+import "github.com/onsi/ginkgo"
+
+func SIGDescribe(text string, body func()) bool {
+	return ginkgo.Describe("[sig-node] "+text, body)
+}

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -31,7 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = framework.KubeDescribe("Resource-usage [Serial] [Slow]", func() {
+var _ = SIGDescribe("Resource-usage [Serial] [Slow]", func() {
 	const (
 		// Interval to poll /stats/container on a node
 		containerStatsPollingPeriod = 10 * time.Second


### PR DESCRIPTION
Follow the SIGDescribe pattern used in test/e2e/foo tests

ref #49161

```release-note
NONE
```