### PR TITLE
remove time waiting after create storage account (save 25s)

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
+++ b/pkg/cloudprovider/providers/azure/azure_blobDiskController.go
@@ -542,14 +542,6 @@ func (c *BlobDiskController) createStorageAccount(storageAccountName string, sto
 		c.addAccountState(storageAccountName, newAccountState)
 	}
 
-	if !bExist {
-		// SA Accounts takes time to be provisioned
-		// so if this account was just created allow it sometime
-		// before polling
-		glog.V(2).Infof("azureDisk - storage account %s was just created, allowing time before polling status", storageAccountName)
-		time.Sleep(25 * time.Second) // as observed 25 is the average time for SA to be provisioned
-	}
-
 	// finally, make sure that we default container is created
 	// before handing it back over
 	return c.ensureDefaultContainer(storageAccountName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I found azure cloud provider will always sleep 25 seconds after creating a new azure storage account:
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/azure/azure_blobDiskController.go#L531
Actually it's not necessary now, since it's already using sync way to create a storage account:
https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/azure/azure_blobDiskController.go#L531
Above code will wait until the storage account is created in azure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56674

**Special notes for your reviewer**:
Below are logs without this PR:
```
I1201 06:41:22.486663       1 azure_blobDiskController.go:522] azureDisk - Creating storage account pvc3329812692002 type Standard_LRS
I1201 06:41:22.486810       1 azure_blobDiskController.go:531] azureDisk - Creating storage account pvc3329812692002 type Standard_LRS begin to wait
I1201 06:41:40.440005       1 azure_blobDiskController.go:533] azureDisk - Creating storage account pvc3329812692002 type Standard_LRS end wait
I1201 06:41:40.440030       1 azure_blobDiskController.go:551] azureDisk - storage account pvc3329812692002 was just created, allowing time before polling status
I1201 06:42:05.440176       1 azure_blobDiskController.go:553] azureDisk - storage account pvc3329812692002 was just created, allowing time before polling status, end wait
```

Below are logs with this PR, it could save 25s now:
```
I1201 07:36:07.755540       1 azure_blobDiskController.go:523] azureDisk - Creating storage account pvc33298126923895004820 type Standard_LRS
I1201 07:36:07.755652       1 azure_blobDiskController.go:532] azureDisk - Creating storage account pvc33298126923895004820 type Standard_LRS begin to wait
I1201 07:36:25.722540       1 azure_blobDiskController.go:534] azureDisk - Creating storage account pvc33298126923895004820 type Standard_LRS end wait
I1201 07:36:25.722557       1 azure_blobDiskController.go:552] azureDisk - storage account pvc33298126923895004820 was just created, allowing time before polling status
I1201 07:36:25.722562       1 azure_blobDiskController.go:554] azureDisk - storage account pvc33298126923895004820 was just created, allowing time before polling status, end wait
I1201 07:36:26.011157       1 azure_blobDiskController.go:436] azureDisk - storage account:pvc33298126923895004820 had no default container(3329812692) and it was created
I1201 07:36:26.011201       1 azure_blobDiskController.go:182] azureDisk - creating page blob andy-mgwin1710-dynamic-pvc-88c50c37-d668-11e7-94dc-000d3a041274.vhd in container 3329812692 account pvc33298126923895004820
```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
remove time waiting after create storage account
```
/sig azure
/assign @khenidak 