### PR TITLE
Disable GCE target for network partition tests

### DIFF
--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -116,6 +116,9 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 		systemPods, err := framework.GetPodsInNamespace(c, ns, ignoreLabels)
 		Expect(err).NotTo(HaveOccurred())
 		systemPodsNo = int32(len(systemPods))
+
+		// TODO(foxish): Re-enable testing on gce after kubernetes#56787 is fixed.
+		framework.SkipUnlessProviderIs("gke", "aws")
 		if strings.Index(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") >= 0 {
 			framework.Failf("Test dose not support cluster setup with more than one MIG: %s", framework.TestContext.CloudConfig.NodeInstanceGroup)
 		} else {
@@ -126,7 +129,6 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 	framework.KubeDescribe("Pods", func() {
 		Context("should return to running and ready state after network partition is healed", func() {
 			BeforeEach(func() {
-				framework.SkipUnlessProviderIs("gce", "gke", "aws")
 				framework.SkipUnlessNodeCountIsAtLeast(2)
 			})
 
@@ -347,7 +349,8 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 		headlessSvcName := "test"
 
 		BeforeEach(func() {
-			framework.SkipUnlessProviderIs("gce", "gke")
+			// TODO(foxish): Re-enable testing on gce after kubernetes#56787 is fixed.
+			framework.SkipUnlessProviderIs("gke")
 			By("creating service " + headlessSvcName + " in namespace " + f.Namespace.Name)
 			headlessService := framework.CreateServiceSpec(headlessSvcName, "", true, labels)
 			_, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(headlessService)
@@ -461,7 +464,6 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 	framework.KubeDescribe("Pods", func() {
 		Context("should be evicted from unready Node", func() {
 			BeforeEach(func() {
-				framework.SkipUnlessProviderIs("gce", "gke", "aws")
 				framework.SkipUnlessNodeCountIsAtLeast(2)
 			})
 


### PR DESCRIPTION
Disabling until https://github.com/kubernetes/kubernetes/issues/56787 is addressed.