### PR TITLE
Fix issue #390

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/nodemanager.go
+++ b/pkg/cloudprovider/providers/vsphere/nodemanager.go
@@ -18,13 +18,14 @@ package vsphere
 
 import (
 	"fmt"
+	"strings"
+	"sync"
+
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
-	"strings"
-	"sync"
 )
 
 // Stores info about the kubernetes node
@@ -241,6 +242,10 @@ func (nm *NodeManager) removeNode(node *v1.Node) {
 	nm.registeredNodesLock.Lock()
 	delete(nm.registeredNodes, node.ObjectMeta.Name)
 	nm.registeredNodesLock.Unlock()
+
+	nm.nodeInfoLock.Lock()
+	delete(nm.nodeInfoMap, node.ObjectMeta.Name)
+	nm.nodeInfoLock.Unlock()
 }
 
 // GetNodeInfo returns a NodeInfo which datacenter, vm and vc server ip address.

--- a/pkg/cloudprovider/providers/vsphere/vsphere_util.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere_util.go
@@ -32,12 +32,13 @@ import (
 
 	"fmt"
 
+	"path/filepath"
+
 	"github.com/vmware/govmomi/vim25/mo"
 	"k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib/diskmanagers"
-	"path/filepath"
 )
 
 const (
@@ -194,13 +195,18 @@ func getSharedDatastoresInK8SCluster(ctx context.Context, dc *vclib.Datacenter, 
 		return nil, fmt.Errorf(msg)
 	}
 	var sharedDatastores []*vclib.DatastoreInfo
-	for index, nodeVmDetail := range nodeVmDetails {
+	for _, nodeVmDetail := range nodeVmDetails {
 		glog.V(9).Infof("Getting accessible datastores for node %s", nodeVmDetail.NodeName)
 		accessibleDatastores, err := getAccessibleDatastores(ctx, &nodeVmDetail, nodeManager)
 		if err != nil {
+			if err == vclib.ErrNoVMFound {
+				glog.V(9).Infof("Got NoVMFound error for node %s", nodeVmDetail.NodeName)
+				continue
+			}
 			return nil, err
 		}
-		if index == 0 {
+
+		if len(sharedDatastores) == 0 {
 			sharedDatastores = accessibleDatastores
 		} else {
 			sharedDatastores = intersect(sharedDatastores, accessibleDatastores)


### PR DESCRIPTION
**What this PR does / why we need it**:
When VM node is removed from vSphere Inventory, the corresponding Kubernetes node is unregistered and removed from registeredNodes cache in nodemanager. However, it is not removed from the other node info cache in nodemanager. The fix is to update the other cache accordingly.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/vmware/kubernetes/issues/390

**Special notes for your reviewer**:
Internally review PR here: https://github.com/vmware/kubernetes/pull/402

**Release note**:
```
NONE
```

Testing Done:
1. Removed the node VM from vSphere inventory.
2. Create storageclass and pvc to provision volume dynamically