### PR TITLE
Automated cherry pick of #56415

### DIFF
--- a/staging/src/k8s.io/client-go/transport/cache.go
+++ b/staging/src/k8s.io/client-go/transport/cache.go
@@ -84,5 +84,5 @@ func tlsConfigKey(c *Config) (string, error) {
 		return "", err
 	}
 	// Only include the things that actually affect the tls.Config
-	return fmt.Sprintf("%v/%x/%x/%x", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData), nil
+	return fmt.Sprintf("%v/%x/%x/%x/%v", c.TLS.Insecure, c.TLS.CAData, c.TLS.CertData, c.TLS.KeyData, c.TLS.ServerName), nil
 }

--- a/staging/src/k8s.io/client-go/transport/cache_test.go
+++ b/staging/src/k8s.io/client-go/transport/cache_test.go
@@ -62,6 +62,20 @@ func TestTLSConfigKey(t *testing.T) {
 				KeyData:  []byte{1},
 			},
 		},
+		"cert 1, key 1, servername 1": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "1",
+			},
+		},
+		"cert 1, key 1, servername 2": {
+			TLS: TLSConfig{
+				CertData:   []byte{1},
+				KeyData:    []byte{1},
+				ServerName: "2",
+			},
+		},
 		"cert 1, key 2": {
 			TLS: TLSConfig{
 				CertData: []byte{1},

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -116,7 +116,12 @@ func TestAggregatedAPIServer(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			kubeClientConfigValue.Store(config.GenericConfig.LoopbackClientConfig)
+			// Adjust the loopback config for external use (external server name and CA)
+			kubeAPIServerClientConfig := *config.GenericConfig.LoopbackClientConfig
+			kubeAPIServerClientConfig.CAFile = path.Join(certDir, "apiserver.crt")
+			kubeAPIServerClientConfig.CAData = nil
+			kubeAPIServerClientConfig.ServerName = ""
+			kubeClientConfigValue.Store(&kubeAPIServerClientConfig)
 
 			if err := app.RunServer(config, sharedInformers, stopCh); err != nil {
 				t.Log(err)


### PR DESCRIPTION
Cherry pick of #56415 on release-1.6.

#56415: Include ServerName in tls transport cache key