### PR TITLE
Use rbac client with explicit version

### DIFF
--- a/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
@@ -104,8 +104,8 @@ func testAdapter(f *framework.Framework, kubeClient clientset.Interface, customM
 	}
 	defer CleanupAdapter()
 
-	_, err = kubeClient.Rbac().ClusterRoleBindings().Create(HPAPermissions)
-	defer kubeClient.Rbac().ClusterRoleBindings().Delete("custom-metrics-reader", &metav1.DeleteOptions{})
+	_, err = kubeClient.RbacV1().ClusterRoleBindings().Create(HPAPermissions)
+	defer kubeClient.RbacV1().ClusterRoleBindings().Delete("custom-metrics-reader", &metav1.DeleteOptions{})
 
 	// Run application that exports the metric
 	err = createSDExporterPods(f, kubeClient)


### PR DESCRIPTION
**What this PR does / why we need it**:
Rbac client without explicit version has been deprecated, change them to the one with explicit version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes partially #55993

**Special notes for your reviewer**:
/cc @caesarxuchao @sttts

This is the cleanup for the last client. Hope there is detailed plan to remove these deprecated clients.

**Release note**:
```release-note
NONE
```