### PR TITLE
admissionregistration use shared informer instead of poll

### DIFF
--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1791,6 +1791,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1beta1",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -1812,6 +1816,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1beta1",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
@@ -21,9 +21,12 @@ go_test(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/listers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 
@@ -42,8 +45,13 @@ go_library(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/informers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/listers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -18,84 +18,82 @@ package configuration
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
-
-	"github.com/golang/glog"
+	"sync/atomic"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	admissionregistrationinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
-
-type MutatingWebhookConfigurationLister interface {
-	List(opts metav1.ListOptions) (*v1beta1.MutatingWebhookConfigurationList, error)
-}
 
 // MutatingWebhookConfigurationManager collects the mutating webhook objects so that they can be called.
 type MutatingWebhookConfigurationManager struct {
-	*poller
+	ready         int32
+	configuration *atomic.Value
+	hasSynced     func() bool
+	lister        admissionregistrationlisters.MutatingWebhookConfigurationLister
 }
 
-func NewMutatingWebhookConfigurationManager(c MutatingWebhookConfigurationLister) *MutatingWebhookConfigurationManager {
-	getFn := func() (runtime.Object, error) {
-		list, err := c.List(metav1.ListOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) || errors.IsForbidden(err) {
-				glog.V(5).Infof("MutatingWebhookConfiguration are disabled due to an error: %v", err)
-				return nil, ErrDisabled
-			}
-			return nil, err
-		}
-		return mergeMutatingWebhookConfigurations(list), nil
+func NewMutatingWebhookConfigurationManager(informer admissionregistrationinformers.MutatingWebhookConfigurationInformer) *MutatingWebhookConfigurationManager {
+	manager := &MutatingWebhookConfigurationManager{
+		ready:         0,
+		configuration: &atomic.Value{},
+		hasSynced:     informer.Informer().HasSynced,
+		lister:        informer.Lister(),
 	}
 
-	return &MutatingWebhookConfigurationManager{
-		newPoller(getFn),
-	}
+	// Start with an empty list
+	manager.configuration.Store(&v1beta1.MutatingWebhookConfiguration{})
+
+	// On any change, rebuild the config
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+	})
+
+	return manager
 }
 
 // Webhooks returns the merged MutatingWebhookConfiguration.
-func (im *MutatingWebhookConfigurationManager) Webhooks() (*v1beta1.MutatingWebhookConfiguration, error) {
-	configuration, err := im.poller.configuration()
+func (m *MutatingWebhookConfigurationManager) Webhooks() (*v1beta1.MutatingWebhookConfiguration, error) {
+	if atomic.LoadInt32(&m.ready) == 0 {
+		if !m.hasSynced() {
+			// Return an error until we've synced
+			return nil, fmt.Errorf("mutating webhook configuration is not ready")
+		}
+		// Remember we're ready
+		atomic.StoreInt32(&m.ready, 1)
+	}
+	return m.configuration.Load().(*v1beta1.MutatingWebhookConfiguration), nil
+}
+
+func (m *MutatingWebhookConfigurationManager) updateConfiguration() {
+	configurations, err := m.lister.List(labels.Everything())
 	if err != nil {
-		return nil, err
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		return
 	}
-	mutatingWebhookConfiguration, ok := configuration.(*v1beta1.MutatingWebhookConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("expected type %v, got type %v", reflect.TypeOf(mutatingWebhookConfiguration), reflect.TypeOf(configuration))
-	}
-	return mutatingWebhookConfiguration, nil
+	m.configuration.Store(mergeMutatingWebhookConfigurations(configurations))
 }
 
-func (im *MutatingWebhookConfigurationManager) Run(stopCh <-chan struct{}) {
-	im.poller.Run(stopCh)
-}
-
-func mergeMutatingWebhookConfigurations(
-	list *v1beta1.MutatingWebhookConfigurationList,
-) *v1beta1.MutatingWebhookConfiguration {
-	configurations := append([]v1beta1.MutatingWebhookConfiguration{}, list.Items...)
+func mergeMutatingWebhookConfigurations(configurations []*v1beta1.MutatingWebhookConfiguration) *v1beta1.MutatingWebhookConfiguration {
 	var ret v1beta1.MutatingWebhookConfiguration
 	// The internal order of webhooks for each configuration is provided by the user
 	// but configurations themselves can be in any order. As we are going to run these
 	// webhooks in serial, they are sorted here to have a deterministic order.
-	sort.Sort(byName(configurations))
+	sort.SliceStable(configurations, MutatingWebhookConfigurationSorter(configurations).ByName)
 	for _, c := range configurations {
 		ret.Webhooks = append(ret.Webhooks, c.Webhooks...)
 	}
 	return &ret
 }
 
-// byName sorts MutatingWebhookConfiguration by name. These objects are all in
-// cluster namespace (aka no namespace) thus they all have unique names.
-type byName []v1beta1.MutatingWebhookConfiguration
+type MutatingWebhookConfigurationSorter []*v1beta1.MutatingWebhookConfiguration
 
-func (x byName) Len() int { return len(x) }
-
-func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
-
-func (x byName) Less(i, j int) bool {
-	return x[i].ObjectMeta.Name < x[j].ObjectMeta.Name
+func (a MutatingWebhookConfigurationSorter) ByName(i, j int) bool {
+	return a[i].Name < a[j].Name
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -17,24 +17,118 @@ limitations under the License.
 package configuration
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/labels"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
-type disabledMutatingWebhookConfigLister struct{}
-
-func (l *disabledMutatingWebhookConfigLister) List(options metav1.ListOptions) (*v1beta1.MutatingWebhookConfigurationList, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: "admissionregistration", Resource: "MutatingWebhookConfigurations"}, "")
+type fakeMutatingWebhookConfigSharedInformer struct {
+	informer *fakeMutatingWebhookConfigInformer
+	lister   *fakeMutatingWebhookConfigLister
 }
-func TestMutatingWebhookConfigDisabled(t *testing.T) {
-	manager := NewMutatingWebhookConfigurationManager(&disabledMutatingWebhookConfigLister{})
-	manager.sync()
-	_, err := manager.Webhooks()
-	if err.Error() != ErrDisabled.Error() {
-		t.Errorf("expected %v, got %v", ErrDisabled, err)
+
+func (f *fakeMutatingWebhookConfigSharedInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+func (f *fakeMutatingWebhookConfigSharedInformer) Lister() admissionregistrationlisters.MutatingWebhookConfigurationLister {
+	return f.lister
+}
+
+type fakeMutatingWebhookConfigInformer struct {
+	eventHandler cache.ResourceEventHandler
+	hasSynced    bool
+}
+
+func (f *fakeMutatingWebhookConfigInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	fmt.Println("added handler")
+	f.eventHandler = handler
+}
+func (f *fakeMutatingWebhookConfigInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetStore() cache.Store {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetController() cache.Controller {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) Run(stopCh <-chan struct{}) {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) HasSynced() bool {
+	return f.hasSynced
+}
+func (f *fakeMutatingWebhookConfigInformer) LastSyncResourceVersion() string {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) AddIndexers(indexers cache.Indexers) error {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetIndexer() cache.Indexer { panic("unsupported") }
+
+type fakeMutatingWebhookConfigLister struct {
+	list []*v1beta1.MutatingWebhookConfiguration
+	err  error
+}
+
+func (f *fakeMutatingWebhookConfigLister) List(selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error) {
+	return f.list, f.err
+}
+
+func (f *fakeMutatingWebhookConfigLister) Get(name string) (*v1beta1.MutatingWebhookConfiguration, error) {
+	panic("unsupported")
+}
+
+func TestGetMutatingWebhookConfig(t *testing.T) {
+	informer := &fakeMutatingWebhookConfigSharedInformer{
+		informer: &fakeMutatingWebhookConfigInformer{},
+		lister:   &fakeMutatingWebhookConfigLister{},
+	}
+
+	// unsynced, error retrieving list
+	informer.informer.hasSynced = false
+	informer.lister.list = nil
+	informer.lister.err = fmt.Errorf("mutating webhook configuration is not ready")
+	manager := NewMutatingWebhookConfigurationManager(informer)
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// list found, still unsynced
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.MutatingWebhookConfiguration{}
+	informer.lister.err = nil
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// items populated, still unsynced
+	webhookContainer := &v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+		Webhooks:   []v1beta1.Webhook{{Name: "webhook1.1"}},
+	}
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.MutatingWebhookConfiguration{webhookContainer.DeepCopy()}
+	informer.lister.err = nil
+	informer.informer.eventHandler.OnAdd(webhookContainer.DeepCopy())
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// sync completed
+	informer.informer.hasSynced = true
+	hooks, err := manager.Webhooks()
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	if !reflect.DeepEqual(hooks.Webhooks, webhookContainer.Webhooks) {
+		t.Errorf("Expected\n%#v\ngot\n%#v", webhookContainer.Webhooks, hooks.Webhooks)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -31,17 +31,13 @@ import (
 
 // ValidatingWebhookConfigurationManager collects the validating webhook objects so that they can be called.
 type ValidatingWebhookConfigurationManager struct {
-	ready         int32
 	configuration *atomic.Value
-	hasSynced     func() bool
 	lister        admissionregistrationlisters.ValidatingWebhookConfigurationLister
 }
 
 func NewValidatingWebhookConfigurationManager(informer admissionregistrationinformers.ValidatingWebhookConfigurationInformer) *ValidatingWebhookConfigurationManager {
 	manager := &ValidatingWebhookConfigurationManager{
-		ready:         0,
 		configuration: &atomic.Value{},
-		hasSynced:     informer.Informer().HasSynced,
 		lister:        informer.Lister(),
 	}
 
@@ -59,16 +55,8 @@ func NewValidatingWebhookConfigurationManager(informer admissionregistrationinfo
 }
 
 // Webhooks returns the merged ValidatingWebhookConfiguration.
-func (v *ValidatingWebhookConfigurationManager) Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error) {
-	if atomic.LoadInt32(&v.ready) == 0 {
-		if !v.hasSynced() {
-			// Return an error until we've synced
-			return nil, fmt.Errorf("validating webhook configuration is not ready")
-		}
-		// Remember we're ready
-		atomic.StoreInt32(&v.ready, 1)
-	}
-	return v.configuration.Load().(*v1beta1.ValidatingWebhookConfiguration), nil
+func (v *ValidatingWebhookConfigurationManager) Webhooks() *v1beta1.ValidatingWebhookConfiguration {
+	return v.configuration.Load().(*v1beta1.ValidatingWebhookConfiguration)
 }
 
 func (v *ValidatingWebhookConfigurationManager) updateConfiguration() {

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -18,67 +18,81 @@ package configuration
 
 import (
 	"fmt"
-	"reflect"
-
-	"github.com/golang/glog"
+	"sort"
+	"sync/atomic"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	admissionregistrationinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
-
-type ValidatingWebhookConfigurationLister interface {
-	List(opts metav1.ListOptions) (*v1beta1.ValidatingWebhookConfigurationList, error)
-}
 
 // ValidatingWebhookConfigurationManager collects the validating webhook objects so that they can be called.
 type ValidatingWebhookConfigurationManager struct {
-	*poller
+	ready         int32
+	configuration *atomic.Value
+	hasSynced     func() bool
+	lister        admissionregistrationlisters.ValidatingWebhookConfigurationLister
 }
 
-func NewValidatingWebhookConfigurationManager(c ValidatingWebhookConfigurationLister) *ValidatingWebhookConfigurationManager {
-	getFn := func() (runtime.Object, error) {
-		list, err := c.List(metav1.ListOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) || errors.IsForbidden(err) {
-				glog.V(5).Infof("ValidatingWebhookConfiguration are disabled due to an error: %v", err)
-				return nil, ErrDisabled
-			}
-			return nil, err
-		}
-		return mergeValidatingWebhookConfigurations(list), nil
+func NewValidatingWebhookConfigurationManager(informer admissionregistrationinformers.ValidatingWebhookConfigurationInformer) *ValidatingWebhookConfigurationManager {
+	manager := &ValidatingWebhookConfigurationManager{
+		ready:         0,
+		configuration: &atomic.Value{},
+		hasSynced:     informer.Informer().HasSynced,
+		lister:        informer.Lister(),
 	}
 
-	return &ValidatingWebhookConfigurationManager{
-		newPoller(getFn),
-	}
+	// Start with an empty list
+	manager.configuration.Store(&v1beta1.ValidatingWebhookConfiguration{})
+
+	// On any change, rebuild the config
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+	})
+
+	return manager
 }
 
 // Webhooks returns the merged ValidatingWebhookConfiguration.
-func (im *ValidatingWebhookConfigurationManager) Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error) {
-	configuration, err := im.poller.configuration()
-	if err != nil {
-		return nil, err
+func (v *ValidatingWebhookConfigurationManager) Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error) {
+	if atomic.LoadInt32(&v.ready) == 0 {
+		if !v.hasSynced() {
+			// Return an error until we've synced
+			return nil, fmt.Errorf("validating webhook configuration is not ready")
+		}
+		// Remember we're ready
+		atomic.StoreInt32(&v.ready, 1)
 	}
-	validatingWebhookConfiguration, ok := configuration.(*v1beta1.ValidatingWebhookConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("expected type %v, got type %v", reflect.TypeOf(validatingWebhookConfiguration), reflect.TypeOf(configuration))
-	}
-	return validatingWebhookConfiguration, nil
+	return v.configuration.Load().(*v1beta1.ValidatingWebhookConfiguration), nil
 }
 
-func (im *ValidatingWebhookConfigurationManager) Run(stopCh <-chan struct{}) {
-	im.poller.Run(stopCh)
+func (v *ValidatingWebhookConfigurationManager) updateConfiguration() {
+	configurations, err := v.lister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		return
+	}
+	v.configuration.Store(mergeValidatingWebhookConfigurations(configurations))
 }
 
 func mergeValidatingWebhookConfigurations(
-	list *v1beta1.ValidatingWebhookConfigurationList,
+	configurations []*v1beta1.ValidatingWebhookConfiguration,
 ) *v1beta1.ValidatingWebhookConfiguration {
-	configurations := list.Items
+	sort.SliceStable(configurations, ValidatingWebhookConfigurationSorter(configurations).ByName)
 	var ret v1beta1.ValidatingWebhookConfiguration
 	for _, c := range configurations {
 		ret.Webhooks = append(ret.Webhooks, c.Webhooks...)
 	}
 	return &ret
+}
+
+type ValidatingWebhookConfigurationSorter []*v1beta1.ValidatingWebhookConfiguration
+
+func (a ValidatingWebhookConfigurationSorter) ByName(i, j int) bool {
+	return a[i].Name < a[j].Name
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -17,24 +17,118 @@ limitations under the License.
 package configuration
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/labels"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
-type disabledValidatingWebhookConfigLister struct{}
-
-func (l *disabledValidatingWebhookConfigLister) List(options metav1.ListOptions) (*v1beta1.ValidatingWebhookConfigurationList, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: "admissionregistration", Resource: "ValidatingWebhookConfigurations"}, "")
+type fakeValidatingWebhookConfigSharedInformer struct {
+	informer *fakeValidatingWebhookConfigInformer
+	lister   *fakeValidatingWebhookConfigLister
 }
-func TestWebhookConfigDisabled(t *testing.T) {
-	manager := NewValidatingWebhookConfigurationManager(&disabledValidatingWebhookConfigLister{})
-	manager.sync()
-	_, err := manager.Webhooks()
-	if err.Error() != ErrDisabled.Error() {
-		t.Errorf("expected %v, got %v", ErrDisabled, err)
+
+func (f *fakeValidatingWebhookConfigSharedInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+func (f *fakeValidatingWebhookConfigSharedInformer) Lister() admissionregistrationlisters.ValidatingWebhookConfigurationLister {
+	return f.lister
+}
+
+type fakeValidatingWebhookConfigInformer struct {
+	eventHandler cache.ResourceEventHandler
+	hasSynced    bool
+}
+
+func (f *fakeValidatingWebhookConfigInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	fmt.Println("added handler")
+	f.eventHandler = handler
+}
+func (f *fakeValidatingWebhookConfigInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetStore() cache.Store {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetController() cache.Controller {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) Run(stopCh <-chan struct{}) {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) HasSynced() bool {
+	return f.hasSynced
+}
+func (f *fakeValidatingWebhookConfigInformer) LastSyncResourceVersion() string {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) AddIndexers(indexers cache.Indexers) error {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetIndexer() cache.Indexer { panic("unsupported") }
+
+type fakeValidatingWebhookConfigLister struct {
+	list []*v1beta1.ValidatingWebhookConfiguration
+	err  error
+}
+
+func (f *fakeValidatingWebhookConfigLister) List(selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error) {
+	return f.list, f.err
+}
+
+func (f *fakeValidatingWebhookConfigLister) Get(name string) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	panic("unsupported")
+}
+
+func TestGettValidatingWebhookConfig(t *testing.T) {
+	informer := &fakeValidatingWebhookConfigSharedInformer{
+		informer: &fakeValidatingWebhookConfigInformer{},
+		lister:   &fakeValidatingWebhookConfigLister{},
+	}
+
+	// unsynced, error retrieving list
+	informer.informer.hasSynced = false
+	informer.lister.list = nil
+	informer.lister.err = fmt.Errorf("validating webhook configuration is not ready")
+	manager := NewValidatingWebhookConfigurationManager(informer)
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// list found, still unsynced
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.ValidatingWebhookConfiguration{}
+	informer.lister.err = nil
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// items populated, still unsynced
+	webhookContainer := &v1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+		Webhooks:   []v1beta1.Webhook{{Name: "webhook1.1"}},
+	}
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.ValidatingWebhookConfiguration{webhookContainer.DeepCopy()}
+	informer.lister.err = nil
+	informer.informer.eventHandler.OnAdd(webhookContainer.DeepCopy())
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// sync completed
+	informer.informer.hasSynced = true
+	hooks, err := manager.Webhooks()
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	if !reflect.DeepEqual(hooks.Webhooks, webhookContainer.Webhooks) {
+		t.Errorf("Expected\n%#v\ngot\n%#v", webhookContainer.Webhooks, hooks.Webhooks)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -30,7 +30,6 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/api/admissionregistration/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
@@ -68,7 +67,7 @@ func Register(plugins *admission.Plugins) {
 
 // WebhookSource can list dynamic webhook plugins.
 type WebhookSource interface {
-	Webhooks() (*v1beta1.MutatingWebhookConfiguration, error)
+	Webhooks() *v1beta1.MutatingWebhookConfiguration
 }
 
 // NewMutatingWebhook returns a generic admission webhook plugin.
@@ -150,8 +149,11 @@ func (a *MutatingWebhook) SetExternalKubeClientSet(client clientset.Interface) {
 func (a *MutatingWebhook) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
 	namespaceInformer := f.Core().V1().Namespaces()
 	a.namespaceMatcher.NamespaceLister = namespaceInformer.Lister()
-	a.SetReadyFunc(namespaceInformer.Informer().HasSynced)
-	a.hookSource = configuration.NewMutatingWebhookConfigurationManager(f.Admissionregistration().V1beta1().MutatingWebhookConfigurations())
+	mutatingWebhookConfigurationsInformer := f.Admissionregistration().V1beta1().MutatingWebhookConfigurations()
+	a.hookSource = configuration.NewMutatingWebhookConfigurationManager(mutatingWebhookConfigurationsInformer)
+	a.SetReadyFunc(func() bool {
+		return namespaceInformer.Informer().HasSynced() && mutatingWebhookConfigurationsInformer.Informer().HasSynced()
+	})
 }
 
 // ValidateInitialization implements the InitializationValidator interface.
@@ -177,27 +179,18 @@ func (a *MutatingWebhook) ValidateInitialization() error {
 	return nil
 }
 
-func (a *MutatingWebhook) loadConfiguration(attr admission.Attributes) (*v1beta1.MutatingWebhookConfiguration, error) {
-	hookConfig, err := a.hookSource.Webhooks()
-	if err != nil {
-		e := apierrors.NewServerTimeout(attr.GetResource().GroupResource(), string(attr.GetOperation()), 1)
-		e.ErrStatus.Message = fmt.Sprintf("Unable to refresh the Webhook configuration: %v", err)
-		e.ErrStatus.Reason = "LoadingConfiguration"
-		e.ErrStatus.Details.Causes = append(e.ErrStatus.Details.Causes, metav1.StatusCause{
-			Type:    "MutatingWebhookConfigurationFailure",
-			Message: "An error has occurred while refreshing the MutatingWebhook configuration, no resources can be created/updated/deleted/connected until a refresh succeeds.",
-		})
-		return nil, e
-	}
-	return hookConfig, nil
+func (a *MutatingWebhook) loadConfiguration(attr admission.Attributes) *v1beta1.MutatingWebhookConfiguration {
+	hookConfig := a.hookSource.Webhooks()
+	return hookConfig
 }
 
 // Admit makes an admission decision based on the request attributes.
 func (a *MutatingWebhook) Admit(attr admission.Attributes) error {
-	hookConfig, err := a.loadConfiguration(attr)
-	if err != nil {
-		return err
+	if !a.WaitForReady() {
+		return admission.NewForbidden(attr, fmt.Errorf("not yet ready to handle request"))
 	}
+
+	hookConfig := a.loadConfiguration(attr)
 	hooks := hookConfig.Webhooks
 	ctx := context.TODO()
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission_test.go
@@ -47,16 +47,16 @@ type fakeHookSource struct {
 	err   error
 }
 
-func (f *fakeHookSource) Webhooks() (*registrationv1beta1.MutatingWebhookConfiguration, error) {
+func (f *fakeHookSource) Webhooks() *registrationv1beta1.MutatingWebhookConfiguration {
 	if f.err != nil {
-		return nil, f.err
+		return nil
 	}
 	for i, h := range f.hooks {
 		if h.NamespaceSelector == nil {
 			f.hooks[i].NamespaceSelector = &metav1.LabelSelector{}
 		}
 	}
-	return &registrationv1beta1.MutatingWebhookConfiguration{Webhooks: f.hooks}, nil
+	return &registrationv1beta1.MutatingWebhookConfiguration{Webhooks: f.hooks}
 }
 
 func (f *fakeHookSource) Run(stopCh <-chan struct{}) {}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission_test.go
@@ -47,16 +47,16 @@ type fakeHookSource struct {
 	err   error
 }
 
-func (f *fakeHookSource) Webhooks() (*registrationv1beta1.ValidatingWebhookConfiguration, error) {
+func (f *fakeHookSource) Webhooks() *registrationv1beta1.ValidatingWebhookConfiguration {
 	if f.err != nil {
-		return nil, f.err
+		return nil
 	}
 	for i, h := range f.hooks {
 		if h.NamespaceSelector == nil {
 			f.hooks[i].NamespaceSelector = &metav1.LabelSelector{}
 		}
 	}
-	return &registrationv1beta1.ValidatingWebhookConfiguration{Webhooks: f.hooks}, nil
+	return &registrationv1beta1.ValidatingWebhookConfiguration{Webhooks: f.hooks}
 }
 
 func (f *fakeHookSource) Run(stopCh <-chan struct{}) {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

poll with 1s interval influence apiserver's performance

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56357 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
