### PR TITLE
Remove SupportIPVSProxyMode feature gate in kubeadm.

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/BUILD
@@ -26,7 +26,6 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/features:go_default_library",
         "//pkg/kubelet/apis/kubeletconfig/v1alpha1:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	kubeletconfigv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/kubeletconfig/v1alpha1"
 	kubeproxyscheme "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/scheme"
 	kubeproxyconfigv1alpha1 "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/v1alpha1"
@@ -117,7 +116,6 @@ func SetDefaults_MasterConfiguration(obj *MasterConfiguration) {
 
 // SetDefaults_ProxyConfiguration assigns default values for the Proxy
 func SetDefaults_ProxyConfiguration(obj *MasterConfiguration) {
-
 	if obj.KubeProxy.Config == nil {
 		obj.KubeProxy.Config = &kubeproxyconfigv1alpha1.KubeProxyConfiguration{}
 	}
@@ -125,10 +123,6 @@ func SetDefaults_ProxyConfiguration(obj *MasterConfiguration) {
 		obj.KubeProxy.Config.ClusterCIDR = obj.Networking.PodSubnet
 	}
 
-	if features.Enabled(obj.FeatureGates, features.SupportIPVSProxyMode) {
-		obj.KubeProxy.Config.FeatureGates = "true"
-		obj.KubeProxy.Config.Mode = "ipvs"
-	}
 	kubeproxyscheme.Scheme.Default(obj.KubeProxy.Config)
 }
 

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -39,9 +39,6 @@ const (
 	// StoreCertsInSecrets is alpha in v1.8
 	StoreCertsInSecrets = "StoreCertsInSecrets"
 
-	// SupportIPVSProxyMode is alpha in v1.8
-	SupportIPVSProxyMode = "SupportIPVSProxyMode"
-
 	// DynamicKubeletConfig is alpha in v1.9
 	DynamicKubeletConfig = "DynamicKubeletConfig"
 )
@@ -53,7 +50,6 @@ var InitFeatureGates = FeatureList{
 	SelfHosting:          {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
 	StoreCertsInSecrets:  {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
 	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
-	SupportIPVSProxyMode: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
 	CoreDNS:              {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
 	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
 }

--- a/cmd/kubeadm/app/phases/addons/proxy/BUILD
+++ b/cmd/kubeadm/app/phases/addons/proxy/BUILD
@@ -36,7 +36,6 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -107,7 +107,6 @@ spec:
         command:
         - /usr/local/bin/kube-proxy
         - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
-        {{ .ExtraParams }}
         {{ .ClusterCIDR }}
         securityContext:
           privileged: true

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -134,12 +134,11 @@ func TestCompileManifests(t *testing.T) {
 		},
 		{
 			manifest: KubeProxyDaemonSet18,
-			data: struct{ ImageRepository, Arch, Version, ImageOverride, ExtraParams, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
+			data: struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
 				ImageRepository: "foo",
 				Arch:            "foo",
 				Version:         "foo",
 				ImageOverride:   "foo",
-				ExtraParams:     "foo",
 				ClusterCIDR:     "foo",
 				MasterTaintKey:  "foo",
 				CloudTaintKey:   "foo",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Since #55972 gets merged, kubeadm now supports using kube-proxy ComponentConfig. Then `SupportIPVSProxyMode` feature gate can be configured in kube-proxy config. There is no need to config the feature gate in kubeadm (workaround introduced by #53962). The benefit of removing it I can think of is that we don't need to care about the IPVS feature evolution in kubeadm any longer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/512

**Special notes for your reviewer**:
/cc @luxas @Lion-Wei @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
