### PR TITLE
openstack: remove orphaned routes from terminated instances

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_routes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes.go
@@ -77,15 +77,9 @@ func (r *Routes) ListRoutes(clusterName string) ([]*cloudprovider.Route, error) 
 
 	var routes []*cloudprovider.Route
 	for _, item := range router.Routes {
-		nodeName, ok := nodeNamesByAddr[item.NextHop]
-		if !ok {
-			// Not one of our routes?
-			glog.V(4).Infof("Skipping route with unknown nexthop %v", item.NextHop)
-			continue
-		}
 		route := cloudprovider.Route{
 			Name:            item.DestinationCIDR,
-			TargetNode:      nodeName,
+			TargetNode:      nodeNamesByAddr[item.NextHop], //empty if NextHop is unknown
 			DestinationCIDR: item.DestinationCIDR,
 		}
 		routes = append(routes, &route)


### PR DESCRIPTION
**What this PR does / why we need it**:
At the moment the openstack cloudprovider only returns routes where the `NextHop` address points to an existing openstack instance. This is a problem when an instance is terminated before the corresponding node is removed from k8s. The existing route is not returned by the cloudprovider anymore and therefore never considered for deletion by the route controller. When the route's `DestinationCIDR` is reassigned to a new node the router ends up with two routes pointing to a different `NextHop` leading to broken networking.

This PR removes skipping routes pointing to unknown next hops when listing routes. This should cause [this conditional](https://github.com/kubernetes/kubernetes/blob/93dc3763b0393b870855b2806b693a3224b039fa/pkg/controller/route/route_controller.go#L208) in the route controller to succeed and have the route removed if the route controller [feels responsible](https://github.com/kubernetes/kubernetes/blob/93dc3763b0393b870855b2806b693a3224b039fa/pkg/controller/route/route_controller.go#L206).

```release-note
OpenStack cloudprovider: Ensure orphaned routes are removed.
```