### PR TITLE
Extracts Volume Attributes from PV.Annotations

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -65,7 +65,7 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 		},
 		Spec: storage.VolumeAttachmentSpec{
 			NodeName: node,
-			Attacher: csiPluginName,
+			Attacher: csiSource.Driver,
 			Source: storage.VolumeAttachmentSource{
 				PersistentVolumeName: &pvName,
 			},

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -36,7 +36,7 @@ func makeTestAttachment(attachID, nodeName, pvName string) *storage.VolumeAttach
 		},
 		Spec: storage.VolumeAttachmentSpec{
 			NodeName: nodeName,
-			Attacher: csiPluginName,
+			Attacher: "mock",
 			Source: storage.VolumeAttachmentSource{
 				PersistentVolumeName: &pvName,
 			},

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -39,6 +39,7 @@ type csiClient interface {
 		targetPath string,
 		accessMode api.PersistentVolumeAccessMode,
 		volumeInfo map[string]string,
+		volumeAttribs map[string]string,
 		fsType string,
 	) error
 	NodeUnpublishVolume(ctx grpctx.Context, volID string, targetPath string) error
@@ -141,6 +142,7 @@ func (c *csiDriverClient) NodePublishVolume(
 	targetPath string,
 	accessMode api.PersistentVolumeAccessMode,
 	volumeInfo map[string]string,
+	volumeAttribs map[string]string,
 	fsType string,
 ) error {
 
@@ -161,6 +163,7 @@ func (c *csiDriverClient) NodePublishVolume(
 		TargetPath:        targetPath,
 		Readonly:          readOnly,
 		PublishVolumeInfo: volumeInfo,
+		VolumeAttributes:  volumeAttribs,
 
 		VolumeCapability: &csipb.VolumeCapability{
 			AccessMode: &csipb.VolumeCapability_AccessMode{

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -90,6 +90,7 @@ func TestClientNodePublishVolume(t *testing.T) {
 			tc.targetPath,
 			api.ReadWriteOnce,
 			map[string]string{"device": "/dev/null"},
+			map[string]string{"attr0": "val0"},
 			tc.fsType,
 		)
 

--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -161,3 +161,50 @@ func TestUnmounterTeardown(t *testing.T) {
 	}
 
 }
+
+func TestGetVolAttribsFromSpec(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		attribs     map[string]string
+		shouldFail  bool
+	}{
+		{
+			name:        "attribs ok",
+			annotations: map[string]string{"key0": "val0", csiVolAttribsAnnotationKey: `{"k0":"attr0","k1":"attr1","k2":"attr2"}`, "keyN": "valN"},
+			attribs:     map[string]string{"k0": "attr0", "k1": "attr1", "k2": "attr2"},
+		},
+
+		{
+			name:        "missing attribs",
+			annotations: map[string]string{"key0": "val0", "keyN": "valN"},
+		},
+		{
+			name: "missing annotations",
+		},
+		{
+			name:        "bad json",
+			annotations: map[string]string{"key0": "val0", csiVolAttribsAnnotationKey: `{"k0""attr0","k1":"attr1,"k2":"attr2"`, "keyN": "valN"},
+			attribs:     map[string]string{"k0": "attr0", "k1": "attr1", "k2": "attr2"},
+			shouldFail:  true,
+		},
+	}
+	spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, testDriver, testVol), false)
+	for _, tc := range testCases {
+		t.Log("test case:", tc.name)
+		spec.PersistentVolume.Annotations = tc.annotations
+		attribs, err := getVolAttribsFromSpec(spec)
+		if !tc.shouldFail && err != nil {
+			t.Error("test case should not fail, but err != nil", err)
+		}
+		eq := true
+		for k, v := range attribs {
+			if tc.attribs[k] != v {
+				eq = false
+			}
+		}
+		if !eq {
+			t.Errorf("expecting attribs %#v, but got %#v", tc.attribs, attribs)
+		}
+	}
+}

--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -34,7 +34,8 @@ import (
 )
 
 const (
-	csiPluginName = "kubernetes.io/csi"
+	csiPluginName              = "kubernetes.io/csi"
+	csiVolAttribsAnnotationKey = "csi.volume.kubernetes.io/volume-attributes"
 
 	// TODO (vladimirvivien) implement a more dynamic way to discover
 	// the unix domain socket path for each installed csi driver.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue with current alpha implementation of CSI that does not pass volume attributes.  As a workaround, this PR extracts the volume attributes information from the `PV.Annotations` map during `mounter.SetUpAt` cycle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56749

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
