### PR TITLE
Validate IPVSConfiguration only when IPVS mode is enabled.

### DIFF
--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
@@ -35,7 +35,9 @@ func Validate(config *kubeproxyconfig.KubeProxyConfiguration) field.ErrorList {
 	newPath := field.NewPath("KubeProxyConfiguration")
 
 	allErrs = append(allErrs, validateKubeProxyIPTablesConfiguration(config.IPTables, newPath.Child("KubeProxyIPTablesConfiguration"))...)
-	allErrs = append(allErrs, validateKubeProxyIPVSConfiguration(config.IPVS, newPath.Child("KubeProxyIPVSConfiguration"))...)
+	if config.Mode == kubeproxyconfig.ProxyModeIPVS {
+		allErrs = append(allErrs, validateKubeProxyIPVSConfiguration(config.IPVS, newPath.Child("KubeProxyIPVSConfiguration"))...)
+	}
 	allErrs = append(allErrs, validateKubeProxyConntrackConfiguration(config.Conntrack, newPath.Child("KubeProxyConntrackConfiguration"))...)
 	allErrs = append(allErrs, validateProxyMode(config.Mode, newPath.Child("Mode"))...)
 	allErrs = append(allErrs, validateClientConnectionConfiguration(config.ClientConnection, newPath.Child("ClientConnection"))...)

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -42,9 +42,30 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 			},
+			Mode: kubeproxyconfig.ProxyModeIPVS,
 			IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
 				SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
 				MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
+			},
+			Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+				Max:        pointer.Int32Ptr(2),
+				MaxPerCore: pointer.Int32Ptr(1),
+				Min:        pointer.Int32Ptr(1),
+				TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+				TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
+			},
+		},
+		{
+			BindAddress:        "192.168.59.103",
+			HealthzBindAddress: "0.0.0.0:10256",
+			MetricsBindAddress: "127.0.0.1:10249",
+			ClusterCIDR:        "192.168.59.0/24",
+			UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+			ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+			IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+				MasqueradeAll: true,
+				SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+				MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 			},
 			Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 				Max:        pointer.Int32Ptr(2),
@@ -80,10 +101,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
-				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
 					MaxPerCore: pointer.Int32Ptr(1),
@@ -107,10 +124,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MasqueradeAll: true,
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
-				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
@@ -136,10 +149,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
-				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
 					MaxPerCore: pointer.Int32Ptr(1),
@@ -163,10 +172,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					MasqueradeAll: true,
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
-				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
 				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
@@ -192,10 +197,6 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
-				},
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
 					MaxPerCore: pointer.Int32Ptr(1),
@@ -220,10 +221,31 @@ func TestValidateKubeProxyConfiguration(t *testing.T) {
 					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
 					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
 				},
-				IPVS: kubeproxyconfig.KubeProxyIPVSConfiguration{
-					SyncPeriod:    metav1.Duration{Duration: 10 * time.Second},
-					MinSyncPeriod: metav1.Duration{Duration: 5 * time.Second},
+				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
+					Max:        pointer.Int32Ptr(2),
+					MaxPerCore: pointer.Int32Ptr(1),
+					Min:        pointer.Int32Ptr(1),
+					TCPEstablishedTimeout: &metav1.Duration{Duration: 5 * time.Second},
+					TCPCloseWaitTimeout:   &metav1.Duration{Duration: 5 * time.Second},
 				},
+			},
+			msg: "must be greater than 0",
+		},
+		{
+			config: kubeproxyconfig.KubeProxyConfiguration{
+				BindAddress:        "192.168.59.103",
+				HealthzBindAddress: "0.0.0.0:10256",
+				MetricsBindAddress: "127.0.0.1:10249",
+				ClusterCIDR:        "192.168.59.0/24",
+				UDPIdleTimeout:     metav1.Duration{Duration: 1 * time.Second},
+				ConfigSyncPeriod:   metav1.Duration{Duration: 1 * time.Second},
+				IPTables: kubeproxyconfig.KubeProxyIPTablesConfiguration{
+					MasqueradeAll: true,
+					SyncPeriod:    metav1.Duration{Duration: 5 * time.Second},
+					MinSyncPeriod: metav1.Duration{Duration: 2 * time.Second},
+				},
+				// not specifying valid period in IPVS mode.
+				Mode: kubeproxyconfig.ProxyModeIPVS,
 				Conntrack: kubeproxyconfig.KubeProxyConntrackConfiguration{
 					Max:        pointer.Int32Ptr(2),
 					MaxPerCore: pointer.Int32Ptr(1),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It's strange for users that they should configuration valid values for ipvs params even when they don't use ipvs mode. Users don't need to care about these params in this case.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
/cc @m1093782566

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
