### PR TITLE
Display AGE column for resources from aggregated API servers

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -38,7 +38,10 @@ go_library(
 
 go_test(
     name = "go_default_xtest",
-    srcs = ["customcolumn_test.go"],
+    srcs = [
+        "common_test.go",
+        "customcolumn_test.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/printers_test",
     deps = [
         ":go_default_library",

--- a/pkg/printers/common.go
+++ b/pkg/printers/common.go
@@ -22,9 +22,9 @@ import (
 	"time"
 )
 
-// ElapsedTime returns the elapsed time since timestamp in
+// ElapsedTimeString returns the elapsed time since timestamp in
 // human-readable approximation.
-func ElapsedTime(timestamp metav1.Time) string {
+func ElapsedTimeString(timestamp metav1.Time) string {
 	if timestamp.IsZero() {
 		return "<unknown>"
 	}

--- a/pkg/printers/common.go
+++ b/pkg/printers/common.go
@@ -18,8 +18,18 @@ package printers
 
 import (
 	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
 )
+
+// ElapsedTime returns the elapsed time since timestamp in
+// human-readable approximation.
+func ElapsedTime(timestamp metav1.Time) string {
+	if timestamp.IsZero() {
+		return "<unknown>"
+	}
+	return ShortHumanDuration(time.Now().Sub(timestamp.Time))
+}
 
 func ShortHumanDuration(d time.Duration) string {
 	// Allow deviation no more than 2 seconds(excluded) to tolerate machine time

--- a/pkg/printers/common_test.go
+++ b/pkg/printers/common_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers_test
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/pkg/printers"
+	"testing"
+	"time"
+)
+
+type stringTestList []struct {
+	name, got, exp string
+}
+
+func TestElapsedTime(t *testing.T) {
+	tl := stringTestList{
+		{"a while from now", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
+		{"almost now", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(1.9e9)}), "0s"},
+		{"now", printers.ElapsedTime(metav1.Time{Time: time.Now()}), "0s"},
+		{"unknown", printers.ElapsedTime(metav1.Time{}), "<unknown>"},
+		{"30 seconds ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-3e10)}), "30s"},
+		{"5 minutes ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-3e11)}), "5m"},
+		{"an hour ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-6e12)}), "1h"},
+		{"2 days ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -2)}), "2d"},
+		{"months ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -90)}), "90d"},
+		{"10 years ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(-10, 0, 0)}), "10y"},
+	}
+	for _, test := range tl {
+		if test.got != test.exp {
+			t.Errorf("On %v, expected '%v', but got '%v'",
+				test.name, test.exp, test.got)
+		}
+	}
+}

--- a/pkg/printers/common_test.go
+++ b/pkg/printers/common_test.go
@@ -24,26 +24,28 @@ import (
 )
 
 type stringTestList []struct {
-	name, got, exp string
+	name     string
+	time     time.Time
+	expected string
 }
 
 func TestElapsedTimeString(t *testing.T) {
 	tl := stringTestList{
-		{"a while from now", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
-		{"almost now", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(1.9e9)}), "0s"},
-		{"now", printers.ElapsedTimeString(metav1.Time{Time: time.Now()}), "0s"},
-		{"unknown", printers.ElapsedTimeString(metav1.Time{}), "<unknown>"},
-		{"30 seconds ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-3e10)}), "30s"},
-		{"5 minutes ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-3e11)}), "5m"},
-		{"an hour ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-6e12)}), "1h"},
-		{"2 days ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -2)}), "2d"},
-		{"months ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -90)}), "90d"},
-		{"10 years ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(-10, 0, 0)}), "10y"},
+		{"a while from now", time.Now().Add(2.1e9), "<invalid>"},
+		{"almost now", time.Now().Add(1.9e9), "0s"},
+		{"now", time.Now(), "0s"},
+		{"unknown", time.Time{}, "<unknown>"},
+		{"30 seconds ago", time.Now().Add(-3e10), "30s"},
+		{"5 minutes ago", time.Now().Add(-3e11), "5m"},
+		{"an hour ago", time.Now().Add(-6e12), "1h"},
+		{"2 days ago", time.Now().UTC().AddDate(0, 0, -2), "2d"},
+		{"months ago", time.Now().UTC().AddDate(0, 0, -90), "90d"},
+		{"10 years ago", time.Now().UTC().AddDate(-10, 0, 0), "10y"},
 	}
 	for _, test := range tl {
-		if test.got != test.exp {
-			t.Errorf("On %v, expected '%v', but got '%v'",
-				test.name, test.exp, test.got)
+		actual := printers.ElapsedTimeString(metav1.Time{Time: test.time})
+		if actual != test.expected {
+			t.Errorf("On %v, expected '%v', but got '%v'", test.name, test.expected, actual)
 		}
 	}
 }

--- a/pkg/printers/common_test.go
+++ b/pkg/printers/common_test.go
@@ -27,18 +27,18 @@ type stringTestList []struct {
 	name, got, exp string
 }
 
-func TestElapsedTime(t *testing.T) {
+func TestElapsedTimeString(t *testing.T) {
 	tl := stringTestList{
-		{"a while from now", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
-		{"almost now", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(1.9e9)}), "0s"},
-		{"now", printers.ElapsedTime(metav1.Time{Time: time.Now()}), "0s"},
-		{"unknown", printers.ElapsedTime(metav1.Time{}), "<unknown>"},
-		{"30 seconds ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-3e10)}), "30s"},
-		{"5 minutes ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-3e11)}), "5m"},
-		{"an hour ago", printers.ElapsedTime(metav1.Time{Time: time.Now().Add(-6e12)}), "1h"},
-		{"2 days ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -2)}), "2d"},
-		{"months ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -90)}), "90d"},
-		{"10 years ago", printers.ElapsedTime(metav1.Time{Time: time.Now().UTC().AddDate(-10, 0, 0)}), "10y"},
+		{"a while from now", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
+		{"almost now", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(1.9e9)}), "0s"},
+		{"now", printers.ElapsedTimeString(metav1.Time{Time: time.Now()}), "0s"},
+		{"unknown", printers.ElapsedTimeString(metav1.Time{}), "<unknown>"},
+		{"30 seconds ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-3e10)}), "30s"},
+		{"5 minutes ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-3e11)}), "5m"},
+		{"an hour ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().Add(-6e12)}), "1h"},
+		{"2 days ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -2)}), "2d"},
+		{"months ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -90)}), "90d"},
+		{"10 years ago", printers.ElapsedTimeString(metav1.Time{Time: time.Now().UTC().AddDate(-10, 0, 0)}), "10y"},
 	}
 	for _, test := range tl {
 		if test.got != test.exp {

--- a/pkg/printers/customcolumn.go
+++ b/pkg/printers/customcolumn.go
@@ -44,10 +44,10 @@ const (
 var jsonRegexp = regexp.MustCompile("^{\\.?([^{}]+)}$|^\\.?([^{}]+)$")
 
 var jsonPathFunctions = map[string]jsonpath.JSONPathFunction{
-	"elapsedTime": elapsedTimeJSONPathFunc,
+	"elapsedTimeString": elapsedTimeStringJSONPathFunc,
 }
 
-func elapsedTimeJSONPathFunc(input []reflect.Value) []reflect.Value {
+func elapsedTimeStringJSONPathFunc(input []reflect.Value) []reflect.Value {
 	results := []reflect.Value{}
 	for _, value := range input {
 		var v string
@@ -55,12 +55,12 @@ func elapsedTimeJSONPathFunc(input []reflect.Value) []reflect.Value {
 		case string:
 			parsedTime, err := time.Parse(time.RFC3339, val)
 			if err == nil {
-				v = ElapsedTime(metav1.NewTime(parsedTime))
+				v = ElapsedTimeString(metav1.NewTime(parsedTime))
 			} else {
 				v = "<err:" + val + ">"
 			}
 		case metav1.Time:
-			v = ElapsedTime(val)
+			v = ElapsedTimeString(val)
 		default:
 			v = "<err>"
 		}

--- a/pkg/printers/customcolumn_test.go
+++ b/pkg/printers/customcolumn_test.go
@@ -317,7 +317,7 @@ foo       baz           <none>
 				},
 				{
 					Header:    "AGE",
-					FieldSpec: "{.metadata.creationTimestamp.elapsedTime()}",
+					FieldSpec: "{.metadata.creationTimestamp.elapsedTimeString()}",
 				},
 			},
 			obj: &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", CreationTimestamp: metav1.NewTime(time.Now().Add(-120 * time.Minute))}},

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -2948,9 +2948,9 @@ func DescribeEvents(el *api.EventList, w PrefixWriter) {
 	for _, e := range el.Items {
 		var interval string
 		if e.Count > 1 {
-			interval = fmt.Sprintf("%s (x%d over %s)", printers.ElapsedTime(e.LastTimestamp), e.Count, printers.ElapsedTime(e.FirstTimestamp))
+			interval = fmt.Sprintf("%s (x%d over %s)", printers.ElapsedTimeString(e.LastTimestamp), e.Count, printers.ElapsedTimeString(e.FirstTimestamp))
 		} else {
-			interval = printers.ElapsedTime(e.FirstTimestamp)
+			interval = printers.ElapsedTimeString(e.FirstTimestamp)
 		}
 		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,

--- a/pkg/printers/internalversion/describe.go
+++ b/pkg/printers/internalversion/describe.go
@@ -2948,9 +2948,9 @@ func DescribeEvents(el *api.EventList, w PrefixWriter) {
 	for _, e := range el.Items {
 		var interval string
 		if e.Count > 1 {
-			interval = fmt.Sprintf("%s (x%d over %s)", translateTimestamp(e.LastTimestamp), e.Count, translateTimestamp(e.FirstTimestamp))
+			interval = fmt.Sprintf("%s (x%d over %s)", printers.ElapsedTime(e.LastTimestamp), e.Count, printers.ElapsedTime(e.FirstTimestamp))
 		} else {
-			interval = translateTimestamp(e.FirstTimestamp)
+			interval = printers.ElapsedTime(e.FirstTimestamp)
 		}
 		w.Write(LEVEL_1, "%v\t%v\t%s\t%v\t%v\n",
 			e.Type,

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -453,7 +453,7 @@ func printObjectMeta(obj runtime.Object, options printers.PrintOptions) ([]metav
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, m.GetName(), printers.ElapsedTime(m.GetCreationTimestamp()))
+	row.Cells = append(row.Cells, m.GetName(), printers.ElapsedTimeString(m.GetCreationTimestamp()))
 	rows = append(rows, row)
 	return rows, nil
 }
@@ -587,7 +587,7 @@ func printPod(pod *api.Pod, options printers.PrintOptions) ([]metav1alpha1.Table
 		reason = "Terminating"
 	}
 
-	row.Cells = append(row.Cells, pod.Name, fmt.Sprintf("%d/%d", readyContainers, totalContainers), reason, restarts, printers.ElapsedTime(pod.CreationTimestamp))
+	row.Cells = append(row.Cells, pod.Name, fmt.Sprintf("%d/%d", readyContainers, totalContainers), reason, restarts, printers.ElapsedTimeString(pod.CreationTimestamp))
 
 	if options.Wide {
 		nodeName := pod.Spec.NodeName
@@ -644,7 +644,7 @@ func printPodDisruptionBudget(obj *policy.PodDisruptionBudget, options printers.
 		maxUnavailable = "N/A"
 	}
 
-	row.Cells = append(row.Cells, obj.Name, minAvailable, maxUnavailable, obj.Status.PodDisruptionsAllowed, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, minAvailable, maxUnavailable, obj.Status.PodDisruptionsAllowed, printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -670,7 +670,7 @@ func printReplicationController(obj *api.ReplicationController, options printers
 	currentReplicas := obj.Status.Replicas
 	readyReplicas := obj.Status.ReadyReplicas
 
-	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, readyReplicas, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, readyReplicas, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images, labels.FormatLabels(obj.Spec.Selector))
@@ -699,7 +699,7 @@ func printReplicaSet(obj *extensions.ReplicaSet, options printers.PrintOptions) 
 	currentReplicas := obj.Status.Replicas
 	readyReplicas := obj.Status.ReadyReplicas
 
-	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, readyReplicas, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, readyReplicas, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images, metav1.FormatLabelSelector(obj.Spec.Selector))
@@ -731,7 +731,7 @@ func printJob(obj *batch.Job, options printers.PrintOptions) ([]metav1alpha1.Tab
 		completions = "<none>"
 	}
 
-	row.Cells = append(row.Cells, obj.Name, completions, obj.Status.Succeeded, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, completions, obj.Status.Succeeded, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images, metav1.FormatLabelSelector(obj.Spec.Selector))
@@ -758,10 +758,10 @@ func printCronJob(obj *batch.CronJob, options printers.PrintOptions) ([]metav1al
 
 	lastScheduleTime := "<none>"
 	if obj.Status.LastScheduleTime != nil {
-		lastScheduleTime = printers.ElapsedTime(*obj.Status.LastScheduleTime)
+		lastScheduleTime = printers.ElapsedTimeString(*obj.Status.LastScheduleTime)
 	}
 
-	row.Cells = append(row.Cells, obj.Name, obj.Spec.Schedule, printBoolPtr(obj.Spec.Suspend), len(obj.Status.Active), lastScheduleTime, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, obj.Spec.Schedule, printBoolPtr(obj.Spec.Suspend), len(obj.Status.Active), lastScheduleTime, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.JobTemplate.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images, metav1.FormatLabelSelector(obj.Spec.JobTemplate.Spec.Selector))
@@ -860,7 +860,7 @@ func printService(obj *api.Service, options printers.PrintOptions) ([]metav1alph
 		svcPorts = "<none>"
 	}
 
-	row.Cells = append(row.Cells, obj.Name, string(svcType), internalIP, externalIP, svcPorts, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, string(svcType), internalIP, externalIP, svcPorts, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		row.Cells = append(row.Cells, labels.FormatLabels(obj.Spec.Selector))
 	}
@@ -924,7 +924,7 @@ func printIngress(obj *extensions.Ingress, options printers.PrintOptions) ([]met
 	hosts := formatHosts(obj.Spec.Rules)
 	address := loadBalancerStatusStringer(obj.Status.LoadBalancer, options.Wide)
 	ports := formatPorts(obj.Spec.TLS)
-	createTime := printers.ElapsedTime(obj.CreationTimestamp)
+	createTime := printers.ElapsedTimeString(obj.CreationTimestamp)
 	row.Cells = append(row.Cells, obj.Name, hosts, address, ports, createTime)
 	return []metav1alpha1.TableRow{row}, nil
 }
@@ -947,7 +947,7 @@ func printStatefulSet(obj *apps.StatefulSet, options printers.PrintOptions) ([]m
 	}
 	desiredReplicas := obj.Spec.Replicas
 	currentReplicas := obj.Status.Replicas
-	createTime := printers.ElapsedTime(obj.CreationTimestamp)
+	createTime := printers.ElapsedTimeString(obj.CreationTimestamp)
 	row.Cells = append(row.Cells, obj.Name, desiredReplicas, currentReplicas, createTime)
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
@@ -979,7 +979,7 @@ func printDaemonSet(obj *extensions.DaemonSet, options printers.PrintOptions) ([
 	numberUpdated := obj.Status.UpdatedNumberScheduled
 	numberAvailable := obj.Status.NumberAvailable
 
-	row.Cells = append(row.Cells, obj.Name, desiredScheduled, currentScheduled, numberReady, numberUpdated, numberAvailable, labels.FormatLabels(obj.Spec.Template.Spec.NodeSelector), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, desiredScheduled, currentScheduled, numberReady, numberUpdated, numberAvailable, labels.FormatLabels(obj.Spec.Template.Spec.NodeSelector), printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		names, images := layoutContainerCells(obj.Spec.Template.Spec.Containers)
 		row.Cells = append(row.Cells, names, images, metav1.FormatLabelSelector(obj.Spec.Selector))
@@ -1003,7 +1003,7 @@ func printEndpoints(obj *api.Endpoints, options printers.PrintOptions) ([]metav1
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, formatEndpoints(obj, nil), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, formatEndpoints(obj, nil), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1023,7 +1023,7 @@ func printNamespace(obj *api.Namespace, options printers.PrintOptions) ([]metav1
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1043,7 +1043,7 @@ func printSecret(obj *api.Secret, options printers.PrintOptions) ([]metav1alpha1
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, obj.Type, len(obj.Data), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, obj.Type, len(obj.Data), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1063,7 +1063,7 @@ func printServiceAccount(obj *api.ServiceAccount, options printers.PrintOptions)
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, len(obj.Secrets), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, len(obj.Secrets), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1112,7 +1112,7 @@ func printNode(obj *api.Node, options printers.PrintOptions) ([]metav1alpha1.Tab
 		roles = "<none>"
 	}
 
-	row.Cells = append(row.Cells, obj.Name, strings.Join(status, ","), roles, printers.ElapsedTime(obj.CreationTimestamp), obj.Status.NodeInfo.KubeletVersion)
+	row.Cells = append(row.Cells, obj.Name, strings.Join(status, ","), roles, printers.ElapsedTimeString(obj.CreationTimestamp), obj.Status.NodeInfo.KubeletVersion)
 	if options.Wide {
 		osImage, kernelVersion, crVersion := obj.Status.NodeInfo.OSImage, obj.Status.NodeInfo.KernelVersion, obj.Status.NodeInfo.ContainerRuntimeVersion
 		if osImage == "" {
@@ -1194,7 +1194,7 @@ func printPersistentVolume(obj *api.PersistentVolume, options printers.PrintOpti
 	row.Cells = append(row.Cells, obj.Name, aSize, modesStr, reclaimPolicyStr,
 		obj.Status.Phase, claimRefUID, helper.GetPersistentVolumeClass(obj),
 		obj.Status.Reason,
-		printers.ElapsedTime(obj.CreationTimestamp))
+		printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1229,7 +1229,7 @@ func printPersistentVolumeClaim(obj *api.PersistentVolumeClaim, options printers
 		capacity = storage.String()
 	}
 
-	row.Cells = append(row.Cells, obj.Name, phase, obj.Spec.VolumeName, capacity, accessModes, helper.GetPersistentVolumeClaimClass(obj), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, phase, obj.Spec.VolumeName, capacity, accessModes, helper.GetPersistentVolumeClaimClass(obj), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1255,8 +1255,8 @@ func printEvent(obj *api.Event, options printers.PrintOptions) ([]metav1alpha1.T
 		FirstTimestamp = obj.FirstTimestamp.String()
 		LastTimestamp = obj.LastTimestamp.String()
 	} else {
-		FirstTimestamp = printers.ElapsedTime(obj.FirstTimestamp)
-		LastTimestamp = printers.ElapsedTime(obj.LastTimestamp)
+		FirstTimestamp = printers.ElapsedTimeString(obj.FirstTimestamp)
+		LastTimestamp = printers.ElapsedTimeString(obj.LastTimestamp)
 	}
 	row.Cells = append(row.Cells, LastTimestamp, FirstTimestamp,
 		obj.Count, obj.Name, obj.InvolvedObject.Kind,
@@ -1285,7 +1285,7 @@ func printRoleBinding(obj *rbac.RoleBinding, options printers.PrintOptions) ([]m
 		Object: runtime.RawExtension{Object: obj},
 	}
 
-	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		roleRef := fmt.Sprintf("%s/%s", obj.RoleRef.Kind, obj.RoleRef.Name)
 		users, groups, sas, _ := rbac.SubjectsStrings(obj.Subjects)
@@ -1312,7 +1312,7 @@ func printClusterRoleBinding(obj *rbac.ClusterRoleBinding, options printers.Prin
 		Object: runtime.RawExtension{Object: obj},
 	}
 
-	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTimeString(obj.CreationTimestamp))
 	if options.Wide {
 		roleRef := fmt.Sprintf("%s/%s", obj.RoleRef.Kind, obj.RoleRef.Name)
 		users, groups, sas, _ := rbac.SubjectsStrings(obj.Subjects)
@@ -1342,7 +1342,7 @@ func printCertificateSigningRequest(obj *certificates.CertificateSigningRequest,
 	if err != nil {
 		return nil, err
 	}
-	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTime(obj.CreationTimestamp), obj.Spec.Username, status)
+	row.Cells = append(row.Cells, obj.Name, printers.ElapsedTimeString(obj.CreationTimestamp), obj.Spec.Username, status)
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1435,7 +1435,7 @@ func printDeployment(obj *extensions.Deployment, options printers.PrintOptions) 
 	currentReplicas := obj.Status.Replicas
 	updatedReplicas := obj.Status.UpdatedReplicas
 	availableReplicas := obj.Status.AvailableReplicas
-	age := printers.ElapsedTime(obj.CreationTimestamp)
+	age := printers.ElapsedTimeString(obj.CreationTimestamp)
 	containers := obj.Spec.Template.Spec.Containers
 	selector, err := metav1.LabelSelectorAsSelector(obj.Spec.Selector)
 	if err != nil {
@@ -1537,7 +1537,7 @@ func printHorizontalPodAutoscaler(obj *autoscaling.HorizontalPodAutoscaler, opti
 	}
 	maxPods := obj.Spec.MaxReplicas
 	currentReplicas := obj.Status.CurrentReplicas
-	row.Cells = append(row.Cells, obj.Name, reference, metrics, minPods, maxPods, currentReplicas, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, reference, metrics, minPods, maxPods, currentReplicas, printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1557,7 +1557,7 @@ func printConfigMap(obj *api.ConfigMap, options printers.PrintOptions) ([]metav1
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, len(obj.Data), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, len(obj.Data), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1599,7 +1599,7 @@ func printNetworkPolicy(obj *networking.NetworkPolicy, options printers.PrintOpt
 	row := metav1alpha1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, metav1.FormatLabelSelector(&obj.Spec.PodSelector), printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, metav1.FormatLabelSelector(&obj.Spec.PodSelector), printers.ElapsedTimeString(obj.CreationTimestamp))
 	return []metav1alpha1.TableRow{row}, nil
 }
 
@@ -1625,7 +1625,7 @@ func printStorageClass(obj *storage.StorageClass, options printers.PrintOptions)
 		name += " (default)"
 	}
 	provtype := obj.Provisioner
-	row.Cells = append(row.Cells, name, provtype, printers.ElapsedTime(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, name, provtype, printers.ElapsedTimeString(obj.CreationTimestamp))
 
 	return []metav1alpha1.TableRow{row}, nil
 }
@@ -1706,7 +1706,7 @@ func printControllerRevision(obj *apps.ControllerRevision, options printers.Prin
 		controllerName = printers.FormatResourceName(controllerRef.Kind, controllerRef.Name, withKind)
 	}
 	revision := obj.Revision
-	age := printers.ElapsedTime(obj.CreationTimestamp)
+	age := printers.ElapsedTimeString(obj.CreationTimestamp)
 	row.Cells = append(row.Cells, obj.Name, controllerName, revision, age)
 	return []metav1alpha1.TableRow{row}, nil
 }

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -1940,31 +1940,6 @@ func TestPrintPodWithLabels(t *testing.T) {
 	}
 }
 
-type stringTestList []struct {
-	name, got, exp string
-}
-
-func TestTranslateTimestamp(t *testing.T) {
-	tl := stringTestList{
-		{"a while from now", translateTimestamp(metav1.Time{Time: time.Now().Add(2.1e9)}), "<invalid>"},
-		{"almost now", translateTimestamp(metav1.Time{Time: time.Now().Add(1.9e9)}), "0s"},
-		{"now", translateTimestamp(metav1.Time{Time: time.Now()}), "0s"},
-		{"unknown", translateTimestamp(metav1.Time{}), "<unknown>"},
-		{"30 seconds ago", translateTimestamp(metav1.Time{Time: time.Now().Add(-3e10)}), "30s"},
-		{"5 minutes ago", translateTimestamp(metav1.Time{Time: time.Now().Add(-3e11)}), "5m"},
-		{"an hour ago", translateTimestamp(metav1.Time{Time: time.Now().Add(-6e12)}), "1h"},
-		{"2 days ago", translateTimestamp(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -2)}), "2d"},
-		{"months ago", translateTimestamp(metav1.Time{Time: time.Now().UTC().AddDate(0, 0, -90)}), "90d"},
-		{"10 years ago", translateTimestamp(metav1.Time{Time: time.Now().UTC().AddDate(-10, 0, 0)}), "10y"},
-	}
-	for _, test := range tl {
-		if test.got != test.exp {
-			t.Errorf("On %v, expected '%v', but got '%v'",
-				test.name, test.exp, test.got)
-		}
-	}
-}
-
 func TestPrintDeployment(t *testing.T) {
 	tests := []struct {
 		deployment extensions.Deployment

--- a/staging/src/k8s.io/client-go/util/jsonpath/node.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/node.go
@@ -43,6 +43,7 @@ const (
 	NodeRecursive
 	NodeUnion
 	NodeBool
+	NodeFunction
 )
 
 var NodeTypeName = map[NodeType]string{
@@ -58,6 +59,7 @@ var NodeTypeName = map[NodeType]string{
 	NodeRecursive:  "NodeRecursive",
 	NodeUnion:      "NodeUnion",
 	NodeBool:       "NodeBool",
+	NodeFunction:   "NodeFunction",
 }
 
 type Node interface {
@@ -252,4 +254,18 @@ func newBool(value bool) *BoolNode {
 
 func (b *BoolNode) String() string {
 	return fmt.Sprintf("%s: %t", b.Type(), b.Value)
+}
+
+// FunctionNode holds a JSONpath function
+type FunctionNode struct {
+	NodeType
+	Name string
+}
+
+func newFunction(name string) *FunctionNode {
+	return &FunctionNode{NodeType: NodeFunction, Name: name}
+}
+
+func (f *FunctionNode) String() string {
+	return fmt.Sprintf("%s: %s", f.Type(), f.Name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubectl shows the AGE column when listing most resources. We want to allow the same for resources from aggregated API servers (such as the Service Catalog resources). Aggregated servers use the `x-kubernetes-print-columns` OpenAPI extension to define which columns should be displayed for a particular aggregated resource. Kubectl uses that extension to configure the `CustomColumnsPrinter` printer. The problem is that you can currently only display the resource's absolute `creationTimestamp`, but can't transform it into the resource's age (i.e. time elapsed since creation).

This PR allows aggregated servers to show the AGE column for aggregated resources. It also allows users to add the AGE column to their own custom columns, whenever they're using `kubectl -o custom-columns`. Here's an example:

```
$ kubectl get po -o 'custom-columns=NAME:.metadata.name,AGE:.metadata.creationTimestamp.elapsedTime()'
NAME                             AGE
default-http-backend-vvrnx       21s
heapster-p7wq5                   21s
influxdb-grafana-hjkwx           21s
kube-addon-manager-minikube      26s
```

To make this possible, I've had to implement two things:
- support JSONPath functions in client-go's `JSONPath` ulitity & allow registering arbitrary functions in it
- register the `elapsedTime()` function in the `JSONPath` object used in the `CustomColumnsPrinter`

Besides allowing users to show the AGE column, this PR opens the path to adding additional transformation functions as the need for them arises. 


**Which issue(s) this PR fixes** 
There was no existing issue & I did not file one. 

**Release note**:
```release-note
It's now possible to show the resource age when using custom-columns in kubectl (kubectl -o 'custom-columns=AGE:.metadata.creationTimestamp.elapsedTime()')
```
