### PR TITLE
e2e: Only create PSP if RBAC is enabled

### DIFF
--- a/test/e2e/framework/psp_util.go
+++ b/test/e2e/framework/psp_util.go
@@ -97,7 +97,7 @@ var (
 )
 
 func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
-	if !IsPodSecurityPolicyEnabled(f) || !IsRBACEnabled(f) {
+	if !IsPodSecurityPolicyEnabled(f) {
 		return
 	}
 	// Create the privileged PSP & role
@@ -114,30 +114,34 @@ func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
 		psp, err = f.ClientSet.ExtensionsV1beta1().PodSecurityPolicies().Create(psp)
 		ExpectNoError(err, "Failed to create PSP %s", podSecurityPolicyPrivileged)
 
-		// Create the Role to bind it to the namespace.
-		_, err = f.ClientSet.RbacV1beta1().ClusterRoles().Create(&rbacv1beta1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{Name: podSecurityPolicyPrivileged},
-			Rules: []rbacv1beta1.PolicyRule{{
-				APIGroups:     []string{"extensions"},
-				Resources:     []string{"podsecuritypolicies"},
-				ResourceNames: []string{podSecurityPolicyPrivileged},
-				Verbs:         []string{"use"},
-			}},
-		})
-		ExpectNoError(err, "Failed to create PSP role")
+		if IsRBACEnabled(f) {
+			// Create the Role to bind it to the namespace.
+			_, err = f.ClientSet.RbacV1beta1().ClusterRoles().Create(&rbacv1beta1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{Name: podSecurityPolicyPrivileged},
+				Rules: []rbacv1beta1.PolicyRule{{
+					APIGroups:     []string{"extensions"},
+					Resources:     []string{"podsecuritypolicies"},
+					ResourceNames: []string{podSecurityPolicyPrivileged},
+					Verbs:         []string{"use"},
+				}},
+			})
+			ExpectNoError(err, "Failed to create PSP role")
+		}
 	})
 
-	By(fmt.Sprintf("Binding the %s PodSecurityPolicy to the default service account in %s",
-		podSecurityPolicyPrivileged, namespace))
-	BindClusterRoleInNamespace(f.ClientSet.RbacV1beta1(),
-		podSecurityPolicyPrivileged,
-		namespace,
-		rbacv1beta1.Subject{
-			Kind:      rbacv1beta1.ServiceAccountKind,
-			Namespace: namespace,
-			Name:      "default",
-		})
-	ExpectNoError(WaitForNamedAuthorizationUpdate(f.ClientSet.AuthorizationV1beta1(),
-		serviceaccount.MakeUsername(namespace, "default"), namespace, "use", podSecurityPolicyPrivileged,
-		schema.GroupResource{Group: "extensions", Resource: "podsecuritypolicies"}, true))
+	if IsRBACEnabled(f) {
+		By(fmt.Sprintf("Binding the %s PodSecurityPolicy to the default service account in %s",
+			podSecurityPolicyPrivileged, namespace))
+		BindClusterRoleInNamespace(f.ClientSet.RbacV1beta1(),
+			podSecurityPolicyPrivileged,
+			namespace,
+			rbacv1beta1.Subject{
+				Kind:      rbacv1beta1.ServiceAccountKind,
+				Namespace: namespace,
+				Name:      "default",
+			})
+		ExpectNoError(WaitForNamedAuthorizationUpdate(f.ClientSet.AuthorizationV1beta1(),
+			serviceaccount.MakeUsername(namespace, "default"), namespace, "use", podSecurityPolicyPrivileged,
+			schema.GroupResource{Group: "extensions", Resource: "podsecuritypolicies"}, true))
+	}
 }

--- a/test/e2e/framework/psp_util.go
+++ b/test/e2e/framework/psp_util.go
@@ -97,7 +97,7 @@ var (
 )
 
 func CreatePrivilegedPSPBinding(f *Framework, namespace string) {
-	if !IsPodSecurityPolicyEnabled(f) {
+	if !IsPodSecurityPolicyEnabled(f) || !IsRBACEnabled(f) {
 		return
 	}
 	// Create the privileged PSP & role


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Creating privileged PSPs during e2e tests depends on RBAC being enabled in the target cluster. However it is possible to use PSPs without having RBAC enabled thus only enable creating PSPs during e2e tests if both PSP and RBAC is enabled.

Fix #57840

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Only create Privileged PSP binding during e2e tests if RBAC is enabled.
```

  