### PR TITLE
Do not log trailing whitespace.

### DIFF
--- a/pkg/registry/rbac/rest/storage_rbac.go
+++ b/pkg/registry/rbac/rest/storage_rbac.go
@@ -264,7 +264,7 @@ func (p *PolicyData) EnsureRBACPolicy() genericapiserver.PostStartHookFunc {
 						case result.Operation == reconciliation.ReconcileUpdate:
 							glog.Infof("updated role.%s/%s in %v with additional permissions: %v", rbac.GroupName, role.Name, namespace, result.MissingRules)
 						case result.Operation == reconciliation.ReconcileCreate:
-							glog.Infof("created role.%s/%s in %v ", rbac.GroupName, role.Name, namespace)
+							glog.Infof("created role.%s/%s in %v", rbac.GroupName, role.Name, namespace)
 						}
 						return nil
 					})


### PR DESCRIPTION
**What this PR does / why we need it**:

Gets rid of useless spaces, makes log parser verification slightly
easier.

**Release note**:
```release-note
NONE
```