### PR TITLE
Drop using cloud provider to set host address feature

### DIFF
--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -21,7 +21,6 @@ go_library(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
-        "//pkg/cloudprovider:go_default_library",
         "//pkg/kubeapiserver/authenticator:go_default_library",
         "//pkg/kubeapiserver/authorizer:go_default_library",
         "//pkg/kubeapiserver/authorizer/modes:go_default_library",
@@ -29,7 +28,6 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",

--- a/pkg/kubeapiserver/options/cloudprovider.go
+++ b/pkg/kubeapiserver/options/cloudprovider.go
@@ -17,15 +17,7 @@ limitations under the License.
 package options
 
 import (
-	"fmt"
-	"os"
-
-	"github.com/golang/glog"
 	"github.com/spf13/pflag"
-
-	"k8s.io/api/core/v1"
-	genericoptions "k8s.io/apiserver/pkg/server/options"
-	"k8s.io/kubernetes/pkg/cloudprovider"
 )
 
 type CloudProviderOptions struct {
@@ -48,45 +40,4 @@ func (s *CloudProviderOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.CloudConfigFile, "cloud-config", s.CloudConfigFile,
 		"The path to the cloud provider configuration file. Empty string for no configuration file.")
-}
-
-func (s *CloudProviderOptions) DefaultExternalHost(genericoptions *genericoptions.ServerRunOptions) error {
-	if len(genericoptions.ExternalHost) != 0 {
-		return nil
-	}
-
-	if cloudprovider.IsCloudProvider(s.CloudProvider) {
-		glog.Info("--external-hostname was not specified. Trying to get it from the cloud provider.")
-
-		cloud, err := cloudprovider.InitCloudProvider(s.CloudProvider, s.CloudConfigFile)
-		if err != nil {
-			return fmt.Errorf("%q cloud provider could not be initialized: %v", s.CloudProvider, err)
-		}
-		instances, supported := cloud.Instances()
-		if !supported {
-			return fmt.Errorf("%q cloud provider has no instances", s.CloudProvider)
-		}
-		hostname, err := os.Hostname()
-		if err != nil {
-			return fmt.Errorf("failed to get hostname: %v", err)
-		}
-		nodeName, err := instances.CurrentNodeName(hostname)
-		if err != nil {
-			return fmt.Errorf("failed to get NodeName from %q cloud provider: %v", s.CloudProvider, err)
-		}
-		addrs, err := instances.NodeAddresses(nodeName)
-		if err != nil {
-			return fmt.Errorf("failed to get external host address from %q cloud provider: %v", s.CloudProvider, err)
-		} else {
-			for _, addr := range addrs {
-				if addr.Type == v1.NodeExternalIP {
-					genericoptions.ExternalHost = addr.Address
-					glog.Warning("[Deprecated] Getting host address using cloud provider is " +
-						"now deprecated. Please use --external-hostname explicitly")
-				}
-			}
-		}
-	}
-
-	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -338,13 +338,17 @@ type CompletedConfig struct {
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedConfig {
-	if len(c.ExternalAddress) == 0 && c.PublicAddress != nil {
-		hostAndPort := c.PublicAddress.String()
-		if c.ReadWritePort != 0 {
-			hostAndPort = net.JoinHostPort(hostAndPort, strconv.Itoa(c.ReadWritePort))
-		}
-		c.ExternalAddress = hostAndPort
+	host := c.ExternalAddress
+	if host == "" && c.PublicAddress != nil {
+		host = c.PublicAddress.String()
 	}
+	if !strings.Contains(host, ":") {
+		if c.ReadWritePort != 0 {
+			host = net.JoinHostPort(host, strconv.Itoa(c.ReadWritePort))
+		}
+	}
+	c.ExternalAddress = host
+
 	if c.OpenAPIConfig != nil && c.OpenAPIConfig.SecurityDefinitions != nil {
 		// Setup OpenAPI security: all APIs will have the same authentication for now.
 		c.OpenAPIConfig.DefaultSecurity = []map[string][]string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Follow up to PR #54516, also see notice to -dev@ : 
https://groups.google.com/forum/#!topic/kubernetes-dev/2NaxUCSbIw8

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kube-apiserver: The external hostname no longer longer use the cloud provider API to select a default. It can be set explicitly using --external-hostname, if needed.
```
