### PR TITLE
Error out if kubectl create with extra argument

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -278,8 +278,8 @@ func createAndRefresh(info *resource.Info) error {
 
 // NameFromCommandArgs is a utility function for commands that assume the first argument is a resource name
 func NameFromCommandArgs(cmd *cobra.Command, args []string) (string, error) {
-	if len(args) == 0 {
-		return "", cmdutil.UsageErrorf(cmd, "NAME is required")
+	if len(args) != 1 {
+		return "", cmdutil.UsageErrorf(cmd, "exactly one NAME is required, got %d", len(args))
 	}
 	return args[0], nil
 }


### PR DESCRIPTION

**What this PR does / why we need it**:
When using `kubectl create` command with extra args, kubectl will accept the first one and ignore the others. 
This pr give a warnning in this case

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubectl#148

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
