### PR TITLE
optimize EventRateLimit admission plugin

### DIFF
--- a/plugin/pkg/admission/eventratelimit/admission.go
+++ b/plugin/pkg/admission/eventratelimit/admission.go
@@ -82,13 +82,11 @@ func (a *Plugin) Validate(attr admission.Attributes) (err error) {
 		return nil
 	}
 
-	var rejectionError error
-	// give each limit enforcer a chance to reject the event
 	for _, enforcer := range a.limitEnforcers {
 		if err := enforcer.accept(attr); err != nil {
-			rejectionError = err
+			return err
 		}
 	}
 
-	return rejectionError
+	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

optimize admission eventRateLimit, not wait until all limitEnforcers accept. Return immediately when one enforcers not accept. Improve apiserver performance at some degree.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
