### PR TITLE
If cloud==nil, it should exits to avoid Panic

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -93,6 +93,10 @@ func Run(s *options.CloudControllerManagerServer) error {
 		glog.Fatalf("Cloud provider could not be initialized: %v", err)
 	}
 
+	if cloud == nil {
+		glog.Fatalf("cloud provider is nil")
+	}
+
 	if cloud.HasClusterID() == false {
 		if s.AllowUntaggedCloud == true {
 			glog.Warning("detected a cluster without a ClusterID.  A ClusterID will be required in the future.  Please tag your cluster to avoid any future issues")


### PR DESCRIPTION
**What this PR does / why we need it**:
If `cloud == nil`， it should exits, otherwise `cloud.HasClusterID()` will panic.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
