### PR TITLE
WIP: Fix definition of RawExtension in OpenAPI schema

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -71299,6 +71299,7 @@
   "definitions": {
    "io.k8s.api.admissionregistration.v1alpha1.Initializer": {
     "description": "Initializer describes the name and the failure policy of an initializer, and what resources it applies to.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -71318,6 +71319,7 @@
    },
    "io.k8s.api.admissionregistration.v1alpha1.InitializerConfiguration": {
     "description": "InitializerConfiguration describes the configuration of initializers.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71351,6 +71353,7 @@
    },
    "io.k8s.api.admissionregistration.v1alpha1.InitializerConfigurationList": {
     "description": "InitializerConfigurationList is a list of InitializerConfiguration.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -71385,6 +71388,7 @@
    },
    "io.k8s.api.admissionregistration.v1alpha1.Rule": {
     "description": "Rule is a tuple of APIGroups, APIVersion, and Resources.It is recommended to make sure that all the tuple expansions are valid.",
+    "type": "object",
     "properties": {
      "apiGroups": {
       "description": "APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.",
@@ -71411,6 +71415,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfiguration": {
     "description": "MutatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and may change the object.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71444,6 +71449,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.MutatingWebhookConfigurationList": {
     "description": "MutatingWebhookConfigurationList is a list of MutatingWebhookConfiguration.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -71478,6 +71484,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.RuleWithOperations": {
     "description": "RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.",
+    "type": "object",
     "properties": {
      "apiGroups": {
       "description": "APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.",
@@ -71511,6 +71518,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.ServiceReference": {
     "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+    "type": "object",
     "required": [
      "namespace",
      "name"
@@ -71532,6 +71540,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfiguration": {
     "description": "ValidatingWebhookConfiguration describes the configuration of and admission webhook that accept or reject and object without changing it.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71565,6 +71574,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhookConfigurationList": {
     "description": "ValidatingWebhookConfigurationList is a list of ValidatingWebhookConfiguration.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -71599,6 +71609,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.Webhook": {
     "description": "Webhook describes an admission webhook and the resources and operations it applies to.",
+    "type": "object",
     "required": [
      "name",
      "clientConfig"
@@ -71631,6 +71642,7 @@
    },
    "io.k8s.api.admissionregistration.v1beta1.WebhookClientConfig": {
     "description": "WebhookClientConfig contains the information to make a TLS connection with the webhook",
+    "type": "object",
     "required": [
      "caBundle"
     ],
@@ -71652,6 +71664,7 @@
    },
    "io.k8s.api.apps.v1.ControllerRevision": {
     "description": "ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+    "type": "object",
     "required": [
      "revision"
     ],
@@ -71662,7 +71675,7 @@
      },
      "data": {
       "description": "Data is the serialized representation of the state.",
-      "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+      "type": "object"
      },
      "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
@@ -71688,6 +71701,7 @@
    },
    "io.k8s.api.apps.v1.ControllerRevisionList": {
     "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -71722,6 +71736,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSet": {
     "description": "DaemonSet represents the configuration of a daemon set.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71754,6 +71769,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSetCondition": {
     "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -71783,6 +71799,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSetList": {
     "description": "DaemonSetList is a collection of daemon sets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -71817,6 +71834,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSetSpec": {
     "description": "DaemonSetSpec is the specification of a daemon set.",
+    "type": "object",
     "required": [
      "selector",
      "template"
@@ -71848,6 +71866,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSetStatus": {
     "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "type": "object",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -71913,6 +71932,7 @@
    },
    "io.k8s.api.apps.v1.DaemonSetUpdateStrategy": {
     "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -71926,6 +71946,7 @@
    },
    "io.k8s.api.apps.v1.Deployment": {
     "description": "Deployment enables declarative updates for Pods and ReplicaSets.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -71958,6 +71979,7 @@
    },
    "io.k8s.api.apps.v1.DeploymentCondition": {
     "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -71991,6 +72013,7 @@
    },
    "io.k8s.api.apps.v1.DeploymentList": {
     "description": "DeploymentList is a list of Deployments.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -72025,6 +72048,7 @@
    },
    "io.k8s.api.apps.v1.DeploymentSpec": {
     "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "type": "object",
     "required": [
      "selector",
      "template"
@@ -72070,6 +72094,7 @@
    },
    "io.k8s.api.apps.v1.DeploymentStatus": {
     "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "type": "object",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -72119,6 +72144,7 @@
    },
    "io.k8s.api.apps.v1.DeploymentStrategy": {
     "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -72132,6 +72158,7 @@
    },
    "io.k8s.api.apps.v1.ReplicaSet": {
     "description": "ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -72164,6 +72191,7 @@
    },
    "io.k8s.api.apps.v1.ReplicaSetCondition": {
     "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -72193,6 +72221,7 @@
    },
    "io.k8s.api.apps.v1.ReplicaSetList": {
     "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -72227,6 +72256,7 @@
    },
    "io.k8s.api.apps.v1.ReplicaSetSpec": {
     "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "type": "object",
     "required": [
      "selector"
     ],
@@ -72253,6 +72283,7 @@
    },
    "io.k8s.api.apps.v1.ReplicaSetStatus": {
     "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -72295,6 +72326,7 @@
    },
    "io.k8s.api.apps.v1.RollingUpdateDaemonSet": {
     "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "type": "object",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -72304,6 +72336,7 @@
    },
    "io.k8s.api.apps.v1.RollingUpdateDeployment": {
     "description": "Spec to control the desired behavior of rolling update.",
+    "type": "object",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is at most 130% of desired pods.",
@@ -72317,6 +72350,7 @@
    },
    "io.k8s.api.apps.v1.RollingUpdateStatefulSetStrategy": {
     "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "type": "object",
     "properties": {
      "partition": {
       "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
@@ -72327,6 +72361,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSet": {
     "description": "StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -72358,6 +72393,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSetCondition": {
     "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -72387,6 +72423,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSetList": {
     "description": "StatefulSetList is a collection of StatefulSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -72419,6 +72456,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSetSpec": {
     "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "type": "object",
     "required": [
      "selector",
      "template",
@@ -72466,6 +72504,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSetStatus": {
     "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -72521,6 +72560,7 @@
    },
    "io.k8s.api.apps.v1.StatefulSetUpdateStrategy": {
     "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
@@ -72534,6 +72574,7 @@
    },
    "io.k8s.api.apps.v1beta1.ControllerRevision": {
     "description": "DEPRECATED - This group version of ControllerRevision is deprecated by apps/v1beta2/ControllerRevision. See the release notes for more information. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+    "type": "object",
     "required": [
      "revision"
     ],
@@ -72544,7 +72585,7 @@
      },
      "data": {
       "description": "Data is the serialized representation of the state.",
-      "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+      "type": "object"
      },
      "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
@@ -72570,6 +72611,7 @@
    },
    "io.k8s.api.apps.v1beta1.ControllerRevisionList": {
     "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -72604,6 +72646,7 @@
    },
    "io.k8s.api.apps.v1beta1.Deployment": {
     "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -72636,6 +72679,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentCondition": {
     "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -72669,6 +72713,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentList": {
     "description": "DeploymentList is a list of Deployments.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -72703,6 +72748,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentRollback": {
     "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "type": "object",
     "required": [
      "name",
      "rollbackTo"
@@ -72742,6 +72788,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentSpec": {
     "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "type": "object",
     "required": [
      "template"
     ],
@@ -72790,6 +72837,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentStatus": {
     "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "type": "object",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -72839,6 +72887,7 @@
    },
    "io.k8s.api.apps.v1beta1.DeploymentStrategy": {
     "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -72852,6 +72901,7 @@
    },
    "io.k8s.api.apps.v1beta1.RollbackConfig": {
     "description": "DEPRECATED.",
+    "type": "object",
     "properties": {
      "revision": {
       "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
@@ -72862,6 +72912,7 @@
    },
    "io.k8s.api.apps.v1beta1.RollingUpdateDeployment": {
     "description": "Spec to control the desired behavior of rolling update.",
+    "type": "object",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
@@ -72875,6 +72926,7 @@
    },
    "io.k8s.api.apps.v1beta1.RollingUpdateStatefulSetStrategy": {
     "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "type": "object",
     "properties": {
      "partition": {
       "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned.",
@@ -72885,6 +72937,7 @@
    },
    "io.k8s.api.apps.v1beta1.Scale": {
     "description": "Scale represents a scaling request for a resource.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -72917,6 +72970,7 @@
    },
    "io.k8s.api.apps.v1beta1.ScaleSpec": {
     "description": "ScaleSpec describes the attributes of a scale subresource",
+    "type": "object",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -72927,6 +72981,7 @@
    },
    "io.k8s.api.apps.v1beta1.ScaleStatus": {
     "description": "ScaleStatus represents the current status of a scale subresource.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -72951,6 +73006,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSet": {
     "description": "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1beta2/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -72982,6 +73038,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSetCondition": {
     "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -73011,6 +73068,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSetList": {
     "description": "StatefulSetList is a collection of StatefulSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73043,6 +73101,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSetSpec": {
     "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "type": "object",
     "required": [
      "template",
      "serviceName"
@@ -73089,6 +73148,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSetStatus": {
     "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -73144,6 +73204,7 @@
    },
    "io.k8s.api.apps.v1beta1.StatefulSetUpdateStrategy": {
     "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
@@ -73157,6 +73218,7 @@
    },
    "io.k8s.api.apps.v1beta2.ControllerRevision": {
     "description": "DEPRECATED - This group version of ControllerRevision is deprecated by apps/v1/ControllerRevision. See the release notes for more information. ControllerRevision implements an immutable snapshot of state data. Clients are responsible for serializing and deserializing the objects that contain their internal state. Once a ControllerRevision has been successfully created, it can not be updated. The API Server will fail validation of all requests that attempt to mutate the Data field. ControllerRevisions may, however, be deleted. Note that, due to its use by both the DaemonSet and StatefulSet controllers for update and rollback, this object is beta. However, it may be subject to name and representation changes in future releases, and clients should not depend on its stability. It is primarily for internal use by controllers.",
+    "type": "object",
     "required": [
      "revision"
     ],
@@ -73167,7 +73229,7 @@
      },
      "data": {
       "description": "Data is the serialized representation of the state.",
-      "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+      "type": "object"
      },
      "kind": {
       "description": "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
@@ -73193,6 +73255,7 @@
    },
    "io.k8s.api.apps.v1beta2.ControllerRevisionList": {
     "description": "ControllerRevisionList is a resource containing a list of ControllerRevision objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73227,6 +73290,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSet": {
     "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -73259,6 +73323,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSetCondition": {
     "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -73288,6 +73353,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSetList": {
     "description": "DaemonSetList is a collection of daemon sets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73322,6 +73388,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSetSpec": {
     "description": "DaemonSetSpec is the specification of a daemon set.",
+    "type": "object",
     "required": [
      "selector",
      "template"
@@ -73353,6 +73420,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSetStatus": {
     "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "type": "object",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -73418,6 +73486,7 @@
    },
    "io.k8s.api.apps.v1beta2.DaemonSetUpdateStrategy": {
     "description": "DaemonSetUpdateStrategy is a struct used to control the update strategy for a DaemonSet.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -73431,6 +73500,7 @@
    },
    "io.k8s.api.apps.v1beta2.Deployment": {
     "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -73463,6 +73533,7 @@
    },
    "io.k8s.api.apps.v1beta2.DeploymentCondition": {
     "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -73496,6 +73567,7 @@
    },
    "io.k8s.api.apps.v1beta2.DeploymentList": {
     "description": "DeploymentList is a list of Deployments.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73530,6 +73602,7 @@
    },
    "io.k8s.api.apps.v1beta2.DeploymentSpec": {
     "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "type": "object",
     "required": [
      "selector",
      "template"
@@ -73575,6 +73648,7 @@
    },
    "io.k8s.api.apps.v1beta2.DeploymentStatus": {
     "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "type": "object",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -73624,6 +73698,7 @@
    },
    "io.k8s.api.apps.v1beta2.DeploymentStrategy": {
     "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -73637,6 +73712,7 @@
    },
    "io.k8s.api.apps.v1beta2.ReplicaSet": {
     "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -73669,6 +73745,7 @@
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetCondition": {
     "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -73698,6 +73775,7 @@
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetList": {
     "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73732,6 +73810,7 @@
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetSpec": {
     "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "type": "object",
     "required": [
      "selector"
     ],
@@ -73758,6 +73837,7 @@
    },
    "io.k8s.api.apps.v1beta2.ReplicaSetStatus": {
     "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -73800,6 +73880,7 @@
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateDaemonSet": {
     "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "type": "object",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -73809,6 +73890,7 @@
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateDeployment": {
     "description": "Spec to control the desired behavior of rolling update.",
+    "type": "object",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. Defaults to 25%. Example: when this is set to 30%, the new ReplicaSet can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new ReplicaSet can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
@@ -73822,6 +73904,7 @@
    },
    "io.k8s.api.apps.v1beta2.RollingUpdateStatefulSetStrategy": {
     "description": "RollingUpdateStatefulSetStrategy is used to communicate parameter for RollingUpdateStatefulSetStrategyType.",
+    "type": "object",
     "properties": {
      "partition": {
       "description": "Partition indicates the ordinal at which the StatefulSet should be partitioned. Default value is 0.",
@@ -73832,6 +73915,7 @@
    },
    "io.k8s.api.apps.v1beta2.Scale": {
     "description": "Scale represents a scaling request for a resource.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -73864,6 +73948,7 @@
    },
    "io.k8s.api.apps.v1beta2.ScaleSpec": {
     "description": "ScaleSpec describes the attributes of a scale subresource",
+    "type": "object",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -73874,6 +73959,7 @@
    },
    "io.k8s.api.apps.v1beta2.ScaleStatus": {
     "description": "ScaleStatus represents the current status of a scale subresource.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -73898,6 +73984,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSet": {
     "description": "DEPRECATED - This group version of StatefulSet is deprecated by apps/v1/StatefulSet. See the release notes for more information. StatefulSet represents a set of pods with consistent identities. Identities are defined as:\n - Network: A single stable DNS and hostname.\n - Storage: As many VolumeClaims as requested.\nThe StatefulSet guarantees that a given network identity will always map to the same storage identity.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -73929,6 +74016,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSetCondition": {
     "description": "StatefulSetCondition describes the state of a statefulset at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -73958,6 +74046,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSetList": {
     "description": "StatefulSetList is a collection of StatefulSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -73990,6 +74079,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSetSpec": {
     "description": "A StatefulSetSpec is the specification of a StatefulSet.",
+    "type": "object",
     "required": [
      "selector",
      "template",
@@ -74037,6 +74127,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSetStatus": {
     "description": "StatefulSetStatus represents the current state of a StatefulSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -74092,6 +74183,7 @@
    },
    "io.k8s.api.apps.v1beta2.StatefulSetUpdateStrategy": {
     "description": "StatefulSetUpdateStrategy indicates the strategy that the StatefulSet controller will use to perform updates. It includes any additional parameters necessary to perform the update for the indicated strategy.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "RollingUpdate is used to communicate parameters when Type is RollingUpdateStatefulSetStrategyType.",
@@ -74105,6 +74197,7 @@
    },
    "io.k8s.api.authentication.v1.TokenReview": {
     "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74139,6 +74232,7 @@
    },
    "io.k8s.api.authentication.v1.TokenReviewSpec": {
     "description": "TokenReviewSpec is a description of the token authentication request.",
+    "type": "object",
     "properties": {
      "token": {
       "description": "Token is the opaque bearer token.",
@@ -74148,6 +74242,7 @@
    },
    "io.k8s.api.authentication.v1.TokenReviewStatus": {
     "description": "TokenReviewStatus is the result of the token authentication request.",
+    "type": "object",
     "properties": {
      "authenticated": {
       "description": "Authenticated indicates that the token was associated with a known user.",
@@ -74165,6 +74260,7 @@
    },
    "io.k8s.api.authentication.v1.UserInfo": {
     "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+    "type": "object",
     "properties": {
      "extra": {
       "description": "Any additional information provided by the authenticator.",
@@ -74195,6 +74291,7 @@
    },
    "io.k8s.api.authentication.v1beta1.TokenReview": {
     "description": "TokenReview attempts to authenticate a token to a known user. Note: TokenReview requests may be cached by the webhook token authenticator plugin in the kube-apiserver.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74229,6 +74326,7 @@
    },
    "io.k8s.api.authentication.v1beta1.TokenReviewSpec": {
     "description": "TokenReviewSpec is a description of the token authentication request.",
+    "type": "object",
     "properties": {
      "token": {
       "description": "Token is the opaque bearer token.",
@@ -74238,6 +74336,7 @@
    },
    "io.k8s.api.authentication.v1beta1.TokenReviewStatus": {
     "description": "TokenReviewStatus is the result of the token authentication request.",
+    "type": "object",
     "properties": {
      "authenticated": {
       "description": "Authenticated indicates that the token was associated with a known user.",
@@ -74255,6 +74354,7 @@
    },
    "io.k8s.api.authentication.v1beta1.UserInfo": {
     "description": "UserInfo holds the information about the user needed to implement the user.Info interface.",
+    "type": "object",
     "properties": {
      "extra": {
       "description": "Any additional information provided by the authenticator.",
@@ -74285,6 +74385,7 @@
    },
    "io.k8s.api.authorization.v1.LocalSubjectAccessReview": {
     "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74319,6 +74420,7 @@
    },
    "io.k8s.api.authorization.v1.NonResourceAttributes": {
     "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "type": "object",
     "properties": {
      "path": {
       "description": "Path is the URL path of the request",
@@ -74332,6 +74434,7 @@
    },
    "io.k8s.api.authorization.v1.NonResourceRule": {
     "description": "NonResourceRule holds information that describes a rule for the non-resource",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -74354,6 +74457,7 @@
    },
    "io.k8s.api.authorization.v1.ResourceAttributes": {
     "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "type": "object",
     "properties": {
      "group": {
       "description": "Group is the API Group of the Resource.  \"*\" means all.",
@@ -74387,6 +74491,7 @@
    },
    "io.k8s.api.authorization.v1.ResourceRule": {
     "description": "ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -74423,6 +74528,7 @@
    },
    "io.k8s.api.authorization.v1.SelfSubjectAccessReview": {
     "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74457,6 +74563,7 @@
    },
    "io.k8s.api.authorization.v1.SelfSubjectAccessReviewSpec": {
     "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "type": "object",
     "properties": {
      "nonResourceAttributes": {
       "description": "NonResourceAttributes describes information for a non-resource access request",
@@ -74470,6 +74577,7 @@
    },
    "io.k8s.api.authorization.v1.SelfSubjectRulesReview": {
     "description": "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74503,6 +74611,7 @@
     ]
    },
    "io.k8s.api.authorization.v1.SelfSubjectRulesReviewSpec": {
+    "type": "object",
     "properties": {
      "namespace": {
       "description": "Namespace to evaluate rules for. Required.",
@@ -74512,6 +74621,7 @@
    },
    "io.k8s.api.authorization.v1.SubjectAccessReview": {
     "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74546,6 +74656,7 @@
    },
    "io.k8s.api.authorization.v1.SubjectAccessReviewSpec": {
     "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "type": "object",
     "properties": {
      "extra": {
       "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
@@ -74584,6 +74695,7 @@
    },
    "io.k8s.api.authorization.v1.SubjectAccessReviewStatus": {
     "description": "SubjectAccessReviewStatus",
+    "type": "object",
     "required": [
      "allowed"
     ],
@@ -74608,6 +74720,7 @@
    },
    "io.k8s.api.authorization.v1.SubjectRulesReviewStatus": {
     "description": "SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.",
+    "type": "object",
     "required": [
      "resourceRules",
      "nonResourceRules",
@@ -74640,6 +74753,7 @@
    },
    "io.k8s.api.authorization.v1beta1.LocalSubjectAccessReview": {
     "description": "LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace. Having a namespace scoped resource makes it much easier to grant namespace scoped policy that includes permissions checking.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74674,6 +74788,7 @@
    },
    "io.k8s.api.authorization.v1beta1.NonResourceAttributes": {
     "description": "NonResourceAttributes includes the authorization attributes available for non-resource requests to the Authorizer interface",
+    "type": "object",
     "properties": {
      "path": {
       "description": "Path is the URL path of the request",
@@ -74687,6 +74802,7 @@
    },
    "io.k8s.api.authorization.v1beta1.NonResourceRule": {
     "description": "NonResourceRule holds information that describes a rule for the non-resource",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -74709,6 +74825,7 @@
    },
    "io.k8s.api.authorization.v1beta1.ResourceAttributes": {
     "description": "ResourceAttributes includes the authorization attributes available for resource requests to the Authorizer interface",
+    "type": "object",
     "properties": {
      "group": {
       "description": "Group is the API Group of the Resource.  \"*\" means all.",
@@ -74742,6 +74859,7 @@
    },
    "io.k8s.api.authorization.v1beta1.ResourceRule": {
     "description": "ResourceRule is the list of actions the subject is allowed to perform on resources. The list ordering isn't significant, may contain duplicates, and possibly be incomplete.",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -74778,6 +74896,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReview": {
     "description": "SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a spec.namespace means \"in all namespaces\".  Self is a special case, because users should always be able to check whether they can perform an action",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74812,6 +74931,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SelfSubjectAccessReviewSpec": {
     "description": "SelfSubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "type": "object",
     "properties": {
      "nonResourceAttributes": {
       "description": "NonResourceAttributes describes information for a non-resource access request",
@@ -74825,6 +74945,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SelfSubjectRulesReview": {
     "description": "SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace. The returned list of actions may be incomplete depending on the server's authorization mode, and any errors experienced during the evaluation. SelfSubjectRulesReview should be used by UIs to show/hide actions, or to quickly let an end user reason about their permissions. It should NOT Be used by external systems to drive authorization decisions as this raises confused deputy, cache lifetime/revocation, and correctness concerns. SubjectAccessReview, and LocalAccessReview are the correct way to defer authorization decisions to the API server.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74858,6 +74979,7 @@
     ]
    },
    "io.k8s.api.authorization.v1beta1.SelfSubjectRulesReviewSpec": {
+    "type": "object",
     "properties": {
      "namespace": {
       "description": "Namespace to evaluate rules for. Required.",
@@ -74867,6 +74989,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SubjectAccessReview": {
     "description": "SubjectAccessReview checks whether or not a user or group can perform an action.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -74901,6 +75024,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewSpec": {
     "description": "SubjectAccessReviewSpec is a description of the access request.  Exactly one of ResourceAuthorizationAttributes and NonResourceAuthorizationAttributes must be set",
+    "type": "object",
     "properties": {
      "extra": {
       "description": "Extra corresponds to the user.Info.GetExtra() method from the authenticator.  Since that is input to the authorizer it needs a reflection here.",
@@ -74939,6 +75063,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SubjectAccessReviewStatus": {
     "description": "SubjectAccessReviewStatus",
+    "type": "object",
     "required": [
      "allowed"
     ],
@@ -74963,6 +75088,7 @@
    },
    "io.k8s.api.authorization.v1beta1.SubjectRulesReviewStatus": {
     "description": "SubjectRulesReviewStatus contains the result of a rules check. This check can be incomplete depending on the set of authorizers the server is configured with and any errors experienced during evaluation. Because authorization rules are additive, if a rule appears in a list it's safe to assume the subject has that permission, even if that list is incomplete.",
+    "type": "object",
     "required": [
      "resourceRules",
      "nonResourceRules",
@@ -74995,6 +75121,7 @@
    },
    "io.k8s.api.autoscaling.v1.CrossVersionObjectReference": {
     "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+    "type": "object",
     "required": [
      "kind",
      "name"
@@ -75016,6 +75143,7 @@
    },
    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscaler": {
     "description": "configuration of a horizontal pod autoscaler.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75048,6 +75176,7 @@
    },
    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerList": {
     "description": "list of horizontal pod autoscaler objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -75082,6 +75211,7 @@
    },
    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerSpec": {
     "description": "specification of a horizontal pod autoscaler.",
+    "type": "object",
     "required": [
      "scaleTargetRef",
      "maxReplicas"
@@ -75110,6 +75240,7 @@
    },
    "io.k8s.api.autoscaling.v1.HorizontalPodAutoscalerStatus": {
     "description": "current status of a horizontal pod autoscaler",
+    "type": "object",
     "required": [
      "currentReplicas",
      "desiredReplicas"
@@ -75143,6 +75274,7 @@
    },
    "io.k8s.api.autoscaling.v1.Scale": {
     "description": "Scale represents a scaling request for a resource.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75175,6 +75307,7 @@
    },
    "io.k8s.api.autoscaling.v1.ScaleSpec": {
     "description": "ScaleSpec describes the attributes of a scale subresource.",
+    "type": "object",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -75185,6 +75318,7 @@
    },
    "io.k8s.api.autoscaling.v1.ScaleStatus": {
     "description": "ScaleStatus represents the current status of a scale subresource.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -75202,6 +75336,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.CrossVersionObjectReference": {
     "description": "CrossVersionObjectReference contains enough information to let you identify the referred resource.",
+    "type": "object",
     "required": [
      "kind",
      "name"
@@ -75223,6 +75358,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ExternalMetricSource": {
     "description": "ExternalMetricSource indicates how to scale on a metric not associated with any Kubernetes object (for example length of queue in cloud messaging service, or QPS from loadbalancer running outside of cluster). Exactly one \"target\" type should be set.",
+    "type": "object",
     "required": [
      "metricName"
     ],
@@ -75247,6 +75383,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ExternalMetricStatus": {
     "description": "ExternalMetricStatus indicates the current value of a global metric not associated with any Kubernetes object.",
+    "type": "object",
     "required": [
      "metricName",
      "currentValue"
@@ -75272,6 +75409,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscaler": {
     "description": "HorizontalPodAutoscaler is the configuration for a horizontal pod autoscaler, which automatically manages the replica count of any resource implementing the scale subresource based on the metrics specified.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75304,6 +75442,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerCondition": {
     "description": "HorizontalPodAutoscalerCondition describes the state of a HorizontalPodAutoscaler at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -75333,6 +75472,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerList": {
     "description": "HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -75367,6 +75507,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerSpec": {
     "description": "HorizontalPodAutoscalerSpec describes the desired functionality of the HorizontalPodAutoscaler.",
+    "type": "object",
     "required": [
      "scaleTargetRef",
      "maxReplicas"
@@ -75397,6 +75538,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.HorizontalPodAutoscalerStatus": {
     "description": "HorizontalPodAutoscalerStatus describes the current status of a horizontal pod autoscaler.",
+    "type": "object",
     "required": [
      "currentReplicas",
      "desiredReplicas",
@@ -75441,6 +75583,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.MetricSpec": {
     "description": "MetricSpec specifies how to scale based on a single metric (only `type` and one other matching field should be set at once).",
+    "type": "object",
     "required": [
      "type"
     ],
@@ -75469,6 +75612,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.MetricStatus": {
     "description": "MetricStatus describes the last-read state of a single metric.",
+    "type": "object",
     "required": [
      "type"
     ],
@@ -75497,6 +75641,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ObjectMetricSource": {
     "description": "ObjectMetricSource indicates how to scale on a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+    "type": "object",
     "required": [
      "target",
      "metricName",
@@ -75519,6 +75664,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ObjectMetricStatus": {
     "description": "ObjectMetricStatus indicates the current value of a metric describing a kubernetes object (for example, hits-per-second on an Ingress object).",
+    "type": "object",
     "required": [
      "target",
      "metricName",
@@ -75541,6 +75687,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.PodsMetricSource": {
     "description": "PodsMetricSource indicates how to scale on a metric describing each pod in the current scale target (for example, transactions-processed-per-second). The values will be averaged together before being compared to the target value.",
+    "type": "object",
     "required": [
      "metricName",
      "targetAverageValue"
@@ -75558,6 +75705,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.PodsMetricStatus": {
     "description": "PodsMetricStatus indicates the current value of a metric describing each pod in the current scale target (for example, transactions-processed-per-second).",
+    "type": "object",
     "required": [
      "metricName",
      "currentAverageValue"
@@ -75575,6 +75723,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ResourceMetricSource": {
     "description": "ResourceMetricSource indicates how to scale on a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  The values will be averaged together before being compared to the target.  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.  Only one \"target\" type should be set.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -75596,6 +75745,7 @@
    },
    "io.k8s.api.autoscaling.v2beta1.ResourceMetricStatus": {
     "description": "ResourceMetricStatus indicates the current value of a resource metric known to Kubernetes, as specified in requests and limits, describing each pod in the current scale target (e.g. CPU or memory).  Such metrics are built in to Kubernetes, and have special scaling options on top of those available to normal per-pod metrics using the \"pods\" source.",
+    "type": "object",
     "required": [
      "name",
      "currentAverageValue"
@@ -75618,6 +75768,7 @@
    },
    "io.k8s.api.batch.v1.Job": {
     "description": "Job represents the configuration of a single job.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75650,6 +75801,7 @@
    },
    "io.k8s.api.batch.v1.JobCondition": {
     "description": "JobCondition describes current state of a job.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -75683,6 +75835,7 @@
    },
    "io.k8s.api.batch.v1.JobList": {
     "description": "JobList is a collection of jobs.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -75717,6 +75870,7 @@
    },
    "io.k8s.api.batch.v1.JobSpec": {
     "description": "JobSpec describes how the job execution will look like.",
+    "type": "object",
     "required": [
      "template"
     ],
@@ -75757,6 +75911,7 @@
    },
    "io.k8s.api.batch.v1.JobStatus": {
     "description": "JobStatus represents the current state of a Job.",
+    "type": "object",
     "properties": {
      "active": {
       "description": "The number of actively running pods.",
@@ -75794,6 +75949,7 @@
    },
    "io.k8s.api.batch.v1beta1.CronJob": {
     "description": "CronJob represents the configuration of a single cron job.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75826,6 +75982,7 @@
    },
    "io.k8s.api.batch.v1beta1.CronJobList": {
     "description": "CronJobList is a collection of cron jobs.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -75860,6 +76017,7 @@
    },
    "io.k8s.api.batch.v1beta1.CronJobSpec": {
     "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
+    "type": "object",
     "required": [
      "schedule",
      "jobTemplate"
@@ -75900,6 +76058,7 @@
    },
    "io.k8s.api.batch.v1beta1.CronJobStatus": {
     "description": "CronJobStatus represents the current state of a cron job.",
+    "type": "object",
     "properties": {
      "active": {
       "description": "A list of pointers to currently running jobs.",
@@ -75916,6 +76075,7 @@
    },
    "io.k8s.api.batch.v1beta1.JobTemplateSpec": {
     "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+    "type": "object",
     "properties": {
      "metadata": {
       "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
@@ -75929,6 +76089,7 @@
    },
    "io.k8s.api.batch.v2alpha1.CronJob": {
     "description": "CronJob represents the configuration of a single cron job.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -75961,6 +76122,7 @@
    },
    "io.k8s.api.batch.v2alpha1.CronJobList": {
     "description": "CronJobList is a collection of cron jobs.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -75995,6 +76157,7 @@
    },
    "io.k8s.api.batch.v2alpha1.CronJobSpec": {
     "description": "CronJobSpec describes how the job execution will look like and when it will actually run.",
+    "type": "object",
     "required": [
      "schedule",
      "jobTemplate"
@@ -76035,6 +76198,7 @@
    },
    "io.k8s.api.batch.v2alpha1.CronJobStatus": {
     "description": "CronJobStatus represents the current state of a cron job.",
+    "type": "object",
     "properties": {
      "active": {
       "description": "A list of pointers to currently running jobs.",
@@ -76051,6 +76215,7 @@
    },
    "io.k8s.api.batch.v2alpha1.JobTemplateSpec": {
     "description": "JobTemplateSpec describes the data a Job should have when created from a template",
+    "type": "object",
     "properties": {
      "metadata": {
       "description": "Standard object's metadata of the jobs created from this template. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
@@ -76064,6 +76229,7 @@
    },
    "io.k8s.api.certificates.v1beta1.CertificateSigningRequest": {
     "description": "Describes a certificate signing request",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -76094,6 +76260,7 @@
     ]
    },
    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestCondition": {
+    "type": "object",
     "required": [
      "type"
     ],
@@ -76117,6 +76284,7 @@
     }
    },
    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestList": {
+    "type": "object",
     "required": [
      "items"
     ],
@@ -76149,6 +76317,7 @@
    },
    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestSpec": {
     "description": "This information is immutable after the request is created. Only the Request and Usages fields can be set on creation, other fields are derived by Kubernetes and cannot be modified by users.",
+    "type": "object",
     "required": [
      "request"
     ],
@@ -76193,6 +76362,7 @@
     }
    },
    "io.k8s.api.certificates.v1beta1.CertificateSigningRequestStatus": {
+    "type": "object",
     "properties": {
      "certificate": {
       "description": "If request was approved, the controller will place the issued certificate here.",
@@ -76210,6 +76380,7 @@
    },
    "io.k8s.api.core.v1.AWSElasticBlockStoreVolumeSource": {
     "description": "Represents a Persistent Disk resource in AWS.\n\nAn AWS EBS disk must exist before mounting to a container. The disk must also be in the same AWS zone as the kubelet. An AWS EBS disk can only be mounted as read/write once. AWS EBS volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "volumeID"
     ],
@@ -76235,6 +76406,7 @@
    },
    "io.k8s.api.core.v1.Affinity": {
     "description": "Affinity is a group of affinity scheduling rules.",
+    "type": "object",
     "properties": {
      "nodeAffinity": {
       "description": "Describes node affinity scheduling rules for the pod.",
@@ -76252,6 +76424,7 @@
    },
    "io.k8s.api.core.v1.AttachedVolume": {
     "description": "AttachedVolume describes a volume attached to a node",
+    "type": "object",
     "required": [
      "name",
      "devicePath"
@@ -76269,6 +76442,7 @@
    },
    "io.k8s.api.core.v1.AzureDiskVolumeSource": {
     "description": "AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.",
+    "type": "object",
     "required": [
      "diskName",
      "diskURI"
@@ -76302,6 +76476,7 @@
    },
    "io.k8s.api.core.v1.AzureFilePersistentVolumeSource": {
     "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+    "type": "object",
     "required": [
      "secretName",
      "shareName"
@@ -76327,6 +76502,7 @@
    },
    "io.k8s.api.core.v1.AzureFileVolumeSource": {
     "description": "AzureFile represents an Azure File Service mount on the host and bind mount to the pod.",
+    "type": "object",
     "required": [
      "secretName",
      "shareName"
@@ -76348,6 +76524,7 @@
    },
    "io.k8s.api.core.v1.Binding": {
     "description": "Binding ties one object to another; for example, a pod is bound to a node by a scheduler. Deprecated in 1.7, please use the bindings subresource of pods instead.",
+    "type": "object",
     "required": [
      "target"
     ],
@@ -76379,6 +76556,7 @@
    },
    "io.k8s.api.core.v1.CSIPersistentVolumeSource": {
     "description": "Represents storage that is managed by an external CSI volume driver (Beta feature)",
+    "type": "object",
     "required": [
      "driver",
      "volumeHandle"
@@ -76423,6 +76601,7 @@
    },
    "io.k8s.api.core.v1.Capabilities": {
     "description": "Adds and removes POSIX capabilities from running containers.",
+    "type": "object",
     "properties": {
      "add": {
       "description": "Added capabilities",
@@ -76442,6 +76621,7 @@
    },
    "io.k8s.api.core.v1.CephFSPersistentVolumeSource": {
     "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "monitors"
     ],
@@ -76477,6 +76657,7 @@
    },
    "io.k8s.api.core.v1.CephFSVolumeSource": {
     "description": "Represents a Ceph Filesystem mount that lasts the lifetime of a pod Cephfs volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "monitors"
     ],
@@ -76512,6 +76693,7 @@
    },
    "io.k8s.api.core.v1.CinderPersistentVolumeSource": {
     "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "volumeID"
     ],
@@ -76536,6 +76718,7 @@
    },
    "io.k8s.api.core.v1.CinderVolumeSource": {
     "description": "Represents a cinder volume resource in Openstack. A Cinder volume must exist before mounting to a container. The volume must also be in the same region as the kubelet. Cinder volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "volumeID"
     ],
@@ -76560,6 +76743,7 @@
    },
    "io.k8s.api.core.v1.ClientIPConfig": {
     "description": "ClientIPConfig represents the configurations of Client IP based session affinity.",
+    "type": "object",
     "properties": {
      "timeoutSeconds": {
       "description": "timeoutSeconds specifies the seconds of ClientIP type session sticky time. The value must be \u003e0 \u0026\u0026 \u003c=86400(for 1 day) if ServiceAffinity == \"ClientIP\". Default value is 10800(for 3 hours).",
@@ -76570,6 +76754,7 @@
    },
    "io.k8s.api.core.v1.ComponentCondition": {
     "description": "Information about the condition of a component.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -76595,6 +76780,7 @@
    },
    "io.k8s.api.core.v1.ComponentStatus": {
     "description": "ComponentStatus (and ComponentStatusList) holds the cluster validation info.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -76628,6 +76814,7 @@
    },
    "io.k8s.api.core.v1.ComponentStatusList": {
     "description": "Status of all the conditions for the component as a list of ComponentStatus objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -76662,6 +76849,7 @@
    },
    "io.k8s.api.core.v1.ConfigMap": {
     "description": "ConfigMap holds configuration data for pods to consume.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -76701,6 +76889,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapEnvSource": {
     "description": "ConfigMapEnvSource selects a ConfigMap to populate the environment variables with.\n\nThe contents of the target ConfigMap's Data field will represent the key-value pairs as environment variables.",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -76714,6 +76903,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapKeySelector": {
     "description": "Selects a key from a ConfigMap.",
+    "type": "object",
     "required": [
      "key"
     ],
@@ -76734,6 +76924,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapList": {
     "description": "ConfigMapList is a resource containing a list of ConfigMap objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -76768,6 +76959,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapNodeConfigSource": {
     "description": "ConfigMapNodeConfigSource contains the information to reference a ConfigMap as a config source for the Node.",
+    "type": "object",
     "required": [
      "namespace",
      "name",
@@ -76798,6 +76990,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapProjection": {
     "description": "Adapts a ConfigMap into a projected volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a projected volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. Note that this is identical to a configmap volume source without the default mode.",
+    "type": "object",
     "properties": {
      "items": {
       "description": "If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
@@ -76818,6 +77011,7 @@
    },
    "io.k8s.api.core.v1.ConfigMapVolumeSource": {
     "description": "Adapts a ConfigMap into a volume.\n\nThe contents of the target ConfigMap's Data field will be presented in a volume as files using the keys in the Data field as the file names, unless the items element is populated with specific mappings of keys to paths. ConfigMap volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "properties": {
      "defaultMode": {
       "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -76843,6 +77037,7 @@
    },
    "io.k8s.api.core.v1.Container": {
     "description": "A single application container that you want to run within a pod.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -76964,6 +77159,7 @@
    },
    "io.k8s.api.core.v1.ContainerImage": {
     "description": "Describe a container image",
+    "type": "object",
     "required": [
      "names"
     ],
@@ -76984,6 +77180,7 @@
    },
    "io.k8s.api.core.v1.ContainerPort": {
     "description": "ContainerPort represents a network port in a single container.",
+    "type": "object",
     "required": [
      "containerPort"
     ],
@@ -77014,6 +77211,7 @@
    },
    "io.k8s.api.core.v1.ContainerState": {
     "description": "ContainerState holds a possible state of container. Only one of its members may be specified. If none of them is specified, the default one is ContainerStateWaiting.",
+    "type": "object",
     "properties": {
      "running": {
       "description": "Details about a running container",
@@ -77031,6 +77229,7 @@
    },
    "io.k8s.api.core.v1.ContainerStateRunning": {
     "description": "ContainerStateRunning is a running state of a container.",
+    "type": "object",
     "properties": {
      "startedAt": {
       "description": "Time at which the container was last (re-)started",
@@ -77040,6 +77239,7 @@
    },
    "io.k8s.api.core.v1.ContainerStateTerminated": {
     "description": "ContainerStateTerminated is a terminated state of a container.",
+    "type": "object",
     "required": [
      "exitCode"
     ],
@@ -77078,6 +77278,7 @@
    },
    "io.k8s.api.core.v1.ContainerStateWaiting": {
     "description": "ContainerStateWaiting is a waiting state of a container.",
+    "type": "object",
     "properties": {
      "message": {
       "description": "Message regarding why the container is not yet running.",
@@ -77091,6 +77292,7 @@
    },
    "io.k8s.api.core.v1.ContainerStatus": {
     "description": "ContainerStatus contains details for the current status of this container.",
+    "type": "object",
     "required": [
      "name",
      "ready",
@@ -77136,6 +77338,7 @@
    },
    "io.k8s.api.core.v1.DaemonEndpoint": {
     "description": "DaemonEndpoint contains information about a single Daemon endpoint.",
+    "type": "object",
     "required": [
      "Port"
     ],
@@ -77149,6 +77352,7 @@
    },
    "io.k8s.api.core.v1.DownwardAPIProjection": {
     "description": "Represents downward API info for projecting into a projected volume. Note that this is identical to a downwardAPI volume source without the default mode.",
+    "type": "object",
     "properties": {
      "items": {
       "description": "Items is a list of DownwardAPIVolume file",
@@ -77161,6 +77365,7 @@
    },
    "io.k8s.api.core.v1.DownwardAPIVolumeFile": {
     "description": "DownwardAPIVolumeFile represents information to create the file containing the pod field",
+    "type": "object",
     "required": [
      "path"
     ],
@@ -77186,6 +77391,7 @@
    },
    "io.k8s.api.core.v1.DownwardAPIVolumeSource": {
     "description": "DownwardAPIVolumeSource represents a volume containing downward API info. Downward API volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "properties": {
      "defaultMode": {
       "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -77203,6 +77409,7 @@
    },
    "io.k8s.api.core.v1.EmptyDirVolumeSource": {
     "description": "Represents an empty directory for a pod. Empty directory volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "properties": {
      "medium": {
       "description": "What type of storage medium should back this directory. The default is \"\" which means to use the node's default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir",
@@ -77216,6 +77423,7 @@
    },
    "io.k8s.api.core.v1.EndpointAddress": {
     "description": "EndpointAddress is a tuple that describes single IP address.",
+    "type": "object",
     "required": [
      "ip"
     ],
@@ -77240,6 +77448,7 @@
    },
    "io.k8s.api.core.v1.EndpointPort": {
     "description": "EndpointPort is a tuple that describes a single port.",
+    "type": "object",
     "required": [
      "port"
     ],
@@ -77261,6 +77470,7 @@
    },
    "io.k8s.api.core.v1.EndpointSubset": {
     "description": "EndpointSubset is a group of addresses with a common set of ports. The expanded set of endpoints is the Cartesian product of Addresses x Ports. For example, given:\n  {\n    Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n    Ports:     [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n  }\nThe resulting set of endpoints can be viewed as:\n    a: [ 10.10.1.1:8675, 10.10.2.2:8675 ],\n    b: [ 10.10.1.1:309, 10.10.2.2:309 ]",
+    "type": "object",
     "properties": {
      "addresses": {
       "description": "IP addresses which offer the related ports that are marked as ready. These endpoints should be considered safe for load balancers and clients to utilize.",
@@ -77287,6 +77497,7 @@
    },
    "io.k8s.api.core.v1.Endpoints": {
     "description": "Endpoints is a collection of endpoints that implement the actual service. Example:\n  Name: \"mysvc\",\n  Subsets: [\n    {\n      Addresses: [{\"ip\": \"10.10.1.1\"}, {\"ip\": \"10.10.2.2\"}],\n      Ports: [{\"name\": \"a\", \"port\": 8675}, {\"name\": \"b\", \"port\": 309}]\n    },\n    {\n      Addresses: [{\"ip\": \"10.10.3.3\"}],\n      Ports: [{\"name\": \"a\", \"port\": 93}, {\"name\": \"b\", \"port\": 76}]\n    },\n ]",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -77318,6 +77529,7 @@
    },
    "io.k8s.api.core.v1.EndpointsList": {
     "description": "EndpointsList is a list of endpoints.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -77352,6 +77564,7 @@
    },
    "io.k8s.api.core.v1.EnvFromSource": {
     "description": "EnvFromSource represents the source of a set of ConfigMaps",
+    "type": "object",
     "properties": {
      "configMapRef": {
       "description": "The ConfigMap to select from",
@@ -77369,6 +77582,7 @@
    },
    "io.k8s.api.core.v1.EnvVar": {
     "description": "EnvVar represents an environment variable present in a Container.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -77389,6 +77603,7 @@
    },
    "io.k8s.api.core.v1.EnvVarSource": {
     "description": "EnvVarSource represents a source for the value of an EnvVar.",
+    "type": "object",
     "properties": {
      "configMapKeyRef": {
       "description": "Selects a key of a ConfigMap.",
@@ -77410,6 +77625,7 @@
    },
    "io.k8s.api.core.v1.Event": {
     "description": "Event is a report of an event somewhere in the cluster.",
+    "type": "object",
     "required": [
      "metadata",
      "involvedObject"
@@ -77495,6 +77711,7 @@
    },
    "io.k8s.api.core.v1.EventList": {
     "description": "EventList is a list of events.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -77529,6 +77746,7 @@
    },
    "io.k8s.api.core.v1.EventSeries": {
     "description": "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
+    "type": "object",
     "properties": {
      "count": {
       "description": "Number of occurrences in this series up to the last heartbeat time",
@@ -77547,6 +77765,7 @@
    },
    "io.k8s.api.core.v1.EventSource": {
     "description": "EventSource contains information for an event.",
+    "type": "object",
     "properties": {
      "component": {
       "description": "Component from which the event is generated.",
@@ -77560,6 +77779,7 @@
    },
    "io.k8s.api.core.v1.ExecAction": {
     "description": "ExecAction describes a \"run in container\" action.",
+    "type": "object",
     "properties": {
      "command": {
       "description": "Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.",
@@ -77572,6 +77792,7 @@
    },
    "io.k8s.api.core.v1.FCVolumeSource": {
     "description": "Represents a Fibre Channel volume. Fibre Channel volumes can only be mounted as read/write once. Fibre Channel volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "properties": {
      "fsType": {
       "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -77604,6 +77825,7 @@
    },
    "io.k8s.api.core.v1.FlexPersistentVolumeSource": {
     "description": "FlexPersistentVolumeSource represents a generic persistent volume resource that is provisioned/attached using an exec based plugin.",
+    "type": "object",
     "required": [
      "driver"
     ],
@@ -77635,6 +77857,7 @@
    },
    "io.k8s.api.core.v1.FlexVolumeSource": {
     "description": "FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.",
+    "type": "object",
     "required": [
      "driver"
     ],
@@ -77666,6 +77889,7 @@
    },
    "io.k8s.api.core.v1.FlockerVolumeSource": {
     "description": "Represents a Flocker volume mounted by the Flocker agent. One and only one of datasetName and datasetUUID should be set. Flocker volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "properties": {
      "datasetName": {
       "description": "Name of the dataset stored as metadata -\u003e name on the dataset for Flocker should be considered as deprecated",
@@ -77679,6 +77903,7 @@
    },
    "io.k8s.api.core.v1.GCEPersistentDiskVolumeSource": {
     "description": "Represents a Persistent Disk resource in Google Compute Engine.\n\nA GCE PD must exist before mounting to a container. The disk must also be in the same GCE project and zone as the kubelet. A GCE PD can only be mounted as read/write once or read-only many times. GCE PDs support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "pdName"
     ],
@@ -77704,6 +77929,7 @@
    },
    "io.k8s.api.core.v1.GitRepoVolumeSource": {
     "description": "Represents a volume that is populated with the contents of a git repository. Git repo volumes do not support ownership management. Git repo volumes support SELinux relabeling.\n\nDEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.",
+    "type": "object",
     "required": [
      "repository"
     ],
@@ -77724,6 +77950,7 @@
    },
    "io.k8s.api.core.v1.GlusterfsVolumeSource": {
     "description": "Represents a Glusterfs mount that lasts the lifetime of a pod. Glusterfs volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "endpoints",
      "path"
@@ -77745,6 +77972,7 @@
    },
    "io.k8s.api.core.v1.HTTPGetAction": {
     "description": "HTTPGetAction describes an action based on HTTP Get requests.",
+    "type": "object",
     "required": [
      "port"
     ],
@@ -77776,6 +78004,7 @@
    },
    "io.k8s.api.core.v1.HTTPHeader": {
     "description": "HTTPHeader describes a custom header to be used in HTTP probes",
+    "type": "object",
     "required": [
      "name",
      "value"
@@ -77793,6 +78022,7 @@
    },
    "io.k8s.api.core.v1.Handler": {
     "description": "Handler defines a specific action that should be taken",
+    "type": "object",
     "properties": {
      "exec": {
       "description": "One and only one of the following should be specified. Exec specifies the action to take.",
@@ -77810,6 +78040,7 @@
    },
    "io.k8s.api.core.v1.HostAlias": {
     "description": "HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.",
+    "type": "object",
     "properties": {
      "hostnames": {
       "description": "Hostnames for the above IP address.",
@@ -77826,6 +78057,7 @@
    },
    "io.k8s.api.core.v1.HostPathVolumeSource": {
     "description": "Represents a host path mapped into a pod. Host path volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "path"
     ],
@@ -77842,6 +78074,7 @@
    },
    "io.k8s.api.core.v1.ISCSIPersistentVolumeSource": {
     "description": "ISCSIPersistentVolumeSource represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "targetPortal",
      "iqn",
@@ -77900,6 +78133,7 @@
    },
    "io.k8s.api.core.v1.ISCSIVolumeSource": {
     "description": "Represents an ISCSI disk. ISCSI volumes can only be mounted as read/write once. ISCSI volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "targetPortal",
      "iqn",
@@ -77958,6 +78192,7 @@
    },
    "io.k8s.api.core.v1.KeyToPath": {
     "description": "Maps a string key to a path within a volume.",
+    "type": "object",
     "required": [
      "key",
      "path"
@@ -77980,6 +78215,7 @@
    },
    "io.k8s.api.core.v1.Lifecycle": {
     "description": "Lifecycle describes actions that the management system should take in response to container lifecycle events. For the PostStart and PreStop lifecycle handlers, management of the container blocks until the action is complete, unless the container process fails, in which case the handler is aborted.",
+    "type": "object",
     "properties": {
      "postStart": {
       "description": "PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks",
@@ -77993,6 +78229,7 @@
    },
    "io.k8s.api.core.v1.LimitRange": {
     "description": "LimitRange sets resource usage limits for each kind of resource in a Namespace.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -78021,6 +78258,7 @@
    },
    "io.k8s.api.core.v1.LimitRangeItem": {
     "description": "LimitRangeItem defines a min/max usage limit for any resource that matches on kind.",
+    "type": "object",
     "properties": {
      "default": {
       "description": "Default resource requirement limit value by resource name if resource limit is omitted.",
@@ -78065,6 +78303,7 @@
    },
    "io.k8s.api.core.v1.LimitRangeList": {
     "description": "LimitRangeList is a list of LimitRange items.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -78099,6 +78338,7 @@
    },
    "io.k8s.api.core.v1.LimitRangeSpec": {
     "description": "LimitRangeSpec defines a min/max usage limit for resources that match on kind.",
+    "type": "object",
     "required": [
      "limits"
     ],
@@ -78114,6 +78354,7 @@
    },
    "io.k8s.api.core.v1.LoadBalancerIngress": {
     "description": "LoadBalancerIngress represents the status of a load-balancer ingress point: traffic intended for the service should be sent to an ingress point.",
+    "type": "object",
     "properties": {
      "hostname": {
       "description": "Hostname is set for load-balancer ingress points that are DNS based (typically AWS load-balancers)",
@@ -78127,6 +78368,7 @@
    },
    "io.k8s.api.core.v1.LoadBalancerStatus": {
     "description": "LoadBalancerStatus represents the status of a load-balancer.",
+    "type": "object",
     "properties": {
      "ingress": {
       "description": "Ingress is a list containing ingress points for the load-balancer. Traffic intended for the service should be sent to these ingress points.",
@@ -78139,6 +78381,7 @@
    },
    "io.k8s.api.core.v1.LocalObjectReference": {
     "description": "LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -78148,6 +78391,7 @@
    },
    "io.k8s.api.core.v1.LocalVolumeSource": {
     "description": "Local represents directly-attached storage with node affinity (Beta feature)",
+    "type": "object",
     "required": [
      "path"
     ],
@@ -78160,6 +78404,7 @@
    },
    "io.k8s.api.core.v1.NFSVolumeSource": {
     "description": "Represents an NFS mount that lasts the lifetime of a pod. NFS volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "server",
      "path"
@@ -78181,6 +78426,7 @@
    },
    "io.k8s.api.core.v1.Namespace": {
     "description": "Namespace provides a scope for Names. Use of multiple namespaces is optional.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -78213,6 +78459,7 @@
    },
    "io.k8s.api.core.v1.NamespaceList": {
     "description": "NamespaceList is a list of Namespaces.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -78247,6 +78494,7 @@
    },
    "io.k8s.api.core.v1.NamespaceSpec": {
     "description": "NamespaceSpec describes the attributes on a Namespace.",
+    "type": "object",
     "properties": {
      "finalizers": {
       "description": "Finalizers is an opaque list of values that must be empty to permanently remove object from storage. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/",
@@ -78259,6 +78507,7 @@
    },
    "io.k8s.api.core.v1.NamespaceStatus": {
     "description": "NamespaceStatus is information about the current status of a Namespace.",
+    "type": "object",
     "properties": {
      "phase": {
       "description": "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/",
@@ -78268,6 +78517,7 @@
    },
    "io.k8s.api.core.v1.Node": {
     "description": "Node is a worker node in Kubernetes. Each node will have a unique identifier in the cache (i.e. in etcd).",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -78300,6 +78550,7 @@
    },
    "io.k8s.api.core.v1.NodeAddress": {
     "description": "NodeAddress contains information for the node's address.",
+    "type": "object",
     "required": [
      "type",
      "address"
@@ -78317,6 +78568,7 @@
    },
    "io.k8s.api.core.v1.NodeAffinity": {
     "description": "Node affinity is a group of node affinity scheduling rules.",
+    "type": "object",
     "properties": {
      "preferredDuringSchedulingIgnoredDuringExecution": {
       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.",
@@ -78333,6 +78585,7 @@
    },
    "io.k8s.api.core.v1.NodeCondition": {
     "description": "NodeCondition contains condition information for a node.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -78366,6 +78619,7 @@
    },
    "io.k8s.api.core.v1.NodeConfigSource": {
     "description": "NodeConfigSource specifies a source of node configuration. Exactly one subfield (excluding metadata) must be non-nil.",
+    "type": "object",
     "properties": {
      "configMap": {
       "description": "ConfigMap is a reference to a Node's ConfigMap",
@@ -78375,6 +78629,7 @@
    },
    "io.k8s.api.core.v1.NodeConfigStatus": {
     "description": "NodeConfigStatus describes the status of the config assigned by Node.Spec.ConfigSource.",
+    "type": "object",
     "properties": {
      "active": {
       "description": "Active reports the checkpointed config the node is actively using. Active will represent either the current version of the Assigned config, or the current LastKnownGood config, depending on whether attempting to use the Assigned config results in an error.",
@@ -78396,6 +78651,7 @@
    },
    "io.k8s.api.core.v1.NodeDaemonEndpoints": {
     "description": "NodeDaemonEndpoints lists ports opened by daemons running on the Node.",
+    "type": "object",
     "properties": {
      "kubeletEndpoint": {
       "description": "Endpoint on which Kubelet is listening.",
@@ -78405,6 +78661,7 @@
    },
    "io.k8s.api.core.v1.NodeList": {
     "description": "NodeList is the whole list of all Nodes which have been registered with master.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -78439,6 +78696,7 @@
    },
    "io.k8s.api.core.v1.NodeSelector": {
     "description": "A node selector represents the union of the results of one or more label queries over a set of nodes; that is, it represents the OR of the selectors represented by the node selector terms.",
+    "type": "object",
     "required": [
      "nodeSelectorTerms"
     ],
@@ -78454,6 +78712,7 @@
    },
    "io.k8s.api.core.v1.NodeSelectorRequirement": {
     "description": "A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "type": "object",
     "required": [
      "key",
      "operator"
@@ -78478,6 +78737,7 @@
    },
    "io.k8s.api.core.v1.NodeSelectorTerm": {
     "description": "A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.",
+    "type": "object",
     "properties": {
      "matchExpressions": {
       "description": "A list of node selector requirements by node's labels.",
@@ -78497,6 +78757,7 @@
    },
    "io.k8s.api.core.v1.NodeSpec": {
     "description": "NodeSpec describes the attributes that a node is created with.",
+    "type": "object",
     "properties": {
      "configSource": {
       "description": "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field",
@@ -78529,6 +78790,7 @@
    },
    "io.k8s.api.core.v1.NodeStatus": {
     "description": "NodeStatus is information about the current status of a node.",
+    "type": "object",
     "properties": {
      "addresses": {
       "description": "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses",
@@ -78603,6 +78865,7 @@
    },
    "io.k8s.api.core.v1.NodeSystemInfo": {
     "description": "NodeSystemInfo is a set of ids/uuids to uniquely identify the node.",
+    "type": "object",
     "required": [
      "machineID",
      "systemUUID",
@@ -78660,6 +78923,7 @@
    },
    "io.k8s.api.core.v1.ObjectFieldSelector": {
     "description": "ObjectFieldSelector selects an APIVersioned field of an object.",
+    "type": "object",
     "required": [
      "fieldPath"
     ],
@@ -78676,6 +78940,7 @@
    },
    "io.k8s.api.core.v1.ObjectReference": {
     "description": "ObjectReference contains enough information to let you inspect or modify the referred object.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "API version of the referent.",
@@ -78709,6 +78974,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolume": {
     "description": "PersistentVolume (PV) is a storage resource provisioned by an administrator. It is analogous to a node. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -78741,6 +79007,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaim": {
     "description": "PersistentVolumeClaim is a user's request for and claim to a persistent volume",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -78773,6 +79040,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaimCondition": {
     "description": "PersistentVolumeClaimCondition contails details about state of pvc",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -78804,6 +79072,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaimList": {
     "description": "PersistentVolumeClaimList is a list of PersistentVolumeClaim items.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -78838,6 +79107,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaimSpec": {
     "description": "PersistentVolumeClaimSpec describes the common attributes of storage devices and allows a Source for provider-specific attributes",
+    "type": "object",
     "properties": {
      "accessModes": {
       "description": "AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
@@ -78870,6 +79140,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaimStatus": {
     "description": "PersistentVolumeClaimStatus is the current status of a persistent volume claim.",
+    "type": "object",
     "properties": {
      "accessModes": {
       "description": "AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1",
@@ -78902,6 +79173,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeClaimVolumeSource": {
     "description": "PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace. This volume finds the bound PV and mounts that volume for the pod. A PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another type of volume that is owned by someone else (the system).",
+    "type": "object",
     "required": [
      "claimName"
     ],
@@ -78918,6 +79190,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeList": {
     "description": "PersistentVolumeList is a list of PersistentVolume items.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -78952,6 +79225,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeSpec": {
     "description": "PersistentVolumeSpec is the specification of a persistent volume.",
+    "type": "object",
     "properties": {
      "accessModes": {
       "description": "AccessModes contains all ways the volume can be mounted. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes",
@@ -79086,6 +79360,7 @@
    },
    "io.k8s.api.core.v1.PersistentVolumeStatus": {
     "description": "PersistentVolumeStatus is the current status of a persistent volume.",
+    "type": "object",
     "properties": {
      "message": {
       "description": "A human-readable message indicating details about why the volume is in this state.",
@@ -79103,6 +79378,7 @@
    },
    "io.k8s.api.core.v1.PhotonPersistentDiskVolumeSource": {
     "description": "Represents a Photon Controller persistent disk resource.",
+    "type": "object",
     "required": [
      "pdID"
     ],
@@ -79119,6 +79395,7 @@
    },
    "io.k8s.api.core.v1.Pod": {
     "description": "Pod is a collection of containers that can run on a host. This resource is created by clients and scheduled onto hosts.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -79151,6 +79428,7 @@
    },
    "io.k8s.api.core.v1.PodAffinity": {
     "description": "Pod affinity is a group of inter pod affinity scheduling rules.",
+    "type": "object",
     "properties": {
      "preferredDuringSchedulingIgnoredDuringExecution": {
       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
@@ -79170,6 +79448,7 @@
    },
    "io.k8s.api.core.v1.PodAffinityTerm": {
     "description": "Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key \u003ctopologyKey\u003e matches that of any node on which a pod of the set of pods is running",
+    "type": "object",
     "required": [
      "topologyKey"
     ],
@@ -79193,6 +79472,7 @@
    },
    "io.k8s.api.core.v1.PodAntiAffinity": {
     "description": "Pod anti affinity is a group of inter pod anti affinity scheduling rules.",
+    "type": "object",
     "properties": {
      "preferredDuringSchedulingIgnoredDuringExecution": {
       "description": "The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding \"weight\" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.",
@@ -79212,6 +79492,7 @@
    },
    "io.k8s.api.core.v1.PodCondition": {
     "description": "PodCondition contains details for the current condition of this pod.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -79245,6 +79526,7 @@
    },
    "io.k8s.api.core.v1.PodDNSConfig": {
     "description": "PodDNSConfig defines the DNS parameters of a pod in addition to those generated from DNSPolicy.",
+    "type": "object",
     "properties": {
      "nameservers": {
       "description": "A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.",
@@ -79271,6 +79553,7 @@
    },
    "io.k8s.api.core.v1.PodDNSConfigOption": {
     "description": "PodDNSConfigOption defines DNS resolver options of a pod.",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Required.",
@@ -79283,6 +79566,7 @@
    },
    "io.k8s.api.core.v1.PodList": {
     "description": "PodList is a list of Pods.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -79317,6 +79601,7 @@
    },
    "io.k8s.api.core.v1.PodReadinessGate": {
     "description": "PodReadinessGate contains the reference to a pod condition",
+    "type": "object",
     "required": [
      "conditionType"
     ],
@@ -79329,6 +79614,7 @@
    },
    "io.k8s.api.core.v1.PodSecurityContext": {
     "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+    "type": "object",
     "properties": {
      "fsGroup": {
       "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
@@ -79372,6 +79658,7 @@
    },
    "io.k8s.api.core.v1.PodSpec": {
     "description": "PodSpec is a description of a pod.",
+    "type": "object",
     "required": [
      "containers"
     ],
@@ -79529,6 +79816,7 @@
    },
    "io.k8s.api.core.v1.PodStatus": {
     "description": "PodStatus represents information about the status of a pod. Status may trail the actual state of a system, especially if the node that hosts the pod cannot contact the control plane.",
+    "type": "object",
     "properties": {
      "conditions": {
       "description": "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions",
@@ -79589,6 +79877,7 @@
    },
    "io.k8s.api.core.v1.PodTemplate": {
     "description": "PodTemplate describes a template for creating copies of a predefined pod.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -79617,6 +79906,7 @@
    },
    "io.k8s.api.core.v1.PodTemplateList": {
     "description": "PodTemplateList is a list of PodTemplates.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -79651,6 +79941,7 @@
    },
    "io.k8s.api.core.v1.PodTemplateSpec": {
     "description": "PodTemplateSpec describes the data a pod should have when created from a template",
+    "type": "object",
     "properties": {
      "metadata": {
       "description": "Standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
@@ -79664,6 +79955,7 @@
    },
    "io.k8s.api.core.v1.PortworxVolumeSource": {
     "description": "PortworxVolumeSource represents a Portworx volume resource.",
+    "type": "object",
     "required": [
      "volumeID"
     ],
@@ -79684,6 +79976,7 @@
    },
    "io.k8s.api.core.v1.PreferredSchedulingTerm": {
     "description": "An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).",
+    "type": "object",
     "required": [
      "weight",
      "preference"
@@ -79702,6 +79995,7 @@
    },
    "io.k8s.api.core.v1.Probe": {
     "description": "Probe describes a health check to be performed against a container to determine whether it is alive or ready to receive traffic.",
+    "type": "object",
     "properties": {
      "exec": {
       "description": "One and only one of the following should be specified. Exec specifies the action to take.",
@@ -79744,6 +80038,7 @@
    },
    "io.k8s.api.core.v1.ProjectedVolumeSource": {
     "description": "Represents a projected volume source",
+    "type": "object",
     "required": [
      "sources"
     ],
@@ -79764,6 +80059,7 @@
    },
    "io.k8s.api.core.v1.QuobyteVolumeSource": {
     "description": "Represents a Quobyte mount that lasts the lifetime of a pod. Quobyte volumes do not support ownership management or SELinux relabeling.",
+    "type": "object",
     "required": [
      "registry",
      "volume"
@@ -79793,6 +80089,7 @@
    },
    "io.k8s.api.core.v1.RBDPersistentVolumeSource": {
     "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "monitors",
      "image"
@@ -79837,6 +80134,7 @@
    },
    "io.k8s.api.core.v1.RBDVolumeSource": {
     "description": "Represents a Rados Block Device mount that lasts the lifetime of a pod. RBD volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "required": [
      "monitors",
      "image"
@@ -79881,6 +80179,7 @@
    },
    "io.k8s.api.core.v1.ReplicationController": {
     "description": "ReplicationController represents the configuration of a replication controller.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -79913,6 +80212,7 @@
    },
    "io.k8s.api.core.v1.ReplicationControllerCondition": {
     "description": "ReplicationControllerCondition describes the state of a replication controller at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -79942,6 +80242,7 @@
    },
    "io.k8s.api.core.v1.ReplicationControllerList": {
     "description": "ReplicationControllerList is a collection of replication controllers.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -79976,6 +80277,7 @@
    },
    "io.k8s.api.core.v1.ReplicationControllerSpec": {
     "description": "ReplicationControllerSpec is the specification of a replication controller.",
+    "type": "object",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -80002,6 +80304,7 @@
    },
    "io.k8s.api.core.v1.ReplicationControllerStatus": {
     "description": "ReplicationControllerStatus represents the current status of a replication controller.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -80044,6 +80347,7 @@
    },
    "io.k8s.api.core.v1.ResourceFieldSelector": {
     "description": "ResourceFieldSelector represents container resources (cpu, memory) and their output format",
+    "type": "object",
     "required": [
      "resource"
     ],
@@ -80064,6 +80368,7 @@
    },
    "io.k8s.api.core.v1.ResourceQuota": {
     "description": "ResourceQuota sets aggregate quota restrictions enforced per namespace",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -80096,6 +80401,7 @@
    },
    "io.k8s.api.core.v1.ResourceQuotaList": {
     "description": "ResourceQuotaList is a list of ResourceQuota items.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -80130,6 +80436,7 @@
    },
    "io.k8s.api.core.v1.ResourceQuotaSpec": {
     "description": "ResourceQuotaSpec defines the desired hard limits to enforce for Quota.",
+    "type": "object",
     "properties": {
      "hard": {
       "description": "hard is the set of desired hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
@@ -80153,6 +80460,7 @@
    },
    "io.k8s.api.core.v1.ResourceQuotaStatus": {
     "description": "ResourceQuotaStatus defines the enforced hard limits and observed use.",
+    "type": "object",
     "properties": {
      "hard": {
       "description": "Hard is the set of enforced hard limits for each named resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/",
@@ -80172,6 +80480,7 @@
    },
    "io.k8s.api.core.v1.ResourceRequirements": {
     "description": "ResourceRequirements describes the compute resource requirements.",
+    "type": "object",
     "properties": {
      "limits": {
       "description": "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/",
@@ -80191,6 +80500,7 @@
    },
    "io.k8s.api.core.v1.SELinuxOptions": {
     "description": "SELinuxOptions are the labels to be applied to the container",
+    "type": "object",
     "properties": {
      "level": {
       "description": "Level is SELinux level label that applies to the container.",
@@ -80212,6 +80522,7 @@
    },
    "io.k8s.api.core.v1.ScaleIOPersistentVolumeSource": {
     "description": "ScaleIOPersistentVolumeSource represents a persistent ScaleIO volume",
+    "type": "object",
     "required": [
      "gateway",
      "system",
@@ -80262,6 +80573,7 @@
    },
    "io.k8s.api.core.v1.ScaleIOVolumeSource": {
     "description": "ScaleIOVolumeSource represents a persistent ScaleIO volume",
+    "type": "object",
     "required": [
      "gateway",
      "system",
@@ -80312,6 +80624,7 @@
    },
    "io.k8s.api.core.v1.ScopeSelector": {
     "description": "A scope selector represents the AND of the selectors represented by the scoped-resource selector requirements.",
+    "type": "object",
     "properties": {
      "matchExpressions": {
       "description": "A list of scope selector requirements by scope of the resources.",
@@ -80324,6 +80637,7 @@
    },
    "io.k8s.api.core.v1.ScopedResourceSelectorRequirement": {
     "description": "A scoped-resource selector requirement is a selector that contains values, a scope name, and an operator that relates the scope name and values.",
+    "type": "object",
     "required": [
      "scopeName",
      "operator"
@@ -80348,6 +80662,7 @@
    },
    "io.k8s.api.core.v1.Secret": {
     "description": "Secret holds secret data of a certain type. The total bytes of the values in the Data field must be less than MaxSecretSize bytes.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -80391,6 +80706,7 @@
    },
    "io.k8s.api.core.v1.SecretEnvSource": {
     "description": "SecretEnvSource selects a Secret to populate the environment variables with.\n\nThe contents of the target Secret's Data field will represent the key-value pairs as environment variables.",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
@@ -80404,6 +80720,7 @@
    },
    "io.k8s.api.core.v1.SecretKeySelector": {
     "description": "SecretKeySelector selects a key of a Secret.",
+    "type": "object",
     "required": [
      "key"
     ],
@@ -80424,6 +80741,7 @@
    },
    "io.k8s.api.core.v1.SecretList": {
     "description": "SecretList is a list of Secret.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -80458,6 +80776,7 @@
    },
    "io.k8s.api.core.v1.SecretProjection": {
     "description": "Adapts a secret into a projected volume.\n\nThe contents of the target Secret's Data field will be presented in a projected volume as files using the keys in the Data field as the file names. Note that this is identical to a secret volume source without the default mode.",
+    "type": "object",
     "properties": {
      "items": {
       "description": "If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.",
@@ -80478,6 +80797,7 @@
    },
    "io.k8s.api.core.v1.SecretReference": {
     "description": "SecretReference represents a Secret Reference. It has enough information to retrieve secret in any namespace",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name is unique within a namespace to reference a secret resource.",
@@ -80491,6 +80811,7 @@
    },
    "io.k8s.api.core.v1.SecretVolumeSource": {
     "description": "Adapts a Secret into a volume.\n\nThe contents of the target Secret's Data field will be presented in a volume as files using the keys in the Data field as the file names. Secret volumes support ownership management and SELinux relabeling.",
+    "type": "object",
     "properties": {
      "defaultMode": {
       "description": "Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.",
@@ -80516,6 +80837,7 @@
    },
    "io.k8s.api.core.v1.SecurityContext": {
     "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+    "type": "object",
     "properties": {
      "allowPrivilegeEscalation": {
       "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
@@ -80555,6 +80877,7 @@
    },
    "io.k8s.api.core.v1.Service": {
     "description": "Service is a named abstraction of software service (for example, mysql) consisting of local port (for example 3306) that the proxy listens on, and the selector that determines which pods will answer requests sent through the proxy.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -80587,6 +80910,7 @@
    },
    "io.k8s.api.core.v1.ServiceAccount": {
     "description": "ServiceAccount binds together: * a name, understood by users, and perhaps by peripheral systems, for an identity * a principal that can be authenticated and authorized * a set of secrets",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -80631,6 +80955,7 @@
    },
    "io.k8s.api.core.v1.ServiceAccountList": {
     "description": "ServiceAccountList is a list of ServiceAccount objects",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -80665,6 +80990,7 @@
    },
    "io.k8s.api.core.v1.ServiceAccountTokenProjection": {
     "description": "ServiceAccountTokenProjection represents a projected service account token volume. This projection can be used to insert a service account token into the pods runtime filesystem for use against APIs (Kubernetes API Server or otherwise).",
+    "type": "object",
     "required": [
      "path"
     ],
@@ -80686,6 +81012,7 @@
    },
    "io.k8s.api.core.v1.ServiceList": {
     "description": "ServiceList holds a list of services.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -80720,6 +81047,7 @@
    },
    "io.k8s.api.core.v1.ServicePort": {
     "description": "ServicePort contains information on service's port.",
+    "type": "object",
     "required": [
      "port"
     ],
@@ -80750,6 +81078,7 @@
    },
    "io.k8s.api.core.v1.ServiceSpec": {
     "description": "ServiceSpec describes the attributes that a user creates on a service.",
+    "type": "object",
     "properties": {
      "clusterIP": {
       "description": "clusterIP is the IP address of the service and is usually assigned randomly by the master. If an address is specified manually and is not in use by others, it will be allocated to the service; otherwise, creation of the service will fail. This field can not be changed through updates. Valid values are \"None\", empty string (\"\"), or a valid IP address. \"None\" can be specified for headless services when proxying is not required. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies",
@@ -80822,6 +81151,7 @@
    },
    "io.k8s.api.core.v1.ServiceStatus": {
     "description": "ServiceStatus represents the current status of a service.",
+    "type": "object",
     "properties": {
      "loadBalancer": {
       "description": "LoadBalancer contains the current status of the load-balancer, if one is present.",
@@ -80831,6 +81161,7 @@
    },
    "io.k8s.api.core.v1.SessionAffinityConfig": {
     "description": "SessionAffinityConfig represents the configurations of session affinity.",
+    "type": "object",
     "properties": {
      "clientIP": {
       "description": "clientIP contains the configurations of Client IP based session affinity.",
@@ -80840,6 +81171,7 @@
    },
    "io.k8s.api.core.v1.StorageOSPersistentVolumeSource": {
     "description": "Represents a StorageOS persistent volume resource.",
+    "type": "object",
     "properties": {
      "fsType": {
       "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -80865,6 +81197,7 @@
    },
    "io.k8s.api.core.v1.StorageOSVolumeSource": {
     "description": "Represents a StorageOS persistent volume resource.",
+    "type": "object",
     "properties": {
      "fsType": {
       "description": "Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. \"ext4\", \"xfs\", \"ntfs\". Implicitly inferred to be \"ext4\" if unspecified.",
@@ -80890,6 +81223,7 @@
    },
    "io.k8s.api.core.v1.Sysctl": {
     "description": "Sysctl defines a kernel parameter to be set",
+    "type": "object",
     "required": [
      "name",
      "value"
@@ -80907,6 +81241,7 @@
    },
    "io.k8s.api.core.v1.TCPSocketAction": {
     "description": "TCPSocketAction describes an action based on opening a socket",
+    "type": "object",
     "required": [
      "port"
     ],
@@ -80923,6 +81258,7 @@
    },
    "io.k8s.api.core.v1.Taint": {
     "description": "The node this Taint is attached to has the \"effect\" on any pod that does not tolerate the Taint.",
+    "type": "object",
     "required": [
      "key",
      "effect"
@@ -80948,6 +81284,7 @@
    },
    "io.k8s.api.core.v1.Toleration": {
     "description": "The pod this Toleration is attached to tolerates any taint that matches the triple \u003ckey,value,effect\u003e using the matching operator \u003coperator\u003e.",
+    "type": "object",
     "properties": {
      "effect": {
       "description": "Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.",
@@ -80974,6 +81311,7 @@
    },
    "io.k8s.api.core.v1.TopologySelectorLabelRequirement": {
     "description": "A topology selector requirement is a selector that matches given label. This is an alpha feature and may change in the future.",
+    "type": "object",
     "required": [
      "key",
      "values"
@@ -80994,6 +81332,7 @@
    },
    "io.k8s.api.core.v1.TopologySelectorTerm": {
     "description": "A topology selector term represents the result of label queries. A null or empty topology selector term matches no objects. The requirements of them are ANDed. It provides a subset of functionality as NodeSelectorTerm. This is an alpha feature and may change in the future.",
+    "type": "object",
     "properties": {
      "matchLabelExpressions": {
       "description": "A list of topology selector requirements by labels.",
@@ -81006,6 +81345,7 @@
    },
    "io.k8s.api.core.v1.Volume": {
     "description": "Volume represents a named volume in a pod that may be accessed by any container in the pod.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -81126,6 +81466,7 @@
    },
    "io.k8s.api.core.v1.VolumeDevice": {
     "description": "volumeDevice describes a mapping of a raw block device within a container.",
+    "type": "object",
     "required": [
      "name",
      "devicePath"
@@ -81143,6 +81484,7 @@
    },
    "io.k8s.api.core.v1.VolumeMount": {
     "description": "VolumeMount describes a mounting of a Volume within a container.",
+    "type": "object",
     "required": [
      "name",
      "mountPath"
@@ -81172,6 +81514,7 @@
    },
    "io.k8s.api.core.v1.VolumeNodeAffinity": {
     "description": "VolumeNodeAffinity defines constraints that limit what nodes this volume can be accessed from.",
+    "type": "object",
     "properties": {
      "required": {
       "description": "Required specifies hard node constraints that must be met.",
@@ -81181,6 +81524,7 @@
    },
    "io.k8s.api.core.v1.VolumeProjection": {
     "description": "Projection that may be projected along with other supported volume types",
+    "type": "object",
     "properties": {
      "configMap": {
       "description": "information about the configMap data to project",
@@ -81202,6 +81546,7 @@
    },
    "io.k8s.api.core.v1.VsphereVirtualDiskVolumeSource": {
     "description": "Represents a vSphere volume resource.",
+    "type": "object",
     "required": [
      "volumePath"
     ],
@@ -81226,6 +81571,7 @@
    },
    "io.k8s.api.core.v1.WeightedPodAffinityTerm": {
     "description": "The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)",
+    "type": "object",
     "required": [
      "weight",
      "podAffinityTerm"
@@ -81244,6 +81590,7 @@
    },
    "io.k8s.api.events.v1beta1.Event": {
     "description": "Event is a report of an event somewhere in the cluster. It generally denotes some state change in the system.",
+    "type": "object",
     "required": [
      "eventTime"
     ],
@@ -81327,6 +81674,7 @@
    },
    "io.k8s.api.events.v1beta1.EventList": {
     "description": "EventList is a list of Event objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -81361,6 +81709,7 @@
    },
    "io.k8s.api.events.v1beta1.EventSeries": {
     "description": "EventSeries contain information on series of events, i.e. thing that was/is happening continuously for some time.",
+    "type": "object",
     "required": [
      "count",
      "lastObservedTime",
@@ -81384,6 +81733,7 @@
    },
    "io.k8s.api.extensions.v1beta1.AllowedFlexVolume": {
     "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used. Deprecated: use AllowedFlexVolume from policy API Group instead.",
+    "type": "object",
     "required": [
      "driver"
     ],
@@ -81396,6 +81746,7 @@
    },
    "io.k8s.api.extensions.v1beta1.AllowedHostPath": {
     "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined. Deprecated: use AllowedHostPath from policy API Group instead.",
+    "type": "object",
     "properties": {
      "pathPrefix": {
       "description": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
@@ -81409,6 +81760,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DaemonSet": {
     "description": "DEPRECATED - This group version of DaemonSet is deprecated by apps/v1beta2/DaemonSet. See the release notes for more information. DaemonSet represents the configuration of a daemon set.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -81441,6 +81793,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetCondition": {
     "description": "DaemonSetCondition describes the state of a DaemonSet at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -81470,6 +81823,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetList": {
     "description": "DaemonSetList is a collection of daemon sets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -81504,6 +81858,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetSpec": {
     "description": "DaemonSetSpec is the specification of a daemon set.",
+    "type": "object",
     "required": [
      "template"
     ],
@@ -81539,6 +81894,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetStatus": {
     "description": "DaemonSetStatus represents the current status of a daemon set.",
+    "type": "object",
     "required": [
      "currentNumberScheduled",
      "numberMisscheduled",
@@ -81603,6 +81959,7 @@
     }
    },
    "io.k8s.api.extensions.v1beta1.DaemonSetUpdateStrategy": {
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if type = \"RollingUpdate\".",
@@ -81616,6 +81973,7 @@
    },
    "io.k8s.api.extensions.v1beta1.Deployment": {
     "description": "DEPRECATED - This group version of Deployment is deprecated by apps/v1beta2/Deployment. See the release notes for more information. Deployment enables declarative updates for Pods and ReplicaSets.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -81648,6 +82006,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentCondition": {
     "description": "DeploymentCondition describes the state of a deployment at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -81681,6 +82040,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentList": {
     "description": "DeploymentList is a list of Deployments.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -81715,6 +82075,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentRollback": {
     "description": "DEPRECATED. DeploymentRollback stores the information required to rollback a deployment.",
+    "type": "object",
     "required": [
      "name",
      "rollbackTo"
@@ -81754,6 +82115,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentSpec": {
     "description": "DeploymentSpec is the specification of the desired behavior of the Deployment.",
+    "type": "object",
     "required": [
      "template"
     ],
@@ -81803,6 +82165,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStatus": {
     "description": "DeploymentStatus is the most recently observed status of the Deployment.",
+    "type": "object",
     "properties": {
      "availableReplicas": {
       "description": "Total number of available pods (ready for at least minReadySeconds) targeted by this deployment.",
@@ -81852,6 +82215,7 @@
    },
    "io.k8s.api.extensions.v1beta1.DeploymentStrategy": {
     "description": "DeploymentStrategy describes how to replace existing pods with new ones.",
+    "type": "object",
     "properties": {
      "rollingUpdate": {
       "description": "Rolling update config params. Present only if DeploymentStrategyType = RollingUpdate.",
@@ -81865,6 +82229,7 @@
    },
    "io.k8s.api.extensions.v1beta1.FSGroupStrategyOptions": {
     "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use FSGroupStrategyOptions from policy API Group instead.",
+    "type": "object",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
@@ -81881,6 +82246,7 @@
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressPath": {
     "description": "HTTPIngressPath associates a path regex with a backend. Incoming urls matching the path are forwarded to the backend.",
+    "type": "object",
     "required": [
      "backend"
     ],
@@ -81897,6 +82263,7 @@
    },
    "io.k8s.api.extensions.v1beta1.HTTPIngressRuleValue": {
     "description": "HTTPIngressRuleValue is a list of http selectors pointing to backends. In the example: http://\u003chost\u003e/\u003cpath\u003e?\u003csearchpart\u003e -\u003e backend where where parts of the url correspond to RFC 3986, this resource will be used to match against everything after the last '/' and before the first '?' or '#'.",
+    "type": "object",
     "required": [
      "paths"
     ],
@@ -81912,6 +82279,7 @@
    },
    "io.k8s.api.extensions.v1beta1.HostPortRange": {
     "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined. Deprecated: use HostPortRange from policy API Group instead.",
+    "type": "object",
     "required": [
      "min",
      "max"
@@ -81931,6 +82299,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IDRange": {
     "description": "IDRange provides a min/max of an allowed range of IDs. Deprecated: use IDRange from policy API Group instead.",
+    "type": "object",
     "required": [
      "min",
      "max"
@@ -81950,6 +82319,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IPBlock": {
     "description": "DEPRECATED 1.9 - This group version of IPBlock is deprecated by networking/v1/IPBlock. IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+    "type": "object",
     "required": [
      "cidr"
     ],
@@ -81969,6 +82339,7 @@
    },
    "io.k8s.api.extensions.v1beta1.Ingress": {
     "description": "Ingress is a collection of rules that allow inbound connections to reach the endpoints defined by a backend. An Ingress can be configured to give services externally-reachable urls, load balance traffic, terminate SSL, offer name based virtual hosting etc.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82001,6 +82372,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressBackend": {
     "description": "IngressBackend describes all endpoints for a given service and port.",
+    "type": "object",
     "required": [
      "serviceName",
      "servicePort"
@@ -82018,6 +82390,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressList": {
     "description": "IngressList is a collection of Ingress.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -82052,6 +82425,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressRule": {
     "description": "IngressRule represents the rules mapping the paths under a specified host to the related backend services. Incoming requests are first evaluated for a host match, then routed to the backend associated with the matching IngressRuleValue.",
+    "type": "object",
     "properties": {
      "host": {
       "description": "Host is the fully qualified domain name of a network host, as defined by RFC 3986. Note the following deviations from the \"host\" part of the URI as defined in the RFC: 1. IPs are not allowed. Currently an IngressRuleValue can only apply to the\n\t  IP in the Spec of the parent Ingress.\n2. The `:` delimiter is not respected because ports are not allowed.\n\t  Currently the port of an Ingress is implicitly :80 for http and\n\t  :443 for https.\nBoth these may change in the future. Incoming requests are matched against the host before the IngressRuleValue. If the host is unspecified, the Ingress routes all traffic based on the specified IngressRuleValue.",
@@ -82064,6 +82438,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressSpec": {
     "description": "IngressSpec describes the Ingress the user wishes to exist.",
+    "type": "object",
     "properties": {
      "backend": {
       "description": "A default backend capable of servicing requests that don't match any rule. At least one of 'backend' or 'rules' must be specified. This field is optional to allow the loadbalancer controller or defaulting logic to specify a global default.",
@@ -82087,6 +82462,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressStatus": {
     "description": "IngressStatus describe the current state of the Ingress.",
+    "type": "object",
     "properties": {
      "loadBalancer": {
       "description": "LoadBalancer contains the current status of the load-balancer.",
@@ -82096,6 +82472,7 @@
    },
    "io.k8s.api.extensions.v1beta1.IngressTLS": {
     "description": "IngressTLS describes the transport layer security associated with an Ingress.",
+    "type": "object",
     "properties": {
      "hosts": {
       "description": "Hosts are a list of hosts included in the TLS certificate. The values in this list must match the name/s used in the tlsSecret. Defaults to the wildcard host setting for the loadbalancer controller fulfilling this Ingress, if left unspecified.",
@@ -82112,6 +82489,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicy": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicy is deprecated by networking/v1/NetworkPolicy. NetworkPolicy describes what network traffic is allowed for a set of Pods",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82140,6 +82518,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyEgressRule": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyEgressRule is deprecated by networking/v1/NetworkPolicyEgressRule. NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8",
+    "type": "object",
     "properties": {
      "ports": {
       "description": "List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
@@ -82159,6 +82538,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyIngressRule": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyIngressRule is deprecated by networking/v1/NetworkPolicyIngressRule. This NetworkPolicyIngressRule matches traffic if and only if the traffic matches both ports AND from.",
+    "type": "object",
     "properties": {
      "from": {
       "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
@@ -82178,6 +82558,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyList": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyList is deprecated by networking/v1/NetworkPolicyList. Network Policy List is a list of NetworkPolicy objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -82212,6 +82593,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyPeer": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyPeer is deprecated by networking/v1/NetworkPolicyPeer.",
+    "type": "object",
     "properties": {
      "ipBlock": {
       "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
@@ -82229,6 +82611,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicyPort": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicyPort is deprecated by networking/v1/NetworkPolicyPort.",
+    "type": "object",
     "properties": {
      "port": {
       "description": "If specified, the port on the given protocol.  This can either be a numerical or named port on a pod.  If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.",
@@ -82242,6 +82625,7 @@
    },
    "io.k8s.api.extensions.v1beta1.NetworkPolicySpec": {
     "description": "DEPRECATED 1.9 - This group version of NetworkPolicySpec is deprecated by networking/v1/NetworkPolicySpec.",
+    "type": "object",
     "required": [
      "podSelector"
     ],
@@ -82275,6 +82659,7 @@
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicy": {
     "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container. Deprecated: use PodSecurityPolicy from policy API Group instead.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82303,6 +82688,7 @@
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicyList": {
     "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects. Deprecated: use PodSecurityPolicyList from policy API Group instead.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -82337,6 +82723,7 @@
    },
    "io.k8s.api.extensions.v1beta1.PodSecurityPolicySpec": {
     "description": "PodSecurityPolicySpec defines the policy enforced. Deprecated: use PodSecurityPolicySpec from policy API Group instead.",
+    "type": "object",
     "required": [
      "seLinux",
      "runAsUser",
@@ -82455,6 +82842,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSet": {
     "description": "DEPRECATED - This group version of ReplicaSet is deprecated by apps/v1beta2/ReplicaSet. See the release notes for more information. ReplicaSet ensures that a specified number of pod replicas are running at any given time.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82487,6 +82875,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetCondition": {
     "description": "ReplicaSetCondition describes the state of a replica set at a certain point.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -82516,6 +82905,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetList": {
     "description": "ReplicaSetList is a collection of ReplicaSets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -82550,6 +82940,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetSpec": {
     "description": "ReplicaSetSpec is the specification of a ReplicaSet.",
+    "type": "object",
     "properties": {
      "minReadySeconds": {
       "description": "Minimum number of seconds for which a newly created pod should be ready without any of its container crashing, for it to be considered available. Defaults to 0 (pod will be considered available as soon as it is ready)",
@@ -82573,6 +82964,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ReplicaSetStatus": {
     "description": "ReplicaSetStatus represents the current status of a ReplicaSet.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -82615,6 +83007,7 @@
    },
    "io.k8s.api.extensions.v1beta1.RollbackConfig": {
     "description": "DEPRECATED.",
+    "type": "object",
     "properties": {
      "revision": {
       "description": "The revision to rollback to. If set to 0, rollback to the last revision.",
@@ -82625,6 +83018,7 @@
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDaemonSet": {
     "description": "Spec to control the desired behavior of daemon set rolling update.",
+    "type": "object",
     "properties": {
      "maxUnavailable": {
       "description": "The maximum number of DaemonSet pods that can be unavailable during the update. Value can be an absolute number (ex: 5) or a percentage of total number of DaemonSet pods at the start of the update (ex: 10%). Absolute number is calculated from percentage by rounding up. This cannot be 0. Default value is 1. Example: when this is set to 30%, at most 30% of the total number of nodes that should be running the daemon pod (i.e. status.desiredNumberScheduled) can have their pods stopped for an update at any given time. The update starts by stopping at most 30% of those DaemonSet pods and then brings up new DaemonSet pods in their place. Once the new pods are available, it then proceeds onto other DaemonSet pods, thus ensuring that at least 70% of original number of DaemonSet pods are available at all times during the update.",
@@ -82634,6 +83028,7 @@
    },
    "io.k8s.api.extensions.v1beta1.RollingUpdateDeployment": {
     "description": "Spec to control the desired behavior of rolling update.",
+    "type": "object",
     "properties": {
      "maxSurge": {
       "description": "The maximum number of pods that can be scheduled above the desired number of pods. Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%). This can not be 0 if MaxUnavailable is 0. Absolute number is calculated from percentage by rounding up. By default, a value of 1 is used. Example: when this is set to 30%, the new RC can be scaled up immediately when the rolling update starts, such that the total number of old and new pods do not exceed 130% of desired pods. Once old pods have been killed, new RC can be scaled up further, ensuring that total number of pods running at any time during the update is atmost 130% of desired pods.",
@@ -82647,6 +83042,7 @@
    },
    "io.k8s.api.extensions.v1beta1.RunAsUserStrategyOptions": {
     "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use RunAsUserStrategyOptions from policy API Group instead.",
+    "type": "object",
     "required": [
      "rule"
     ],
@@ -82666,6 +83062,7 @@
    },
    "io.k8s.api.extensions.v1beta1.SELinuxStrategyOptions": {
     "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy. Deprecated: use SELinuxStrategyOptions from policy API Group instead.",
+    "type": "object",
     "required": [
      "rule"
     ],
@@ -82682,6 +83079,7 @@
    },
    "io.k8s.api.extensions.v1beta1.Scale": {
     "description": "represents a scaling request for a resource.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82714,6 +83112,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ScaleSpec": {
     "description": "describes the attributes of a scale subresource",
+    "type": "object",
     "properties": {
      "replicas": {
       "description": "desired number of instances for the scaled object.",
@@ -82724,6 +83123,7 @@
    },
    "io.k8s.api.extensions.v1beta1.ScaleStatus": {
     "description": "represents the current status of a scale subresource.",
+    "type": "object",
     "required": [
      "replicas"
     ],
@@ -82748,6 +83148,7 @@
    },
    "io.k8s.api.extensions.v1beta1.SupplementalGroupsStrategyOptions": {
     "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy. Deprecated: use SupplementalGroupsStrategyOptions from policy API Group instead.",
+    "type": "object",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",
@@ -82764,6 +83165,7 @@
    },
    "io.k8s.api.networking.v1.IPBlock": {
     "description": "IPBlock describes a particular CIDR (Ex. \"192.168.1.1/24\") that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs that should not be included within this rule.",
+    "type": "object",
     "required": [
      "cidr"
     ],
@@ -82783,6 +83185,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicy": {
     "description": "NetworkPolicy describes what network traffic is allowed for a set of Pods",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82811,6 +83214,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicyEgressRule": {
     "description": "NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8",
+    "type": "object",
     "properties": {
      "ports": {
       "description": "List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.",
@@ -82830,6 +83234,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicyIngressRule": {
     "description": "NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.",
+    "type": "object",
     "properties": {
      "from": {
       "description": "List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least on item, this rule allows traffic only if the traffic matches at least one item in the from list.",
@@ -82849,6 +83254,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicyList": {
     "description": "NetworkPolicyList is a list of NetworkPolicy objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -82883,6 +83289,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicyPeer": {
     "description": "NetworkPolicyPeer describes a peer to allow traffic from. Only certain combinations of fields are allowed",
+    "type": "object",
     "properties": {
      "ipBlock": {
       "description": "IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.",
@@ -82900,6 +83307,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicyPort": {
     "description": "NetworkPolicyPort describes a port to allow traffic on",
+    "type": "object",
     "properties": {
      "port": {
       "description": "The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers.",
@@ -82913,6 +83321,7 @@
    },
    "io.k8s.api.networking.v1.NetworkPolicySpec": {
     "description": "NetworkPolicySpec provides the specification of a NetworkPolicy",
+    "type": "object",
     "required": [
      "podSelector"
     ],
@@ -82946,6 +83355,7 @@
    },
    "io.k8s.api.policy.v1beta1.AllowedFlexVolume": {
     "description": "AllowedFlexVolume represents a single Flexvolume that is allowed to be used.",
+    "type": "object",
     "required": [
      "driver"
     ],
@@ -82958,6 +83368,7 @@
    },
    "io.k8s.api.policy.v1beta1.AllowedHostPath": {
     "description": "AllowedHostPath defines the host volume conditions that will be enabled by a policy for pods to use. It requires the path prefix to be defined.",
+    "type": "object",
     "properties": {
      "pathPrefix": {
       "description": "pathPrefix is the path prefix that the host volume must match. It does not support `*`. Trailing slashes are trimmed when validating the path prefix with a host path.\n\nExamples: `/foo` would allow `/foo`, `/foo/` and `/foo/bar` `/foo` would not allow `/food` or `/etc/foo`",
@@ -82971,6 +83382,7 @@
    },
    "io.k8s.api.policy.v1beta1.Eviction": {
     "description": "Eviction evicts a pod from its node subject to certain policies and safety constraints. This is a subresource of Pod.  A request to cause such an eviction is created by POSTing to .../pods/\u003cpod name\u003e/evictions.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -82999,6 +83411,7 @@
    },
    "io.k8s.api.policy.v1beta1.FSGroupStrategyOptions": {
     "description": "FSGroupStrategyOptions defines the strategy type and options used to create the strategy.",
+    "type": "object",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of fs groups.  If you would like to force a single fs group then supply a single range with the same start and end. Required for MustRunAs.",
@@ -83015,6 +83428,7 @@
    },
    "io.k8s.api.policy.v1beta1.HostPortRange": {
     "description": "HostPortRange defines a range of host ports that will be enabled by a policy for pods to use.  It requires both the start and end to be defined.",
+    "type": "object",
     "required": [
      "min",
      "max"
@@ -83034,6 +83448,7 @@
    },
    "io.k8s.api.policy.v1beta1.IDRange": {
     "description": "IDRange provides a min/max of an allowed range of IDs.",
+    "type": "object",
     "required": [
      "min",
      "max"
@@ -83053,6 +83468,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodDisruptionBudget": {
     "description": "PodDisruptionBudget is an object to define the max disruption that can be caused to a collection of pods",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -83084,6 +83500,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetList": {
     "description": "PodDisruptionBudgetList is a collection of PodDisruptionBudgets.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83116,6 +83533,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetSpec": {
     "description": "PodDisruptionBudgetSpec is a description of a PodDisruptionBudget.",
+    "type": "object",
     "properties": {
      "maxUnavailable": {
       "description": "An eviction is allowed if at most \"maxUnavailable\" pods selected by \"selector\" are unavailable after the eviction, i.e. even in absence of the evicted pod. For example, one can prevent all voluntary evictions by specifying 0. This is a mutually exclusive setting with \"minAvailable\".",
@@ -83133,6 +83551,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodDisruptionBudgetStatus": {
     "description": "PodDisruptionBudgetStatus represents information about the status of a PodDisruptionBudget. Status may trail the actual state of a system.",
+    "type": "object",
     "required": [
      "disruptedPods",
      "disruptionsAllowed",
@@ -83177,6 +83596,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodSecurityPolicy": {
     "description": "PodSecurityPolicy governs the ability to make requests that affect the Security Context that will be applied to a pod and container.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -83205,6 +83625,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodSecurityPolicyList": {
     "description": "PodSecurityPolicyList is a list of PodSecurityPolicy objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83239,6 +83660,7 @@
    },
    "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec": {
     "description": "PodSecurityPolicySpec defines the policy enforced.",
+    "type": "object",
     "required": [
      "seLinux",
      "runAsUser",
@@ -83357,6 +83779,7 @@
    },
    "io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions": {
     "description": "RunAsUserStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "type": "object",
     "required": [
      "rule"
     ],
@@ -83376,6 +83799,7 @@
    },
    "io.k8s.api.policy.v1beta1.SELinuxStrategyOptions": {
     "description": "SELinuxStrategyOptions defines the strategy type and any options used to create the strategy.",
+    "type": "object",
     "required": [
      "rule"
     ],
@@ -83392,6 +83816,7 @@
    },
    "io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions": {
     "description": "SupplementalGroupsStrategyOptions defines the strategy type and options used to create the strategy.",
+    "type": "object",
     "properties": {
      "ranges": {
       "description": "ranges are the allowed ranges of supplemental groups.  If you would like to force a single supplemental group then supply a single range with the same start and end. Required for MustRunAs.",
@@ -83408,6 +83833,7 @@
    },
    "io.k8s.api.rbac.v1.AggregationRule": {
     "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+    "type": "object",
     "properties": {
      "clusterRoleSelectors": {
       "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
@@ -83420,6 +83846,7 @@
    },
    "io.k8s.api.rbac.v1.ClusterRole": {
     "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -83458,6 +83885,7 @@
    },
    "io.k8s.api.rbac.v1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -83496,6 +83924,7 @@
    },
    "io.k8s.api.rbac.v1.ClusterRoleBindingList": {
     "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83530,6 +83959,7 @@
    },
    "io.k8s.api.rbac.v1.ClusterRoleList": {
     "description": "ClusterRoleList is a collection of ClusterRoles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83564,6 +83994,7 @@
    },
    "io.k8s.api.rbac.v1.PolicyRule": {
     "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -83607,6 +84038,7 @@
    },
    "io.k8s.api.rbac.v1.Role": {
     "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -83641,6 +84073,7 @@
    },
    "io.k8s.api.rbac.v1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -83679,6 +84112,7 @@
    },
    "io.k8s.api.rbac.v1.RoleBindingList": {
     "description": "RoleBindingList is a collection of RoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83713,6 +84147,7 @@
    },
    "io.k8s.api.rbac.v1.RoleList": {
     "description": "RoleList is a collection of Roles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83747,6 +84182,7 @@
    },
    "io.k8s.api.rbac.v1.RoleRef": {
     "description": "RoleRef contains information that points to the role being used",
+    "type": "object",
     "required": [
      "apiGroup",
      "kind",
@@ -83769,6 +84205,7 @@
    },
    "io.k8s.api.rbac.v1.Subject": {
     "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "type": "object",
     "required": [
      "kind",
      "name"
@@ -83794,6 +84231,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.AggregationRule": {
     "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+    "type": "object",
     "properties": {
      "clusterRoleSelectors": {
       "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
@@ -83806,6 +84244,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.ClusterRole": {
     "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -83844,6 +84283,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -83882,6 +84322,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.ClusterRoleBindingList": {
     "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83916,6 +84357,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.ClusterRoleList": {
     "description": "ClusterRoleList is a collection of ClusterRoles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -83950,6 +84392,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.PolicyRule": {
     "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -83993,6 +84436,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.Role": {
     "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -84027,6 +84471,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -84065,6 +84510,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.RoleBindingList": {
     "description": "RoleBindingList is a collection of RoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84099,6 +84545,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.RoleList": {
     "description": "RoleList is a collection of Roles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84133,6 +84580,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.RoleRef": {
     "description": "RoleRef contains information that points to the role being used",
+    "type": "object",
     "required": [
      "apiGroup",
      "kind",
@@ -84155,6 +84603,7 @@
    },
    "io.k8s.api.rbac.v1alpha1.Subject": {
     "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "type": "object",
     "required": [
      "kind",
      "name"
@@ -84180,6 +84629,7 @@
    },
    "io.k8s.api.rbac.v1beta1.AggregationRule": {
     "description": "AggregationRule describes how to locate ClusterRoles to aggregate into the ClusterRole",
+    "type": "object",
     "properties": {
      "clusterRoleSelectors": {
       "description": "ClusterRoleSelectors holds a list of selectors which will be used to find ClusterRoles and create the rules. If any of the selectors match, then the ClusterRole's permissions will be added",
@@ -84192,6 +84642,7 @@
    },
    "io.k8s.api.rbac.v1beta1.ClusterRole": {
     "description": "ClusterRole is a cluster level, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding or ClusterRoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -84230,6 +84681,7 @@
    },
    "io.k8s.api.rbac.v1beta1.ClusterRoleBinding": {
     "description": "ClusterRoleBinding references a ClusterRole, but not contain it.  It can reference a ClusterRole in the global namespace, and adds who information via Subject.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -84268,6 +84720,7 @@
    },
    "io.k8s.api.rbac.v1beta1.ClusterRoleBindingList": {
     "description": "ClusterRoleBindingList is a collection of ClusterRoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84302,6 +84755,7 @@
    },
    "io.k8s.api.rbac.v1beta1.ClusterRoleList": {
     "description": "ClusterRoleList is a collection of ClusterRoles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84336,6 +84790,7 @@
    },
    "io.k8s.api.rbac.v1beta1.PolicyRule": {
     "description": "PolicyRule holds information that describes a policy rule, but does not contain information about who the rule applies to or which namespace the rule applies to.",
+    "type": "object",
     "required": [
      "verbs"
     ],
@@ -84379,6 +84834,7 @@
    },
    "io.k8s.api.rbac.v1beta1.Role": {
     "description": "Role is a namespaced, logical grouping of PolicyRules that can be referenced as a unit by a RoleBinding.",
+    "type": "object",
     "required": [
      "rules"
     ],
@@ -84413,6 +84869,7 @@
    },
    "io.k8s.api.rbac.v1beta1.RoleBinding": {
     "description": "RoleBinding references a role, but does not contain it.  It can reference a Role in the same namespace or a ClusterRole in the global namespace. It adds who information via Subjects and namespace information by which namespace it exists in.  RoleBindings in a given namespace only have effect in that namespace.",
+    "type": "object",
     "required": [
      "roleRef"
     ],
@@ -84451,6 +84908,7 @@
    },
    "io.k8s.api.rbac.v1beta1.RoleBindingList": {
     "description": "RoleBindingList is a collection of RoleBindings",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84485,6 +84943,7 @@
    },
    "io.k8s.api.rbac.v1beta1.RoleList": {
     "description": "RoleList is a collection of Roles",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84519,6 +84978,7 @@
    },
    "io.k8s.api.rbac.v1beta1.RoleRef": {
     "description": "RoleRef contains information that points to the role being used",
+    "type": "object",
     "required": [
      "apiGroup",
      "kind",
@@ -84541,6 +85001,7 @@
    },
    "io.k8s.api.rbac.v1beta1.Subject": {
     "description": "Subject contains a reference to the object or user identities a role binding applies to.  This can either hold a direct API object reference, or a value for non-objects such as user and group names.",
+    "type": "object",
     "required": [
      "kind",
      "name"
@@ -84566,6 +85027,7 @@
    },
    "io.k8s.api.scheduling.v1alpha1.PriorityClass": {
     "description": "PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
+    "type": "object",
     "required": [
      "value"
     ],
@@ -84606,6 +85068,7 @@
    },
    "io.k8s.api.scheduling.v1alpha1.PriorityClassList": {
     "description": "PriorityClassList is a collection of priority classes.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84640,6 +85103,7 @@
    },
    "io.k8s.api.scheduling.v1beta1.PriorityClass": {
     "description": "PriorityClass defines mapping from a priority class name to the priority integer value. The value can be any valid integer.",
+    "type": "object",
     "required": [
      "value"
     ],
@@ -84680,6 +85144,7 @@
    },
    "io.k8s.api.scheduling.v1beta1.PriorityClassList": {
     "description": "PriorityClassList is a collection of priority classes.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84714,6 +85179,7 @@
    },
    "io.k8s.api.settings.v1alpha1.PodPreset": {
     "description": "PodPreset is a policy resource that defines additional runtime requirements for a Pod.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -84740,6 +85206,7 @@
    },
    "io.k8s.api.settings.v1alpha1.PodPresetList": {
     "description": "PodPresetList is a list of PodPreset objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84774,6 +85241,7 @@
    },
    "io.k8s.api.settings.v1alpha1.PodPresetSpec": {
     "description": "PodPresetSpec is a description of a pod preset.",
+    "type": "object",
     "properties": {
      "env": {
       "description": "Env defines the collection of EnvVar to inject into containers.",
@@ -84811,6 +85279,7 @@
    },
    "io.k8s.api.storage.v1.StorageClass": {
     "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "type": "object",
     "required": [
      "provisioner"
     ],
@@ -84875,6 +85344,7 @@
    },
    "io.k8s.api.storage.v1.StorageClassList": {
     "description": "StorageClassList is a collection of storage classes.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84909,6 +85379,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeAttachment": {
     "description": "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.\n\nVolumeAttachment objects are non-namespaced.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -84944,6 +85415,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeAttachmentList": {
     "description": "VolumeAttachmentList is a collection of VolumeAttachment objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -84978,6 +85450,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeAttachmentSource": {
     "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+    "type": "object",
     "properties": {
      "persistentVolumeName": {
       "description": "Name of the persistent volume to attach.",
@@ -84987,6 +85460,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeAttachmentSpec": {
     "description": "VolumeAttachmentSpec is the specification of a VolumeAttachment request.",
+    "type": "object",
     "required": [
      "attacher",
      "source",
@@ -85009,6 +85483,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeAttachmentStatus": {
     "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
+    "type": "object",
     "required": [
      "attached"
     ],
@@ -85036,6 +85511,7 @@
    },
    "io.k8s.api.storage.v1alpha1.VolumeError": {
     "description": "VolumeError captures an error encountered during a volume operation.",
+    "type": "object",
     "properties": {
      "message": {
       "description": "String detailing the error encountered during Attach or Detach operation. This string maybe logged, so it should not contain sensitive information.",
@@ -85049,6 +85525,7 @@
    },
    "io.k8s.api.storage.v1beta1.StorageClass": {
     "description": "StorageClass describes the parameters for a class of storage for which PersistentVolumes can be dynamically provisioned.\n\nStorageClasses are non-namespaced; the name of the storage class according to etcd is in ObjectMeta.Name.",
+    "type": "object",
     "required": [
      "provisioner"
     ],
@@ -85113,6 +85590,7 @@
    },
    "io.k8s.api.storage.v1beta1.StorageClassList": {
     "description": "StorageClassList is a collection of storage classes.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -85147,6 +85625,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeAttachment": {
     "description": "VolumeAttachment captures the intent to attach or detach the specified volume to/from the specified node.\n\nVolumeAttachment objects are non-namespaced.",
+    "type": "object",
     "required": [
      "spec"
     ],
@@ -85182,6 +85661,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeAttachmentList": {
     "description": "VolumeAttachmentList is a collection of VolumeAttachment objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -85216,6 +85696,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeAttachmentSource": {
     "description": "VolumeAttachmentSource represents a volume that should be attached. Right now only PersistenVolumes can be attached via external attacher, in future we may allow also inline volumes in pods. Exactly one member can be set.",
+    "type": "object",
     "properties": {
      "persistentVolumeName": {
       "description": "Name of the persistent volume to attach.",
@@ -85225,6 +85706,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeAttachmentSpec": {
     "description": "VolumeAttachmentSpec is the specification of a VolumeAttachment request.",
+    "type": "object",
     "required": [
      "attacher",
      "source",
@@ -85247,6 +85729,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeAttachmentStatus": {
     "description": "VolumeAttachmentStatus is the status of a VolumeAttachment request.",
+    "type": "object",
     "required": [
      "attached"
     ],
@@ -85274,6 +85757,7 @@
    },
    "io.k8s.api.storage.v1beta1.VolumeError": {
     "description": "VolumeError captures an error encountered during a volume operation.",
+    "type": "object",
     "properties": {
      "message": {
       "description": "String detailing the error encountered during Attach or Detach operation. This string maybe logged, so it should not contain sensitive information.",
@@ -85287,6 +85771,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition": {
     "description": "CustomResourceColumnDefinition specifies a column for server side printing.",
+    "type": "object",
     "required": [
      "name",
      "type",
@@ -85322,6 +85807,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition": {
     "description": "CustomResourceDefinition represents a resource that should be exposed on the API server.  Its name MUST be in the format \u003c.spec.name\u003e.\u003c.spec.group\u003e.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -85353,6 +85839,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionCondition": {
     "description": "CustomResourceDefinitionCondition contains details for the current condition of this pod.",
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -85382,6 +85869,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionList": {
     "description": "CustomResourceDefinitionList is a list of CustomResourceDefinition objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -85415,6 +85903,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames": {
     "description": "CustomResourceDefinitionNames indicates the names to serve this CustomResourceDefinition",
+    "type": "object",
     "required": [
      "plural",
      "kind"
@@ -85454,6 +85943,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionSpec": {
     "description": "CustomResourceDefinitionSpec describes how a user wants their resource to appear",
+    "type": "object",
     "required": [
      "group",
      "names",
@@ -85502,6 +85992,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionStatus": {
     "description": "CustomResourceDefinitionStatus indicates the state of the CustomResourceDefinition",
+    "type": "object",
     "required": [
      "conditions",
      "acceptedNames",
@@ -85529,6 +86020,7 @@
     }
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion": {
+    "type": "object",
     "required": [
      "name",
      "served",
@@ -85551,6 +86043,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceScale": {
     "description": "CustomResourceSubresourceScale defines how to serve the scale subresource for CustomResources.",
+    "type": "object",
     "required": [
      "specReplicasPath",
      "statusReplicasPath"
@@ -85571,10 +86064,12 @@
     }
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresourceStatus": {
-    "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza"
+    "description": "CustomResourceSubresourceStatus defines how to serve the status subresource for CustomResources. Status is represented by the `.status` JSON path inside of a CustomResource. When set, * exposes a /status subresource for the custom resource * PUT requests to the /status subresource take a custom resource object, and ignore changes to anything except the status stanza * PUT/POST/PATCH requests to the custom resource ignore changes to the status stanza",
+    "type": "object"
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceSubresources": {
     "description": "CustomResourceSubresources defines the status and scale subresources for CustomResources.",
+    "type": "object",
     "properties": {
      "scale": {
       "description": "Scale denotes the scale subresource for CustomResources",
@@ -85588,6 +86083,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceValidation": {
     "description": "CustomResourceValidation is a list of validation methods for CustomResources.",
+    "type": "object",
     "properties": {
      "openAPIV3Schema": {
       "description": "OpenAPIV3Schema is the OpenAPI v3 schema to be validated against.",
@@ -85597,6 +86093,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.ExternalDocumentation": {
     "description": "ExternalDocumentation allows referencing an external resource for extended documentation.",
+    "type": "object",
     "properties": {
      "description": {
       "type": "string"
@@ -85608,6 +86105,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSON": {
     "description": "JSON represents any valid JSON value. These types are supported: bool, int64, float64, string, []interface{}, map[string]interface{} and nil.",
+    "type": "object",
     "required": [
      "Raw"
     ],
@@ -85620,6 +86118,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps": {
     "description": "JSONSchemaProps is a JSON-Schema following Specification Draft 4 (http://json-schema.org/).",
+    "type": "object",
     "properties": {
      "$ref": {
       "type": "string"
@@ -85769,6 +86268,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrArray": {
     "description": "JSONSchemaPropsOrArray represents a value that can either be a JSONSchemaProps or an array of JSONSchemaProps. Mainly here for serialization purposes.",
+    "type": "object",
     "required": [
      "Schema",
      "JSONSchemas"
@@ -85787,6 +86287,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrBool": {
     "description": "JSONSchemaPropsOrBool represents JSONSchemaProps or a boolean value. Defaults to true for the boolean property.",
+    "type": "object",
     "required": [
      "Allows",
      "Schema"
@@ -85802,6 +86303,7 @@
    },
    "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaPropsOrStringArray": {
     "description": "JSONSchemaPropsOrStringArray represents a JSONSchemaProps or a string array.",
+    "type": "object",
     "required": [
      "Schema",
      "Property"
@@ -85823,6 +86325,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup": {
     "description": "APIGroup contains the name, the supported versions, and the preferred version of a group.",
+    "type": "object",
     "required": [
      "name",
      "versions"
@@ -85869,6 +86372,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroupList": {
     "description": "APIGroupList is a list of APIGroup, to allow clients to discover the API at /apis.",
+    "type": "object",
     "required": [
      "groups"
     ],
@@ -85899,6 +86403,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
     "description": "APIResource specifies the name of a resource and whether it is namespaced.",
+    "type": "object",
     "required": [
      "name",
      "singularName",
@@ -85956,6 +86461,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.APIResourceList": {
     "description": "APIResourceList is a list of APIResource, it is used to expose the name of the resources supported in a specific group and version, and if the resource is namespaced.",
+    "type": "object",
     "required": [
      "groupVersion",
      "resources"
@@ -85991,6 +86497,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.APIVersions": {
     "description": "APIVersions lists the versions that are available, to allow clients to discover the API at /api, which is the root path of the legacy v1 API.",
+    "type": "object",
     "required": [
      "versions",
      "serverAddressByClientCIDRs"
@@ -86029,6 +86536,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions": {
     "description": "DeleteOptions may be provided when deleting an API object.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -86231,6 +86739,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.GroupVersionForDiscovery": {
     "description": "GroupVersion contains the \"group/version\" and \"version\" string of a version. It is made a struct to keep extensibility.",
+    "type": "object",
     "required": [
      "groupVersion",
      "version"
@@ -86248,6 +86757,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializer": {
     "description": "Initializer is information about an initializer that has not yet completed.",
+    "type": "object",
     "required": [
      "name"
     ],
@@ -86260,6 +86770,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.Initializers": {
     "description": "Initializers tracks the progress of initialization.",
+    "type": "object",
     "required": [
      "pending"
     ],
@@ -86281,6 +86792,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector": {
     "description": "A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.",
+    "type": "object",
     "properties": {
      "matchExpressions": {
       "description": "matchExpressions is a list of label selector requirements. The requirements are ANDed.",
@@ -86300,6 +86812,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelectorRequirement": {
     "description": "A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.",
+    "type": "object",
     "required": [
      "key",
      "operator"
@@ -86326,6 +86839,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.ListMeta": {
     "description": "ListMeta describes metadata that synthetic resources must have, including lists and various status objects. A resource may have only one of {ObjectMeta, ListMeta}.",
+    "type": "object",
     "properties": {
      "continue": {
       "description": "continue may be set if the user set a limit on the number of items returned, and indicates that the server has more data available. The value is opaque and may be used to issue another request to the endpoint that served this list to retrieve the next set of available objects. Continuing a list may not be possible if the server configuration has changed or more than a few minutes have passed. The resourceVersion field returned when using this continue value will be identical to the value in the first response.",
@@ -86347,6 +86861,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta": {
     "description": "ObjectMeta is metadata that all persisted resources must have, which includes all objects users must create.",
+    "type": "object",
     "properties": {
      "annotations": {
       "description": "Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
@@ -86433,6 +86948,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference": {
     "description": "OwnerReference contains enough information to let you identify an owning object. Currently, an owning object must be in the same namespace, so there is no namespace field.",
+    "type": "object",
     "required": [
      "apiVersion",
      "kind",
@@ -86467,10 +86983,12 @@
     }
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.Patch": {
-    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body."
+    "description": "Patch is provided to give a concrete name and type to the Kubernetes PATCH request body.",
+    "type": "object"
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.Preconditions": {
     "description": "Preconditions must be fulfilled before an operation (update, delete, etc.) is carried out.",
+    "type": "object",
     "properties": {
      "uid": {
       "description": "Specifies the target UID.",
@@ -86480,6 +86998,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.ServerAddressByClientCIDR": {
     "description": "ServerAddressByClientCIDR helps the client to determine the server address that they should use, depending on the clientCIDR that they match.",
+    "type": "object",
     "required": [
      "clientCIDR",
      "serverAddress"
@@ -86497,6 +87016,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.Status": {
     "description": "Status is a return value for calls that don't return other objects.",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -86542,6 +87062,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusCause": {
     "description": "StatusCause provides more information about an api.Status failure, including cases when multiple errors are encountered.",
+    "type": "object",
     "properties": {
      "field": {
       "description": "The field of the resource that has caused this error, as named by its JSON serialization. May include dot and postfix notation for nested attributes. Arrays are zero-indexed.  Fields may appear more than once in an array of causes due to fields having multiple errors. Optional.\n\nExamples:\n  \"name\" - the field \"name\" on the current resource\n  \"items[0].name\" - the field \"name\" on the first array entry in \"items\"",
@@ -86559,6 +87080,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.StatusDetails": {
     "description": "StatusDetails is a set of additional properties that MAY be set by the server to provide additional information about a response. The Reason field of a Status object defines what attributes will be set. Clients must ignore fields that do not match the defined type of each attribute, and should assume that any attribute may be empty, invalid, or under defined.",
+    "type": "object",
     "properties": {
      "causes": {
       "description": "The Causes array includes more details associated with the StatusReason failure. Not all StatusReasons may provide detailed causes.",
@@ -86596,6 +87118,7 @@
    },
    "io.k8s.apimachinery.pkg.apis.meta.v1.WatchEvent": {
     "description": "Event represents a single event to a watched resource.",
+    "type": "object",
     "required": [
      "type",
      "object"
@@ -86603,7 +87126,7 @@
     "properties": {
      "object": {
       "description": "Object is:\n * If Type is Added or Modified: the new state of the object.\n * If Type is Deleted: the state of the object immediately before deletion.\n * If Type is Error: *Status is recommended; other types may make sense\n   depending on context.",
-      "$ref": "#/definitions/io.k8s.apimachinery.pkg.runtime.RawExtension"
+      "type": "object"
      },
      "type": {
       "type": "string"
@@ -86782,25 +87305,13 @@
      }
     ]
    },
-   "io.k8s.apimachinery.pkg.runtime.RawExtension": {
-    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
-    "required": [
-     "Raw"
-    ],
-    "properties": {
-     "Raw": {
-      "description": "Raw is the underlying serialization of this object.",
-      "type": "string",
-      "format": "byte"
-     }
-    }
-   },
    "io.k8s.apimachinery.pkg.util.intstr.IntOrString": {
     "type": "string",
     "format": "int-or-string"
    },
    "io.k8s.apimachinery.pkg.version.Info": {
     "description": "Info contains versioning information. how we'll want to distribute that information.",
+    "type": "object",
     "required": [
      "major",
      "minor",
@@ -86844,6 +87355,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIService": {
     "description": "APIService represents a server for a particular GroupVersion. Name must be \"version.group\".",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -86874,6 +87386,7 @@
     ]
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition": {
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -86903,6 +87416,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceList": {
     "description": "APIServiceList is a list of APIService objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -86935,6 +87449,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceSpec": {
     "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
+    "type": "object",
     "required": [
      "service",
      "groupPriorityMinimum",
@@ -86976,6 +87491,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceStatus": {
     "description": "APIServiceStatus contains derived information about an API server",
+    "type": "object",
     "properties": {
      "conditions": {
       "description": "Current service state of apiService.",
@@ -86990,6 +87506,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.ServiceReference": {
     "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name is the name of the service",
@@ -87003,6 +87520,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIService": {
     "description": "APIService represents a server for a particular GroupVersion. Name must be \"version.group\".",
+    "type": "object",
     "properties": {
      "apiVersion": {
       "description": "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
@@ -87033,6 +87551,7 @@
     ]
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition": {
+    "type": "object",
     "required": [
      "type",
      "status"
@@ -87062,6 +87581,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceList": {
     "description": "APIServiceList is a list of APIService objects.",
+    "type": "object",
     "required": [
      "items"
     ],
@@ -87094,6 +87614,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceSpec": {
     "description": "APIServiceSpec contains information for locating and communicating with a server. Only https is supported, though you are able to disable certificate verification.",
+    "type": "object",
     "required": [
      "service",
      "groupPriorityMinimum",
@@ -87135,6 +87656,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceStatus": {
     "description": "APIServiceStatus contains derived information about an API server",
+    "type": "object",
     "properties": {
      "conditions": {
       "description": "Current service state of apiService.",
@@ -87149,6 +87671,7 @@
    },
    "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.ServiceReference": {
     "description": "ServiceReference holds a reference to Service.legacy.k8s.io",
+    "type": "object",
     "properties": {
      "name": {
       "description": "Name is the name of the service",

--- a/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
+++ b/pkg/kubectl/cmd/util/openapi/validation/validation_test.go
@@ -406,4 +406,18 @@ spec:
 `))
 		Expect(err).To(BeNil())
 	})
+
+	It("validates a valid ControllerRevision (check if RawExtension properties are validated properly)", func() {
+		err := validator.ValidateBytes([]byte(`
+apiVersion: apps/v1beta2
+kind: ControllerRevision
+metadata:
+  name: name
+revision: 1
+data:
+  customProperty:
+    withSubProperty: someValue
+`))
+		Expect(err).To(BeNil())
+	})
 })

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/generated.proto
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/generated.proto
@@ -71,6 +71,7 @@ option go_package = "runtime";
 // +k8s:deepcopy-gen=true
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen:schema-type-format=object,
 message RawExtension {
   // Raw is the underlying serialization of this object.
   // 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/types.go
@@ -89,6 +89,7 @@ const (
 // +k8s:deepcopy-gen=true
 // +protobuf=true
 // +k8s:openapi-gen=true
+// +k8s:openapi-gen:schema-type-format=object,
 type RawExtension struct {
 	// Raw is the underlying serialization of this object.
 	//

--- a/staging/src/k8s.io/code-generator/cmd/openapi-gen/README
+++ b/staging/src/k8s.io/code-generator/cmd/openapi-gen/README
@@ -2,6 +2,7 @@
 
 - To generate definition for a specific type or package add "+k8s:openapi-gen=true" tag to the type/package comment lines.
 - To exclude a type or a member from a tagged package/type, add "+k8s:openapi-gen=false" tag to the comment lines.
+- To map a type to an open API type,format pair, add "+k8s:openapi-gen:schema-type-format=type,format" tag to the comment lines.
 
 # OpenAPI Extensions
 OpenAPI spec can have extensions on types. To define one or more extensions on a type or its member


### PR DESCRIPTION
Currently, the `RawExtension` definiton in the OpenAPI schema is wrong, as it doesn't allow for arbitrary values to be passed in fields with the `RawExtension` type. 

This is the current definition:
```
   "io.k8s.apimachinery.pkg.runtime.RawExtension": {
    "description": "RawExtension is used to hold extensions in external versions.\n\nTo use this, make a field which has RawExtension as its type in your external, versioned struct, and Object in your internal struct. You also need to register your various plugin types.\n\n// Internal package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.Object `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// External package: type MyAPIObject struct {\n\truntime.TypeMeta `json:\",inline\"`\n\tMyPlugin runtime.RawExtension `json:\"myPlugin\"`\n} type PluginA struct {\n\tAOption string `json:\"aOption\"`\n}\n\n// On the wire, the JSON will look something like this: {\n\t\"kind\":\"MyAPIObject\",\n\t\"apiVersion\":\"v1\",\n\t\"myPlugin\": {\n\t\t\"kind\":\"PluginA\",\n\t\t\"aOption\":\"foo\",\n\t},\n}\n\nSo what happens? Decode first uses json or yaml to unmarshal the serialized data into your external MyAPIObject. That causes the raw JSON to be stored, but not unpacked. The next step is to copy (using pkg/conversion) into the internal struct. The runtime package's DefaultScheme has conversion functions installed which will unpack the JSON stored in RawExtension, turning it into the correct object type, and storing it in the Object. (TODO: In the case where the object is of an unknown type, a runtime.Unknown object will be created and stored.)",
    "required": [
     "Raw"
    ],
    "properties": {
     "Raw": {
      "description": "Raw is the underlying serialization of this object.",
      "type": "string",
      "format": "byte"
     }
    }
   },
```

**What this PR does / why we need it**:
This PR changes the OpenAPI definition of RawExtension so that any object, array or primitive is accepted. This is the new definition:
```
   "io.k8s.apimachinery.pkg.runtime.RawExtension": {
    "description": "Any value (any object, array or primitive)"
   },
```

**Which issue(s) this PR fixes** 
Fixes https://github.com/kubernetes/kubernetes/issues/55890

**Special notes for your reviewer**:
This PR requires a PR in kube-openapi: https://github.com/kubernetes/kube-openapi/pull/25
I've already vendored the required changes into this PR, even though I'm sure that's not the proper way to do it. I guess I should get the other PR merged first, then properly vendor in the whole kube-openapi in a separate commit, right? Please advise.

**Release note**:
```release-note
NONE
```
