### PR TITLE
Remove gke from expected providers of audit e2e test.

### DIFF
--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -53,7 +53,7 @@ var (
 var _ = SIGDescribe("Advanced Audit", func() {
 	f := framework.NewDefaultFramework("audit")
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce", "gke")
+		framework.SkipUnlessProviderIs("gce")
 	})
 
 	It("should audit API calls", func() {


### PR DESCRIPTION
In case of GKE we don't write logs to the file.

```release-note
NONE
```
