### PR TITLE
[Test Fix] Fake docker client can remove containers which have not been started

### DIFF
--- a/pkg/kubelet/dockershim/libdocker/fake_client.go
+++ b/pkg/kubelet/dockershim/libdocker/fake_client.go
@@ -661,6 +661,15 @@ func (f *FakeDockerClient) RemoveContainer(id string, opts dockertypes.Container
 		}
 
 	}
+	for i := range f.RunningContainerList {
+		// allow removal of running containers which are not running
+		if f.RunningContainerList[i].ID == id && !f.ContainerMap[id].State.Running {
+			delete(f.ContainerMap, id)
+			f.RunningContainerList = append(f.RunningContainerList[:i], f.RunningContainerList[i+1:]...)
+			f.appendContainerTrace("Removed", id)
+			return nil
+		}
+	}
 	// To be a good fake, report error if container is not stopped.
 	return fmt.Errorf("container not stopped")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
During kubemark-5000 scalability tests, which use the fake docker client, we encountered a bug where containers where the pod was deleted before the container was started could not be deleted.
This is because we only remove pods from the `ExitedContainers` list.  Containers are only added to this when they have been created, started, and then stopped.  However, containers that have only been created, but not started cannot be deleted.  This PR fixes this issue by allowing containers with `State.Running=false` to be deleted.

**Which issue(s) this PR fixes**:
Ref #53327 

**Release note**:
```release-note
NONE
```
/sig node
/kind bug
/priority critical-urgent
/assign @Random-Liu @dchen1107 @shyamjvs 