### PR TITLE
Using deepCopy to construct a new pod

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1321,7 +1321,9 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *exten
 }
 
 func NewPod(ds *extensions.DaemonSet, nodeName string) *v1.Pod {
-	newPod := &v1.Pod{Spec: ds.Spec.Template.Spec, ObjectMeta: ds.Spec.Template.ObjectMeta}
+	oldPod := &v1.Pod{Spec: ds.Spec.Template.Spec, ObjectMeta: ds.Spec.Template.ObjectMeta}
+	newPod := oldPod.DeepCopy()
+
 	newPod.Namespace = ds.Namespace
 	newPod.Spec.NodeName = nodeName
 	return newPod


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes, pod's `ObjectMeta` include `map` struct. `shallowCopy` may lead to Panic easily, we should use `deepCopy`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
