### PR TITLE
WIP: admission/webhook: do not override set client values

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/config/client.go
@@ -111,7 +111,7 @@ func (cm *ClientManager) HookClient(h *v1beta1.Webhook) (*rest.RESTClient, error
 	}
 
 	complete := func(cfg *rest.Config) (*rest.RESTClient, error) {
-		if len(h.ClientConfig.CABundle) != 0 {
+		if len(cfg.TLSClientConfig.CAData) == 0 {
 			cfg.TLSClientConfig.CAData = h.ClientConfig.CABundle
 		}
 		cfg.ContentConfig.NegotiatedSerializer = cm.negotiatedSerializer


### PR DESCRIPTION
The loopback client returned by the WebhookAuthWrapper is damaged by
this old code. Hence:

- only set the CA bundle if it is set in the webhook config
- only override the server name if it not set in the client config
- only override the host if it is not set in the client config

Without this, the use-case where the admission webhook is served by an aggregated apiserver is broken with the default auth client config, i.e. without an explicit webhook config file and a separate kubeconfig.

TODO:
- [ ] test with a stock 1.9 cluster without special admission setup