### PR TITLE
Update systemstat9 to allow compilation on OSX

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -11,7 +11,7 @@
 	"Deps": [
 		{
 			"ImportPath": "bitbucket.org/bertimus9/systemstat",
-			"Rev": "1468fd0db20598383c9393cccaa547de6ad99e5e"
+			"Rev": "6edb7bbcb021f6510db33e604f7e18861293a14a"
 		},
 		{
 			"ImportPath": "bitbucket.org/ww/goautoneg",

--- a/vendor/bitbucket.org/bertimus9/systemstat/BUILD
+++ b/vendor/bitbucket.org/bertimus9/systemstat/BUILD
@@ -4,6 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "systemstat.go",
+        "systemstat_ex.go",
+        "utils.go",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux_amd64": [
             "systemstat_linux.go",

--- a/vendor/bitbucket.org/bertimus9/systemstat/systemstat_ex.go
+++ b/vendor/bitbucket.org/bertimus9/systemstat/systemstat_ex.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2013 Phillip Bond
+// Licensed under the MIT License
+// see file LICENSE
+
+// +build !linux
+
+package systemstat
+
+import (
+	"syscall"
+	"time"
+)
+
+func getUptime(procfile string) (uptime UptimeSample) {
+	notImplemented("getUptime")
+	uptime.Time = time.Now()
+	return
+}
+
+func getLoadAvgSample(procfile string) (samp LoadAvgSample) {
+	notImplemented("getLoadAvgSample")
+	samp.Time = time.Now()
+	return
+}
+
+func getMemSample(procfile string) (samp MemSample) {
+	notImplemented("getMemSample")
+	samp.Time = time.Now()
+	return
+}
+
+func getProcCPUSample() (s ProcCPUSample) {
+	var processInfo syscall.Rusage
+	syscall.Getrusage(syscall.RUSAGE_SELF, &processInfo)
+
+	s.Time = time.Now()
+	s.ProcMemUsedK = int64(processInfo.Maxrss)
+	s.User = float64(processInfo.Utime.Usec)/1000000 + float64(processInfo.Utime.Sec)
+	s.System = float64(processInfo.Stime.Usec)/1000000 + float64(processInfo.Stime.Sec)
+	s.Total = s.User + s.System
+
+	return
+}
+
+func getCPUSample(procfile string) (samp CPUSample) {
+	notImplemented("getCPUSample")
+	samp.Time = time.Now()
+	return
+}

--- a/vendor/bitbucket.org/bertimus9/systemstat/systemstat_linux.go
+++ b/vendor/bitbucket.org/bertimus9/systemstat/systemstat_linux.go
@@ -11,8 +11,6 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"log"
-	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
@@ -162,83 +160,4 @@ func getCPUSample(procfile string) (samp CPUSample) {
 		}
 	}
 	return
-}
-
-func getSimpleCPUAverage(first CPUSample, second CPUSample) (avg SimpleCPUAverage) {
-	//walltimediff := second.Time.Sub(first.Time)
-	//dT := float64(first.Total - second.Total)
-
-	dI := float64(second.Idle - first.Idle)
-	dTot := float64(second.Total - first.Total)
-	avg.IdlePct = dI / dTot * 100
-	avg.BusyPct = (dTot - dI) * 100 / dTot
-	//log.Printf("cpu idle ticks %f, total ticks %f, idle pct %f, busy pct %f\n", dI, dTot, avg.IdlePct, avg.BusyPct)
-	return
-}
-
-func subtractAndConvertTicks(first uint64, second uint64) float64 {
-	return float64(first - second)
-}
-
-func getCPUAverage(first CPUSample, second CPUSample) (avg CPUAverage) {
-	dTot := float64(second.Total - first.Total)
-	invQuotient := 100.00 / dTot
-
-	avg.UserPct = subtractAndConvertTicks(second.User, first.User) * invQuotient
-	avg.NicePct = subtractAndConvertTicks(second.Nice, first.Nice) * invQuotient
-	avg.SystemPct = subtractAndConvertTicks(second.System, first.System) * invQuotient
-	avg.IdlePct = subtractAndConvertTicks(second.Idle, first.Idle) * invQuotient
-	avg.IowaitPct = subtractAndConvertTicks(second.Iowait, first.Iowait) * invQuotient
-	avg.IrqPct = subtractAndConvertTicks(second.Irq, first.Irq) * invQuotient
-	avg.SoftIrqPct = subtractAndConvertTicks(second.SoftIrq, first.SoftIrq) * invQuotient
-	avg.StealPct = subtractAndConvertTicks(second.Steal, first.Steal) * invQuotient
-	avg.GuestPct = subtractAndConvertTicks(second.Guest, first.Guest) * invQuotient
-	avg.Time = second.Time
-	avg.Seconds = second.Time.Sub(first.Time).Seconds()
-	return
-}
-
-func getProcCPUAverage(first ProcCPUSample, second ProcCPUSample, procUptime float64) (avg ProcCPUAverage) {
-	dT := second.Time.Sub(first.Time).Seconds()
-
-	avg.UserPct = 100 * (second.User - first.User) / dT
-	avg.SystemPct = 100 * (second.System - first.System) / dT
-	avg.TotalPct = 100 * (second.Total - first.Total) / dT
-	avg.PossiblePct = 100.0 * float64(runtime.NumCPU())
-	avg.CumulativeTotalPct = 100 * second.Total / procUptime
-	avg.Time = second.Time
-	avg.Seconds = dT
-	return
-}
-
-func parseCPUFields(fields []string, stat *CPUSample) {
-	numFields := len(fields)
-	stat.Name = fields[0]
-	for i := 1; i < numFields; i++ {
-		val, numerr := strconv.ParseUint(fields[i], 10, 64)
-		if numerr != nil {
-			log.Println("systemstat.parseCPUFields(): Error parsing (field, value): ", i, fields[i])
-		}
-		stat.Total += val
-		switch i {
-		case 1:
-			stat.User = val
-		case 2:
-			stat.Nice = val
-		case 3:
-			stat.System = val
-		case 4:
-			stat.Idle = val
-		case 5:
-			stat.Iowait = val
-		case 6:
-			stat.Irq = val
-		case 7:
-			stat.SoftIrq = val
-		case 8:
-			stat.Steal = val
-		case 9:
-			stat.Guest = val
-		}
-	}
 }

