### PR TITLE
apimachinery: improve error handling for unstructured helpers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured.go
@@ -138,8 +138,8 @@ func (u *Unstructured) setNestedMap(value map[string]string, fields ...string) {
 }
 
 func (u *Unstructured) GetOwnerReferences() []metav1.OwnerReference {
-	field, ok := nestedFieldNoCopy(u.Object, "metadata", "ownerReferences")
-	if !ok {
+	field, found, err := nestedFieldNoCopy(u.Object, "metadata", "ownerReferences")
+	if !found || err != nil {
 		return nil
 	}
 	original, ok := field.([]interface{})
@@ -228,8 +228,8 @@ func (u *Unstructured) SetResourceVersion(version string) {
 }
 
 func (u *Unstructured) GetGeneration() int64 {
-	val, ok := NestedInt64(u.Object, "metadata", "generation")
-	if !ok {
+	val, found, err := NestedInt64(u.Object, "metadata", "generation")
+	if !found || err != nil {
 		return 0
 	}
 	return val
@@ -289,8 +289,8 @@ func (u *Unstructured) SetDeletionTimestamp(timestamp *metav1.Time) {
 }
 
 func (u *Unstructured) GetDeletionGracePeriodSeconds() *int64 {
-	val, ok := NestedInt64(u.Object, "metadata", "deletionGracePeriodSeconds")
-	if !ok {
+	val, found, err := NestedInt64(u.Object, "metadata", "deletionGracePeriodSeconds")
+	if !found || err != nil {
 		return nil
 	}
 	return &val
@@ -305,7 +305,7 @@ func (u *Unstructured) SetDeletionGracePeriodSeconds(deletionGracePeriodSeconds 
 }
 
 func (u *Unstructured) GetLabels() map[string]string {
-	m, _ := NestedStringMap(u.Object, "metadata", "labels")
+	m, _, _ := NestedStringMap(u.Object, "metadata", "labels")
 	return m
 }
 
@@ -314,7 +314,7 @@ func (u *Unstructured) SetLabels(labels map[string]string) {
 }
 
 func (u *Unstructured) GetAnnotations() map[string]string {
-	m, _ := NestedStringMap(u.Object, "metadata", "annotations")
+	m, _, _ := NestedStringMap(u.Object, "metadata", "annotations")
 	return m
 }
 
@@ -337,8 +337,8 @@ func (u *Unstructured) GroupVersionKind() schema.GroupVersionKind {
 }
 
 func (u *Unstructured) GetInitializers() *metav1.Initializers {
-	m, ok := nestedMapNoCopy(u.Object, "metadata", "initializers")
-	if !ok {
+	m, found, err := nestedMapNoCopy(u.Object, "metadata", "initializers")
+	if !found || err != nil {
 		return nil
 	}
 	out := &metav1.Initializers{}
@@ -362,7 +362,7 @@ func (u *Unstructured) SetInitializers(initializers *metav1.Initializers) {
 }
 
 func (u *Unstructured) GetFinalizers() []string {
-	val, _ := NestedStringSlice(u.Object, "metadata", "finalizers")
+	val, _, _ := NestedStringSlice(u.Object, "metadata", "finalizers")
 	return val
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructured_list_test.go
@@ -35,8 +35,9 @@ func TestUnstructuredList(t *testing.T) {
 	content := list.UnstructuredContent()
 	items := content["items"].([]interface{})
 	require.Len(t, items, 1)
-	val, ok := NestedFieldCopy(items[0].(map[string]interface{}), "metadata", "name")
-	require.True(t, ok)
+	val, found, err := NestedFieldCopy(items[0].(map[string]interface{}), "metadata", "name")
+	require.True(t, found)
+	require.NoError(t, err)
 	assert.Equal(t, "test", val)
 }
 


### PR DESCRIPTION
Improve error handling for unstructured helpers to give more information - if the field is missing or a wrong type exists. (taken from https://github.com/kubernetes/kubernetes/pull/55168)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts ash2k 