### PR TITLE
Automated cherry pick of #53609

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -912,6 +912,32 @@ __EOF__
   set +o errexit
 }
 
+# runs specific kubectl create tests
+run_create_tests() {
+    set -o nounset
+    set -o errexit
+
+    ### Create generic secret with explicit namespace
+    # Pre-condition: secret 'mysecret' does not exist
+    output_message=$(! kubectl get secrets mysecret 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${output_message}" 'secrets "mysecret" not found'
+    # Command
+    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run --from-literal=foo=bar -o jsonpath='{.metadata.namespace}' --namespace=user-specified)
+    # Post-condition: mysecret still not created since --dry-run was used
+    # Output from 'create' command should contain the specified --namespace value
+    failure_message=$(! kubectl get secrets mysecret 2>&1 "${kube_flags[@]}")
+    kube::test::if_has_string "${failure_message}" 'secrets "mysecret" not found'
+    kube::test::if_has_string "${output_message}" 'user-specified'
+    # Command
+    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run --from-literal=foo=bar -o jsonpath='{.metadata.namespace}')
+    # Post-condition: jsonpath for .metadata.namespace should be empty for object since --namespace was not explicitly specified
+    kube::test::if_empty_string "${output_message}"
+
+    set +o nounset
+    set +o errexit
+}
+
+
 # Runs tests related to kubectl apply.
 run_kubectl_apply_tests() {
   set -o nounset
@@ -4482,6 +4508,14 @@ runTests() {
     # TODO: Move get tests to run on rs instead of pods so that they can be
     # run for federation apiserver as well.
     record_command run_kubectl_get_tests
+  fi
+
+
+  ######################
+  # Create             #
+  ######################
+  if kube::test::if_supports_resource "${secrets}" ; then
+    record_command run_create_tests
   fi
 
   ##################

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -23,7 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"k8s.io/kubernetes/pkg/kubectl"
 	"k8s.io/kubernetes/pkg/kubectl/cmd/templates"
 	cmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
@@ -247,7 +249,7 @@ type CreateSubcommandOptions struct {
 
 // RunCreateSubcommand executes a create subcommand using the specified options
 func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, options *CreateSubcommandOptions) error {
-	namespace, _, err := f.DefaultNamespace()
+	namespace, nsOverriden, err := f.DefaultNamespace()
 	if err != nil {
 		return err
 	}
@@ -287,6 +289,10 @@ func RunCreateSubcommand(f cmdutil.Factory, cmd *cobra.Command, out io.Writer, o
 		obj, err = resource.NewHelper(client, mapping).Create(namespace, false, info.Object)
 		if err != nil {
 			return err
+		}
+	} else {
+		if meta, err := meta.Accessor(obj); err == nil && nsOverriden {
+			meta.SetNamespace(namespace)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #53609 on release-1.8.

#53609: add user-specified  ns to --dry-run created obj


```release-note
NONE
```