### PR TITLE
prevent duplicate resources when expanding an alias

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -484,8 +484,16 @@ func (b *Builder) ReplaceAliases(input string) string {
 	replaced := []string{}
 	for _, arg := range strings.Split(input, ",") {
 		if resources, ok := b.categoryExpander.Expand(arg); ok {
+			seen := sets.NewString()
 			asStrings := []string{}
 			for _, resource := range resources {
+				// prevent a resource in multiple groups from
+				// being expanded more than once per alias
+				if seen.Has(resource.Resource) {
+					continue
+				}
+				seen.Insert(resource.Resource)
+
 				if len(resource.Group) == 0 {
 					asStrings = append(asStrings, resource.Resource)
 					continue


### PR DESCRIPTION
**Release note**:
```release-note
NONE
```

Prevent an alias (such as "all") from mapping to duplicate resources
when a resource exists in multiple groups.
Related downstream issue: https://github.com/openshift/origin/issues/17446

cc @kubernetes/sig-cli-misc @fabianofranz @mfojtik 