### PR TITLE
validate externalTrafficPolicy: local when feature gate AllowExtTrafficLocalEndpoints not enabled

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -3596,6 +3596,10 @@ func validateServiceExternalTrafficFieldsValue(service *core.Service) field.Erro
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("externalTrafficPolicy"), service.Spec.ExternalTrafficPolicy,
 			fmt.Sprintf("ExternalTrafficPolicy must be empty, %v or %v", core.ServiceExternalTrafficPolicyTypeCluster, core.ServiceExternalTrafficPolicyTypeLocal)))
 	}
+	if service.Spec.ExternalTrafficPolicy == core.ServiceExternalTrafficPolicyTypeLocal &&
+		!utilfeature.DefaultFeatureGate.Enabled(features.ExternalTrafficLocalOnly) {
+		allErrs = append(allErrs, field.Forbidden(field.NewPath("spec", "externalTrafficPolicy"), "externalTrafficPolicy: Local may only be set if the AllowExtTrafficLocalEndpoints feature gate is enabled)"))
+	}
 	if service.Spec.HealthCheckNodePort < 0 {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("healthCheckNodePort"), service.Spec.HealthCheckNodePort,
 			"HealthCheckNodePort must be not less than 0"))


### PR DESCRIPTION

**What this PR does / why we need it**:
When set `externalTrafficPolicy: Local`, if feature gate is disabled, will slightly fall back to other mode, it maybe not make sense to users.
See talk in this pr: #56319
In this pr ,we will validate this situation and error out tell users to enable feature gate `AllowExtTrafficLocalEndpoints`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
