### PR TITLE
Cluster Autoscaler 1.1.0-beta1

### DIFF
--- a/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
+++ b/cluster/saltbase/salt/cluster-autoscaler/cluster-autoscaler.manifest
@@ -25,7 +25,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.0-alpha1",
+                "image": "gcr.io/google_containers/cluster-autoscaler:v1.1.0-beta1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR will be shortly followed with one updating Cluster Autoscaler to 1.1.0 (final).
```release-note
NONE
```
