### PR TITLE
Updates kubectl CLI help pointing to source code

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -221,7 +221,7 @@ func NewKubectlCommand(f cmdutil.Factory, in io.Reader, out, err io.Writer) *cob
 		Long: templates.LongDesc(`
       kubectl controls the Kubernetes cluster manager.
 
-      Find more information at https://github.com/kubernetes/kubernetes.`),
+      Find more information at https://kubernetes.io/docs/reference/kubectl/overview/ `),
 		Run: runHelp,
 		BashCompletionFunction: bashCompletionFunc,
 	}


### PR DESCRIPTION
On running "kubectl" or "kubectl help" points to the source code
for more information about the commands. Instead the patch updates
the link to the kubectl documentation.

Fixes #56511