### PR TITLE
Add wildcard tolerations to kube-proxy

### DIFF
--- a/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
+++ b/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml
@@ -22,6 +22,10 @@ spec:
             - matchExpressions:
               - key: cloud.google.com/gke-accelerator
                 operator: Exists
+      tolerations:
+      - key: "nvidia.com/gpu"
+        effect: "NoSchedule"
+        operator: "Exists"
       hostNetwork: true
       hostPID: true
       volumes:

--- a/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
+++ b/cluster/addons/fluentd-gcp/fluentd-gcp-ds.yaml
@@ -107,7 +107,6 @@ spec:
         effect: "NoSchedule"
       - operator: "Exists"
         effect: "NoExecute"
-      #TODO: remove this toleration once #44445 is properly fixed.
       - operator: "Exists"
         effect: "NoSchedule"
       terminationGracePeriodSeconds: 30

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -28,6 +28,11 @@ spec:
       hostNetwork: true
       nodeSelector:
         beta.kubernetes.io/kube-proxy-ds-ready: "true"
+      tolerations:
+      - operator: "Exists"
+        effect: "NoExecute"
+      - operator: "Exists"
+        effect: "NoSchedule"
       containers:
       - name: kube-proxy
         image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -65,6 +65,11 @@ metadata:
 spec:
   {{pod_priority}}
   hostNetwork: true
+  tolerations:
+  - operator: "Exists"
+    effect: "NoExecute"
+  - operator: "Exists"
+    effect: "NoSchedule"
   containers:
   - name: kube-proxy
     image: {{pillar['kube_docker_registry']}}/kube-proxy:{{pillar['kube-proxy_docker_tag']}}


### PR DESCRIPTION
- Add wildcard tolerations to kube-proxy.
- Add `nvidia.com/gpu` toleration to nvidia-gpu-device-plugin.

Related to #55080 and #44445.

/kind bug
/priority critical-urgent
/sig scheduling

**Release note**:
```release-note
kube-proxy addon tolerates all NoExecute and NoSchedule taints by default.
```

/assign @davidopp @bsalamat @vishh @jiayingz 