### PR TITLE
Put process of getting pod controller reference into metadata

### DIFF
--- a/plugin/pkg/scheduler/algorithm/priorities/metadata.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/metadata.go
@@ -21,6 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
+	priorityutil "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities/util"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/schedulercache"
 )
 
@@ -47,6 +48,7 @@ type priorityMetadata struct {
 	podTolerations []v1.Toleration
 	affinity       *v1.Affinity
 	podSelectors   []labels.Selector
+	controllerRef  *metav1.OwnerReference
 }
 
 // PriorityMetadata is a MetadataProducer.  Node info can be nil.
@@ -62,6 +64,7 @@ func (pmf *PriorityMetadataFactory) PriorityMetadata(pod *v1.Pod, nodeNameToInfo
 		podTolerations: tolerationsPreferNoSchedule,
 		affinity:       pod.Spec.Affinity,
 		podSelectors:   podSelectors,
+		controllerRef:  priorityutil.GetControllerRef(pod),
 	}
 }
 

--- a/plugin/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods.go
+++ b/plugin/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	priorityutil "k8s.io/kubernetes/plugin/pkg/scheduler/algorithm/priorities/util"
 	schedulerapi "k8s.io/kubernetes/plugin/pkg/scheduler/api"
@@ -31,8 +32,14 @@ func CalculateNodePreferAvoidPodsPriorityMap(pod *v1.Pod, meta interface{}, node
 	if node == nil {
 		return schedulerapi.HostPriority{}, fmt.Errorf("node not found")
 	}
+	var controllerRef *metav1.OwnerReference
+	if priorityMeta, ok := meta.(*priorityMetadata); ok {
+		controllerRef = priorityMeta.controllerRef
+	} else {
+		// We couldn't parse metadata - fallback to the podspec.
+		controllerRef = priorityutil.GetControllerRef(pod)
+	}
 
-	controllerRef := priorityutil.GetControllerRef(pod)
 	if controllerRef != nil {
 		// Ignore pods that are owned by other controller than ReplicationController
 		// or ReplicaSet.


### PR DESCRIPTION
**What this PR does / why we need it**:
We should extract our common process/data into metadata just as other map priority functions do, so we could avoid getting same required data repeatedly in every node map process.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
None

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
