### PR TITLE
Add e2e test for when a webhook does not return.

### DIFF
--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -56,6 +56,7 @@ const (
 	skipNamespaceLabelValue      = "yes"
 	skippedNamespaceName         = "exempted-namesapce"
 	disallowedPodName            = "disallowed-pod"
+	hangingPodName               = "hanging-pod"
 	disallowedConfigMapName      = "disallowed-configmap"
 	allowedConfigMapName         = "allowed-configmap"
 	crdName                      = "e2e-test-webhook-crd"
@@ -99,7 +100,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		// Note that in 1.9 we will have backwards incompatible change to
 		// admission webhooks, so the image will be updated to 1.9 sometime in
 		// the development 1.9 cycle.
-		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6", context)
+		deployWebhookAndService(f, "gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7", context)
 	})
 	AfterEach(func() {
 		cleanWebhookTest(client, namespaceName)
@@ -453,6 +454,17 @@ func testWebhook(f *framework.Framework) {
 		framework.Failf("expect error contains %q, got %q", expectedErrMsg2, err.Error())
 	}
 
+	By("create a pod that causes the webhook to hang")
+	client = f.ClientSet
+	// Creating the pod, the request should be rejected
+	pod = hangingPod(f)
+	_, err = client.CoreV1().Pods(f.Namespace.Name).Create(pod)
+	Expect(err).NotTo(BeNil())
+	expectedTimeoutErr := "request did not complete within allowed duration"
+	if !strings.Contains(err.Error(), expectedTimeoutErr) {
+		framework.Failf("expect timeout error %q, got %q", expectedTimeoutErr, err.Error())
+	}
+
 	By("create a configmap that should be denied by the webhook")
 	// Creating the configmap, the request should be rejected
 	configmap := nonCompliantConfigMap(f)
@@ -624,6 +636,25 @@ func nonCompliantPod(f *framework.Framework) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Name:  "webhook-disallow",
+					Image: framework.GetPauseImageName(f.ClientSet),
+				},
+			},
+		},
+	}
+}
+
+func hangingPod(f *framework.Framework) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: hangingPodName,
+			Labels: map[string]string{
+				"webhook-e2e-test": "wait-forever",
+			},
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "wait-forever",
 					Image: framework.GetPauseImageName(f.ClientSet),
 				},
 			},

--- a/test/images/webhook/Makefile
+++ b/test/images/webhook/Makefile
@@ -14,7 +14,7 @@
 
 build:
 	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o webhook .
-	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6 .
+	docker build --no-cache -t gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7 .
 	rm -rf webhook
 push:
-	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v6
+	gcloud docker -- push gcr.io/kubernetes-e2e-test-images/k8s-sample-admission-webhook-amd64:1.8v7

--- a/test/images/webhook/main.go
+++ b/test/images/webhook/main.go
@@ -85,10 +85,15 @@ func admitPods(ar v1beta1.AdmissionReview) *v1beta1.AdmissionResponse {
 	reviewResponse.Allowed = true
 
 	var msg string
-	for k, v := range pod.Labels {
-		if k == "webhook-e2e-test" && v == "webhook-disallow" {
+	if v, ok := pod.Labels["webhook-e2e-test"]; ok {
+		if v == "webhook-disallow" {
 			reviewResponse.Allowed = false
 			msg = msg + "the pod contains unwanted label; "
+		}
+		if v == "wait-forever" {
+			reviewResponse.Allowed = false
+			msg = msg + "the pod response should not be sent; "
+			<-make(chan int) // Sleep forever - no one sends to this channel
 		}
 	}
 	for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
**What this PR does / why we need it**: Adding an e2e test to simulate a webhook not returning. Making sure this does not just hang the API.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref https://github.com/kubernetes/features/issues/492

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
