### PR TITLE
validate print flag in 'kubectl create'

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -113,9 +113,13 @@ func TestCreateStaticPodFilesAndWrappers(t *testing.T) {
 		tmpdir := testutil.SetupTempDir(t)
 		defer os.RemoveAll(tmpdir)
 
+		api := kubeadmapi.API{
+			AdvertiseAddress: "1.2.3.4",
+		}
 		// Creates a Master Configuration
 		cfg := &kubeadmapi.MasterConfiguration{
 			KubernetesVersion: "v1.8.0",
+			API:               api,
 		}
 
 		// Execute createStaticPodFunction

--- a/pkg/kubectl/cmd/annotate.go
+++ b/pkg/kubectl/cmd/annotate.go
@@ -134,7 +134,7 @@ func NewCmdAnnotate(f cmdutil.Factory, out io.Writer) *cobra.Command {
 	cmd.Flags().Bool("overwrite", false, "If true, allow annotations to be overwritten, otherwise reject annotation updates that overwrite existing annotations.")
 	cmd.Flags().Bool("local", false, "If true, annotation will NOT contact api-server but run locally.")
 	cmd.Flags().StringP("selector", "l", "", "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2).")
-	cmd.Flags().Bool("all", false, "Select all resources, including uninitialized ones, in the namespace of the specified resource types.")
+	cmd.Flags().Bool("all", false, "Select pkg/kubectl/cmd/util/helpers.goall resources, including uninitialized ones, in the namespace of the specified resource types.")
 	cmd.Flags().String("resource-version", "", i18n.T("If non-empty, the annotation update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource."))
 	usage := "identifying the resource to update the annotation"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)

--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -76,6 +76,7 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 				return
 			}
 			cmdutil.CheckErr(options.ValidateArgs(cmd, args))
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			cmdutil.CheckErr(RunCreate(f, cmd, out, errOut, &options))
 		},
 	}

--- a/pkg/kubectl/cmd/create_clusterrole.go
+++ b/pkg/kubectl/cmd/create_clusterrole.go
@@ -73,6 +73,7 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(c.Complete(f, cmd, args))
 			cmdutil.CheckErr(c.Validate())
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			cmdutil.CheckErr(c.RunCreateRole())
 		},
 	}

--- a/pkg/kubectl/cmd/create_clusterrolebinding.go
+++ b/pkg/kubectl/cmd/create_clusterrolebinding.go
@@ -44,6 +44,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.
 		Long:    clusterRoleBindingLong,
 		Example: clusterRoleBindingExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateClusterRoleBinding(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_configmap.go
+++ b/pkg/kubectl/cmd/create_configmap.go
@@ -66,6 +66,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 		Long:    configMapLong,
 		Example: configMapExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateConfigMap(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_deployment.go
+++ b/pkg/kubectl/cmd/create_deployment.go
@@ -47,6 +47,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.
 		Long:    deploymentLong,
 		Example: deploymentExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := createDeployment(f, cmdOut, cmdErr, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_namespace.go
+++ b/pkg/kubectl/cmd/create_namespace.go
@@ -45,6 +45,7 @@ func NewCmdCreateNamespace(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 		Long:    namespaceLong,
 		Example: namespaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateNamespace(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_pdb.go
+++ b/pkg/kubectl/cmd/create_pdb.go
@@ -50,6 +50,7 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, cmdOut io.Writer) *cobra
 		Long:    pdbLong,
 		Example: pdbExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreatePodDisruptionBudget(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_priorityclass.go
+++ b/pkg/kubectl/cmd/create_priorityclass.go
@@ -48,6 +48,7 @@ func NewCmdCreatePriorityClass(f cmdutil.Factory, cmdOut io.Writer) *cobra.Comma
 		Long:    pcLong,
 		Example: pcExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			cmdutil.CheckErr(CreatePriorityClass(f, cmdOut, cmd, args))
 		},
 	}

--- a/pkg/kubectl/cmd/create_quota.go
+++ b/pkg/kubectl/cmd/create_quota.go
@@ -48,6 +48,7 @@ func NewCmdCreateQuota(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 		Long:    quotaLong,
 		Example: quotaExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateQuota(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_role.go
+++ b/pkg/kubectl/cmd/create_role.go
@@ -128,6 +128,7 @@ func NewCmdCreateRole(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(c.Complete(f, cmd, args))
 			cmdutil.CheckErr(c.Validate())
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			cmdutil.CheckErr(c.RunCreateRole())
 		},
 	}

--- a/pkg/kubectl/cmd/create_rolebinding.go
+++ b/pkg/kubectl/cmd/create_rolebinding.go
@@ -44,6 +44,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, cmdOut io.Writer) *cobra.Command
 		Long:    roleBindingLong,
 		Example: roleBindingExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateRoleBinding(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/create_serviceaccount.go
+++ b/pkg/kubectl/cmd/create_serviceaccount.go
@@ -45,6 +45,7 @@ func NewCmdCreateServiceAccount(f cmdutil.Factory, cmdOut io.Writer) *cobra.Comm
 		Long:    serviceAccountLong,
 		Example: serviceAccountExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlCreate)
 			err := CreateServiceAccount(f, cmdOut, cmd, args)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/delete.go
+++ b/pkg/kubectl/cmd/delete.go
@@ -132,7 +132,7 @@ func NewCmdDelete(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 		Long:    delete_long,
 		Example: delete_example,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
+			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlDelete))
 			if err := options.Complete(f, out, errOut, args, cmd); err != nil {
 				cmdutil.CheckErr(err)
 			}

--- a/pkg/kubectl/cmd/replace.go
+++ b/pkg/kubectl/cmd/replace.go
@@ -69,7 +69,7 @@ func NewCmdReplace(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    replaceLong,
 		Example: replaceExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
+			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlReplace))
 			err := RunReplace(f, out, cmd, args, options)
 			cmdutil.CheckErr(err)
 		},

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -211,15 +211,9 @@ func (options *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 // Validate checks the set of flags provided by the user.
 func (options *GetOptions) Validate(cmd *cobra.Command) error {
 	if len(options.Raw) > 0 && (options.Watch || options.WatchOnly || len(options.LabelSelector) > 0 || options.Export) {
-		return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
+		return cmdutil.UsageErrorf(cmd, "--raw may not be specified with other flags that filter the server request or alter the output")
 	}
-	if cmdutil.GetFlagBool(cmd, "show-labels") {
-		outputOption := cmd.Flags().Lookup("output").Value.String()
-		if outputOption != "" && outputOption != "wide" {
-			return fmt.Errorf("--show-labels option cannot be used with %s printer", outputOption)
-		}
-	}
-	return nil
+	return cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlGet)
 }
 
 // Run performs the get operation.

--- a/pkg/kubectl/cmd/scale.go
+++ b/pkg/kubectl/cmd/scale.go
@@ -69,7 +69,7 @@ func NewCmdScale(f cmdutil.Factory, out io.Writer) *cobra.Command {
 		Long:    scaleLong,
 		Example: scaleExample,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd))
+			cmdutil.CheckErr(cmdutil.ValidateOutputArgs(cmd, cmdutil.KubectlScale))
 			shortOutput := cmdutil.GetFlagString(cmd, "output") == "name"
 			err := RunScale(f, out, cmd, args, shortOutput, options)
 			cmdutil.CheckErr(err)


### PR DESCRIPTION

**What this PR does / why we need it**:
Add warning when using `kubectl create` with print flag like `--show-labels` but without `--output` or `-o`. Cause in this case, will not have anything output.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubectl#146

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
