### PR TITLE
Fix bad column alignment when using custom columns from OpenAPI schema

### DIFF
--- a/pkg/printers/customcolumn.go
+++ b/pkg/printers/customcolumn.go
@@ -31,14 +31,6 @@ import (
 	"k8s.io/client-go/util/jsonpath"
 )
 
-const (
-	columnwidth       = 10
-	tabwidth          = 4
-	padding           = 3
-	padding_character = ' '
-	flags             = 0
-)
-
 var jsonRegexp = regexp.MustCompile("^\\{\\.?([^{}]+)\\}$|^\\.?([^{}]+)$")
 
 // RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
@@ -163,7 +155,11 @@ func (s *CustomColumnsPrinter) AfterPrint(w io.Writer, res string) error {
 }
 
 func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error {
-	w := tabwriter.NewWriter(out, columnwidth, tabwidth, padding, padding_character, flags)
+	if w, found := out.(*tabwriter.Writer); !found {
+		w = GetNewTabWriter(out)
+		out = w
+		defer w.Flush()
+	}
 
 	t := reflect.TypeOf(obj)
 	if !s.NoHeaders && t != s.lastType {
@@ -171,7 +167,7 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 		for ix := range s.Columns {
 			headers[ix] = s.Columns[ix].Header
 		}
-		fmt.Fprintln(w, strings.Join(headers, "\t"))
+		fmt.Fprintln(out, strings.Join(headers, "\t"))
 		s.lastType = t
 	}
 	parsers := make([]*jsonpath.JSONPath, len(s.Columns))
@@ -188,16 +184,16 @@ func (s *CustomColumnsPrinter) PrintObj(obj runtime.Object, out io.Writer) error
 			return err
 		}
 		for ix := range objs {
-			if err := s.printOneObject(objs[ix], parsers, w); err != nil {
+			if err := s.printOneObject(objs[ix], parsers, out); err != nil {
 				return err
 			}
 		}
 	} else {
-		if err := s.printOneObject(obj, parsers, w); err != nil {
+		if err := s.printOneObject(obj, parsers, out); err != nil {
 			return err
 		}
 	}
-	return w.Flush()
+	return nil
 }
 
 func (s *CustomColumnsPrinter) printOneObject(obj runtime.Object, parsers []*jsonpath.JSONPath, out io.Writer) error {


### PR DESCRIPTION
Columns printed by `kubectl get` weren't aligned properly when they were coming from the OpenAPI schema. 

This was caused by `CustomColumnPrinter.PrintObj`, which was creating a new `tabwriter.Writer` instead of re-using the tabwriter received through the `out` method parameter (basically, a tabwriter was writing to another tabwriter). Because the PrintObj flushed the tabwriter after writing each individual line, the column widths would reset.

**What this PR does / why we need it**:
This PR fixes the bad column alignment.

**Which issue(s) this PR fixes** 
Fixes #56282 

**Special notes for your reviewer**:
I've aligned how `CustomColumnPrinter.PrintObj` handles tabwriter with how `HumanReadablePrinter.PrintObj` does it (see https://github.com/kubernetes/kubernetes/blob/master/pkg/printers/humanreadable.go#L299-L303)

**Release note**:
```release-note
Fixed column alignment when kubectl get is used with custom columns from OpenAPI schema
```
