### PR TITLE
Collect all the assorted image URLs from e2e tests in one place

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -41,6 +41,7 @@ import (
 	rbacapi "k8s.io/kubernetes/pkg/apis/rbac"
 	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 	samplev1alpha1 "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
@@ -70,7 +71,7 @@ var _ = SIGDescribe("Aggregator", func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 
 		// Testing a 1.7 version of the sample-apiserver
-		TestSampleAPIServer(f, "gcr.io/kubernetes-e2e-test-images/k8s-aggregator-sample-apiserver-amd64:1.7v2")
+		TestSampleAPIServer(f, imageutils.GetE2EImage(imageutils.APIServer))
 	})
 })
 

--- a/test/e2e/apimachinery/initializers.go
+++ b/test/e2e/apimachinery/initializers.go
@@ -315,7 +315,7 @@ func newReplicaset() *v1beta1.ReplicaSet {
 					Containers: []v1.Container{
 						{
 							Name:  name + "-container",
-							Image: "k8s.gcr.io/porter:4524579c0eb935c056c8e75563b4e1eda31587e0",
+							Image: imageutils.GetE2EImage(imageutils.Porter),
 						},
 					},
 				},

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -39,6 +39,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	utilversion "k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -100,7 +101,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		// Note that in 1.9 we will have backwards incompatible change to
 		// admission webhooks, so the image will be updated to 1.9 sometime in
 		// the development 1.9 cycle.
