### PR TITLE
Ensure PVL controller is next pending initializer before labeling the PV

### DIFF
--- a/pkg/controller/cloud/pvlcontroller.go
+++ b/pkg/controller/cloud/pvlcontroller.go
@@ -182,7 +182,7 @@ func (pvlc *PersistentVolumeLabelController) addLabels(key string) error {
 
 func (pvlc *PersistentVolumeLabelController) addLabelsToVolume(vol *v1.PersistentVolume) error {
 	var volumeLabels map[string]string
-	// Only add labels if in the list of initializers
+	// Only add labels if the next pending initializer.
 	if needsInitialization(vol.Initializers, initializerName) {
 		if labeler, ok := (pvlc.cloud).(cloudprovider.PVLabeler); ok {
 			labels, err := labeler.GetLabelsForVolume(vol)
@@ -265,16 +265,17 @@ func removeInitializer(initializers *metav1.Initializers, name string) *metav1.I
 	return &metav1.Initializers{Pending: updated}
 }
 
+// needsInitialization checks whether or not the PVL is the next pending initializer.
 func needsInitialization(initializers *metav1.Initializers, name string) bool {
-	hasInitializer := false
-
-	if initializers != nil {
-		for _, pending := range initializers.Pending {
-			if pending.Name == name {
-				hasInitializer = true
-				break
-			}
-		}
+	if initializers == nil {
+		return false
 	}
-	return hasInitializer
+
+	if len(initializers.Pending) == 0 {
+		return false
+	}
+
+	// There is at least one initializer still pending so check to
+	// see if the PVL is the next in line.
+	return initializers.Pending[0].Name == name
 }

--- a/pkg/controller/cloud/pvlcontroller_test.go
+++ b/pkg/controller/cloud/pvlcontroller_test.go
@@ -146,9 +146,14 @@ func TestAddLabelsToVolume(t *testing.T) {
 			initializers: &metav1.Initializers{Pending: []metav1.Initializer{{Name: initializerName}}},
 			shouldLabel:  true,
 		},
-		"PV with other initializers": {
+		"PV with other initializers only": {
 			vol:          pv,
 			initializers: &metav1.Initializers{Pending: []metav1.Initializer{{Name: "OtherInit"}}},
+			shouldLabel:  false,
+		},
+		"PV with other initializers first": {
+			vol:          pv,
+			initializers: &metav1.Initializers{Pending: []metav1.Initializer{{Name: "OtherInit"}, {Name: initializerName}}},
 			shouldLabel:  false,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

According the [documentation](https://kubernetes.io/docs/admin/extensible-admission-controllers/#how-are-initializers-triggered), initializer controllers should only initialize the object once its name is at `metadata.initializers.pending[0]`.[Currently](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/cloud/pvlcontroller.go#L268), the PVL controller just checks if its name is in the list at all and ignores ordering. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #56830

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix the PersistentVolumeLabel controller from initializing the PV labels when it's not the next pending initializer.
```

/kind bug
/sig storage
/area cloudprovider

/cc @wlan0 @luxas @liggitt
