### PR TITLE
kubeadm: Fix bugs in the codebase related to upgrades/downgrades

### DIFF
--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/defaults.go
@@ -156,26 +156,24 @@ func SetDefaults_NodeConfiguration(obj *NodeConfiguration) {
 	}
 }
 
-// SetDefaultsEtcdSelfHosted sets defaults for self-hosted etcd
+// SetDefaultsEtcdSelfHosted sets defaults for self-hosted etcd if used
 func SetDefaultsEtcdSelfHosted(obj *MasterConfiguration) {
-	if obj.Etcd.SelfHosted == nil {
-		obj.Etcd.SelfHosted = &SelfHostedEtcd{}
-	}
+	if obj.Etcd.SelfHosted != nil {
+		if obj.Etcd.SelfHosted.ClusterServiceName == "" {
+			obj.Etcd.SelfHosted.ClusterServiceName = DefaultEtcdClusterServiceName
+		}
 
-	if obj.Etcd.SelfHosted.ClusterServiceName == "" {
-		obj.Etcd.SelfHosted.ClusterServiceName = DefaultEtcdClusterServiceName
-	}
+		if obj.Etcd.SelfHosted.EtcdVersion == "" {
+			obj.Etcd.SelfHosted.EtcdVersion = constants.DefaultEtcdVersion
+		}
 
-	if obj.Etcd.SelfHosted.EtcdVersion == "" {
-		obj.Etcd.SelfHosted.EtcdVersion = constants.DefaultEtcdVersion
-	}
+		if obj.Etcd.SelfHosted.OperatorVersion == "" {
+			obj.Etcd.SelfHosted.OperatorVersion = DefaultEtcdOperatorVersion
+		}
 
-	if obj.Etcd.SelfHosted.OperatorVersion == "" {
-		obj.Etcd.SelfHosted.OperatorVersion = DefaultEtcdOperatorVersion
-	}
-
-	if obj.Etcd.SelfHosted.CertificatesDir == "" {
-		obj.Etcd.SelfHosted.CertificatesDir = DefaultEtcdCertDir
+		if obj.Etcd.SelfHosted.CertificatesDir == "" {
+			obj.Etcd.SelfHosted.CertificatesDir = DefaultEtcdCertDir
+		}
 	}
 }
 

--- a/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/kubeadm/v1alpha1/types.go
@@ -147,7 +147,7 @@ type NodeConfiguration struct {
 
 // KubeletConfiguration contains elements describing initial remote configuration of kubelet
 type KubeletConfiguration struct {
-	BaseConfig *kubeletconfigv1alpha1.KubeletConfiguration `json:"baseConfig"`
+	BaseConfig *kubeletconfigv1alpha1.KubeletConfiguration `json:"baseConfig,omitempty"`
 }
 
 // HostPathMount contains elements describing volumes that are mounted from the

--- a/cmd/kubeadm/app/cmd/init.go
+++ b/cmd/kubeadm/app/cmd/init.go
@@ -433,7 +433,7 @@ func (i *Init) Run(out io.Writer) error {
 		// Temporary control plane is up, now we create our self hosted control
 		// plane components and remove the static manifests:
 		fmt.Println("[self-hosted] Creating self-hosted control plane.")
-		if err := selfhostingphase.CreateSelfHostedControlPlane(manifestDir, kubeConfigDir, i.cfg, client, waiter); err != nil {
+		if err := selfhostingphase.CreateSelfHostedControlPlane(manifestDir, kubeConfigDir, i.cfg, client, waiter, i.dryRun); err != nil {
 			return fmt.Errorf("error creating self hosted control plane: %v", err)
 		}
 	}

--- a/cmd/kubeadm/app/cmd/phases/selfhosting.go
+++ b/cmd/kubeadm/app/cmd/phases/selfhosting.go
@@ -103,7 +103,7 @@ func getSelfhostingSubCommand() *cobra.Command {
 
 			// Converts the Static Pod-hosted control plane into a self-hosted one
 			waiter := apiclient.NewKubeWaiter(client, 2*time.Minute, os.Stdout)
-			err = selfhosting.CreateSelfHostedControlPlane(constants.GetStaticPodDirectory(), constants.KubernetesDir, internalcfg, client, waiter)
+			err = selfhosting.CreateSelfHostedControlPlane(constants.GetStaticPodDirectory(), constants.KubernetesDir, internalcfg, client, waiter, false)
 			kubeadmutil.CheckErr(err)
 		},
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -52,8 +52,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  keyFile: ""
 	imageRepository: ""
 	kubeProxy: {}
-	kubeletConfiguration:
-	  baseConfig: null
+	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1
 	networking:
 	  dnsDomain: ""
@@ -86,8 +85,7 @@ func TestPrintConfiguration(t *testing.T) {
 	  keyFile: ""
 	imageRepository: ""
 	kubeProxy: {}
-	kubeletConfiguration:
-	  baseConfig: null
+	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1
 	networking:
 	  dnsDomain: ""
@@ -130,8 +128,7 @@ func TestPrintConfiguration(t *testing.T) {
 	    operatorVersion: v0.1.0
 	imageRepository: ""
 	kubeProxy: {}
-	kubeletConfiguration:
-	  baseConfig: null
+	kubeletConfiguration: {}
 	kubernetesVersion: v1.7.1
 	networking:
 	  dnsDomain: ""

--- a/cmd/kubeadm/app/cmd/upgrade/plan.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan.go
@@ -54,8 +54,8 @@ func NewCmdPlan(parentFlags *cmdUpgradeFlags) *cobra.Command {
 
 // RunPlan takes care of outputting available versions to upgrade to for the user
 func RunPlan(parentFlags *cmdUpgradeFlags) error {
-	// Start with the basics, verify that the cluster is healthy, build a client and a versionGetter. Never set dry-run for plan.
-	upgradeVars, err := enforceRequirements(parentFlags.featureGatesString, parentFlags.kubeConfigPath, parentFlags.cfgPath, parentFlags.printConfig, false, parentFlags.ignorePreflightErrorsSet)
+	// Start with the basics, verify that the cluster is healthy, build a client and a versionGetter. Never dry-run when planning.
+	upgradeVars, err := enforceRequirements(parentFlags, false, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -33,10 +33,10 @@ const (
 	// CoreDNS is alpha in v1.9
 	CoreDNS = "CoreDNS"
 
-	// SelfHosting is beta in v1.8
+	// SelfHosting is beta in v1.9
 	SelfHosting = "SelfHosting"
 
-	// StoreCertsInSecrets is alpha in v1.8
+	// StoreCertsInSecrets is alpha in v1.8 and v1.9
 	StoreCertsInSecrets = "StoreCertsInSecrets"
 
 	// DynamicKubeletConfig is alpha in v1.9
@@ -47,9 +47,10 @@ var v190 = version.MustParseSemantic("v1.9.0-alpha.1")
 
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	SelfHosting:          {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
-	StoreCertsInSecrets:  {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
-	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
+	SelfHosting:         {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Beta}},
+	StoreCertsInSecrets: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}},
+	// We don't want to advertise this feature gate exists in v1.9 to avoid confusion as it is not yet working
+	HighAvailability:     {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190, HiddenInHelpText: true},
 	CoreDNS:              {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
 	DynamicKubeletConfig: {FeatureSpec: utilfeature.FeatureSpec{Default: false, PreRelease: utilfeature.Alpha}, MinimumVersion: v190},
 }
@@ -57,7 +58,8 @@ var InitFeatureGates = FeatureList{
 // Feature represents a feature being gated
 type Feature struct {
 	utilfeature.FeatureSpec
-	MinimumVersion *version.Version
+	MinimumVersion   *version.Version
+	HiddenInHelpText bool
 }
 
 // FeatureList represents a list of feature gates
@@ -113,6 +115,10 @@ func Keys(featureList FeatureList) []string {
 func KnownFeatures(f *FeatureList) []string {
 	var known []string
 	for k, v := range *f {
+		if v.HiddenInHelpText {
+			continue
+		}
+
 		pre := ""
 		if v.PreRelease != utilfeature.GA {
 			pre = fmt.Sprintf("%s - ", v.PreRelease)

--- a/cmd/kubeadm/app/phases/kubelet/kubelet.go
+++ b/cmd/kubeadm/app/phases/kubelet/kubelet.go
@@ -43,7 +43,7 @@ import (
 
 // CreateBaseKubeletConfiguration creates base kubelet configuration for dynamic kubelet configuration feature.
 func CreateBaseKubeletConfiguration(cfg *kubeadmapi.MasterConfiguration, client clientset.Interface) error {
-	fmt.Printf("[kubelet] Uploading a ConfigMap %q in namespace %s with base configuration for the kubelets in the cluster",
+	fmt.Printf("[kubelet] Uploading a ConfigMap %q in namespace %s with base configuration for the kubelets in the cluster\n",
 		kubeadmconstants.KubeletBaseConfigurationConfigMap, metav1.NamespaceSystem)
 
 	_, kubeletCodecs, err := kubeletconfigscheme.NewSchemeAndCodecs()
@@ -95,7 +95,7 @@ func ConsumeBaseKubeletConfiguration(nodeName string) error {
 
 // updateNodeWithConfigMap updates node ConfigSource with KubeletBaseConfigurationConfigMap
 func updateNodeWithConfigMap(client clientset.Interface, nodeName string) error {
-	fmt.Printf("[kubelet] Using Dynamic Kubelet Config for node %q; config sourced from ConfigMap %q in namespace %s",
+	fmt.Printf("[kubelet] Using Dynamic Kubelet Config for node %q; config sourced from ConfigMap %q in namespace %s\n",
 		nodeName, kubeadmconstants.KubeletBaseConfigurationConfigMap, metav1.NamespaceSystem)
 
 	// Loop on every falsy return. Return with an error if raised. Exit successfully if true is returned.
@@ -203,7 +203,7 @@ func getLocalNodeTLSBootstrappedClient() (clientset.Interface, error) {
 
 // WriteInitKubeletConfigToDiskOnMaster writes base kubelet configuration to disk on master.
 func WriteInitKubeletConfigToDiskOnMaster(cfg *kubeadmapi.MasterConfiguration) error {
-	fmt.Printf("[kubelet] Writing base configuration of kubelets to disk on master node %s", cfg.NodeName)
+	fmt.Printf("[kubelet] Writing base configuration of kubelets to disk on master node %s\n", cfg.NodeName)
 
 	_, kubeletCodecs, err := kubeletconfigscheme.NewSchemeAndCodecs()
 	if err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/config:go_default_library",
+        "//cmd/kubeadm/app/util/dryrun:go_default_library",
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/util/version:go_default_library",
         "//pkg/version:go_default_library",

--- a/cmd/kubeadm/app/phases/upgrade/policy.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy.go
@@ -28,6 +28,9 @@ const (
 	// MaximumAllowedMinorVersionUpgradeSkew describes how many minor versions kubeadm can upgrade the control plane version in one go
 	MaximumAllowedMinorVersionUpgradeSkew = 1
 
+	// MaximumAllowedMinorVersionDowngradeSkew describes how many minor versions kubeadm can upgrade the control plane version in one go
+	MaximumAllowedMinorVersionDowngradeSkew = 1
+
 	// MaximumAllowedMinorVersionKubeletSkew describes how many minor versions the control plane version and the kubelet can skew in a kubeadm cluster
 	MaximumAllowedMinorVersionKubeletSkew = 1
 )
@@ -72,23 +75,41 @@ func EnforceVersionPolicies(versionGetter VersionGetter, newK8sVersionStr string
 		skewErrors.Mandatory = append(skewErrors.Mandatory, fmt.Errorf("Specified version to upgrade to %q is equal to or lower than the minimum supported version %q. Please specify a higher version to upgrade to", newK8sVersionStr, clusterVersionStr))
 	}
 
-	// Make sure new version is higher than the current Kubernetes version
-	if clusterVersion.AtLeast(newK8sVersion) {
-		// Even though we don't officially support downgrades, it "should work", and if user(s) need it and are willing to try; they can do so with --force
-		skewErrors.Skippable = append(skewErrors.Skippable, fmt.Errorf("Specified version to upgrade to %q is equal to or lower than the cluster version %q. Downgrades are not supported yet", newK8sVersionStr, clusterVersionStr))
-	} else {
-		// If this code path runs, it's an upgrade (this code will run most of the time)
-		// kubeadm doesn't support upgrades between two minor versions; e.g. a v1.7 -> v1.9 upgrade is not supported. Enforce that here
-		if newK8sVersion.Minor() > clusterVersion.Minor()+MaximumAllowedMinorVersionUpgradeSkew {
-			skewErrors.Mandatory = append(skewErrors.Mandatory, fmt.Errorf("Specified version to upgrade to %q is too high; kubeadm can upgrade only %d minor version at a time", newK8sVersionStr, MaximumAllowedMinorVersionUpgradeSkew))
+	// kubeadm doesn't support upgrades between two minor versions; e.g. a v1.7 -> v1.9 upgrade is not supported right away
+	if newK8sVersion.Minor() > clusterVersion.Minor()+MaximumAllowedMinorVersionUpgradeSkew {
+		tooLargeUpgradeSkewErr := fmt.Errorf("Specified version to upgrade to %q is too high; kubeadm can upgrade only %d minor version at a time", newK8sVersionStr, MaximumAllowedMinorVersionUpgradeSkew)
+		// If the version that we're about to upgrade to is a released version, we should fully enforce this policy
+		// If the version is a CI/dev/experimental version, it's okay to jump two minor version steps, but then require the -f flag
+		if len(newK8sVersion.PreRelease()) == 0 {
+			skewErrors.Mandatory = append(skewErrors.Mandatory, tooLargeUpgradeSkewErr)
+		} else {
+			skewErrors.Skippable = append(skewErrors.Skippable, tooLargeUpgradeSkewErr)
+		}
+	}
+
+	// kubeadm doesn't support downgrades between two minor versions; e.g. a v1.9 -> v1.7 downgrade is not supported right away
+	if newK8sVersion.Minor() < clusterVersion.Minor()-MaximumAllowedMinorVersionDowngradeSkew {
+		tooLargeDowngradeSkewErr := fmt.Errorf("Specified version to downgrade to %q is too low; kubeadm can downgrade only %d minor version at a time", newK8sVersionStr, MaximumAllowedMinorVersionDowngradeSkew)
+		// If the version that we're about to downgrade to is a released version, we should fully enforce this policy
+		// If the version is a CI/dev/experimental version, it's okay to jump two minor version steps, but then require the -f flag
+		if len(newK8sVersion.PreRelease()) == 0 {
+			skewErrors.Mandatory = append(skewErrors.Mandatory, tooLargeDowngradeSkewErr)
+		} else {
+			skewErrors.Skippable = append(skewErrors.Skippable, tooLargeDowngradeSkewErr)
 		}
 	}
 
 	// If the kubeadm version is lower than what we want to upgrade to; error
 	if kubeadmVersion.LessThan(newK8sVersion) {
 		if newK8sVersion.Minor() > kubeadmVersion.Minor() {
-			// This is totally unsupported; kubeadm has no idea how it should handle a newer minor release than itself
-			skewErrors.Mandatory = append(skewErrors.Mandatory, fmt.Errorf("Specified version to upgrade to %q is one minor release higher than the kubeadm minor release (%d > %d). Such an upgrade is not supported", newK8sVersionStr, newK8sVersion.Minor(), kubeadmVersion.Minor()))
+			tooLargeKubeadmSkew := fmt.Errorf("Specified version to upgrade to %q is at least one minor release higher than the kubeadm minor release (%d > %d). Such an upgrade is not supported", newK8sVersionStr, newK8sVersion.Minor(), kubeadmVersion.Minor())
+			// This is unsupported; kubeadm has no idea how it should handle a newer minor release than itself
+			// If the version is a CI/dev/experimental version though, lower the severity of this check, but then require the -f flag
+			if len(newK8sVersion.PreRelease()) == 0 {
+				skewErrors.Mandatory = append(skewErrors.Mandatory, tooLargeKubeadmSkew)
+			} else {
+				skewErrors.Skippable = append(skewErrors.Skippable, tooLargeKubeadmSkew)
+			}
 		} else {
 			// Upgrading to a higher patch version than kubeadm is ok if the user specifies --force. Not recommended, but possible.
 			skewErrors.Skippable = append(skewErrors.Skippable, fmt.Errorf("Specified version to upgrade to %q is higher than the kubeadm version %q. Upgrade kubeadm first using the tool you used to install kubeadm", newK8sVersionStr, kubeadmVersionStr))

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -46,23 +46,21 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			},
 			newK8sVersion: "v1.9.0",
 		},
-		{ // downgrades not supported
+		{ // downgrades ok
 			vg: &fakeVersionGetter{
 				clusterVersion: "v1.8.3",
 				kubeletVersion: "v1.8.3",
 				kubeadmVersion: "v1.8.3",
 			},
-			newK8sVersion:         "v1.8.2",
-			expectedSkippableErrs: 1,
+			newK8sVersion: "v1.8.2",
 		},
-		{ // upgrades without bumping the version number not supported yet. TODO: Change this?
+		{ // upgrades without bumping the version number ok
 			vg: &fakeVersionGetter{
 				clusterVersion: "v1.8.3",
 				kubeletVersion: "v1.8.3",
 				kubeadmVersion: "v1.8.3",
 			},
-			newK8sVersion:         "v1.8.3",
-			expectedSkippableErrs: 1,
+			newK8sVersion: "v1.8.3",
 		},
 		{ // new version must be higher than v1.8.0
 			vg: &fakeVersionGetter{
@@ -72,7 +70,6 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			},
 			newK8sVersion:         "v1.7.10",
 			expectedMandatoryErrs: 1, // version must be higher than v1.8.0
-			expectedSkippableErrs: 1, // version shouldn't be downgraded
 		},
 		{ // upgrading two minor versions in one go is not supported
 			vg: &fakeVersionGetter{
@@ -83,6 +80,15 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			newK8sVersion:         "v1.10.0",
 			expectedMandatoryErrs: 1, // can't upgrade two minor versions
 			expectedSkippableErrs: 1, // kubelet <-> apiserver skew too large
+		},
+		{ // downgrading two minor versions in one go is not supported
+			vg: &fakeVersionGetter{
+				clusterVersion: "v1.10.3",
+				kubeletVersion: "v1.10.3",
+				kubeadmVersion: "v1.10.0",
+			},
+			newK8sVersion:         "v1.8.3",
+			expectedMandatoryErrs: 1, // can't downgrade two minor versions
 		},
 		{ // kubeadm version must be higher than the new kube version. However, patch version skews may be forced
 			vg: &fakeVersionGetter{

--- a/cmd/kubeadm/app/phases/upgrade/postupgrade_v18_19.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade_v18_19.go
@@ -30,7 +30,9 @@ import (
 	"k8s.io/kubernetes/pkg/util/version"
 )
 
+// TODO: Maybe move these constants elsewhere in future releases
 var v190 = version.MustParseSemantic("v1.9.0")
+var v190alpha3 = version.MustParseSemantic("v1.9.0-alpha.3")
 var expiry = 180 * 24 * time.Hour
 
 // backupAPIServerCertAndKey backups the old cert and key of kube-apiserver to a specified directory.

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -107,6 +107,15 @@ func DeleteDaemonSetForeground(client clientset.Interface, namespace, name strin
 	return client.AppsV1beta2().DaemonSets(namespace).Delete(name, deleteOptions)
 }
 
+// DeleteDeploymentForeground deletes the specified Deployment in foreground mode; i.e. it blocks until/makes sure all the managed Pods are deleted
+func DeleteDeploymentForeground(client clientset.Interface, namespace, name string) error {
+	foregroundDelete := metav1.DeletePropagationForeground
+	deleteOptions := &metav1.DeleteOptions{
+		PropagationPolicy: &foregroundDelete,
+	}
+	return client.AppsV1beta2().Deployments(namespace).Delete(name, deleteOptions)
+}
+
 // CreateOrUpdateRole creates a Role if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
 func CreateOrUpdateRole(client clientset.Interface, role *rbac.Role) error {
 	if _, err := client.RbacV1().Roles(role.ObjectMeta.Namespace).Create(role); err != nil {

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -80,7 +80,7 @@ func checkErr(prefix string, err error, handleErr func(string, int)) {
 func FormatErrMsg(errs []error) string {
 	var errMsg string
 	for _, err := range errs {
-		errMsg = fmt.Sprintf("%s\t-%s\n", errMsg, err.Error())
+		errMsg = fmt.Sprintf("%s\t- %s\n", errMsg, err.Error())
 	}
 	return errMsg
 }

--- a/cmd/kubeadm/app/util/error_test.go
+++ b/cmd/kubeadm/app/util/error_test.go
@@ -64,13 +64,13 @@ func TestFormatErrMsg(t *testing.T) {
 				fmt.Errorf(errMsg1),
 				fmt.Errorf(errMsg2),
 			},
-			expect: "\t-" + errMsg1 + "\n" + "\t-" + errMsg2 + "\n",
+			expect: "\t- " + errMsg1 + "\n" + "\t- " + errMsg2 + "\n",
 		},
 		{
 			errs: []error{
 				fmt.Errorf(errMsg1),
 			},
-			expect: "\t-" + errMsg1 + "\n",
+			expect: "\t- " + errMsg1 + "\n",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes bugs related to the upgrade / downgrade paths I found in the codebase
Hides the HighAvailability flag from help text as that feature didn't make it in fully
Fixes some small things in defaulting and the config JSON schema
Fixes a bug when cloud-config is referenced but not mounted into the static pod

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
@kubernetes/sig-cluster-lifecycle-pr-reviews 