### PR TITLE
e2e: test containers projected volume updates should not exit

### DIFF
--- a/test/e2e/common/projected.go
+++ b/test/e2e/common/projected.go
@@ -1517,7 +1517,7 @@ func projectedDownwardAPIVolumePodForUpdateTest(name string, labels, annotations
 		{
 			Name:    "client-container",
 			Image:   mountImage,
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",


### PR DESCRIPTION
The mounttest container should be running until the test determines to
give up (i.e., time out) and kill it. It should not exit prematurely by
itself. Bump the `--retry-timeout` to a much higher value.
