### PR TITLE
Avoid duplicated addresses in External IP list

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -827,18 +827,18 @@ func getServiceExternalIP(svc *api.Service, wide bool) string {
 		lbIps := loadBalancerStatusStringer(svc.Status.LoadBalancer, wide)
 		if len(svc.Spec.ExternalIPs) > 0 {
 			results := []string{}
-			mresults := make(map[string]bool)
+			seenResults := make(map[string]bool)
 			if len(lbIps) > 0 {
 				results = append(results, strings.Split(lbIps, ",")...)
 			}
 			results = append(results, svc.Spec.ExternalIPs...)
-			//Avoid repeated addresses
-			for _, value := range results {
-				mresults[value] = true
-			}
+			// Avoid repeated addresses
 			ips := []string{}
-			for k := range mresults {
-				ips = append(ips, k)
+			for _, value := range results {
+				if !seenResults[value] {
+					ips = append(ips, value)
+					seenResults[value] = true
+				}
 			}
 			return strings.Join(ips, ",")
 		}

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -827,11 +827,20 @@ func getServiceExternalIP(svc *api.Service, wide bool) string {
 		lbIps := loadBalancerStatusStringer(svc.Status.LoadBalancer, wide)
 		if len(svc.Spec.ExternalIPs) > 0 {
 			results := []string{}
+			mresults := make(map[string]bool)
 			if len(lbIps) > 0 {
 				results = append(results, strings.Split(lbIps, ",")...)
 			}
 			results = append(results, svc.Spec.ExternalIPs...)
-			return strings.Join(results, ",")
+			//Avoid repeated addresses
+			for _, value := range results {
+				mresults[value] = true
+			}
+			ips := []string{}
+			for k := range mresults {
+				ips = append(ips, k)
+			}
+			return strings.Join(ips, ",")
 		}
 		if len(lbIps) > 0 {
 			return lbIps

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1176,6 +1176,9 @@ func TestPrintHumanReadableService(t *testing.T) {
 							IP: "2.3.4.5",
 						},
 						{
+							IP: "2.3.4.5",
+						},
+						{
 							IP: "3.4.5.6",
 						},
 					},
@@ -1290,6 +1293,11 @@ func TestPrintHumanReadableService(t *testing.T) {
 				if (n == 0 || wide) && !strings.Contains(output, ip) {
 					t.Errorf("expected to contain ingress ip %s with wide=%v, but doesn't: %s", ip, wide, output)
 				}
+				// Check for duplicate ip's
+				if strings.Count(output, ip) > 1 {
+					t.Errorf("expected to contain non duplicate ip's %s but got: %s", ip, output)
+				}
+
 			}
 
 			for _, port := range svc.Spec.Ports {


### PR DESCRIPTION
**What this PR does / why we need it**:
There are cases like OpenShift baremetal implementations in which the
Load Balancer IP might be the same as the External IP and
it will appear two times in the EXTERNAL-IP column, this can be
confusing for the administrator.

