### PR TITLE
Fixed service controller cache storing failed services

### DIFF
--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -257,8 +257,6 @@ func (s *ServiceController) processServiceUpdate(cachedService *cachedService, s
 		}
 	}
 
-	// cache the service, we need the info for service deletion
-	cachedService.state = service
 	err, retry := s.createLoadBalancerIfNeeded(key, service)
 	if err != nil {
 		message := "Error creating load balancer"
@@ -278,6 +276,7 @@ func (s *ServiceController) processServiceUpdate(cachedService *cachedService, s
 	// NOTE: Since we update the cached service if and only if we successfully
 	// processed it, a cached service being nil implies that it hasn't yet
 	// been successfully processed.
+	cachedService.state = service
 	s.cache.set(key, cachedService)
 
 	cachedService.resetRetryDelay()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

Calling `cachedService.state = service` updates the cachedService object. Since the cache was updated regardless if an error occurred or not it would cause a resync to no-op since it would appear as if no changes had occurred. You can see that in the logs below:
```
I1127 18:58:31.025599       5 service_controller.go:314] Ensuring LB for service e2e-tests-esipp-d8n2b/external-local
I1127 18:59:22.898597       5 service_controller.go:748] Finished syncing service "e2e-tests-esipp-d8n2b/external-local" (51.873000694s)
I1127 19:04:29.256808       5 service_controller.go:304] Deleting existing load balancer for service e2e-tests-esipp-d8n2b/external-local that no longer needs a load balancer.
E1127 19:05:03.225080       5 service_controller.go:774] Failed to process service e2e-tests-esipp-d8n2b/external-local. Retrying in 5s: googleapi: Error 400: The resource 'projects/k8s-jkns-gce-1-3/global/httpHealthChecks/k8s-8c07463df6cc1ea0-node' is not ready, resourceNotReady
I1127 19:05:03.225092       5 service_controller.go:748] Finished syncing service "e2e-tests-esipp-d8n2b/external-local" (34.30973142s)
I1127 19:06:58.303294       5 service_controller.go:748] Finished syncing service "e2e-tests-esipp-d8n2b/external-local" (3.4µs)
I1127 19:21:00.668053       5 service_controller.go:761] Service has been deleted e2e-tests-esipp-d8n2b/external-local
I1127 19:21:00.668090       5 service_controller.go:748] Finished syncing service "e2e-tests-esipp-d8n2b/external-local" (76.104µs)
```

At `19:05:03.225080` an error occurred which caused the service to be requeued; however, since the failed service was cached, the resync at `19:06:58.303294` was a no-op and didn't attempt to delete the load balancer. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #56443

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed service controller caching services that failed and would cause the retry attempt to do nothing.
```

/cc @luxas @thockin @wlan0 @liggitt @MrHohn

/sig network
/area cloudprovider
/priority critical-urgent
/kind bug 