### PR TITLE
Reduce memory footprint of admission metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -69,11 +69,9 @@ func TestObserveAdmissionController(t *testing.T) {
 		"rejected":    "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
 
 	wantLabels["type"] = "validate"
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
 }
 
 func TestObserveWebhook(t *testing.T) {
@@ -90,7 +88,6 @@ func TestObserveWebhook(t *testing.T) {
 		"rejected":    "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_webhook_admission_latencies_seconds_summary", wantLabels)
 }
 
 func TestWithMetrics(t *testing.T) {


### PR DESCRIPTION
Fix #56061

Remove `SummaryVec` from all but the top level metric and reduce buckets for the histogram from 7 to 5.

Tested this with a small GCE cluster. The `Individual Memory Usage: kube-system kube-apiserver-kubernetes-master` grafana metric showed the memory footprint of apiserver at 655MB before this change and 415MB after, suggesting this accounts for the vast majority of the ~200MB of memory increase found in #56061.

```release-note
None
```