-		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7", context)
+		deployWebhookAndService(f, imageutils.GetE2EImage(imageutils.AdmissionWebhook), context)
 	})
 	AfterEach(func() {
 		cleanWebhookTest(client, namespaceName)

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // schedulingTimeout is longer specifically because sometimes we need to wait
@@ -257,7 +258,7 @@ func createPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 				Containers: []v1.Container{
 					{
 						Name:  "busybox",
-						Image: "k8s.gcr.io/echoserver:1.6",
+						Image: imageutils.GetE2EImage(imageutils.EchoServer),
 					},
 				},
 				RestartPolicy: v1.RestartPolicyAlways,
@@ -301,7 +302,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 func createReplicaSetOrDie(cs kubernetes.Interface, ns string, size int32, exclusive bool) {
 	container := v1.Container{
 		Name:  "busybox",
-		Image: "k8s.gcr.io/echoserver:1.6",
+		Image: imageutils.GetE2EImage(imageutils.EchoServer),
 	}
 	if exclusive {
 		container.Ports = []v1.ContainerPort{

--- a/test/e2e/auth/metadata_concealment.go
+++ b/test/e2e/auth/metadata_concealment.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	imageutil "k8s.io/kubernetes/test/utils/image"
 )
 
 var _ = SIGDescribe("Metadata Concealment", func() {
@@ -45,7 +46,7 @@ var _ = SIGDescribe("Metadata Concealment", func() {
 						Containers: []v1.Container{
 							{
 								Name:  "check-metadata-concealment",
-								Image: "k8s.gcr.io/check-metadata-concealment:v0.0.2",
+								Image: imageutil.GetE2EImage(imageutil.CheckMetadataConcealment),
 							},
 						},
 						RestartPolicy: v1.RestartPolicyOnFailure,

--- a/test/e2e/common/apparmor.go
+++ b/test/e2e/common/apparmor.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	. "github.com/onsi/gomega"
 )
@@ -185,7 +186,7 @@ func createAppArmorProfileLoader(f *framework.Framework) {
 				Spec: api.PodSpec{
 					Containers: []api.Container{{
 						Name:  "apparmor-loader",
-						Image: "k8s.gcr.io/apparmor-loader:0.1",
+						Image: imageutils.GetE2EImage(imageutils.AppArmorLoader),
 						Args:  []string{"-poll", "10s", "/profiles"},
 						SecurityContext: &api.SecurityContext{
 							Privileged: &True,

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -61,9 +61,9 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.ServeHostname),
 	imageutils.GetE2EImage(imageutils.TestWebserver),
 	imageutils.GetE2EImage(imageutils.Hostexec),
-	"k8s.gcr.io/volume-nfs:0.8",
-	"k8s.gcr.io/volume-gluster:0.2",
-	"k8s.gcr.io/e2e-net-amd64:1.0",
+	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
+	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
+	imageutils.GetE2EImage(imageutils.E2ENet),
 )
 
 func svcByName(name string, port int) *v1.Service {

--- a/test/e2e/framework/pv_util.go
+++ b/test/e2e/framework/pv_util.go
@@ -40,6 +40,7 @@ import (
 	awscloud "k8s.io/kubernetes/pkg/cloudprovider/providers/aws"
 	gcecloud "k8s.io/kubernetes/pkg/cloudprovider/providers/gce"
 	"k8s.io/kubernetes/pkg/volume/util/volumehelper"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -856,7 +857,7 @@ func MakeSecPod(ns string, pvclaims []*v1.PersistentVolumeClaim, isPrivileged bo
 			Containers: []v1.Container{
 				{
 					Name:    "write-pod",
-					Image:   "k8s.gcr.io/busybox:1.24",
+					Image:   imageutils.GetE2EImage(imageutils.BusyBox),
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", command},
 					SecurityContext: &v1.SecurityContext{

--- a/test/e2e/framework/service_util.go
+++ b/test/e2e/framework/service_util.go
@@ -802,7 +802,7 @@ func newEchoServerPodSpec(podName string) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "echoserver",
-					Image: "k8s.gcr.io/echoserver:1.6",
+					Image: imageutils.GetE2EImage(imageutils.EchoServer),
 					Ports: []v1.ContainerPort{{ContainerPort: int32(port)}},
 				},
 			},

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -33,7 +33,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	goruntime "runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -154,10 +153,6 @@ const (
 	// How long claims have to become dynamically provisioned
 	ClaimProvisionTimeout = 5 * time.Minute
 
-	// When these values are updated, also update cmd/kubelet/app/options/options.go
-	currentPodInfraContainerImageName    = "k8s.gcr.io/pause"
-	currentPodInfraContainerImageVersion = "3.0"
-
 	// How long a node is allowed to become "Ready" after it is restarted before
 	// the test is considered failed.
 	RestartNodeReadyAgainTimeout = 5 * time.Minute
@@ -230,13 +225,13 @@ func GetServerArchitecture(c clientset.Interface) string {
 
 // GetPauseImageName fetches the pause image name for the same architecture as the apiserver.
 func GetPauseImageName(c clientset.Interface) string {
-	return currentPodInfraContainerImageName + "-" + GetServerArchitecture(c) + ":" + currentPodInfraContainerImageVersion
+	return imageutils.GetE2EImageWithArch(imageutils.Pause, GetServerArchitecture(c))
 }
 
 // GetPauseImageNameForHostArch fetches the pause image name for the same architecture the test is running on.
 // TODO: move this function to the test/utils
 func GetPauseImageNameForHostArch() string {
-	return currentPodInfraContainerImageName + "-" + goruntime.GOARCH + ":" + currentPodInfraContainerImageVersion
+	return imageutils.GetE2EImage(imageutils.Pause)
 }
 
 func GetServicesProxyRequest(c clientset.Interface, request *restclient.Request) (*restclient.Request, error) {

--- a/test/e2e/framework/volume_util.go
+++ b/test/e2e/framework/volume_util.go
@@ -48,19 +48,11 @@ import (
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/golang/glog"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-)
-
-// Current supported images for e2e volume testing to be assigned to VolumeTestConfig.serverImage
-const (
-	NfsServerImage       string = "k8s.gcr.io/volume-nfs:0.8"
-	IscsiServerImage     string = "k8s.gcr.io/volume-iscsi:0.1"
-	GlusterfsServerImage string = "k8s.gcr.io/volume-gluster:0.2"
-	CephServerImage      string = "k8s.gcr.io/volume-ceph:0.1"
-	RbdServerImage       string = "k8s.gcr.io/volume-rbd:0.1"
 )
 
 const (
@@ -116,7 +108,7 @@ func NewNFSServer(cs clientset.Interface, namespace string, args []string) (conf
 	config = VolumeTestConfig{
 		Namespace:   namespace,
 		Prefix:      "nfs",
-		ServerImage: NfsServerImage,
+		ServerImage: imageutils.GetE2EImage(imageutils.VolumeNFSServer),
 		ServerPorts: []int{2049},
 	}
 	if len(args) > 0 {
@@ -131,7 +123,7 @@ func NewGlusterfsServer(cs clientset.Interface, namespace string) (config Volume
 	config = VolumeTestConfig{
 		Namespace:   namespace,
 		Prefix:      "gluster",
-		ServerImage: GlusterfsServerImage,
+		ServerImage: imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
 		ServerPorts: []int{24007, 24008, 49152},
 	}
 	pod, ip = CreateStorageServer(cs, config)
@@ -173,7 +165,7 @@ func NewISCSIServer(cs clientset.Interface, namespace string) (config VolumeTest
 	config = VolumeTestConfig{
 		Namespace:   namespace,
 		Prefix:      "iscsi",
-		ServerImage: IscsiServerImage,
+		ServerImage: imageutils.GetE2EImage(imageutils.VolumeISCSIServer),
 		ServerPorts: []int{3260},
 		ServerVolumes: map[string]string{
 			// iSCSI container needs to insert modules from the host
@@ -189,7 +181,7 @@ func NewRBDServer(cs clientset.Interface, namespace string) (config VolumeTestCo
 	config = VolumeTestConfig{
 		Namespace:   namespace,
 		Prefix:      "rbd",
-		ServerImage: RbdServerImage,
+		ServerImage: imageutils.GetE2EImage(imageutils.VolumeRBDServer),
 		ServerPorts: []int{6789},
 		ServerVolumes: map[string]string{
 			"/lib/modules": "/lib/modules",

--- a/test/e2e/instrumentation/logging/utils/BUILD
+++ b/test/e2e/instrumentation/logging/utils/BUILD
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/utils/image:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/instrumentation/logging/utils/logging_pod.go
+++ b/test/e2e/instrumentation/logging/utils/logging_pod.go
@@ -21,10 +21,12 @@ import (
 	"time"
 
 	"fmt"
+
 	api_v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 const (
@@ -101,7 +103,7 @@ func (p *loadLoggingPod) Start(f *framework.Framework) error {
 			Containers: []api_v1.Container{
 				{
 					Name:  loggingContainerName,
-					Image: "k8s.gcr.io/logs-generator:v0.1.0",
+					Image: imageutils.GetE2EImage(imageutils.LogsGenerator),
 					Env: []api_v1.EnvVar{
 						{
 							Name:  "LOGS_GENERATOR_LINES_TOTAL",

--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/instrumentation/common:go_default_library",
+        "//test/utils/image:go_default_library",
         "//vendor/github.com/influxdata/influxdb/client/v2:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -25,6 +25,7 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var (
@@ -98,7 +99,7 @@ func stackdriverExporterPodSpec(metricName string, metricValue int64) corev1.Pod
 		Containers: []corev1.Container{
 			{
 				Name:            "stackdriver-exporter",
-				Image:           "k8s.gcr.io/sd-dummy-exporter:v0.1.0",
+				Image:           imageutils.GetE2EImage(imageutils.SDDummyExporter),
 				ImagePullPolicy: corev1.PullPolicy("Always"),
 				Command:         []string{"/sd_dummy_exporter", "--pod-id=$(POD_ID)", "--metric-name=" + metricName, fmt.Sprintf("--metric-value=%v", metricValue)},
 				Env: []corev1.EnvVar{

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -242,7 +242,7 @@ func (t *dnsTestCommon) createDNSServer(aRecords map[string]string) {
 			Containers: []v1.Container{
 				{
 					Name:  "dns",
-					Image: "k8s.gcr.io/k8s-dns-dnsmasq-amd64:1.14.5",
+					Image: imageutils.GetE2EImage(imageutils.DNSMasq),
 					Command: []string{
 						"/usr/sbin/dnsmasq",
 						"-u", "root",

--- a/test/e2e/storage/volumes.go
+++ b/test/e2e/storage/volumes.go
@@ -57,6 +57,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 	vspheretest "k8s.io/kubernetes/test/e2e/storage/vsphere"
+	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 func DeleteCinderVolume(name string) error {
@@ -260,7 +261,7 @@ var _ = utils.SIGDescribe("Volumes", func() {
 			config := framework.VolumeTestConfig{
 				Namespace:   namespace.Name,
 				Prefix:      "cephfs",
-				ServerImage: framework.CephServerImage,
+				ServerImage: imageutils.GetE2EImage(imageutils.VolumeCephServer),
 				ServerPorts: []int{6789},
 			}
 

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -32,6 +32,7 @@ type ImageConfig struct {
 	registry string
 	name     string
 	version  string
+	hasArch  bool
 }
 
 func (i *ImageConfig) SetRegistry(registry string) {
@@ -47,42 +48,66 @@ func (i *ImageConfig) SetVersion(version string) {
 }
 
 var (
-	ClusterTester      = ImageConfig{e2eRegistry, "clusterapi-tester", "1.0"}
-	CudaVectorAdd      = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0"}
-	Dnsutils           = ImageConfig{e2eRegistry, "dnsutils", "1.0"}
-	EntrypointTester   = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0"}
-	Fakegitserver      = ImageConfig{e2eRegistry, "fakegitserver", "1.0"}
-	GBFrontend         = ImageConfig{sampleRegistry, "gb-frontend", "v5"}
-	GBRedisSlave       = ImageConfig{sampleRegistry, "gb-redisslave", "v2"}
-	Goproxy            = ImageConfig{e2eRegistry, "goproxy", "1.0"}
-	Hostexec           = ImageConfig{e2eRegistry, "hostexec", "1.0"}
-	Iperf              = ImageConfig{e2eRegistry, "iperf", "1.0"}
-	JessieDnsutils     = ImageConfig{e2eRegistry, "jessie-dnsutils", "1.0"}
-	Kitten             = ImageConfig{e2eRegistry, "kitten", "1.0"}
-	Liveness           = ImageConfig{e2eRegistry, "liveness", "1.0"}
-	LogsGenerator      = ImageConfig{e2eRegistry, "logs-generator", "1.0"}
-	Mounttest          = ImageConfig{e2eRegistry, "mounttest", "1.0"}
-	MounttestUser      = ImageConfig{e2eRegistry, "mounttest-user", "1.0"}
-	Nautilus           = ImageConfig{e2eRegistry, "nautilus", "1.0"}
-	Net                = ImageConfig{e2eRegistry, "net", "1.0"}
-	Netexec            = ImageConfig{e2eRegistry, "netexec", "1.0"}
-	Nettest            = ImageConfig{e2eRegistry, "nettest", "1.0"}
-	NginxSlim          = ImageConfig{gcRegistry, "nginx-slim", "0.20"}
-	NginxSlimNew       = ImageConfig{gcRegistry, "nginx-slim", "0.21"}
-	Nonewprivs         = ImageConfig{e2eRegistry, "nonewprivs", "1.0"}
-	NoSnatTest         = ImageConfig{e2eRegistry, "no-snat-test", "1.0"}
-	NoSnatTestProxy    = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0"}
-	NWayHTTP           = ImageConfig{e2eRegistry, "n-way-http", "1.0"}
-	Pause              = ImageConfig{gcRegistry, "pause", "3.0"}
-	Porter             = ImageConfig{e2eRegistry, "porter", "1.0"}
-	PortForwardTester  = ImageConfig{e2eRegistry, "port-forward-tester", "1.0"}
-	Redis              = ImageConfig{e2eRegistry, "redis", "1.0"}
-	ResourceConsumer   = ImageConfig{e2eRegistry, "resource-consumer", "1.3"}
-	ResourceController = ImageConfig{e2eRegistry, "resource-consumer/controller", "1.0"}
-	ServeHostname      = ImageConfig{e2eRegistry, "serve-hostname", "1.0"}
-	TestWebserver      = ImageConfig{e2eRegistry, "test-webserver", "1.0"}
+	AdmissionWebhook         = ImageConfig{e2eRegistry, "k8s-sample-admission-webhook", "1.8v7", true}
+	APIServer                = ImageConfig{e2eRegistry, "k8s-aggregator-sample-apiserver", "1.7v2", true}
+	AppArmorLoader           = ImageConfig{gcRegistry, "apparmor-loader", "0.1", false}
+	BusyBox                  = ImageConfig{gcRegistry, "busybox", "1.24", false}
+	CheckMetadataConcealment = ImageConfig{gcRegistry, "check-metadata-concealment", "v0.0.2", false}
+	ClusterTester            = ImageConfig{e2eRegistry, "clusterapi-tester", "1.0", true}
+	CudaVectorAdd            = ImageConfig{e2eRegistry, "cuda-vector-add", "1.0", true}
+	Dnsutils                 = ImageConfig{e2eRegistry, "dnsutils", "1.0", true}
+	DNSMasq                  = ImageConfig{gcRegistry, "k8s-dns-dnsmasq", "1.14.5", true}
+	EchoServer               = ImageConfig{gcRegistry, "echoserver", "1.6", false}
+	EntrypointTester         = ImageConfig{e2eRegistry, "entrypoint-tester", "1.0", true}
+	E2ENet                   = ImageConfig{gcRegistry, "e2e-net", "1.0", true}
+	Fakegitserver            = ImageConfig{e2eRegistry, "fakegitserver", "1.0", true}
+	GBFrontend               = ImageConfig{sampleRegistry, "gb-frontend", "v5", true}
+	GBRedisSlave             = ImageConfig{sampleRegistry, "gb-redisslave", "v2", true}
+	Goproxy                  = ImageConfig{e2eRegistry, "goproxy", "1.0", true}
+	Hostexec                 = ImageConfig{e2eRegistry, "hostexec", "1.0", true}
+	Iperf                    = ImageConfig{e2eRegistry, "iperf", "1.0", true}
+	JessieDnsutils           = ImageConfig{e2eRegistry, "jessie-dnsutils", "1.0", true}
+	Kitten                   = ImageConfig{e2eRegistry, "kitten", "1.0", true}
+	Liveness                 = ImageConfig{e2eRegistry, "liveness", "1.0", true}
+	LogsGenerator            = ImageConfig{gcRegistry, "logs-generator", "v0.1.0", false}
+	Mounttest                = ImageConfig{e2eRegistry, "mounttest", "1.0", true}
+	MounttestUser            = ImageConfig{e2eRegistry, "mounttest-user", "1.0", true}
+	Nautilus                 = ImageConfig{e2eRegistry, "nautilus", "1.0", true}
+	Net                      = ImageConfig{e2eRegistry, "net", "1.0", true}
+	Netexec                  = ImageConfig{e2eRegistry, "netexec", "1.0", true}
+	Nettest                  = ImageConfig{e2eRegistry, "nettest", "1.0", true}
+	NginxSlim                = ImageConfig{gcRegistry, "nginx-slim", "0.20", true}
+	NginxSlimNew             = ImageConfig{gcRegistry, "nginx-slim", "0.21", true}
+	Nonewprivs               = ImageConfig{e2eRegistry, "nonewprivs", "1.0", true}
+	NoSnatTest               = ImageConfig{e2eRegistry, "no-snat-test", "1.0", true}
+	NoSnatTestProxy          = ImageConfig{e2eRegistry, "no-snat-test-proxy", "1.0", true}
+	NWayHTTP                 = ImageConfig{e2eRegistry, "n-way-http", "1.0", true}
+	// When these values are updated, also update cmd/kubelet/app/options/options.go
+	Pause               = ImageConfig{gcRegistry, "pause", "3.0", false}
+	Porter              = ImageConfig{e2eRegistry, "porter", "1.0", true}
+	PortForwardTester   = ImageConfig{e2eRegistry, "port-forward-tester", "1.0", true}
+	Redis               = ImageConfig{e2eRegistry, "redis", "1.0", true}
+	ResourceConsumer    = ImageConfig{e2eRegistry, "resource-consumer", "1.3", true}
+	ResourceController  = ImageConfig{e2eRegistry, "resource-consumer/controller", "1.0", true}
+	SDDummyExporter     = ImageConfig{gcRegistry, "sd-dummy-exporter", "v0.1.0", false}
+	ServeHostname       = ImageConfig{e2eRegistry, "serve-hostname", "1.0", true}
+	TestWebserver       = ImageConfig{e2eRegistry, "test-webserver", "1.0", true}
+	VolumeNFSServer     = ImageConfig{gcRegistry, "volume-nfs", "0.8", false}
+	VolumeISCSIServer   = ImageConfig{gcRegistry, "volume-icsci", "0.1", false}
+	VolumeGlusterServer = ImageConfig{gcRegistry, "volume-gluster", "0.2", false}
+	VolumeCephServer    = ImageConfig{gcRegistry, "volume-ceph", "0.1", false}
+	VolumeRBDServer     = ImageConfig{gcRegistry, "volume-rbd", "0.1", false}
 )
 
 func GetE2EImage(image ImageConfig) string {
-	return fmt.Sprintf("%s/%s-%s:%s", image.registry, image.name, runtime.GOARCH, image.version)
+	return GetE2EImageWithArch(image, runtime.GOARCH)
+}
+
+func GetE2EImageWithArch(image ImageConfig, arch string) string {
+	if image.hasArch {
+		return fmt.Sprintf("%s/%s-%s:%s", image.registry, image.name, arch, image.version)
+	} else {
+		return fmt.Sprintf("%s/%s:%s", image.registry, image.name, image.version)
+
+	}
 }


### PR DESCRIPTION
utils/image/manifest has an additional `arch` parameter, which determines
whether an image ends in `-$ARCH` (like `-amd64`).

All locations that previously had gcr.io urls referenced in costants or inline
have been updated to refere test/utils/image.

**What this PR does / why we need it**:

Previously, all sorts of `gcr.io/` URLs were scattered all over the E2E tests codebase. This PR unifies them all in one place, making it easier to see what is needed to run the E2E tests, as well as making sure all tests use the same version of docker images.

Heptio is working on a project to get the E2E tests running in airgapped environments. Part of that task is collecting all images in one place. A future PR will allow modification of the registry URLs to point at a private docker registry.

**Special notes for your reviewer**:

Two images, https://github.com/kubernetes/kubernetes/pull/56716/files#diff-e3afa632328a4a5271f4b8578faa34bdL318 and https://github.com/kubernetes/kubernetes/pull/56716/files#diff-7dc1ebd3b2f2f6ca1ff248e6601016a6L104 are now pointing to slightly different images. If this breaks the E2E tests, the variables can be duplicated to restore the old dependencies, and the duplicates can be removed at a later date.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
