### PR TITLE
kube-apiserver: integration test to smoke test OpenAPI aggregation

### DIFF
--- a/test/integration/master/BUILD
+++ b/test/integration/master/BUILD
@@ -29,6 +29,7 @@ go_test(
         "//vendor/k8s.io/api/apps/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -49,6 +50,7 @@ go_test(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Replaces https://github.com/kubernetes/kubernetes/pull/51715.

This is mostly https://github.com/kubernetes/kubernetes/pull/51715, but rebased to current master.