### PR TITLE
apiserver self sign certs with a real external address

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -96,7 +96,7 @@ func (o CustomResourceDefinitionsServerOptions) Config() (*apiserver.Config, err
 	if err != nil {
 		return nil, err
 	}
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), []string{"localhost"}, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/start.go
@@ -92,8 +92,11 @@ func (o *CustomResourceDefinitionsServerOptions) Complete() error {
 }
 
 func (o CustomResourceDefinitionsServerOptions) Config() (*apiserver.Config, error) {
-	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	advertiseAddr, err := o.RecommendedOptions.SecureServing.DefaultExternalAddress()
+	if err != nil {
+		return nil, err
+	}
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -102,8 +102,11 @@ func (o *AggregatorOptions) Complete() error {
 }
 
 func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
-	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, nil); err != nil {
+	advertiseAddr, err := o.RecommendedOptions.SecureServing.DefaultExternalAddress()
+	if err != nil {
+		return err
+	}
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 
@@ -126,7 +129,6 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 		},
 	}
 
-	var err error
 	config.ExtraConfig.ProxyClientCert, err = ioutil.ReadFile(o.ProxyClientCertFile)
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/cmd/server/start.go
@@ -106,7 +106,7 @@ func (o AggregatorOptions) RunAggregator(stopCh <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, nil); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), []string{"localhost"}, nil); err != nil {
 		return fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -99,8 +99,11 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 	// register admission plugins
 	banflunder.Register(o.Admission.Plugins)
 
-	// TODO have a "real" external address
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts("localhost", nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	advertiseAddr, err := o.RecommendedOptions.SecureServing.DefaultExternalAddress()
+	if err != nil {
+		return nil, err
+	}
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -103,7 +103,7 @@ func (o WardleServerOptions) Config() (*apiserver.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), nil, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
+	if err := o.RecommendedOptions.SecureServing.MaybeDefaultWithSelfSignedCerts(advertiseAddr.String(), []string{"localhost"}, []net.IP{net.ParseIP("127.0.0.1")}); err != nil {
 		return nil, fmt.Errorf("error creating self-signed certificates: %v", err)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

apiserver self sign certs with a real external address 


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
