### PR TITLE
Include ServerName in tls transport cache key

### DIFF
--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -88,5 +88,5 @@ func tlsConfigKey(c *Config) (string, error) {
 		return "", err
 	}
 	// Only include the things that actually affect the tls.Config
-	return fmt.Sprintf("%v/%x/%x/%x", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData), nil
+	return fmt.Sprintf("%v/%x/%x/%x/%v", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData, c.TLS.ServerName), nil
 }

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -62,6 +62,20 @@ func TestTLSConfigKey(t *testing.T) {
 				KeyData:  []byte{1},
 			},
 		},
+		"cert 1, key 1, servername 1": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "1",
+			},
+		},
+		"cert 1, key 1, servername 2": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "2",
+			},
+		},
 		"cert 1, key 2": {
 			TLS: TLSConfig{
 				CertData: []byte{1},

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -120,7 +120,12 @@ func TestAggregatedAPIServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			kubeClientConfigValue.Store(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
+			// Adjust the loopback config for external use (external server name and CA)
+			kubeAPIServerClientConfig := rest.CopyConfig(kubeAPIServerConfig.GenericConfig.LoopbackClientConfig)
+			kubeAPIServerClientConfig.CAFile = path.Join(certDir, "apiserver.crt")
+			kubeAPIServerClientConfig.CAData = nil
+			kubeAPIServerClientConfig.ServerName = ""
+			kubeClientConfigValue.Store(kubeAPIServerClientConfig)
 
 			kubeAPIServer, err := app.CreateKubeAPIServer(kubeAPIServerConfig, genericapiserver.EmptyDelegate, sharedInformers, versionedInformers)
 			if err != nil {


### PR DESCRIPTION
Fixes #56385 

```release-note
Fixes server name verification of aggregated API servers and webhook admission endpoints
```