### PR TITLE
Fix AppArmor upgrade test

### DIFF
--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -92,9 +92,6 @@ func (t *AppArmorUpgradeTest) verifyPodStillUp(f *framework.Framework) {
 func (t *AppArmorUpgradeTest) verifyNewPodSucceeds(f *framework.Framework) {
 	By("Verifying an AppArmor profile is enforced for a new pod")
 	common.CreateAppArmorTestPod(f, false, true)
-
-	By("Verifying an unconfined AppArmor profile is enforced for a new pod")
-	common.CreateAppArmorTestPod(f, true, true)
 }
 
 func (t *AppArmorUpgradeTest) verifyNodesAppArmorEnabled(f *framework.Framework) {


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/52395 Introduced the `unconfined` AppArmor profile, but this feature should not be tested in the upgrade test since it doesn't exist prior to 1.9 (so the test always fails when checking it prior to the upgrade).

Fixes #56422

```release-note
NONE
```