### PR TITLE
Fix a typo in kubectl/diff cmd long description.

### DIFF
--- a/pkg/kubectl/cmd/diff.go
+++ b/pkg/kubectl/cmd/diff.go
@@ -44,7 +44,7 @@ var (
 		Diff configurations specified by filename or stdin between their local,
 		last-applied, live and/or "merged" versions.
 
-		LOCAL and LIVE versions are diffed by default. Other availble keywords
+		LOCAL and LIVE versions are diffed by default. Other available keywords
 		are MERGED and LAST.
 
 		Output is always YAML.


### PR DESCRIPTION
**What this PR does / why we need it**:

Correct a typo in kubelet alpha diff cmd long description.

**Release note**:
```release-note
NONE
```