### PR TITLE
Backward compatibility in EmptyDirVolumeSource after v1.7.8

### DIFF
--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -14,7 +14,9 @@ go_library(
     tags = ["automanaged"],
     deps = [
         "//pkg/api:go_default_library",
+        "//pkg/features:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -18,7 +18,9 @@ package pod
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // Visitor is called with each object name, and returns true if visiting should continue
@@ -224,4 +226,17 @@ func UpdatePodCondition(status *api.PodStatus, condition *api.PodCondition) bool
 	status.Conditions[conditionIndex] = *condition
 	// Return true if one of the fields have changed.
 	return !isEqual
+}
+
+// DropDisabledAlphaFields removes disabled fields from the pod spec.
+// Back-ported from release-1.8
+// This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a pod spec.
+func DropDisabledAlphaFields(podSpec *api.PodSpec) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+		for i := range podSpec.Volumes {
+			if podSpec.Volumes[i].EmptyDir != nil {
+				podSpec.Volumes[i].EmptyDir.SizeLimit = nil
+			}
+		}
+	}
 }

--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -18,6 +18,7 @@ go_library(
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/api/helper/qos:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/api/validation:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",


### PR DESCRIPTION
In lower versions of k8s client sdk (golang, java..), requests can be incompatible with apiserver after v1.7.8 because of [this commit](https://github.com/kubernetes/kubernetes/commit/4d6da1fd9af5e1a1925848bb3241400c51c20fb4). The field `SizeLimit` in`EmptyDirVolumeSource` struct is no longer a value but a pointer of `resource.Quantity`. And the default value of `SizeLimit` is {"Medium":"", "SizeLimit":"0"} but now a nil.

So this PR make apiserver able to process client request made by lower versions of k8s client sdk without simply throw out an error:
>Forbidden: pod updates may not change fields other than spec.containers[ ].image, spec.initContainers[].image, spec.activeDeadlineSeconds or spec.tolerations (only additions to existing tolerations)


<!--  Thanks for sending a pull request!  Here are some tips for you:
#56381 
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56381 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Provides compatibility of fields SizeLimit in types.EmptyDirVolumeSource since v1.7.8
```
