### PR TITLE
Bump apiserver memory limit for 100 node tests.

### DIFF
--- a/test/e2e/scalability/density.go
+++ b/test/e2e/scalability/density.go
@@ -169,7 +169,7 @@ func density30AddonResourceVerifier(numNodes int) map[string]framework.ResourceC
 	} else {
 		if numNodes <= 100 {
 			apiserverCPU = 1.8
-			apiserverMem = 1500 * (1024 * 1024)
+			apiserverMem = 1600 * (1024 * 1024)
 			controllerCPU = 0.5
 			controllerMem = 500 * (1024 * 1024)
 			schedulerCPU = 0.4


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a workaround for #56061 - current top flake of 100 node tests.

**Special notes for your reviewer**:

/kind bug
/sig scalability
/priority critical-urgent
/cc @shyamjvs please add this PR to v1.9

**Release note**:
```release-note
NONE
```