### PR TITLE
change default azure file/dir mode to 0755

### DIFF
--- a/pkg/volume/azure_file/azure_util.go
+++ b/pkg/volume/azure_file/azure_util.go
@@ -30,8 +30,8 @@ const (
 	fileMode        = "file_mode"
 	dirMode         = "dir_mode"
 	vers            = "vers"
-	defaultFileMode = "0700"
-	defaultDirMode  = "0700"
+	defaultFileMode = "0755"
+	defaultDirMode  = "0755"
 	defaultVers     = "3.0"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
change default azure file/dir mode to 0755, users complain current `0700` value a lot.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54610

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
change default azure file/dir mode to 0755
```
/sig azure
/assign @rootfs 
