### PR TITLE
Updates Kubeproxy validators to allow Windows 'kernelspace' mode.

### DIFF
--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -152,11 +152,13 @@ type KubeProxyConfiguration struct {
 	ConfigSyncPeriod metav1.Duration
 }
 
-// Currently two modes of proxying are available: 'userspace' (older, stable) or 'iptables'
-// (newer, faster). If blank, use the best-available proxy (currently iptables, but may
-// change in future versions).  If the iptables proxy is selected, regardless of how, but
-// the system's kernel or iptables versions are insufficient, this always falls back to the
-// userspace proxy.
+// Currently, four modes of proxying are available total: 'userspace' (older, stable), 'iptables'
+// (newer, faster), 'ipvs', and 'kernelspace' (Windows only, newer).
+//
+// If blank, use the best-available proxy (currently iptables, but may change in
+// future versions). If the iptables proxy is selected, regardless of how, but
+// the system's kernel or iptables versions are insufficient, this always falls
+// back to the userspace proxy.
 type ProxyMode string
 
 const (

--- a/pkg/proxy/apis/kubeproxyconfig/types.go
+++ b/pkg/proxy/apis/kubeproxyconfig/types.go
@@ -160,9 +160,10 @@ type KubeProxyConfiguration struct {
 type ProxyMode string
 
 const (
-	ProxyModeUserspace ProxyMode = "userspace"
-	ProxyModeIPTables  ProxyMode = "iptables"
-	ProxyModeIPVS      ProxyMode = "ipvs"
+	ProxyModeUserspace   ProxyMode = "userspace"
+	ProxyModeIPTables    ProxyMode = "iptables"
+	ProxyModeIPVS        ProxyMode = "ipvs"
+	ProxyModeKernelspace ProxyMode = "kernelspace"
 )
 
 // IPVSSchedulerMethod is the algorithm for allocating TCP connections and

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation.go
@@ -146,9 +146,10 @@ func validateProxyMode(mode kubeproxyconfig.ProxyMode, fldPath *field.Path) fiel
 	case kubeproxyconfig.ProxyModeUserspace:
 	case kubeproxyconfig.ProxyModeIPTables:
 	case kubeproxyconfig.ProxyModeIPVS:
+	case kubeproxyconfig.ProxyModeKernelspace:
 	case "":
 	default:
-		modes := []string{string(kubeproxyconfig.ProxyModeUserspace), string(kubeproxyconfig.ProxyModeIPTables), string(kubeproxyconfig.ProxyModeIPVS)}
+		modes := []string{string(kubeproxyconfig.ProxyModeUserspace), string(kubeproxyconfig.ProxyModeIPTables), string(kubeproxyconfig.ProxyModeIPVS), string(kubeproxyconfig.ProxyModeKernelspace)}
 		errMsg := fmt.Sprintf("must be %s or blank (blank means the best-available proxy (currently iptables)", strings.Join(modes, ","))
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("ProxyMode"), string(mode), errMsg))
 	}

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -510,7 +510,7 @@ func TestValidateProxyMode(t *testing.T) {
 	}{
 		{
 			mode: kubeproxyconfig.ProxyMode("non-existing"),
-			msg:  "or blank (blank means the best-available proxy [currently iptables])",
+			msg:  "or blank (blank means the",
 		},
 	}
 

--- a/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
+++ b/pkg/proxy/apis/kubeproxyconfig/validation/validation_test.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -488,9 +489,13 @@ func TestValidateProxyMode(t *testing.T) {
 	newPath := field.NewPath("KubeProxyConfiguration")
 	successCases := []kubeproxyconfig.ProxyMode{
 		kubeproxyconfig.ProxyModeUserspace,
-		kubeproxyconfig.ProxyModeIPTables,
-		kubeproxyconfig.ProxyModeIPVS,
 		kubeproxyconfig.ProxyMode(""),
+	}
+
+	if runtime.GOOS == "windows" {
+		successCases = append(successCases, kubeproxyconfig.ProxyModeKernelspace)
+	} else {
+		successCases = append(successCases, kubeproxyconfig.ProxyModeIPTables, kubeproxyconfig.ProxyModeIPVS)
 	}
 
 	for _, successCase := range successCases {
@@ -505,13 +510,13 @@ func TestValidateProxyMode(t *testing.T) {
 	}{
 		{
 			mode: kubeproxyconfig.ProxyMode("non-existing"),
-			msg:  "or blank (blank means the best-available proxy (currently iptables)",
+			msg:  "or blank (blank means the best-available proxy [currently iptables])",
 		},
 	}
 
 	for _, errorCase := range errorCases {
 		if errs := validateProxyMode(errorCase.mode, newPath.Child("ProxyMode")); len(errs) == 0 {
-			t.Errorf("expected failure for %s", errorCase.msg)
+			t.Errorf("expected failure %s for %v", errorCase.msg, errorCase.mode)
 		} else if !strings.Contains(errs[0].Error(), errorCase.msg) {
 			t.Errorf("unexpected error: %v, expected: %s", errs[0], errorCase.msg)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 
Allows necessary `--proxy-mode` parameter in Kubeproxy, so that it can proceed as usual on Windows.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*: 
Fixes #56522

```release-note
NONE
```