### PR TITLE
certs: add month buckets to expiration metric

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -47,6 +47,10 @@ var clientCertificateExpirationHistogram = prometheus.NewHistogram(
 			(2 * 24 * time.Hour).Seconds(),
 			(4 * 24 * time.Hour).Seconds(),
 			(7 * 24 * time.Hour).Seconds(),
+			(30 * 24 * time.Hour).Seconds(),
+			(3 * 30 * 24 * time.Hour).Seconds(),
+			(6 * 30 * 24 * time.Hour).Seconds(),
+			(12 * 30 * 24 * time.Hour).Seconds(),
 		},
 	},
 )


### PR DESCRIPTION
7 days isn't enough warning for cert expiration alerting.

#56444