### PR TITLE
Allow custom VolumeClaim names in a StatefulSet

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -98,6 +98,12 @@ func getPodName(set *apps.StatefulSet, ordinal int) string {
 // must be a PersistentVolumeClaim from set's VolumeClaims template.
 func getPersistentVolumeClaimName(set *apps.StatefulSet, claim *v1.PersistentVolumeClaim, ordinal int) string {
 	// NOTE: This name format is used by the heuristics for zone spreading in ChooseZoneForVolume
+	// Milo:
+	var volumeClaimBaseName string
+	volumeClaimBaseName = claim.ObjectMeta.Annotations["volumeClaimBaseName"]
+	if volumeClaimBaseName != "" {
+		return fmt.Sprintf("%s-%d", volumeClaimBaseName, ordinal)
+	}
 	return fmt.Sprintf("%s-%s-%d", claim.Name, set.Name, ordinal)
 }
 

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -98,7 +98,6 @@ func getPodName(set *apps.StatefulSet, ordinal int) string {
 // must be a PersistentVolumeClaim from set's VolumeClaims template.
 func getPersistentVolumeClaimName(set *apps.StatefulSet, claim *v1.PersistentVolumeClaim, ordinal int) string {
 	// NOTE: This name format is used by the heuristics for zone spreading in ChooseZoneForVolume
-	// Milo:
 	var volumeClaimBaseName string
 	volumeClaimBaseName = claim.ObjectMeta.Annotations["volumeClaimBaseName"]
 	if volumeClaimBaseName != "" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In our environment we have a department that manages the storage and also creates the VolumeClaims. Those names are preverably short and not prone to changes. StatefulSets use a template for the claims and generate a name like \<claimname\>-\<statefulSet name\>-\<ordinal\>. This means that if somebody likes to change the name of the statefulset the name of the claim should also change. As this happens a lot this creates a lot of work. Allowing for more stable PVC names helps in managing the cluster.
The proposal is to use \<baseName\>-\<ordinal\> where the baseName is user defined.

For example:
```
  volumeClaimTemplates: 
  - metadata: 
      name: myClaim
      annotations: 
        volumeClaimBaseName: storageClaim 
    spec: 
      accessModes: [ "ReadWriteMany" ] 

```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow custom VolumeClaim name in StatefulSet volumeClaimTemplates
```
