### PR TITLE
Enable SD custom metric autoscaling e2e on GKE

### DIFF
--- a/test/e2e/autoscaling/custom_metrics_autoscaling.go
+++ b/test/e2e/autoscaling/custom_metrics_autoscaling.go
@@ -42,7 +42,7 @@ const (
 
 var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: Custom Metrics from Stackdriver)", func() {
 	BeforeEach(func() {
-		framework.SkipUnlessProviderIs("gce")
+		framework.SkipUnlessProviderIs("gce", "gke")
 	})
 
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")


### PR DESCRIPTION
This test should now be able to run on GKE, so enabling it there.