--- a/vendor/bitbucket.org/bertimus9/systemstat/utils.go
+++ b/vendor/bitbucket.org/bertimus9/systemstat/utils.go
@@ -1,0 +1,90 @@
+package systemstat
+
+import (
+	"log"
+	"runtime"
+	"strconv"
+)
+
+func notImplemented(fn string) {
+	log.Printf("systemstat/%s is not implemented for this OS: %s\n", fn, runtime.GOOS)
+}
+
+func getSimpleCPUAverage(first CPUSample, second CPUSample) (avg SimpleCPUAverage) {
+	//walltimediff := second.Time.Sub(first.Time)
+	//dT := float64(first.Total - second.Total)
+
+	dI := float64(second.Idle - first.Idle)
+	dTot := float64(second.Total - first.Total)
+	avg.IdlePct = dI / dTot * 100
+	avg.BusyPct = (dTot - dI) * 100 / dTot
+	//log.Printf("cpu idle ticks %f, total ticks %f, idle pct %f, busy pct %f\n", dI, dTot, avg.IdlePct, avg.BusyPct)
+	return
+}
+
+func subtractAndConvertTicks(first uint64, second uint64) float64 {
+	return float64(first - second)
+}
+
+func getCPUAverage(first CPUSample, second CPUSample) (avg CPUAverage) {
+	dTot := float64(second.Total - first.Total)
+	invQuotient := 100.00 / dTot
+
+	avg.UserPct = subtractAndConvertTicks(second.User, first.User) * invQuotient
+	avg.NicePct = subtractAndConvertTicks(second.Nice, first.Nice) * invQuotient
+	avg.SystemPct = subtractAndConvertTicks(second.System, first.System) * invQuotient
+	avg.IdlePct = subtractAndConvertTicks(second.Idle, first.Idle) * invQuotient
+	avg.IowaitPct = subtractAndConvertTicks(second.Iowait, first.Iowait) * invQuotient
+	avg.IrqPct = subtractAndConvertTicks(second.Irq, first.Irq) * invQuotient
+	avg.SoftIrqPct = subtractAndConvertTicks(second.SoftIrq, first.SoftIrq) * invQuotient
+	avg.StealPct = subtractAndConvertTicks(second.Steal, first.Steal) * invQuotient
+	avg.GuestPct = subtractAndConvertTicks(second.Guest, first.Guest) * invQuotient
+	avg.Time = second.Time
+	avg.Seconds = second.Time.Sub(first.Time).Seconds()
+	return
+}
+
+func getProcCPUAverage(first ProcCPUSample, second ProcCPUSample, procUptime float64) (avg ProcCPUAverage) {
+	dT := second.Time.Sub(first.Time).Seconds()
+
+	avg.UserPct = 100 * (second.User - first.User) / dT
+	avg.SystemPct = 100 * (second.System - first.System) / dT
+	avg.TotalPct = 100 * (second.Total - first.Total) / dT
+	avg.PossiblePct = 100.0 * float64(runtime.NumCPU())
+	avg.CumulativeTotalPct = 100 * second.Total / procUptime
+	avg.Time = second.Time
+	avg.Seconds = dT
+	return
+}
+
+func parseCPUFields(fields []string, stat *CPUSample) {
+	numFields := len(fields)
+	stat.Name = fields[0]
+	for i := 1; i < numFields; i++ {
+		val, numerr := strconv.ParseUint(fields[i], 10, 64)
+		if numerr != nil {
+			log.Println("systemstat.parseCPUFields(): Error parsing (field, value): ", i, fields[i])
+		}
+		stat.Total += val
+		switch i {
+		case 1:
+			stat.User = val
+		case 2:
+			stat.Nice = val
+		case 3:
+			stat.System = val
+		case 4:
+			stat.Idle = val
+		case 5:
+			stat.Iowait = val
+		case 6:
+			stat.Irq = val
+		case 7:
+			stat.SoftIrq = val
+		case 8:
+			stat.Steal = val
+		case 9:
+			stat.Guest = val
+		}
+	}
+}


### PR DESCRIPTION
The latest version of system statadds stubbed out methods for non-Linux OSes:
https://bitbucket.org/bertimus9/systemstat/pull-requests/2

**What this PR does / why we need it**:

The current version of Systemstat is Linux-only. This pull request bumps bertimus9/systemstat to a slightly newer revision which does compile on OSX.

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
