### PR TITLE
kubelet: add flag for docker custom http headers

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -352,6 +352,7 @@ func UnsecuredDependencies(s *options.KubeletServer) (*kubelet.Dependencies, err
 			DockerEndpoint:            s.DockerEndpoint,
 			RuntimeRequestTimeout:     s.RuntimeRequestTimeout.Duration,
 			ImagePullProgressDeadline: s.ImagePullProgressDeadline.Duration,
+			CustomHTTPHeaders:         s.DockerCustomHTTPHeaders,
 		}
 	}
 
@@ -1115,6 +1116,7 @@ func RunDockershim(f *options.KubeletFlags, c *kubeletconfiginternal.KubeletConf
 		DockerEndpoint:            r.DockerEndpoint,
 		RuntimeRequestTimeout:     c.RuntimeRequestTimeout.Duration,
 		ImagePullProgressDeadline: r.ImagePullProgressDeadline.Duration,
+		CustomHTTPHeaders:         r.DockerCustomHTTPHeaders,
 	}
 
 	// Initialize network plugin settings.

--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -75,6 +75,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/util/flag"
 )
 
 type ContainerRuntimeOptions struct {
@@ -53,6 +54,10 @@ type ContainerRuntimeOptions struct {
 	// the image pulling will be cancelled. Defaults to 1m0s.
 	// +optional
 	ImagePullProgressDeadline metav1.Duration
+	// This flag, if set, it will set the custom http headers for docker client.
+	// see: https://docs.docker.com/engine/reference/commandline/cli/#configuration-files
+	// +optional
+	DockerCustomHTTPHeaders map[string]string
 
 	// Network plugin options.
 
@@ -88,6 +93,7 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("The image whose network/ipc namespaces containers in each pod will use. %s", dockerOnlyWarning))
 	fs.StringVar(&s.DockerEndpoint, "docker-endpoint", s.DockerEndpoint, fmt.Sprintf("Use this for the docker endpoint to communicate with %s", dockerOnlyWarning))
 	fs.DurationVar(&s.ImagePullProgressDeadline.Duration, "image-pull-progress-deadline", s.ImagePullProgressDeadline.Duration, fmt.Sprintf("If no pulling progress is made before this deadline, the image pulling will be cancelled. %s", dockerOnlyWarning))
+	fs.Var(flag.NewMapStringString(&s.DockerCustomHTTPHeaders), "docker-custom-http-headers", fmt.Sprintf("The http headers set for the docker client, the header will pass to the docker daemon. %s", dockerOnlyWarning))
 
 	// Network plugin settings for Docker.
 	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, fmt.Sprintf("<Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle. %s", dockerOnlyWarning))

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -162,6 +162,7 @@ type ClientConfig struct {
 	DockerEndpoint            string
 	RuntimeRequestTimeout     time.Duration
 	ImagePullProgressDeadline time.Duration
+	CustomHTTPHeaders         map[string]string
 
 	// Configuration for fake docker client
 	EnableSleep       bool
@@ -177,6 +178,7 @@ func NewDockerClientFromConfig(config *ClientConfig) libdocker.Interface {
 			config.DockerEndpoint,
 			config.RuntimeRequestTimeout,
 			config.ImagePullProgressDeadline,
+			config.CustomHTTPHeaders,
 			config.WithTraceDisabled,
 			config.EnableSleep,
 		)

--- a/pkg/kubelet/dockershim/libdocker/client.go
+++ b/pkg/kubelet/dockershim/libdocker/client.go
@@ -85,7 +85,7 @@ func getDockerClient(dockerEndpoint string) (*dockerapi.Client, error) {
 // will be cancelled and throw out an error. If requestTimeout is 0, a default
 // value will be applied.
 func ConnectToDockerOrDie(dockerEndpoint string, requestTimeout, imagePullProgressDeadline time.Duration,
-	withTraceDisabled bool, enableSleep bool) Interface {
+	headers map[string]string, withTraceDisabled bool, enableSleep bool) Interface {
 	if dockerEndpoint == FakeDockerEndpoint {
 		fakeClient := NewFakeDockerClient()
 		if withTraceDisabled {
@@ -101,6 +101,7 @@ func ConnectToDockerOrDie(dockerEndpoint string, requestTimeout, imagePullProgre
 	if err != nil {
 		glog.Fatalf("Couldn't connect to docker: %v", err)
 	}
+	client.SetCustomHTTPHeaders(headers)
 	glog.Infof("Start docker client with request timeout=%v", requestTimeout)
 	return newKubeDockerClient(client, requestTimeout, imagePullProgressDeadline)
 }


### PR DESCRIPTION
docker api allows you to set custom http headers, which would be
sent to the docker daemon. This PR enables this possiblity with a
new flag in kubelet.

```release-note
NONE
```