### PR TITLE
using bool instead of error

### DIFF
--- a/pkg/api/ref/ref.go
+++ b/pkg/api/ref/ref.go
@@ -65,8 +65,8 @@ func GetReference(scheme *runtime.Scheme, obj runtime.Object) (*api.ObjectRefere
 	var listMeta metav1.Common
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
-		listMeta, err = meta.CommonAccessor(obj)
-		if err != nil {
+		listMeta, boolean = meta.CommonAccessor(obj)
+		if !boolean {
 			return nil, err
 		}
 	} else {

--- a/pkg/printers/humanreadable.go
+++ b/pkg/printers/humanreadable.go
@@ -530,7 +530,7 @@ func (h *HumanReadablePrinter) PrintTable(obj runtime.Object, options PrintOptio
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
 	} else {
-		if m, err := meta.CommonAccessor(obj); err == nil {
+		if m, boolean := meta.CommonAccessor(obj); boolean {
 			table.ResourceVersion = m.GetResourceVersion()
 			table.SelfLink = m.GetSelfLink()
 		}

--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/meta.go
@@ -36,34 +36,33 @@ var errNotList = fmt.Errorf("object does not implement the List interfaces")
 
 var errNotCommon = fmt.Errorf("object does not implement the common interface for accessing the SelfLink")
 
-// CommonAccessor returns a Common interface for the provided object or an error if the object does
-// not provide List.
-// TODO: return bool instead of error
-func CommonAccessor(obj interface{}) (metav1.Common, error) {
+// CommonAccessor returns a Common interface for the provided object or a boolean value wether the object to
+// provide List.
+func CommonAccessor(obj interface{}) (metav1.Common, bool) {
 	switch t := obj.(type) {
 	case List:
-		return t, nil
+		return t, true
 	case metav1.ListInterface:
-		return t, nil
+		return t, true
 	case ListMetaAccessor:
 		if m := t.GetListMeta(); m != nil {
-			return m, nil
+			return m, true
 		}
-		return nil, errNotCommon
+		return nil, false
 	case metav1.ListMetaAccessor:
 		if m := t.GetListMeta(); m != nil {
-			return m, nil
+			return m, true
 		}
-		return nil, errNotCommon
+		return nil, false
 	case metav1.Object:
-		return t, nil
+		return t, true
 	case metav1.ObjectMetaAccessor:
 		if m := t.GetObjectMeta(); m != nil {
-			return m, nil
+			return m, true
 		}
-		return nil, errNotCommon
+		return nil, false
 	default:
-		return nil, errNotCommon
+		return nil, false
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/table.go
@@ -63,12 +63,12 @@ func (c defaultTableConvertor) ConvertToTable(ctx genericapirequest.Context, obj
 			return nil, err
 		}
 	}
-	if m, err := meta.ListAccessor(object); err == nil {
+	if m, boolean := meta.ListAccessor(object); !boolean {
 		table.ResourceVersion = m.GetResourceVersion()
 		table.SelfLink = m.GetSelfLink()
 		table.Continue = m.GetContinue()
 	} else {
-		if m, err := meta.CommonAccessor(object); err == nil {
+		if m, boolean := meta.CommonAccessor(object); err == nil {
 			table.ResourceVersion = m.GetResourceVersion()
 			table.SelfLink = m.GetSelfLink()
 		}

--- a/staging/src/k8s.io/client-go/tools/reference/ref.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref.go
@@ -65,8 +65,8 @@ func GetReference(scheme *runtime.Scheme, obj runtime.Object) (*v1.ObjectReferen
 	var listMeta metav1.Common
 	objectMeta, err := meta.Accessor(obj)
 	if err != nil {
-		listMeta, err = meta.CommonAccessor(obj)
-		if err != nil {
+		listMeta, boolean = meta.CommonAccessor(obj)
+		if !boolean {
 			return nil, err
 		}
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

CommonAccessor returns a Common interface for the provided object or a boolean value wether the object to provide list

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
