### PR TITLE
[Kubectl] Update RunCreate to follow more conventions

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -42,6 +42,8 @@ type CreateOptions struct {
 	Selector         string
 	EditBeforeCreate bool
 	Raw              string
+	Out              io.Writer
+	ErrOut           io.Writer
 }
 
 var (
@@ -62,7 +64,10 @@ var (
 )
 
 func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
-	var options CreateOptions
+	options := &CreateOptions{
+		Out:    out,
+		ErrOut: errOut,
+	}
 
 	cmd := &cobra.Command{
 		Use:     "create -f FILENAME",
@@ -76,7 +81,7 @@ func NewCmdCreate(f cmdutil.Factory, out, errOut io.Writer) *cobra.Command {
 				return
 			}
 			cmdutil.CheckErr(options.ValidateArgs(cmd, args))
-			cmdutil.CheckErr(RunCreate(f, cmd, out, errOut, &options))
+			cmdutil.CheckErr(options.RunCreate(f, cmd))
 		},
 	}
 
@@ -143,36 +148,15 @@ func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, options *CreateOptions) error {
+func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 	// raw only makes sense for a single file resource multiple objects aren't likely to do what you want.
 	// the validator enforces this, so
-	if len(options.Raw) > 0 {
-		restClient, err := f.RESTClient()
-		if err != nil {
-			return err
-		}
-
-		var data io.ReadCloser
-		if options.FilenameOptions.Filenames[0] == "-" {
-			data = os.Stdin
-		} else {
-			data, err = os.Open(options.FilenameOptions.Filenames[0])
-			if err != nil {
-				return err
-			}
-		}
-		// TODO post content with stream.  Right now it ignores body content
-		bytes, err := restClient.Post().RequestURI(options.Raw).Body(data).DoRaw()
-		if err != nil {
-			return err
-		}
-
-		fmt.Fprintf(out, "%v", string(bytes))
-		return nil
+	if len(o.Raw) > 0 {
+		return o.raw(f)
 	}
 
-	if options.EditBeforeCreate {
-		return RunEditOnCreate(f, out, errOut, cmd, &options.FilenameOptions)
+	if o.EditBeforeCreate {
+		return RunEditOnCreate(f, o.Out, o.ErrOut, cmd, &o.FilenameOptions)
 	}
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	if err != nil {
@@ -189,8 +173,8 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 		Schema(schema).
 		ContinueOnError().
 		NamespaceParam(cmdNamespace).DefaultNamespace().
-		FilenameParam(enforceNamespace, &options.FilenameOptions).
-		LabelSelectorParam(options.Selector).
+		FilenameParam(enforceNamespace, &o.FilenameOptions).
+		LabelSelectorParam(o.Selector).
 		Flatten().
 		Do()
 	err = r.Err()
@@ -227,13 +211,13 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 
 		shortOutput := output == "name"
 		if len(output) > 0 && !shortOutput {
-			return f.PrintResourceInfoForCommand(cmd, info, out)
+			return f.PrintResourceInfoForCommand(cmd, info, o.Out)
 		}
 		if !shortOutput {
-			f.PrintObjectSpecificMessage(info.Object, out)
+			f.PrintObjectSpecificMessage(info.Object, o.Out)
 		}
 
-		f.PrintSuccess(mapper, shortOutput, out, info.Mapping.Resource, info.Name, dryRun, "created")
+		f.PrintSuccess(mapper, shortOutput, o.Out, info.Mapping.Resource, info.Name, dryRun, "created")
 		return nil
 	})
 	if err != nil {
@@ -242,6 +226,33 @@ func RunCreate(f cmdutil.Factory, cmd *cobra.Command, out, errOut io.Writer, opt
 	if count == 0 {
 		return fmt.Errorf("no objects passed to create")
 	}
+	return nil
+}
+
+// raw makes a simple HTTP request to the provided path on the server using the default
+// credentials.
+func (o *CreateOptions) raw(f cmdutil.Factory) error {
+	restClient, err := f.RESTClient()
+	if err != nil {
+		return err
+	}
+
+	var data io.ReadCloser
+	if o.FilenameOptions.Filenames[0] == "-" {
+		data = os.Stdin
+	} else {
+		data, err = os.Open(o.FilenameOptions.Filenames[0])
+		if err != nil {
+			return err
+		}
+	}
+	// TODO post content with stream.  Right now it ignores body content
+	bytes, err := restClient.Post().RequestURI(o.Raw).Body(data).DoRaw()
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "%v", string(bytes))
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Make RunCreate with options like other commands, and abstract raw() into separated func.

**Release note**:

```release-note
NONE
```
