### PR TITLE
fluentd-elasticsearch add-on: Add missing selector to Fluentd DaemonSet

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -56,6 +56,10 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-es
+      version: v2.0.2
   template:
     metadata:
       labels:


### PR DESCRIPTION
fluentd-es-ds.yaml lacks a `selector` field in its DaemonSet definition, which this PR rectifies.

```release-note
NONE
```