### PR TITLE
use init container load kernel modules in kube-proxy

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -57,6 +57,18 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
+      initContainers:
+      - name: init-kube-proxy
+        image: gcr.io/google_containers/busybox:1.27.2
+        command:
+        - /bin/sh
+        - -c
+        - echo "{{params}}" | grep "\-\-proxy-mode=ipvs" &&
+          modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4 ||
+          echo "didn't load ipvs related kernel modules"
+        securityContext:
+          privileged: true
+        volumeMounts:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true

--- a/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
+++ b/cluster/saltbase/salt/kube-proxy/kube-proxy.manifest
@@ -101,6 +101,18 @@ spec:
     - mountPath: /run/xtables.lock
       name: iptableslock
       readOnly: false
+  initContainers:
+  - name: init-kube-proxy
+    image: gcr.io/google_containers/busybox:1.27.2
+    command:
+    - /bin/sh
+    - -c
+    - echo "{{params}}" | grep "\-\-proxy-mode=ipvs" &&
+      modprobe -a ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4 ||
+      echo "didn't load ipvs related kernel modules"
+    securityContext:
+      privileged: true
+    volumeMounts:
     - mountPath: /lib/modules
       name: lib-modules
       readOnly: true

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -175,6 +175,24 @@ spec:
         - mountPath: /run/xtables.lock
           name: xtables-lock
           readOnly: false
+      initContainers:
+      - name: init-kube-proxy
+        image: gcr.io/google_containers/busybox:1.27.2
+        command:
+        - /bin/sh
+        - -c
+        - 'echo $(PROXY_CONFIG) | grep "mode: ipvs" && modprobe -a
+          ip_vs ip_vs_rr ip_vs_wrr ip_vs_sh nf_conntrack_ipv4 || echo "did not load
+          ipvs related kernel modules"'
+        env:
+        - name: PROXY_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: kube-proxy
+              key: config.conf
+        securityContext:
+          privileged: true
+        volumeMounts:
         - mountPath: /lib/modules
           name: lib-modules
           readOnly: true

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -698,7 +698,7 @@ func CanUseIPVSProxier(ipsetver IPSetVersioner) (bool, error) {
 		err := utilexec.New().Command("modprobe", "--", kmod).Run()
 		if err != nil {
 			glog.Warningf("Failed to load kernel module %v with modprobe. "+
-				"You can ignore this message when kube-proxy is running inside container without mounting /lib/modules", kmod)
+				"You can ignore this message when kube-proxy is running inside container", kmod)
 		}
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

kube-proxy ipvs mode need load kernel modules `ip_vs`/`ip_vs_*` . Now we do this in kube-proxy container, but have some safety concern. Had some discussion in this pr: #52003 . Mostly think use init container load kernel modules is a good idea.

This pr to use init container load kernel modules instead of load those modules inside kube-proxy container, so that we can lower the kube-proxy container permission. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #54497 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
