### PR TITLE
Use authentication client with explicit version

### DIFF
--- a/cmd/cloud-controller-manager/app/controllermanager.go
+++ b/cmd/cloud-controller-manager/app/controllermanager.go
@@ -136,7 +136,7 @@ func Run(s *options.CloudControllerManagerServer) error {
 			clientBuilder = controller.SAControllerClientBuilder{
 				ClientConfig:         restclient.AnonymousClientConfig(kubeconfig),
 				CoreClient:           kubeClient.CoreV1(),
-				AuthenticationClient: kubeClient.Authentication(),
+				AuthenticationClient: kubeClient.AuthenticationV1(),
 				Namespace:            "kube-system",
 			}
 		} else {

--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -139,7 +139,7 @@ func Run(s *options.CMServer) error {
 			clientBuilder = controller.SAControllerClientBuilder{
 				ClientConfig:         restclient.AnonymousClientConfig(kubeconfig),
 				CoreClient:           kubeClient.CoreV1(),
-				AuthenticationClient: kubeClient.Authentication(),
+				AuthenticationClient: kubeClient.AuthenticationV1(),
 				Namespace:            "kube-system",
 			}
 		} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Authentication client without explicit version has been deprecated, change them to the one with explicit version.

**Which issue(s) this PR fixes**:
Fixes partially #55993

**Special notes for your reviewer**:
/cc @caesarxuchao @sttts

**Release note**:
```release-note
NONE
```