### PR TITLE
clear resourceversion for migrated cluster roles

### DIFF
--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -343,6 +343,7 @@ func primeAggregatedClusterRoles(clusterRolesToAggregate map[string]string, clus
 		}
 		glog.V(1).Infof("migrating %v to %v", existingRole.Name, newName)
 		existingRole.Name = newName
+		existingRole.ResourceVersion = "" // clear this so the object can be created.
 		if _, err := clusterRoleClient.ClusterRoles().Create(existingRole); err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}


### PR DESCRIPTION
Fixes #56248

Need to clear the resource version.  Alternatively, we could clear it in storage when we clear and stomp other fields.

Works locally for me.