### PR TITLE
kubectl: point info url to user guide overview

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -221,7 +221,8 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		Long: templates.LongDesc(`
       kubectl controls the Kubernetes cluster manager.
 
-      Find more information at https://github.com/kubernetes/kubernetes.`),
+      Find more information at:
+            https://kubernetes.io/docs/reference/kubectl/overview/`),
 		Run: runHelp,
 		BashCompletionFunction: bashCompletionFunc,
 	}


### PR DESCRIPTION
The kubectl command output suggests a user find more information at the
github source repo, eg:

	$ kubectl --help
	kubectl controls the Kubernetes cluster manager.

	Find more information at https://github.com/kubernetes/kubernetes.

But there is curated user documentation available at, eg:

	https://kubernetes.io/docs/reference/kubectl/overview/

which upon referencing yields a much better experience for a user than the
top of the source repo.

Fixes #56511

Signed-off-by: Tim Pepper <tpepper@vmware.com>

```release-note
NONE
```