### PR TITLE
e2e: bump coreos test images to use coreos-stable

### DIFF
--- a/test/e2e_node/jenkins/image-config-serial.yaml
+++ b/test/e2e_node/jenkins/image-config-serial.yaml
@@ -5,8 +5,8 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+  coreos-stable:
+    image: coreos-stable # docker 1.12.6
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:

--- a/test/e2e_node/jenkins/image-config.yaml
+++ b/test/e2e_node/jenkins/image-config.yaml
@@ -5,8 +5,8 @@ images:
   ubuntu:
     image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
     project: ubuntu-os-gke-cloud
-  coreos-alpha:
-    image: coreos-alpha-1122-0-0-v20160727 # docker 1.11.2
+  coreos-stable:
+    image: coreos-stable # docker 1.12.6
     project: coreos-cloud
     metadata: "user-data<test/e2e_node/jenkins/coreos-init.json"
   containervm:


### PR DESCRIPTION
**What this PR does / why we need it**: Attempts to fix the flaky CoreOS test found in Issue #56234. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56234 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
