### PR TITLE
Fix status messaging when juju masters upgrade

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -102,25 +102,11 @@ def check_for_upgrade_needed():
     add_rbac_roles()
     set_state('reconfigure.authentication.setup')
     remove_state('authentication.setup')
-    if should_reinstall_snaps():
-        set_upgrade_needed()
-
-
-def should_reinstall_snaps():
-    ''' Return true if we should redeploy snaps. '''
-    # Snaps should be upgrades if:
-    # a) channel changed, or
-    # b) the Charms attached snaps (resources) changed
-    config = hookenv.config()
-    previous_channel = config.previous('channel')
-    new_channel = hookenv.config('channel')
-    if new_channel != previous_channel:
-        return True
-
     resources = ['kubectl', 'kube-apiserver', 'kube-controller-manager',
                  'kube-scheduler', 'cdk-addons']
     paths = [hookenv.resource_get(resource) for resource in resources]
-    return any_file_changed(paths)
+    if any_file_changed(paths):
+        set_upgrade_needed()
 
 
 def add_rbac_roles():

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -114,7 +114,6 @@ def check_for_upgrade_needed():
         set_upgrade_needed(forced=True)
 
 
-
 def snap_resources_changed():
     '''
     Check if the snapped resources have changed. The first time this method is


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: When upgrading masters we want to not skip the message prompting the admin to trigger an upgrade action.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```
