### PR TITLE
Refactor retry logic away from updateCIDRAllocation()

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidr_allocator.go
+++ b/pkg/controller/nodeipam/ipam/cidr_allocator.go
@@ -68,7 +68,7 @@ const (
 	cidrUpdateQueueSize = 5000
 
 	// cidrUpdateRetries is the no. of times a NodeSpec update will be retried before dropping it.
-	cidrUpdateRetries = 10
+	cidrUpdateRetries = 3
 )
 
 // CIDRAllocator is an interface implemented by things that know how


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/52292 (this is the last improvement left under it)

/cc @wojtek-t 

```release-note
NONE
```

cc @kubernetes/sig-network-misc