### PR TITLE
fix wrong number of args in apiserver/pkg

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/resttest/resttest.go
@@ -1321,7 +1321,7 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 			t.Errorf("column %d has unexpected format: %q with type %q", j, column.Format, column.Type)
 		}
 		if column.Priority < 0 || column.Priority > 2 {
-			t.Errorf("column %d has unexpected priority", j, column.Priority)
+			t.Errorf("column %d has unexpected priority: %q", j, column.Priority)
 		}
 		if len(column.Description) == 0 {
 			t.Errorf("column %d has no description", j)
@@ -1332,7 +1332,7 @@ func (t *Tester) testListTableConversion(obj runtime.Object, assignFn AssignFunc
 	}
 	for i, row := range table.Rows {
 		if len(row.Cells) != len(table.ColumnDefinitions) {
-			t.Errorf("row %d did not have the correct number of cells: %d in %v", len(table.ColumnDefinitions), row.Cells)
+			t.Errorf("row %d did not have the correct number of cells: %d in %v", i, len(table.ColumnDefinitions), row.Cells)
 		}
 		for j, cell := range row.Cells {
 			// do not add to this test without discussion - may break clients

--- a/staging/src/k8s.io/apiserver/pkg/server/filters/compression_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/filters/compression_test.go
@@ -94,7 +94,7 @@ func TestCompression(t *testing.T) {
 		}
 		body, err := ioutil.ReadAll(reader)
 		if err != nil {
-			t.Fatal("unexpected error: %v", err)
+			t.Fatalf("unexpected error: %v", err)
 		}
 		if !bytes.Equal(body, responseData) {
 			t.Fatalf("Expected response body %s to equal %s", body, responseData)


### PR DESCRIPTION
Signed-off-by: yuexiao-wang <wang.yuexiao@zte.com.cn>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
fix wrong number of args in apiserver/pkg

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
