### PR TITLE
cloudprovider/openstack: update gophercloud deps to bring in safe concurrent reauth

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1633,115 +1633,143 @@
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/common/extensions",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/compute/v2/images",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/compute/v2/servers",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/extensions/trusts",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/floatingips",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/layer3/routers",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/listeners",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/monitors",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/pools",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/networking/v2/ports",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Comment": "v1.0.0-1479-g7883fd95",
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gorilla/context",

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -408,31 +408,31 @@
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gregjones/httpcache",

--- a/staging/src/k8s.io/client-go/Godeps/Godeps.json
+++ b/staging/src/k8s.io/client-go/Godeps/Godeps.json
@@ -172,31 +172,31 @@
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tenants",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v2/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/identity/v3/tokens",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/openstack/utils",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gophercloud/gophercloud/pagination",
-			"Rev": "db5f840b1d1a595280d643defc09ce277996959e"
+			"Rev": "7883fd95c9c94c0ce123f546f05d38660e97704a"
 		},
 		{
 			"ImportPath": "github.com/gregjones/httpcache",

--- a/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/auth_env.go
@@ -16,7 +16,12 @@ The following variables provide sources of truth: OS_AUTH_URL, OS_USERNAME,
 OS_PASSWORD, OS_TENANT_ID, and OS_TENANT_NAME.
 
 Of these, OS_USERNAME, OS_PASSWORD, and OS_AUTH_URL must have settings,
-or an error will result.  OS_TENANT_ID and OS_TENANT_NAME are optional.
+or an error will result.  OS_TENANT_ID, OS_TENANT_NAME, OS_PROJECT_ID, and
+OS_PROJECT_NAME are optional.
+
+OS_TENANT_ID and OS_TENANT_NAME are mutually exclusive to OS_PROJECT_ID and
+OS_PROJECT_NAME. If OS_PROJECT_ID and OS_PROJECT_NAME are set, they will
+still be referred as "tenant" in Gophercloud.
 
 To use this function, first set the OS_* environment variables (for example,
 by sourcing an `openrc` file), then:
@@ -33,6 +38,16 @@ func AuthOptionsFromEnv() (gophercloud.AuthOptions, error) {
 	tenantName := os.Getenv("OS_TENANT_NAME")
 	domainID := os.Getenv("OS_DOMAIN_ID")
 	domainName := os.Getenv("OS_DOMAIN_NAME")
+
+	// If OS_PROJECT_ID is set, overwrite tenantID with the value.
+	if v := os.Getenv("OS_PROJECT_ID"); v != "" {
+		tenantID = v
+	}
+
+	// If OS_PROJECT_NAME is set, overwrite tenantName with the value.
+	if v := os.Getenv("OS_PROJECT_NAME"); v != "" {
+		tenantName = v
+	}
 
 	if authURL == "" {
 		err := gophercloud.ErrMissingInput{Argument: "authURL"}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -261,3 +261,9 @@ func UploadImage(client *gophercloud.ServiceClient, id string, opts UploadImageO
 	})
 	return
 }
+
+// ForceDelete will delete the volume regardless of state.
+func ForceDelete(client *gophercloud.ServiceClient, id string) (r ForceDeleteResult) {
+	_, r.Err = client.Post(forceDeleteURL(client, id), map[string]interface{}{"os-force_delete": ""}, nil, nil)
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
@@ -184,3 +184,8 @@ func (r UploadImageResult) Extract() (VolumeImage, error) {
 	err := r.ExtractInto(&s)
 	return s.VolumeImage, err
 }
+
+// ForceDeleteResult contains the response body and error from a ForceDelete request.
+type ForceDeleteResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -37,3 +37,7 @@ func teminateConnectionURL(c *gophercloud.ServiceClient, id string) string {
 func extendSizeURL(c *gophercloud.ServiceClient, id string) string {
 	return attachURL(c, id)
 }
+
+func forceDeleteURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes/requests.go
@@ -83,14 +83,21 @@ type ListOptsBuilder interface {
 // ListOpts holds options for listing Volumes. It is passed to the volumes.List
 // function.
 type ListOpts struct {
-	// admin-only option. Set it to true to see all tenant volumes.
+	// AllTenants will retrieve volumes of all tenants/projects.
 	AllTenants bool `q:"all_tenants"`
-	// List only volumes that contain Metadata.
+
+	// Metadata will filter results based on specified metadata.
 	Metadata map[string]string `q:"metadata"`
-	// List only volumes that have Name as the display name.
+
+	// Name will filter by the specified volume name.
 	Name string `q:"name"`
-	// List only volumes that have a status of Status.
+
+	// Status will filter by the specified status.
 	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required for this.
+	TenantID string `q:"project_id"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes/requests.go
@@ -83,14 +83,21 @@ type ListOptsBuilder interface {
 // ListOpts holds options for listing Volumes. It is passed to the volumes.List
 // function.
 type ListOpts struct {
-	// admin-only option. Set it to true to see all tenant volumes.
+	// AllTenants will retrieve volumes of all tenants/projects.
 	AllTenants bool `q:"all_tenants"`
-	// List only volumes that contain Metadata.
+
+	// Metadata will filter results based on specified metadata.
 	Metadata map[string]string `q:"metadata"`
-	// List only volumes that have Name as the display name.
+
+	// Name will filter by the specified volume name.
 	Name string `q:"name"`
-	// List only volumes that have a status of Status.
+
+	// Status will filter by the specified status.
 	Status string `q:"status"`
+
+	// TenantID will filter by a specific tenant/project ID.
+	// Setting AllTenants is required for this.
+	TenantID string `q:"project_id"`
 }
 
 // ToVolumeListQuery formats a ListOpts into a query string.

--- a/vendor/github.com/gophercloud/gophercloud/openstack/client.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/client.go
@@ -56,11 +56,12 @@ func NewClient(endpoint string) (*gophercloud.ProviderClient, error) {
 	endpoint = gophercloud.NormalizeURL(endpoint)
 	base = gophercloud.NormalizeURL(base)
 
-	return &gophercloud.ProviderClient{
-		IdentityBase:     base,
-		IdentityEndpoint: endpoint,
-	}, nil
+	p := new(gophercloud.ProviderClient)
+	p.IdentityBase = base
+	p.IdentityEndpoint = endpoint
+	p.UseTokenLock()
 
+	return p, nil
 }
 
 /*

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/doc.go
@@ -18,5 +18,14 @@ Example of Listing a Server's Interfaces
 	for _, interface := range allInterfaces {
 		fmt.Printf("%+v\n", interface)
 	}
+
+Example to Get a Server's Interface
+
+	portID = "0dde1598-b374-474e-986f-5b8dd1df1d4e"
+	serverID := "b07e7a3b-d951-4efc-a4f9-ac9f001afb7f"
+	interface, err := attachinterfaces.Get(computeClient, serverID, portID).Extract()
+	if err != nil {
+		panic(err)
+	}
 */
 package attachinterfaces

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/requests.go
@@ -11,3 +11,11 @@ func List(client *gophercloud.ServiceClient, serverID string) pagination.Pager {
 		return InterfacePage{pagination.SinglePageBase(r)}
 	})
 }
+
+// Get requests details on a single interface attachment by the server and port IDs.
+func Get(client *gophercloud.ServiceClient, serverID, portID string) (r GetResult) {
+	_, r.Err = client.Get(getInterfaceURL(client, serverID, portID), &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/results.go
@@ -1,8 +1,28 @@
 package attachinterfaces
 
 import (
+	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 )
+
+type attachInterfaceResult struct {
+	gophercloud.Result
+}
+
+// Extract interprets any attachInterfaceResult as an Interface, if possible.
+func (r attachInterfaceResult) Extract() (*Interface, error) {
+	var s struct {
+		Interface *Interface `json:"interfaceAttachment"`
+	}
+	err := r.ExtractInto(&s)
+	return s.Interface, err
+}
+
+// GetResult is the response from a Get operation. Call its Extract
+// method to interpret it as a Interface.
+type GetResult struct {
+	attachInterfaceResult
+}
 
 // FixedIP represents a Fixed IP Address.
 type FixedIP struct {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/attachinterfaces/urls.go
@@ -5,3 +5,7 @@ import "github.com/gophercloud/gophercloud"
 func listInterfaceURL(client *gophercloud.ServiceClient, serverID string) string {
 	return client.ServiceURL("servers", serverID, "os-interface")
 }
+
+func getInterfaceURL(client *gophercloud.ServiceClient, serverID, portID string) string {
+	return client.ServiceURL("servers", serverID, "os-interface", portID)
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/flavors/results.go
@@ -65,7 +65,7 @@ type Flavor struct {
 	VCPUs int `json:"vcpus"`
 
 	// IsPublic indicates whether the flavor is public.
-	IsPublic bool `json:"is_public"`
+	IsPublic bool `json:"os-flavor-access:is_public"`
 }
 
 func (r *Flavor) UnmarshalJSON(b []byte) error {

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -515,7 +515,7 @@ func (opts ResizeOpts) ToServerResizeMap() (map[string]interface{}, error) {
 // Note that this implies rebuilding it.
 //
 // Unfortunately, one cannot pass rebuild parameters to the resize function.
-// When the resize completes, the server will be in RESIZE_VERIFY state.
+// When the resize completes, the server will be in VERIFY_RESIZE state.
 // While in this state, you can explore the use of the new server's
 // configuration. If you like it, call ConfirmResize() to commit the resize
 // permanently. Otherwise, call RevertResize() to restore the old configuration.

--- a/vendor/github.com/gophercloud/gophercloud/params.go
+++ b/vendor/github.com/gophercloud/gophercloud/params.go
@@ -347,12 +347,21 @@ func BuildQueryString(opts interface{}) (*url.URL, error) {
 								params.Add(tags[0], v.Index(i).String())
 							}
 						}
+					case reflect.Map:
+						if v.Type().Key().Kind() == reflect.String && v.Type().Elem().Kind() == reflect.String {
+							var s []string
+							for _, k := range v.MapKeys() {
+								value := v.MapIndex(k).String()
+								s = append(s, fmt.Sprintf("'%s':'%s'", k.String(), value))
+							}
+							params.Add(tags[0], fmt.Sprintf("{%s}", strings.Join(s, ", ")))
+						}
 					}
 				} else {
 					// Otherwise, the field is not set.
 					if len(tags) == 2 && tags[1] == "required" {
 						// And the field is required. Return an error.
-						return nil, fmt.Errorf("Required query parameter [%s] not set.", f.Name)
+						return &url.URL{}, fmt.Errorf("Required query parameter [%s] not set.", f.Name)
 					}
 				}
 			}

--- a/vendor/github.com/gophercloud/gophercloud/provider_client.go
+++ b/vendor/github.com/gophercloud/gophercloud/provider_client.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"sync"
 )
 
 // DefaultUserAgent is the default User-Agent string set in the request header.
@@ -51,6 +52,8 @@ type ProviderClient struct {
 	IdentityEndpoint string
 
 	// TokenID is the ID of the most recently issued valid token.
+	// NOTE: Aside from within a custom ReauthFunc, this field shouldn't be set by an application.
+	// To safely read or write this value, call `Token` or `SetToken`, respectively
 	TokenID string
 
 	// EndpointLocator describes how this provider discovers the endpoints for
@@ -68,16 +71,59 @@ type ProviderClient struct {
 	// authentication functions for different Identity service versions.
 	ReauthFunc func() error
 
-	Debug bool
+	mut *sync.RWMutex
+
+	reauthmut *reauthlock
+}
+
+type reauthlock struct {
+	sync.RWMutex
+	reauthing bool
 }
 
 // AuthenticatedHeaders returns a map of HTTP headers that are common for all
 // authenticated service requests.
-func (client *ProviderClient) AuthenticatedHeaders() map[string]string {
-	if client.TokenID == "" {
-		return map[string]string{}
+func (client *ProviderClient) AuthenticatedHeaders() (m map[string]string) {
+	if client.reauthmut != nil {
+		client.reauthmut.RLock()
+		if client.reauthmut.reauthing {
+			client.reauthmut.RUnlock()
+			return
+		}
+		client.reauthmut.RUnlock()
 	}
-	return map[string]string{"X-Auth-Token": client.TokenID}
+	t := client.Token()
+	if t == "" {
+		return
+	}
+	return map[string]string{"X-Auth-Token": t}
+}
+
+// UseTokenLock creates a mutex that is used to allow safe concurrent access to the auth token.
+// If the application's ProviderClient is not used concurrently, this doesn't need to be called.
+func (client *ProviderClient) UseTokenLock() {
+	client.mut = new(sync.RWMutex)
+	client.reauthmut = new(reauthlock)
+}
+
+// Token safely reads the value of the auth token from the ProviderClient. Applications should
+// call this method to access the token instead of the TokenID field
+func (client *ProviderClient) Token() string {
+	if client.mut != nil {
+		client.mut.RLock()
+		defer client.mut.RUnlock()
+	}
+	return client.TokenID
+}
+
+// SetToken safely sets the value of the auth token in the ProviderClient. Applications may
+// use this method in a custom ReauthFunc
+func (client *ProviderClient) SetToken(t string) {
+	if client.mut != nil {
+		client.mut.Lock()
+		defer client.mut.Unlock()
+	}
+	client.TokenID = t
 }
 
 // RequestOpts customizes the behavior of the provider.Request() method.
@@ -166,6 +212,8 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	// Set connection parameter to close the connection immediately when we've got the response
 	req.Close = true
 
+	prereqtok := req.Header.Get("X-Auth-Token")
+
 	// Issue the request.
 	resp, err := client.HTTPClient.Do(req)
 	if err != nil {
@@ -189,9 +237,6 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 	if !ok {
 		body, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		//pc := make([]uintptr, 1)
-		//runtime.Callers(2, pc)
-		//f := runtime.FuncForPC(pc[0])
 		respErr := ErrUnexpectedResponseCode{
 			URL:      url,
 			Method:   method,
@@ -199,7 +244,6 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			Actual:   resp.StatusCode,
 			Body:     body,
 		}
-		//respErr.Function = "gophercloud.ProviderClient.Request"
 
 		errType := options.ErrorContext
 		switch resp.StatusCode {
@@ -210,7 +254,21 @@ func (client *ProviderClient) Request(method, url string, options *RequestOpts) 
 			}
 		case http.StatusUnauthorized:
 			if client.ReauthFunc != nil {
-				err = client.ReauthFunc()
+				if client.mut != nil {
+					client.mut.Lock()
+					client.reauthmut.Lock()
+					client.reauthmut.reauthing = true
+					client.reauthmut.Unlock()
+					if curtok := client.TokenID; curtok == prereqtok {
+						err = client.ReauthFunc()
+					}
+					client.reauthmut.Lock()
+					client.reauthmut.reauthing = false
+					client.reauthmut.Unlock()
+					client.mut.Unlock()
+				} else {
+					err = client.ReauthFunc()
+				}
 				if err != nil {
 					e := &ErrUnableToReauthenticate{}
 					e.ErrOriginal = respErr


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR updates the vendored Gophercloud dependencies. Among the changes is a change to allow safe concurrent re-authentication. Because the OpenStack cloud provider calls `NewClient` to create a `gophercloud.ProviderClient`, the `openstack` package will get this functionality for free (without having to make changes to its code).

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Safe concurrent re-authentication support in OpenStack cloud provider
```
