### PR TITLE
remove leaked file of unit test from workspace

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -19,6 +19,7 @@ package deviceplugin
 import (
 	"flag"
 	"fmt"
+	"os"
 	"reflect"
 	"sync/atomic"
 	"testing"
@@ -299,6 +300,7 @@ func TestCheckpoint(t *testing.T) {
 	expectedAllDevices := testManager.allDevices
 
 	err := testManager.writeCheckpoint()
+	defer os.Remove(testManager.checkpointFile())
 	as := assert.New(t)
 
 	as.Nil(err)


### PR DESCRIPTION
After unit test, there is a leaked file in workspace
```
make test WHAT=k8s.io/kubernetes/pkg/kubelet/cm/deviceplugin KUBE_TEST_ARGS='-run ^TestCheckpoint$'
```

Fixes: https://github.com/kubernetes/kubernetes/issues/56365

**Release note**:

```release-note
NONE
```
