### PR TITLE
New release for pause container

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -18,14 +18,15 @@ REGISTRY ?= k8s.gcr.io
 IMAGE = $(REGISTRY)/pause-$(ARCH)
 LEGACY_AMD64_IMAGE = $(REGISTRY)/pause
 
-TAG = 3.0
+TAG = 3.1
+REV = $(shell git describe --contains --always --match='v*')
 
 # Architectures supported: amd64, arm, arm64, ppc64le and s390x
 ARCH ?= amd64
 
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
-CFLAGS = -Os -Wall -Werror -static
+CFLAGS = -Os -Wall -Werror -static -DVERSION=v$(TAG)-$(REV)
 KUBE_CROSS_IMAGE ?= k8s.gcr.io/kube-cross
 KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
 
@@ -37,7 +38,7 @@ ifeq ($(ARCH),amd64)
 endif
 
 ifeq ($(ARCH),arm)
-	TRIPLE ?= arm-linux-gnueabi
+	TRIPLE ?= arm-linux-gnueabihf
 endif
 
 ifeq ($(ARCH),arm64)

--- a/build/pause/pause.c
+++ b/build/pause/pause.c
@@ -17,9 +17,17 @@ limitations under the License.
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#define STRINGIFY(x) #x
+#define VERSION_STRING(x) STRINGIFY(x)
+
+#ifndef VERSION
+#define VERSION HEAD
+#endif
 
 static void sigdown(int signo) {
   psignal(signo, "Shutting down, got signal");
@@ -27,10 +35,19 @@ static void sigdown(int signo) {
 }
 
 static void sigreap(int signo) {
-  while (waitpid(-1, NULL, WNOHANG) > 0);
+  while (waitpid(-1, NULL, WNOHANG) > 0)
+    ;
 }
 
-int main() {
+int main(int argc, char **argv) {
+  int i;
+  for (i = 1; i < argc; ++i) {
+    if (!strcasecmp(argv[i], "-v")) {
+      printf("pause.c %s\n", VERSION_STRING(VERSION));
+      return 0;
+    }
+  }
+
   if (getpid() != 1)
     /* Not an error because pause sees use outside of infra containers. */
     fprintf(stderr, "Warning: pause should be the first process\n");


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the TAG for the pause container so that we can build a new release with affecting older Kubernetes releases. Once the new release has been pushed to gcr.io/google_containers, I will follow up with a PR to update the kubelet/runtimes to use the new container.

In addition to bumping the tag, this PR also:

* Updates the pause Makefile to reflect a name change in the arm compiler used in kube-cross
* Adds a very simple version string to pause.c to help troubleshoot issues like #50865 in the future.

**Which issue(s) this PR fixes**:
First of two PRs for #56253, #50865

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
