### PR TITLE
Implement VolumeHost.GetNodeName method to return k8s node name

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -603,3 +603,7 @@ func (adc *attachDetachController) addNodeToDswp(node *v1.Node, nodeName types.N
 func (adc *attachDetachController) GetNodeLabels() (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in Attach/Detach controller")
 }
+
+func (adc *attachDetachController) GetNodeName() types.NodeName {
+	return ""
+}

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -277,3 +277,7 @@ func (expc *expandController) GetConfigMapFunc() func(namespace, name string) (*
 func (expc *expandController) GetNodeLabels() (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels unsupported in expandController")
 }
+
+func (expc *expandController) GetNodeName() types.NodeName {
+	return ""
+}

--- a/pkg/controller/volume/persistentvolume/volume_host.go
+++ b/pkg/controller/volume/persistentvolume/volume_host.go
@@ -108,3 +108,7 @@ func (adc *PersistentVolumeController) GetExec(pluginName string) mount.Exec {
 func (ctrl *PersistentVolumeController) GetNodeLabels() (map[string]string, error) {
 	return nil, fmt.Errorf("GetNodeLabels() unsupported in PersistentVolumeController")
 }
+
+func (ctrl *PersistentVolumeController) GetNodeName() types.NodeName {
+	return ""
+}

--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -188,6 +188,10 @@ func (kvh *kubeletVolumeHost) GetNodeLabels() (map[string]string, error) {
 	return node.Labels, nil
 }
 
+func (kvh *kubeletVolumeHost) GetNodeName() types.NodeName {
+	return kvh.kubelet.nodeName
+}
+
 func (kvh *kubeletVolumeHost) GetExec(pluginName string) mount.Exec {
 	exec, err := kvh.getMountExec(pluginName)
 	if err != nil {

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -303,6 +303,9 @@ type VolumeHost interface {
 
 	// Returns the labels on the node
 	GetNodeLabels() (map[string]string, error)
+
+	// Returns the name of the node
+	GetNodeName() types.NodeName
 }
 
 // VolumePluginMgr tracks registered plugins.

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -53,6 +53,7 @@ type fakeVolumeHost struct {
 	exec       mount.Exec
 	writer     io.Writer
 	nodeLabels map[string]string
+	nodeName   string
 }
 
 func NewFakeVolumeHost(rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin) *fakeVolumeHost {
@@ -66,6 +67,12 @@ func NewFakeVolumeHostWithCloudProvider(rootDir string, kubeClient clientset.Int
 func NewFakeVolumeHostWithNodeLabels(rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, labels map[string]string) *fakeVolumeHost {
 	volHost := newFakeVolumeHost(rootDir, kubeClient, plugins, nil)
 	volHost.nodeLabels = labels
+	return volHost
+}
+
+func NewFakeVolumeHostWithNodeName(rootDir string, kubeClient clientset.Interface, plugins []VolumePlugin, nodeName string) *fakeVolumeHost {
+	volHost := newFakeVolumeHost(rootDir, kubeClient, plugins, nil)
+	volHost.nodeName = nodeName
 	return volHost
 }
 
@@ -175,6 +182,10 @@ func (f *fakeVolumeHost) GetNodeLabels() (map[string]string, error) {
 		f.nodeLabels = map[string]string{"test-label": "test-value"}
 	}
 	return f.nodeLabels, nil
+}
+
+func (f *fakeVolumeHost) GetNodeName() types.NodeName {
+	return types.NodeName(f.nodeName)
 }
 
 func ProbeVolumePlugins(config VolumeConfig) []VolumePlugin {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements `VolumeHost.GetNodeName()` method which provides a central place where the name of the currently running node can be obtained.  This is needed as part of the CSI in-tree volume plugin implementation and will also be useful for future uses. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56667 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
