### PR TITLE
move runtimeService to generic runtime in kubelet

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -122,6 +122,8 @@ type KubeGenericRuntime interface {
 	kubecontainer.Runtime
 	kubecontainer.IndirectStreamingRuntime
 	kubecontainer.ContainerCommandRunner
+
+	GetRuntimeService() internalapi.RuntimeService
 }
 
 // LegacyLogProvider gives the ability to use unsupported docker log drivers (e.g. journald)
@@ -922,4 +924,8 @@ func (m *kubeGenericRuntimeManager) UpdatePodCIDR(podCIDR string) error {
 				PodCidr: podCIDR,
 			},
 		})
+}
+
+func (m *kubeGenericRuntimeManager) GetRuntimeService() internalapi.RuntimeService {
+	return m.runtimeService
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
refactor runtimeService field in Kubelet struct, move it to kubeGenericRuntimeManager

**Special notes for your reviewer**:
RuntimeService is used in containerManager start function, and I convert kubecontainer.Runtime to KubeGenericRuntime directly. It seems like that rkt does not use RuntimeService. So, is this modification ok? Do u have other methods? Looking forward your ideas. Thanks.

**Release note**:
```release-note
None
```
