### PR TITLE
Log actual return code, not the default value.

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2130,8 +2130,8 @@ func (b kubectlBuilder) Exec() (string, error) {
 		if err != nil {
 			var rc int = 127
 			if ee, ok := err.(*exec.ExitError); ok {
-				Logf("rc: %d", rc)
 				rc = int(ee.Sys().(syscall.WaitStatus).ExitStatus())
+				Logf("rc: %d", rc)
 			}
 			return "", uexec.CodeExitError{
 				Err:  fmt.Errorf("error running %v:\nCommand stdout:\n%v\nstderr:\n%v\nerror:\n%v\n", cmd, cmd.Stdout, cmd.Stderr, err),


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the code would log 127, no matter what, which is quite
useless..

**Release note**:
```release-note
NONE
```