### PR TITLE
matching resourceNames pattern in RBAC roles

### DIFF
--- a/pkg/apis/rbac/helpers.go
+++ b/pkg/apis/rbac/helpers.go
@@ -18,6 +18,7 @@ package rbac
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,8 @@ func ResourceNameMatches(rule *PolicyRule, requestedName string) bool {
 	}
 
 	for _, ruleName := range rule.ResourceNames {
-		if ruleName == requestedName {
+		valid, err := regexp.MatchString(ruleName, requestedName)
+		if err == nil && valid {
 			return true
 		}
 	}

--- a/pkg/apis/rbac/helpers_test.go
+++ b/pkg/apis/rbac/helpers_test.go
@@ -175,3 +175,28 @@ func TestResourceMatches(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceNameMatches(t *testing.T) {
+	requestName := "my-pod-xyz"
+	rules := []rbac.PolicyRule{
+		{
+			ResourceNames: []string{"my-pod"},
+		},
+		{
+			ResourceNames: []string{"my-pod*"},
+		},
+		{
+			ResourceNames: []string{"^my-pod"},
+		},
+		{
+			ResourceNames: []string{"^my-pod-xyz$"},
+		},
+	}
+
+	for idx, rule := range rules {
+		matched := rbac.ResourceNameMatches(&rule, requestName)
+		if !matched {
+			t.Fatalf("%d: not matched", idx)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enhance `resourceNames` field in `RBAC` role to give permissions to all instances of a resource matching some pattern.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56582

**Special notes for your reviewer**:
/assign @liggitt 
/cc @kubernetes/sig-auth-feature-requests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
matching resourceNames pattern in RBAC roles
```
