### PR TITLE
should not ignore error when register rate limiter metric for controller

### DIFF
--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -67,7 +67,7 @@ func NewNamespaceController(
 	discoverResourcesFn func() ([]*metav1.APIResourceList, error),
 	namespaceInformer coreinformers.NamespaceInformer,
 	resyncPeriod time.Duration,
-	finalizerToken v1.FinalizerName) *NamespaceController {
+	finalizerToken v1.FinalizerName) (*NamespaceController, error) {
 
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
@@ -76,7 +76,9 @@ func NewNamespaceController(
 	}
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("namespace_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 
 	// configure the namespace informer event handlers
@@ -96,7 +98,7 @@ func NewNamespaceController(
 	namespaceController.lister = namespaceInformer.Lister()
 	namespaceController.listerSynced = namespaceInformer.Informer().HasSynced
 
-	return namespaceController
+	return namespaceController, nil
 }
 
 // enqueueNamespace adds an object to the controller work queue

--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -250,7 +250,10 @@ func NewNodeController(
 		})
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("node_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
+
 	}
 
 	if allocateNodeCIDRs {

--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -65,9 +65,11 @@ type RouteController struct {
 	recorder         record.EventRecorder
 }
 
-func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInformer coreinformers.NodeInformer, clusterName string, clusterCIDR *net.IPNet) *RouteController {
+func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInformer coreinformers.NodeInformer, clusterName string, clusterCIDR *net.IPNet) (*RouteController, error) {
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {
-		metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter())
+		if err := metrics.RegisterMetricAndTrackRateLimiterUsage("route_controller", kubeClient.CoreV1().RESTClient().GetRateLimiter()); err != nil {
+			return nil, err
+		}
 	}
 
 	if clusterCIDR == nil {
@@ -89,7 +91,7 @@ func New(routes cloudprovider.Routes, kubeClient clientset.Interface, nodeInform
 		recorder:         recorder,
 	}
 
-	return rc
+	return rc, nil
 }
 
 func (rc *RouteController) Run(stopCh <-chan struct{}, syncPeriod time.Duration) {


### PR DESCRIPTION
**What this PR does / why we need it**:
`metrics.RegisterMetricAndTrackRateLimiterUsage` method will return messages about register rate limiter metric for controller, we should not ignore it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
