### PR TITLE
Fix ToLower in package path's in client-gen

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -101,10 +101,10 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 	if err != nil {
 		return nil, err
 	}
-	autoRegistrationController := autoregister.NewAutoRegisterController(aggregatorServer.APIRegistrationInformers.Apiregistration().InternalVersion().APIServices(), apiRegistrationClient)
+	autoRegistrationController := autoregister.NewAutoRegisterController(aggregatorServer.APIRegistrationInformers.Apiregistration().Internalversion().APIServices(), apiRegistrationClient)
 	apiServices := apiServicesToRegister(delegateAPIServer, autoRegistrationController)
 	crdRegistrationController := crdregistration.NewAutoRegistrationController(
-		apiExtensionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
+		apiExtensionInformers.Apiextensions().Internalversion().CustomResourceDefinitions(),
 		autoRegistrationController)
 
 	aggregatorServer.GenericAPIServer.AddPostStartHook("kube-apiserver-autoregistration", func(context genericapiserver.PostStartHookContext) error {
@@ -122,7 +122,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		makeAPIServiceAvailableHealthzCheck(
 			"autoregister-completion",
 			apiServices,
-			aggregatorServer.APIRegistrationInformers.Apiregistration().InternalVersion().APIServices(),
+			aggregatorServer.APIRegistrationInformers.Apiregistration().Internalversion().APIServices(),
 		),
 	)
 

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -539,7 +539,7 @@ func BuildAuthenticator(s *options.ServerRunOptions, storageFactory serverstorag
 		glog.Errorf("Failed to setup bootstrap token authenticator because the loopback clientset was not setup properly.")
 	} else {
 		authenticatorConfig.BootstrapTokenAuthenticator = bootstrap.NewTokenAuthenticator(
-			sharedInformers.Core().InternalVersion().Secrets().Lister().Secrets(v1.NamespaceSystem),
+			sharedInformers.Core().Internalversion().Secrets().Lister().Secrets(v1.NamespaceSystem),
 		)
 	}
 	return authenticatorConfig.New()

--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -531,11 +531,11 @@ func (s *ProxyServer) Run() error {
 	// Note: RegisterHandler() calls need to happen before creation of Sources because sources
 	// only notify on changes, and the initial update (on process start) may be lost if no handlers
 	// are registered yet.
-	serviceConfig := config.NewServiceConfig(informerFactory.Core().InternalVersion().Services(), s.ConfigSyncPeriod)
+	serviceConfig := config.NewServiceConfig(informerFactory.Core().Internalversion().Services(), s.ConfigSyncPeriod)
 	serviceConfig.RegisterEventHandler(s.ServiceEventHandler)
 	go serviceConfig.Run(wait.NeverStop)
 
-	endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().InternalVersion().Endpoints(), s.ConfigSyncPeriod)
+	endpointsConfig := config.NewEndpointsConfig(informerFactory.Core().Internalversion().Endpoints(), s.ConfigSyncPeriod)
 	endpointsConfig.RegisterEventHandler(s.EndpointsEventHandler)
 	go endpointsConfig.Run(wait.NeverStop)
 

--- a/pkg/client/informers/informers_generated/internalversion/admissionregistration/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/admissionregistration/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/apps/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/apps/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/autoscaling/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/autoscaling/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/batch/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/batch/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/certificates/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/certificates/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/core/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/core/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/extensions/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/extensions/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/generic.go
+++ b/pkg/client/informers/informers_generated/internalversion/generic.go
@@ -63,111 +63,111 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=admissionregistration.k8s.io, Version=internalVersion
+	// Group=admissionregistration.k8s.io, Version=internalversion
 	case admissionregistration.SchemeGroupVersion.WithResource("initializerconfigurations"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().InternalVersion().InitializerConfigurations().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().Internalversion().InitializerConfigurations().Informer()}, nil
 	case admissionregistration.SchemeGroupVersion.WithResource("mutatingwebhookconfigurations"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().InternalVersion().MutatingWebhookConfigurations().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().Internalversion().MutatingWebhookConfigurations().Informer()}, nil
 	case admissionregistration.SchemeGroupVersion.WithResource("validatingwebhookconfigurations"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().InternalVersion().ValidatingWebhookConfigurations().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Admissionregistration().Internalversion().ValidatingWebhookConfigurations().Informer()}, nil
 
-		// Group=apps, Version=internalVersion
+		// Group=apps, Version=internalversion
 	case apps.SchemeGroupVersion.WithResource("controllerrevisions"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Apps().InternalVersion().ControllerRevisions().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Apps().Internalversion().ControllerRevisions().Informer()}, nil
 	case apps.SchemeGroupVersion.WithResource("statefulsets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Apps().InternalVersion().StatefulSets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Apps().Internalversion().StatefulSets().Informer()}, nil
 
-		// Group=autoscaling, Version=internalVersion
+		// Group=autoscaling, Version=internalversion
 	case autoscaling.SchemeGroupVersion.WithResource("horizontalpodautoscalers"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Autoscaling().InternalVersion().HorizontalPodAutoscalers().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Autoscaling().Internalversion().HorizontalPodAutoscalers().Informer()}, nil
 
-		// Group=batch, Version=internalVersion
+		// Group=batch, Version=internalversion
 	case batch.SchemeGroupVersion.WithResource("cronjobs"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Batch().InternalVersion().CronJobs().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Batch().Internalversion().CronJobs().Informer()}, nil
 	case batch.SchemeGroupVersion.WithResource("jobs"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Batch().InternalVersion().Jobs().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Batch().Internalversion().Jobs().Informer()}, nil
 
-		// Group=certificates.k8s.io, Version=internalVersion
+		// Group=certificates.k8s.io, Version=internalversion
 	case certificates.SchemeGroupVersion.WithResource("certificatesigningrequests"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Certificates().InternalVersion().CertificateSigningRequests().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Certificates().Internalversion().CertificateSigningRequests().Informer()}, nil
 
-		// Group=core, Version=internalVersion
+		// Group=core, Version=internalversion
 	case core.SchemeGroupVersion.WithResource("componentstatuses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().ComponentStatuses().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().ComponentStatuses().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("configmaps"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().ConfigMaps().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().ConfigMaps().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("endpoints"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Endpoints().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Endpoints().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("events"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Events().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Events().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("limitranges"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().LimitRanges().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().LimitRanges().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("namespaces"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Namespaces().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Namespaces().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("nodes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Nodes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Nodes().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("persistentvolumes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().PersistentVolumes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().PersistentVolumes().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("persistentvolumeclaims"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().PersistentVolumeClaims().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().PersistentVolumeClaims().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("pods"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Pods().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Pods().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("podtemplates"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().PodTemplates().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().PodTemplates().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("replicationcontrollers"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().ReplicationControllers().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().ReplicationControllers().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("resourcequotas"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().ResourceQuotas().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().ResourceQuotas().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("secrets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Secrets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Secrets().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("services"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().Services().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().Services().Informer()}, nil
 	case core.SchemeGroupVersion.WithResource("serviceaccounts"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().InternalVersion().ServiceAccounts().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Core().Internalversion().ServiceAccounts().Informer()}, nil
 
-		// Group=extensions, Version=internalVersion
+		// Group=extensions, Version=internalversion
 	case extensions.SchemeGroupVersion.WithResource("daemonsets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().InternalVersion().DaemonSets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().Internalversion().DaemonSets().Informer()}, nil
 	case extensions.SchemeGroupVersion.WithResource("deployments"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().InternalVersion().Deployments().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().Internalversion().Deployments().Informer()}, nil
 	case extensions.SchemeGroupVersion.WithResource("ingresses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().InternalVersion().Ingresses().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().Internalversion().Ingresses().Informer()}, nil
 	case extensions.SchemeGroupVersion.WithResource("podsecuritypolicies"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().InternalVersion().PodSecurityPolicies().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().Internalversion().PodSecurityPolicies().Informer()}, nil
 	case extensions.SchemeGroupVersion.WithResource("replicasets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().InternalVersion().ReplicaSets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Extensions().Internalversion().ReplicaSets().Informer()}, nil
 
-		// Group=networking.k8s.io, Version=internalVersion
+		// Group=networking.k8s.io, Version=internalversion
 	case networking.SchemeGroupVersion.WithResource("networkpolicies"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().InternalVersion().NetworkPolicies().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Networking().Internalversion().NetworkPolicies().Informer()}, nil
 
-		// Group=policy, Version=internalVersion
+		// Group=policy, Version=internalversion
 	case policy.SchemeGroupVersion.WithResource("poddisruptionbudgets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Policy().InternalVersion().PodDisruptionBudgets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Policy().Internalversion().PodDisruptionBudgets().Informer()}, nil
 
-		// Group=rbac.authorization.k8s.io, Version=internalVersion
+		// Group=rbac.authorization.k8s.io, Version=internalversion
 	case rbac.SchemeGroupVersion.WithResource("clusterroles"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().InternalVersion().ClusterRoles().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().Internalversion().ClusterRoles().Informer()}, nil
 	case rbac.SchemeGroupVersion.WithResource("clusterrolebindings"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().InternalVersion().ClusterRoleBindings().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().Internalversion().ClusterRoleBindings().Informer()}, nil
 	case rbac.SchemeGroupVersion.WithResource("roles"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().InternalVersion().Roles().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().Internalversion().Roles().Informer()}, nil
 	case rbac.SchemeGroupVersion.WithResource("rolebindings"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().InternalVersion().RoleBindings().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Rbac().Internalversion().RoleBindings().Informer()}, nil
 
-		// Group=scheduling.k8s.io, Version=internalVersion
+		// Group=scheduling.k8s.io, Version=internalversion
 	case scheduling.SchemeGroupVersion.WithResource("priorityclasses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Scheduling().InternalVersion().PriorityClasses().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Scheduling().Internalversion().PriorityClasses().Informer()}, nil
 
-		// Group=settings.k8s.io, Version=internalVersion
+		// Group=settings.k8s.io, Version=internalversion
 	case settings.SchemeGroupVersion.WithResource("podpresets"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Settings().InternalVersion().PodPresets().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Settings().Internalversion().PodPresets().Informer()}, nil
 
-		// Group=storage.k8s.io, Version=internalVersion
+		// Group=storage.k8s.io, Version=internalversion
 	case storage.SchemeGroupVersion.WithResource("storageclasses"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Storage().InternalVersion().StorageClasses().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Storage().Internalversion().StorageClasses().Informer()}, nil
 	case storage.SchemeGroupVersion.WithResource("volumeattachments"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Storage().InternalVersion().VolumeAttachments().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Storage().Internalversion().VolumeAttachments().Informer()}, nil
 
 	}
 

--- a/pkg/client/informers/informers_generated/internalversion/networking/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/networking/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/policy/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/policy/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/rbac/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/rbac/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/scheduling/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/scheduling/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/settings/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/settings/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/client/informers/informers_generated/internalversion/storage/interface.go
+++ b/pkg/client/informers/informers_generated/internalversion/storage/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/pkg/kubeapiserver/authorizer/config.go
+++ b/pkg/kubeapiserver/authorizer/config.go
@@ -77,8 +77,8 @@ func (config AuthorizationConfig) New() (authorizer.Authorizer, authorizer.RuleR
 			graph := node.NewGraph()
 			node.AddGraphEventHandlers(
 				graph,
-				config.InformerFactory.Core().InternalVersion().Pods(),
-				config.InformerFactory.Core().InternalVersion().PersistentVolumes(),
+				config.InformerFactory.Core().Internalversion().Pods(),
+				config.InformerFactory.Core().Internalversion().PersistentVolumes(),
 			)
 			nodeAuthorizer := node.NewAuthorizer(graph, nodeidentifier.NewDefaultNodeIdentifier(), bootstrappolicy.NodeRules())
 			authorizers = append(authorizers, nodeAuthorizer)
@@ -115,10 +115,10 @@ func (config AuthorizationConfig) New() (authorizer.Authorizer, authorizer.RuleR
 			ruleResolvers = append(ruleResolvers, webhookAuthorizer)
 		case modes.ModeRBAC:
 			rbacAuthorizer := rbac.New(
-				&rbac.RoleGetter{Lister: config.InformerFactory.Rbac().InternalVersion().Roles().Lister()},
-				&rbac.RoleBindingLister{Lister: config.InformerFactory.Rbac().InternalVersion().RoleBindings().Lister()},
-				&rbac.ClusterRoleGetter{Lister: config.InformerFactory.Rbac().InternalVersion().ClusterRoles().Lister()},
-				&rbac.ClusterRoleBindingLister{Lister: config.InformerFactory.Rbac().InternalVersion().ClusterRoleBindings().Lister()},
+				&rbac.RoleGetter{Lister: config.InformerFactory.Rbac().Internalversion().Roles().Lister()},
+				&rbac.RoleBindingLister{Lister: config.InformerFactory.Rbac().Internalversion().RoleBindings().Lister()},
+				&rbac.ClusterRoleGetter{Lister: config.InformerFactory.Rbac().Internalversion().ClusterRoles().Lister()},
+				&rbac.ClusterRoleBindingLister{Lister: config.InformerFactory.Rbac().Internalversion().ClusterRoleBindings().Lister()},
 			)
 			authorizers = append(authorizers, rbacAuthorizer)
 			ruleResolvers = append(ruleResolvers, rbacAuthorizer)

--- a/pkg/proxy/config/api_test.go
+++ b/pkg/proxy/config/api_test.go
@@ -54,7 +54,7 @@ func TestNewServicesSourceApi_UpdatesAndMultipleServices(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	serviceConfig := NewServiceConfig(sharedInformers.Core().InternalVersion().Services(), time.Minute)
+	serviceConfig := NewServiceConfig(sharedInformers.Core().Internalversion().Services(), time.Minute)
 	serviceConfig.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
 	go serviceConfig.Run(stopCh)
@@ -122,7 +122,7 @@ func TestNewEndpointsSourceApi_UpdatesAndMultipleEndpoints(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	endpointsConfig := NewEndpointsConfig(sharedInformers.Core().InternalVersion().Endpoints(), time.Minute)
+	endpointsConfig := NewEndpointsConfig(sharedInformers.Core().Internalversion().Endpoints(), time.Minute)
 	endpointsConfig.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
 	go endpointsConfig.Run(stopCh)
@@ -198,8 +198,8 @@ func TestInitialSync(t *testing.T) {
 	client := fake.NewSimpleClientset(svc1, svc2, eps2, eps1)
 	sharedInformers := informers.NewSharedInformerFactory(client, 0)
 
-	svcConfig := NewServiceConfig(sharedInformers.Core().InternalVersion().Services(), 0)
-	epsConfig := NewEndpointsConfig(sharedInformers.Core().InternalVersion().Endpoints(), 0)
+	svcConfig := NewServiceConfig(sharedInformers.Core().Internalversion().Services(), 0)
+	epsConfig := NewEndpointsConfig(sharedInformers.Core().Internalversion().Endpoints(), 0)
 	svcHandler := newSvcHandler(t, []*api.Service{svc2, svc1}, wg.Done)
 	svcConfig.RegisterEventHandler(svcHandler)
 	epsHandler := newEpsHandler(t, []*api.Endpoints{eps2, eps1}, wg.Done)

--- a/pkg/proxy/config/config_test.go
+++ b/pkg/proxy/config/config_test.go
@@ -233,7 +233,7 @@ func TestNewServiceAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().InternalVersion().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().Internalversion().Services(), time.Minute)
 	handler := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
@@ -257,7 +257,7 @@ func TestServiceAddedRemovedSetAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().InternalVersion().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().Internalversion().Services(), time.Minute)
 	handler := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
 	go sharedInformers.Start(stopCh)
@@ -293,7 +293,7 @@ func TestNewServicesMultipleHandlersAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewServiceConfig(sharedInformers.Core().InternalVersion().Services(), time.Minute)
+	config := NewServiceConfig(sharedInformers.Core().Internalversion().Services(), time.Minute)
 	handler := NewServiceHandlerMock()
 	handler2 := NewServiceHandlerMock()
 	config.RegisterEventHandler(handler)
@@ -327,7 +327,7 @@ func TestNewEndpointsMultipleHandlersAddedAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewEndpointsConfig(sharedInformers.Core().InternalVersion().Endpoints(), time.Minute)
+	config := NewEndpointsConfig(sharedInformers.Core().Internalversion().Endpoints(), time.Minute)
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
 	config.RegisterEventHandler(handler)
@@ -367,7 +367,7 @@ func TestNewEndpointsMultipleHandlersAddRemoveSetAndNotified(t *testing.T) {
 
 	sharedInformers := informers.NewSharedInformerFactory(client, time.Minute)
 
-	config := NewEndpointsConfig(sharedInformers.Core().InternalVersion().Endpoints(), time.Minute)
+	config := NewEndpointsConfig(sharedInformers.Core().Internalversion().Endpoints(), time.Minute)
 	handler := NewEndpointsHandlerMock()
 	handler2 := NewEndpointsHandlerMock()
 	config.RegisterEventHandler(handler)

--- a/plugin/pkg/admission/limitranger/admission.go
+++ b/plugin/pkg/admission/limitranger/admission.go
@@ -74,7 +74,7 @@ type liveLookupEntry struct {
 }
 
 func (l *LimitRanger) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	limitRangeInformer := f.Core().InternalVersion().LimitRanges()
+	limitRangeInformer := f.Core().Internalversion().LimitRanges()
 	l.SetReadyFunc(limitRangeInformer.Informer().HasSynced)
 	l.lister = limitRangeInformer.Lister()
 }

--- a/plugin/pkg/admission/namespace/autoprovision/admission.go
+++ b/plugin/pkg/admission/namespace/autoprovision/admission.go
@@ -102,7 +102,7 @@ func (p *Provision) SetInternalKubeClientSet(client internalclientset.Interface)
 
 // SetInternalKubeInformerFactory implements the WantsInternalKubeInformerFactory interface.
 func (p *Provision) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	namespaceInformer := f.Core().InternalVersion().Namespaces()
+	namespaceInformer := f.Core().Internalversion().Namespaces()
 	p.namespaceLister = namespaceInformer.Lister()
 	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/namespace/exists/admission.go
+++ b/plugin/pkg/admission/namespace/exists/admission.go
@@ -97,7 +97,7 @@ func (e *Exists) SetInternalKubeClientSet(client internalclientset.Interface) {
 
 // SetInternalKubeInformerFactory implements the WantsInternalKubeInformerFactory interface.
 func (e *Exists) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	namespaceInformer := f.Core().InternalVersion().Namespaces()
+	namespaceInformer := f.Core().Internalversion().Namespaces()
 	e.namespaceLister = namespaceInformer.Lister()
 	e.SetReadyFunc(namespaceInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/persistentvolume/resize/admission.go
+++ b/plugin/pkg/admission/persistentvolume/resize/admission.go
@@ -60,9 +60,9 @@ func newPlugin() *persistentVolumeClaimResize {
 }
 
 func (pvcr *persistentVolumeClaimResize) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	pvcInformer := f.Core().InternalVersion().PersistentVolumes()
+	pvcInformer := f.Core().Internalversion().PersistentVolumes()
 	pvcr.pvLister = pvcInformer.Lister()
-	scInformer := f.Storage().InternalVersion().StorageClasses()
+	scInformer := f.Storage().Internalversion().StorageClasses()
 	pvcr.scLister = scInformer.Lister()
 	pvcr.SetReadyFunc(func() bool {
 		return pvcInformer.Informer().HasSynced() && scInformer.Informer().HasSynced()

--- a/plugin/pkg/admission/persistentvolume/resize/admission_test.go
+++ b/plugin/pkg/admission/persistentvolume/resize/admission_test.go
@@ -304,7 +304,7 @@ func TestPVCResizeAdmission(t *testing.T) {
 	pvs = append(pvs, pv1, pv2)
 
 	for _, pv := range pvs {
-		err := informerFactory.Core().InternalVersion().PersistentVolumes().Informer().GetStore().Add(pv)
+		err := informerFactory.Core().Internalversion().PersistentVolumes().Informer().GetStore().Add(pv)
 		if err != nil {
 			fmt.Println("add pv error: ", err)
 		}
@@ -313,7 +313,7 @@ func TestPVCResizeAdmission(t *testing.T) {
 	scs := []*storage.StorageClass{}
 	scs = append(scs, goldClass, silverClass)
 	for _, sc := range scs {
-		err := informerFactory.Storage().InternalVersion().StorageClasses().Informer().GetStore().Add(sc)
+		err := informerFactory.Storage().Internalversion().StorageClasses().Informer().GetStore().Add(sc)
 		if err != nil {
 			fmt.Println("add storageclass error: ", err)
 		}

--- a/plugin/pkg/admission/persistentvolumeclaim/pvcprotection/admission.go
+++ b/plugin/pkg/admission/persistentvolumeclaim/pvcprotection/admission.go
@@ -62,7 +62,7 @@ func newPlugin() *pvcProtectionPlugin {
 }
 
 func (c *pvcProtectionPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	informer := f.Core().InternalVersion().PersistentVolumeClaims()
+	informer := f.Core().Internalversion().PersistentVolumeClaims()
 	c.lister = informer.Lister()
 	c.SetReadyFunc(informer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -208,7 +208,7 @@ func (a *podNodeSelector) SetInternalKubeClientSet(client internalclientset.Inte
 }
 
 func (p *podNodeSelector) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	namespaceInformer := f.Core().InternalVersion().Namespaces()
+	namespaceInformer := f.Core().Internalversion().Namespaces()
 	p.namespaceLister = namespaceInformer.Lister()
 	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/podnodeselector/admission_test.go
+++ b/plugin/pkg/admission/podnodeselector/admission_test.go
@@ -159,7 +159,7 @@ func TestPodAdmission(t *testing.T) {
 	for _, test := range tests {
 		if !test.ignoreTestNamespaceNodeSelector {
 			namespace.ObjectMeta.Annotations = map[string]string{"scheduler.alpha.kubernetes.io/node-selector": test.namespaceNodeSelector}
-			informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
+			informerFactory.Core().Internalversion().Namespaces().Informer().GetStore().Update(namespace)
 		}
 		handler.clusterNodeSelectors = make(map[string]string)
 		handler.clusterNodeSelectors["clusterDefaultNodeSelector"] = test.defaultNodeSelector
@@ -237,7 +237,7 @@ func TestIgnoreUpdatingInitializedPod(t *testing.T) {
 			Annotations: map[string]string{"scheduler.alpha.kubernetes.io/node-selector": namespaceNodeSelector},
 		},
 	}
-	err = informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
+	err = informerFactory.Core().Internalversion().Namespaces().Informer().GetStore().Update(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/pkg/admission/podpreset/admission.go
+++ b/plugin/pkg/admission/podpreset/admission.go
@@ -85,7 +85,7 @@ func (a *podPresetPlugin) SetInternalKubeClientSet(client internalclientset.Inte
 }
 
 func (a *podPresetPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	podPresetInformer := f.Settings().InternalVersion().PodPresets()
+	podPresetInformer := f.Settings().Internalversion().PodPresets()
 	a.lister = podPresetInformer.Lister()
 	a.SetReadyFunc(podPresetInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/podpreset/admission_test.go
+++ b/plugin/pkg/admission/podpreset/admission_test.go
@@ -807,9 +807,9 @@ func TestAdmitEmptyPodNamespace(t *testing.T) {
 
 func admitPod(pod *api.Pod, pip *settings.PodPreset) error {
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	store := informerFactory.Settings().InternalVersion().PodPresets().Informer().GetStore()
+	store := informerFactory.Settings().Internalversion().PodPresets().Informer().GetStore()
 	store.Add(pip)
-	plugin := NewTestAdmission(informerFactory.Settings().InternalVersion().PodPresets().Lister())
+	plugin := NewTestAdmission(informerFactory.Settings().Internalversion().PodPresets().Lister())
 	attrs := kadmission.NewAttributesRecord(
 		pod,
 		nil,

--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -203,7 +203,7 @@ func (a *podTolerationsPlugin) SetInternalKubeClientSet(client clientset.Interfa
 }
 
 func (p *podTolerationsPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	namespaceInformer := f.Core().InternalVersion().Namespaces()
+	namespaceInformer := f.Core().Internalversion().Namespaces()
 	p.namespaceLister = namespaceInformer.Lister()
 	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)
 

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -246,7 +246,7 @@ func TestPodAdmission(t *testing.T) {
 			namespace.Annotations[NSWLTolerations] = string(tolerationStr)
 		}
 
-		informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
+		informerFactory.Core().Internalversion().Namespaces().Informer().GetStore().Update(namespace)
 
 		handler.pluginConfig = &pluginapi.Configuration{Default: test.defaultClusterTolerations, Whitelist: test.clusterWhitelist}
 		pod := test.pod
@@ -340,7 +340,7 @@ func TestIgnoreUpdatingInitializedPod(t *testing.T) {
 		},
 	}
 	namespace.Annotations = map[string]string{NSDefaultTolerations: string(tolerationsStr)}
-	err = informerFactory.Core().InternalVersion().Namespaces().Informer().GetStore().Update(namespace)
+	err = informerFactory.Core().Internalversion().Namespaces().Informer().GetStore().Update(namespace)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/pkg/admission/priority/admission.go
+++ b/plugin/pkg/admission/priority/admission.go
@@ -94,7 +94,7 @@ func (p *PriorityPlugin) SetInternalKubeClientSet(client internalclientset.Inter
 
 // SetInternalKubeInformerFactory implements the WantsInternalKubeInformerFactory interface.
 func (p *PriorityPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	priorityInformer := f.Scheduling().InternalVersion().PriorityClasses()
+	priorityInformer := f.Scheduling().Internalversion().PriorityClasses()
 	p.lister = priorityInformer.Lister()
 	p.SetReadyFunc(priorityInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/priority/admission_test.go
+++ b/plugin/pkg/admission/priority/admission_test.go
@@ -37,7 +37,7 @@ func addPriorityClasses(ctrl *PriorityPlugin, priorityClasses []*scheduling.Prio
 	ctrl.SetInternalKubeInformerFactory(informerFactory)
 	// First add the existing classes to the cache.
 	for _, c := range priorityClasses {
-		informerFactory.Scheduling().InternalVersion().PriorityClasses().Informer().GetStore().Add(c)
+		informerFactory.Scheduling().Internalversion().PriorityClasses().Informer().GetStore().Add(c)
 	}
 }
 

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -98,7 +98,7 @@ func (a *QuotaAdmission) SetInternalKubeClientSet(client internalclientset.Inter
 }
 
 func (a *QuotaAdmission) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	a.quotaAccessor.lister = f.Core().InternalVersion().ResourceQuotas().Lister()
+	a.quotaAccessor.lister = f.Core().Internalversion().ResourceQuotas().Lister()
 }
 
 func (a *QuotaAdmission) SetQuotaConfiguration(c quota.Configuration) {

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -130,7 +130,7 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -166,7 +166,7 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -175,7 +175,7 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("123", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
 	err := handler.Validate(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
@@ -211,7 +211,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -220,7 +220,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
 	err := handler.Validate(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
@@ -295,7 +295,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -304,7 +304,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	// old service was a load balancer, but updated version is a node port.
 	existingService := &api.Service{
@@ -402,7 +402,7 @@ func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -411,7 +411,7 @@ func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	oldPVC := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", ResourceVersion: "1"},
@@ -469,7 +469,7 @@ func TestAdmitHandlesPVCUpdates(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -478,7 +478,7 @@ func TestAdmitHandlesPVCUpdates(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	oldPVC := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: "pvc-to-update", Namespace: "test", ResourceVersion: "1"},
@@ -568,7 +568,7 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -577,7 +577,7 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	// old service didn't exist, so this update is actually a create
 	oldService := &api.Service{
@@ -663,7 +663,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -672,7 +672,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("3", "2Gi"), getResourceList("", "")))
 	err := handler.Validate(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err == nil {
@@ -708,7 +708,7 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -717,7 +717,7 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	// verify all values are specified as required on the quota
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
 	err := handler.Validate(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
@@ -762,7 +762,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	quotaAccessor.liveLookupCache = liveLookupCache
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
@@ -773,7 +773,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 		evaluator: evaluator,
 	}
 	// Add to the index
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("not-allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("200m", "")))
 	// Add to the lru cache so we do not do a live client lookup
 	liveLookupCache.Add(newPod.Namespace, liveLookupEntry{expiry: time.Now().Add(time.Duration(30 * time.Second)), items: []*api.ResourceQuota{}})
@@ -830,7 +830,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -839,8 +839,8 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaNonTerminating)
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaTerminating)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaNonTerminating)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaTerminating)
 
 	// create a pod that has an active deadline
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "2Gi"), getResourceList("", "")))
@@ -936,7 +936,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -945,8 +945,8 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaBestEffort)
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaNotBestEffort)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaBestEffort)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuotaNotBestEffort)
 
 	// create a pod that is best effort because it does not make a request for anything
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
@@ -1029,7 +1029,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -1038,7 +1038,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("100m", "1Gi"), getResourceList("", "")))
 	err := handler.Validate(admission.NewAttributesRecord(newPod, nil, api.Kind("Pod").WithVersion("version"), newPod.Namespace, newPod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, nil))
 	if err != nil {
@@ -1115,7 +1115,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -1124,7 +1124,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	newPod := validPod("pod-without-namespace", 1, getResourceRequirements(getResourceList("1", "2Gi"), getResourceList("", "")))
 
 	// unset the namespace
@@ -1161,7 +1161,7 @@ func TestAdmitRejectsNegativeUsage(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -1170,7 +1170,7 @@ func TestAdmitRejectsNegativeUsage(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 	// verify quota rejects negative pvc storage requests
 	newPvc := validPersistentVolumeClaim("not-allowed-pvc", getResourceRequirements(api.ResourceList{api.ResourceStorage: resource.MustParse("-1Gi")}, api.ResourceList{}))
 	err := handler.Validate(admission.NewAttributesRecord(newPvc, nil, api.Kind("PersistentVolumeClaim").WithVersion("version"), newPvc.Namespace, newPvc.Name, api.Resource("persistentvolumeclaims").WithVersion("version"), "", admission.Create, nil))
@@ -1208,7 +1208,7 @@ func TestAdmitWhenUnrelatedResourceExceedsQuota(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
 	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
@@ -1217,7 +1217,7 @@ func TestAdmitWhenUnrelatedResourceExceedsQuota(t *testing.T) {
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
 		evaluator: evaluator,
 	}
-	informerFactory.Core().InternalVersion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
+	informerFactory.Core().Internalversion().ResourceQuotas().Informer().GetIndexer().Add(resourceQuota)
 
 	// create a pod that should pass existing quota
 	newPod := validPod("allowed-pod", 1, getResourceRequirements(getResourceList("", ""), getResourceList("", "")))
@@ -1236,7 +1236,7 @@ func TestAdmitLimitedResourceNoQuota(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 
 	// disable consumption of cpu unless there is a covering quota.
 	config := &resourcequotaapi.Configuration{
@@ -1270,7 +1270,7 @@ func TestAdmitLimitedResourceNoQuotaIgnoresNonMatchingResources(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 
 	// disable consumption of cpu unless there is a covering quota.
 	config := &resourcequotaapi.Configuration{
@@ -1316,7 +1316,7 @@ func TestAdmitLimitedResourceWithQuota(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 
 	// disable consumption of cpu unless there is a covering quota.
 	// disable consumption of cpu unless there is a covering quota.
@@ -1375,7 +1375,7 @@ func TestAdmitLimitedResourceWithMultipleQuota(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 
 	// disable consumption of cpu unless there is a covering quota.
 	// disable consumption of cpu unless there is a covering quota.
@@ -1424,7 +1424,7 @@ func TestAdmitLimitedResourceWithQuotaThatDoesNotCover(t *testing.T) {
 	informerFactory := informers.NewSharedInformerFactory(kubeClient, controller.NoResyncPeriodFunc())
 	quotaAccessor, _ := newQuotaAccessor()
 	quotaAccessor.client = kubeClient
-	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
+	quotaAccessor.lister = informerFactory.Core().Internalversion().ResourceQuotas().Lister()
 
 	// disable consumption of cpu unless there is a covering quota.
 	// disable consumption of cpu unless there is a covering quota.

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -94,7 +94,7 @@ func newPlugin(strategyFactory psp.StrategyFactory, failOnNoPolicies bool) *PodS
 }
 
 func (a *PodSecurityPolicyPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	podSecurityPolicyInformer := f.Extensions().InternalVersion().PodSecurityPolicies()
+	podSecurityPolicyInformer := f.Extensions().Internalversion().PodSecurityPolicies()
 	a.lister = podSecurityPolicyInformer.Lister()
 	a.SetReadyFunc(podSecurityPolicyInformer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -49,11 +49,11 @@ const defaultContainerName = "test-c"
 // NewTestAdmission provides an admission plugin with test implementations of internal structs.
 func NewTestAdmission(psps []*extensions.PodSecurityPolicy, authz authorizer.Authorizer) *PodSecurityPolicyPlugin {
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
-	store := informerFactory.Extensions().InternalVersion().PodSecurityPolicies().Informer().GetStore()
+	store := informerFactory.Extensions().Internalversion().PodSecurityPolicies().Informer().GetStore()
 	for _, psp := range psps {
 		store.Add(psp)
 	}
-	lister := informerFactory.Extensions().InternalVersion().PodSecurityPolicies().Lister()
+	lister := informerFactory.Extensions().Internalversion().PodSecurityPolicies().Lister()
 	if authz == nil {
 		authz = &TestAuthorizer{}
 	}

--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -108,10 +108,10 @@ func (a *serviceAccount) SetInternalKubeClientSet(cl internalclientset.Interface
 }
 
 func (a *serviceAccount) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	serviceAccountInformer := f.Core().InternalVersion().ServiceAccounts()
+	serviceAccountInformer := f.Core().Internalversion().ServiceAccounts()
 	a.serviceAccountLister = serviceAccountInformer.Lister()
 
-	secretInformer := f.Core().InternalVersion().Secrets()
+	secretInformer := f.Core().Internalversion().Secrets()
 	a.secretLister = secretInformer.Lister()
 
 	a.SetReadyFunc(func() bool {

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -148,7 +148,7 @@ func TestAssignsDefaultServiceAccountAndToleratesMissingAPIToken(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -176,7 +176,7 @@ func TestAssignsDefaultServiceAccountAndRejectsMissingAPIToken(t *testing.T) {
 	admit.RequireAPIToken = true
 
 	// Add the default service account for the ns into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -263,7 +263,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 	admit.RequireAPIToken = true
 
 	// Add the default service account for the ns with a token into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
 			Namespace: ns,
@@ -274,7 +274,7 @@ func TestAutomountsAPIToken(t *testing.T) {
 		},
 	})
 	// Add a token for the service account into the cache
-	informerFactory.Core().InternalVersion().Secrets().Informer().GetStore().Add(&api.Secret{
+	informerFactory.Core().Internalversion().Secrets().Informer().GetStore().Add(&api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tokenName,
 			Namespace: ns,
@@ -413,7 +413,7 @@ func TestRespectsExistingMount(t *testing.T) {
 	admit.RequireAPIToken = true
 
 	// Add the default service account for the ns with a token into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceAccountName,
 			Namespace: ns,
@@ -424,7 +424,7 @@ func TestRespectsExistingMount(t *testing.T) {
 		},
 	})
 	// Add a token for the service account into the cache
-	informerFactory.Core().InternalVersion().Secrets().Informer().GetStore().Add(&api.Secret{
+	informerFactory.Core().Internalversion().Secrets().Informer().GetStore().Add(&api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tokenName,
 			Namespace: ns,
@@ -511,7 +511,7 @@ func TestAllowsReferencedSecret(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns with a secret reference into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -592,7 +592,7 @@ func TestRejectsUnreferencedSecretVolumes(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -670,7 +670,7 @@ func TestAllowUnreferencedSecretVolumesForPermissiveSAs(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        DefaultServiceAccountName,
 			Namespace:   ns,
@@ -702,7 +702,7 @@ func TestAllowsReferencedImagePullSecrets(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns with a secret reference into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -734,7 +734,7 @@ func TestRejectsUnreferencedImagePullSecrets(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -763,7 +763,7 @@ func TestDoNotAddImagePullSecrets(t *testing.T) {
 	admit.RequireAPIToken = false
 
 	// Add the default service account for the ns with a secret reference into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(&api.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      DefaultServiceAccountName,
 			Namespace: ns,
@@ -810,7 +810,7 @@ func TestAddImagePullSecrets(t *testing.T) {
 		},
 	}
 	// Add the default service account for the ns with a secret reference into the cache
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(sa)
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(sa)
 
 	pod := &api.Pod{}
 	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, nil)
@@ -855,10 +855,10 @@ func TestMultipleReferencedSecrets(t *testing.T) {
 			{Name: token2},
 		},
 	}
-	informerFactory.Core().InternalVersion().ServiceAccounts().Informer().GetStore().Add(sa)
+	informerFactory.Core().Internalversion().ServiceAccounts().Informer().GetStore().Add(sa)
 
 	// Add two tokens for the service account into the cache.
-	informerFactory.Core().InternalVersion().Secrets().Informer().GetStore().Add(&api.Secret{
+	informerFactory.Core().Internalversion().Secrets().Informer().GetStore().Add(&api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      token2,
 			Namespace: ns,
@@ -872,7 +872,7 @@ func TestMultipleReferencedSecrets(t *testing.T) {
 			api.ServiceAccountTokenKey: []byte("token-data"),
 		},
 	})
-	informerFactory.Core().InternalVersion().Secrets().Informer().GetStore().Add(&api.Secret{
+	informerFactory.Core().Internalversion().Secrets().Informer().GetStore().Add(&api.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      token1,
 			Namespace: ns,

--- a/plugin/pkg/admission/storageclass/setdefault/admission.go
+++ b/plugin/pkg/admission/storageclass/setdefault/admission.go
@@ -65,7 +65,7 @@ func newPlugin() *claimDefaulterPlugin {
 }
 
 func (a *claimDefaulterPlugin) SetInternalKubeInformerFactory(f informers.SharedInformerFactory) {
-	informer := f.Storage().InternalVersion().StorageClasses()
+	informer := f.Storage().Internalversion().StorageClasses()
 	a.lister = informer.Lister()
 	a.SetReadyFunc(informer.Informer().HasSynced)
 }

--- a/plugin/pkg/admission/storageclass/setdefault/admission_test.go
+++ b/plugin/pkg/admission/storageclass/setdefault/admission_test.go
@@ -197,7 +197,7 @@ func TestAdmission(t *testing.T) {
 		informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
 		ctrl.SetInternalKubeInformerFactory(informerFactory)
 		for _, c := range test.classes {
-			informerFactory.Storage().InternalVersion().StorageClasses().Informer().GetStore().Add(c)
+			informerFactory.Storage().Internalversion().StorageClasses().Informer().GetStore().Add(c)
 		}
 		attrs := admission.NewAttributesRecord(
 			claim, // new object

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -177,8 +177,8 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		versionDiscoveryHandler,
 		groupDiscoveryHandler,
 		s.GenericAPIServer.RequestContextMapper(),
-		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions().Lister(),
-		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
+		s.Informers.Apiextensions().Internalversion().CustomResourceDefinitions().Lister(),
+		s.Informers.Apiextensions().Internalversion().CustomResourceDefinitions(),
 		delegateHandler,
 		c.ExtraConfig.CRDRESTOptionsGetter,
 		c.GenericConfig.AdmissionControl,
@@ -191,10 +191,10 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		return s, nil
 	}
 
-	crdController := NewDiscoveryController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler, c.GenericConfig.RequestContextMapper)
-	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(), crdClient.Apiextensions())
+	crdController := NewDiscoveryController(s.Informers.Apiextensions().Internalversion().CustomResourceDefinitions(), versionDiscoveryHandler, groupDiscoveryHandler, c.GenericConfig.RequestContextMapper)
+	namingController := status.NewNamingConditionController(s.Informers.Apiextensions().Internalversion().CustomResourceDefinitions(), crdClient.Apiextensions())
 	finalizingController := finalizer.NewCRDFinalizer(
-		s.Informers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
+		s.Informers.Apiextensions().Internalversion().CustomResourceDefinitions(),
 		crdClient.Apiextensions(),
 		crdHandler,
 	)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/interface.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/apiextensions/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/generic.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/internalversion/generic.go
@@ -51,9 +51,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=apiextensions.k8s.io, Version=internalVersion
+	// Group=apiextensions.k8s.io, Version=internalversion
 	case apiextensions.SchemeGroupVersion.WithResource("customresourcedefinitions"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Apiextensions().InternalVersion().CustomResourceDefinitions().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Apiextensions().Internalversion().CustomResourceDefinitions().Informer()}, nil
 
 	}
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example/interface.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/interface.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/example2/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/generic.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/informers/internalversion/generic.go
@@ -52,13 +52,13 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=example.apiserver.code-generator.k8s.io, Version=internalVersion
+	// Group=example.apiserver.code-generator.k8s.io, Version=internalversion
 	case example.SchemeGroupVersion.WithResource("testtypes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().InternalVersion().TestTypes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Example().Internalversion().TestTypes().Informer()}, nil
 
-		// Group=example.test.apiserver.code-generator.k8s.io, Version=internalVersion
+		// Group=example.test.apiserver.code-generator.k8s.io, Version=internalversion
 	case example2.SchemeGroupVersion.WithResource("testtypes"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.SecondExample().InternalVersion().TestTypes().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.SecondExample().Internalversion().TestTypes().Informer()}, nil
 
 	}
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -130,9 +130,9 @@ func DefaultNameSystem() string {
 }
 
 func packageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, clientsetPackage string, groupPackageName string, groupGoName string, apiPath string, srcTreePath string, inputPackage string, boilerplate []byte) generator.Package {
-	groupVersionClientPackage := strings.ToLower(filepath.Join(clientsetPackage, "typed", groupPackageName, gv.Version.NonEmpty()))
+	groupVersionClientPackage := filepath.Join(clientsetPackage, "typed", groupPackageName, gv.Version.NonEmpty())
 	return &generator.DefaultPackage{
-		PackageName: strings.ToLower(gv.Version.NonEmpty()),
+		PackageName: gv.Version.NonEmpty(),
 		PackagePath: groupVersionClientPackage,
 		HeaderText:  boilerplate,
 		PackageDocumentation: []byte(

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/fake_client_generator.go
@@ -30,7 +30,7 @@ import (
 )
 
 func PackageForGroup(gv clientgentypes.GroupVersion, typeList []*types.Type, clientsetPackage string, groupPackageName string, groupGoName string, inputPackage string, boilerplate []byte) generator.Package {
-	outputPackage := strings.ToLower(filepath.Join(clientsetPackage, "typed", groupPackageName, gv.Version.NonEmpty(), "fake"))
+	outputPackage := filepath.Join(clientsetPackage, "typed", groupPackageName, gv.Version.NonEmpty(), "fake")
 	// TODO: should make this a function, called by here and in client-generator.go
 	realClientPackage := filepath.Join(clientsetPackage, "typed", groupPackageName, gv.Version.NonEmpty())
 	return &generator.DefaultPackage{

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -64,8 +64,8 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 			fakeGroupClientPackage := filepath.Join(groupClientPackage, "fake")
 
 			groupAlias := strings.ToLower(g.groupGoNames[clientgentypes.GroupVersion{group.Group, version}])
-			imports = append(imports, strings.ToLower(fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), groupClientPackage)))
-			imports = append(imports, strings.ToLower(fmt.Sprintf("fake%s%s \"%s\"", groupAlias, version.NonEmpty(), fakeGroupClientPackage)))
+			imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), groupClientPackage))
+			imports = append(imports, fmt.Sprintf("fake%s%s \"%s\"", groupAlias, version.NonEmpty(), fakeGroupClientPackage))
 		}
 	}
 	// the package that has the clientset Interface

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_group.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"strings"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -64,7 +63,7 @@ func (g *genFakeForGroup) Namers(c *generator.Context) namer.NameSystems {
 func (g *genFakeForGroup) Imports(c *generator.Context) (imports []string) {
 	imports = g.imports.ImportLines()
 	if len(g.types) != 0 {
-		imports = append(imports, strings.ToLower(fmt.Sprintf("%s \"%s\"", filepath.Base(g.realClientPackage), g.realClientPackage)))
+		imports = append(imports, fmt.Sprintf("%s \"%s\"", filepath.Base(g.realClientPackage), g.realClientPackage))
 	}
 	return imports
 }
@@ -90,7 +89,7 @@ func (g *genFakeForGroup) GenerateType(c *generator.Context, t *types.Type, w io
 			"type":              t,
 			"GroupGoName":       g.groupGoName,
 			"Version":           namer.IC(g.version),
-			"realClientPackage": strings.ToLower(filepath.Base(g.realClientPackage)),
+			"realClientPackage": filepath.Base(g.realClientPackage),
 		}
 		if tags.NonNamespaced {
 			sw.Do(getterImplNonNamespaced, wrapper)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_clientset.go
@@ -60,7 +60,7 @@ func (g *genClientset) Imports(c *generator.Context) (imports []string) {
 		for _, version := range group.Versions {
 			typedClientPath := filepath.Join(g.clientsetPackage, "typed", group.PackageName, version.NonEmpty())
 			groupAlias := strings.ToLower(g.groupGoNames[clientgentypes.GroupVersion{group.Group, version}])
-			imports = append(imports, strings.ToLower(fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), typedClientPath)))
+			imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), typedClientPath))
 		}
 	}
 	return

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/scheme/generator_for_scheme.go
@@ -69,10 +69,10 @@ func (g *GenScheme) Imports(c *generator.Context) (imports []string) {
 					packagePath = filepath.Dir(packagePath)
 				}
 				packagePath = filepath.Join(packagePath, "install")
-				imports = append(imports, strings.ToLower(fmt.Sprintf("%s \"%s\"", groupAlias, path.Vendorless(packagePath))))
+				imports = append(imports, fmt.Sprintf("%s \"%s\"", groupAlias, path.Vendorless(packagePath)))
 				break
 			} else {
-				imports = append(imports, strings.ToLower(fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), path.Vendorless(packagePath))))
+				imports = append(imports, fmt.Sprintf("%s%s \"%s\"", groupAlias, version.NonEmpty(), path.Vendorless(packagePath)))
 			}
 		}
 	}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/types/types.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/types/types.go
@@ -24,7 +24,7 @@ func (v Version) String() string {
 
 func (v Version) NonEmpty() string {
 	if v == "" {
-		return "internalVersion"
+		return "internalversion"
 	}
 	return v.String()
 }

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/groupinterface.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/groupinterface.go
@@ -19,7 +19,6 @@ package generators
 import (
 	"io"
 	"path/filepath"
-	"strings"
 
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	"k8s.io/gengo/generator"
@@ -70,7 +69,7 @@ func (g *groupInterfaceGenerator) GenerateType(c *generator.Context, t *types.Ty
 	versions := make([]versionData, 0, len(g.groupVersions.Versions))
 	for _, version := range g.groupVersions.Versions {
 		gv := clientgentypes.GroupVersion{Group: g.groupVersions.Group, Version: version}
-		versionPackage := filepath.Join(g.outputPackage, strings.ToLower(gv.Version.NonEmpty()))
+		versionPackage := filepath.Join(g.outputPackage, gv.Version.NonEmpty())
 		iface := c.Universe.Type(types.Name{Package: versionPackage, Name: "Interface"})
 		versions = append(versions, versionData{
 			Name:      namer.IC(version.NonEmpty()),

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/informer.go
@@ -19,7 +19,6 @@ package generators
 import (
 	"fmt"
 	"io"
-	"strings"
 
 	"k8s.io/gengo/generator"
 	"k8s.io/gengo/namer"
@@ -68,7 +67,7 @@ func (g *informerGenerator) GenerateType(c *generator.Context, t *types.Type, w 
 
 	glog.V(5).Infof("processing type %v", t)
 
-	listerPackage := fmt.Sprintf("%s/%s/%s", g.listersPackage, g.groupPkgName, strings.ToLower(g.groupVersion.Version.NonEmpty()))
+	listerPackage := fmt.Sprintf("%s/%s/%s", g.listersPackage, g.groupPkgName, g.groupVersion.Version.NonEmpty())
 	clientSetInterface := c.Universe.Type(types.Name{Package: g.clientSetPackage, Name: "Interface"})
 	informerFor := "InformerFor"
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -158,7 +158,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			gv.Version = clientgentypes.Version(parts[len(parts)-1])
 			targetGroupVersions = externalGroupVersions
 		}
-		groupPkgName := strings.ToLower(gv.Group.NonEmpty())
+		groupPkgName := gv.Group.NonEmpty()
 
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
@@ -315,10 +315,10 @@ func groupPackage(basePackage string, groupVersions clientgentypes.GroupVersions
 }
 
 func versionPackage(basePackage string, groupPkgName string, gv clientgentypes.GroupVersion, groupGoName string, boilerplate []byte, typesToGenerate []*types.Type, clientSetPackage, listersPackage string) generator.Package {
-	packagePath := filepath.Join(basePackage, groupPkgName, strings.ToLower(gv.Version.NonEmpty()))
+	packagePath := filepath.Join(basePackage, groupPkgName, gv.Version.NonEmpty())
 
 	return &generator.DefaultPackage{
-		PackageName: strings.ToLower(gv.Version.NonEmpty()),
+		PackageName: gv.Version.NonEmpty(),
 		PackagePath: packagePath,
 		HeaderText:  boilerplate,
 		GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -107,7 +107,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 			internalGVPkg = strings.Join(parts[0:len(parts)-1], "/")
 		}
-		groupPackageName := strings.ToLower(gv.Group.NonEmpty())
+		groupPackageName := gv.Group.NonEmpty()
 
 		// If there's a comment of the form "// +groupName=somegroup" or
 		// "// +groupName=somegroup.foo.bar.io", use the first field (somegroup) as the name of the
@@ -130,9 +130,9 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		orderer := namer.Orderer{Namer: namer.NewPrivateNamer(0)}
 		typesToGenerate = orderer.OrderTypes(typesToGenerate)
 
-		packagePath := filepath.Join(arguments.OutputPackagePath, groupPackageName, strings.ToLower(gv.Version.NonEmpty()))
+		packagePath := filepath.Join(arguments.OutputPackagePath, groupPackageName, gv.Version.NonEmpty())
 		packageList = append(packageList, &generator.DefaultPackage{
-			PackageName: strings.ToLower(gv.Version.NonEmpty()),
+			PackageName: gv.Version.NonEmpty(),
 			PackagePath: packagePath,
 			HeaderText:  boilerplate,
 			GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -176,7 +176,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		proxyTransport:   c.ExtraConfig.ProxyTransport,
 		proxyHandlers:    map[string]*proxyHandler{},
 		handledGroups:    sets.String{},
-		lister:           informerFactory.Apiregistration().InternalVersion().APIServices().Lister(),
+		lister:           informerFactory.Apiregistration().Internalversion().APIServices().Lister(),
 		APIRegistrationInformers: informerFactory,
 		serviceResolver:          c.ExtraConfig.ServiceResolver,
 	}
@@ -201,9 +201,9 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 	s.GenericAPIServer.Handler.NonGoRestfulMux.Handle("/apis", apisHandler)
 	s.GenericAPIServer.Handler.NonGoRestfulMux.UnlistedHandle("/apis/", apisHandler)
 
-	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().InternalVersion().APIServices(), c.GenericConfig.SharedInformerFactory.Core().V1().Services(), s)
+	apiserviceRegistrationController := NewAPIServiceRegistrationController(informerFactory.Apiregistration().Internalversion().APIServices(), c.GenericConfig.SharedInformerFactory.Core().V1().Services(), s)
 	availableController := statuscontrollers.NewAvailableConditionController(
-		informerFactory.Apiregistration().InternalVersion().APIServices(),
+		informerFactory.Apiregistration().Internalversion().APIServices(),
 		c.GenericConfig.SharedInformerFactory.Core().V1().Services(),
 		c.GenericConfig.SharedInformerFactory.Core().V1().Endpoints(),
 		apiregistrationClient.Apiregistration(),

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/interface.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/apiregistration/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/generic.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/informers/internalversion/generic.go
@@ -51,9 +51,9 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=apiregistration.k8s.io, Version=internalVersion
+	// Group=apiregistration.k8s.io, Version=internalversion
 	case apiregistration.SchemeGroupVersion.WithResource("apiservices"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Apiregistration().InternalVersion().APIServices().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Apiregistration().Internalversion().APIServices().Informer()}, nil
 
 	}
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder/admission.go
@@ -81,7 +81,7 @@ func (d *DisallowFlunder) Admit(a admission.Attributes) error {
 // SetInternalWardleInformerFactory gets Lister from SharedInformerFactory.
 // The lister knows how to lists Fischers.
 func (d *DisallowFlunder) SetInternalWardleInformerFactory(f informers.SharedInformerFactory) {
-	d.lister = f.Wardle().InternalVersion().Fischers().Lister()
+	d.lister = f.Wardle().Internalversion().Fischers().Lister()
 }
 
 // ValidaValidateInitializationte checks whether the plugin was correctly initialized.

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers/internalversion/generic.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers/internalversion/generic.go
@@ -51,11 +51,11 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=wardle.k8s.io, Version=internalVersion
+	// Group=wardle.k8s.io, Version=internalversion
 	case wardle.SchemeGroupVersion.WithResource("fischers"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().InternalVersion().Fischers().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().Internalversion().Fischers().Informer()}, nil
 	case wardle.SchemeGroupVersion.WithResource("flunders"):
-		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().InternalVersion().Flunders().Informer()}, nil
+		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().Internalversion().Flunders().Informer()}, nil
 
 	}
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/client/informers/internalversion/wardle/interface.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/client/informers/internalversion/wardle/interface.go
@@ -25,8 +25,8 @@ import (
 
 // Interface provides access to each of this group's versions.
 type Interface interface {
-	// InternalVersion provides access to shared informers for resources in InternalVersion.
-	InternalVersion() internalversion.Interface
+	// Internalversion provides access to shared informers for resources in Internalversion.
+	Internalversion() internalversion.Interface
 }
 
 type group struct {
@@ -40,7 +40,7 @@ func New(f internalinterfaces.SharedInformerFactory, namespace string, tweakList
 	return &group{factory: f, namespace: namespace, tweakListOptions: tweakListOptions}
 }
 
-// InternalVersion returns a new internalversion.Interface.
-func (g *group) InternalVersion() internalversion.Interface {
+// Internalversion returns a new internalversion.Interface.
+func (g *group) Internalversion() internalversion.Interface {
 	return internalversion.New(g.factory, g.namespace, g.tweakListOptions)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The current client-gen breaks for projects with non-lowercase names. Like github.com/mrIncompetent/foo

client-gen used to lowercas all package path's which is the reason it broke for me.

```release-note
Fix client-gen for non-lowercase repos
```
