### PR TITLE
Assign driver name to VolumeAttachment.Spec.Attacher

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -65,7 +65,7 @@ func (c *csiAttacher) Attach(spec *volume.Spec, nodeName types.NodeName) (string
 		},
 		Spec: storage.VolumeAttachmentSpec{
 			NodeName: node,
-			Attacher: csiPluginName,
+			Attacher: csiSource.Driver,
 			Source: storage.VolumeAttachmentSource{
 				PersistentVolumeName: &pvName,
 			},

--- a/pkg/volume/csi/csi_attacher_test.go
+++ b/pkg/volume/csi/csi_attacher_test.go
@@ -36,7 +36,7 @@ func makeTestAttachment(attachID, nodeName, pvName string) *storage.VolumeAttach
 		},
 		Spec: storage.VolumeAttachmentSpec{
 			NodeName: nodeName,
-			Attacher: csiPluginName,
+			Attacher: "mock",
 			Source: storage.VolumeAttachmentSource{
 				PersistentVolumeName: &pvName,
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug in CSI implementation that uses the wrong value for `VolumeAttachment.Spec.Attacher` to use the driver name instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56743

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
