### PR TITLE
 Allow custom LoadBalancer name for service via annotations

### DIFF
--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -60,6 +60,16 @@ type Clusters interface {
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
 func GetLoadBalancerName(service *v1.Service) string {
+        // Check if annotation for custom loadbalancer name is defined
+        lbname, ok := service.Annotations["load-balancer-name"]
+	if ok {
+                //AWS requires that the name of a load balancer is shorter than 32 bytes.
+	        if len(lbname) > 32 {
+		  lbname = lbname[:32]
+	        }
+		return lbname
+	}
+
 	//GCE requires that the name of a load balancer starts with a lower case letter.
 	ret := "a" + string(service.UID)
 	ret = strings.Replace(ret, "-", "", -1)

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -66,19 +66,14 @@ type Clusters interface {
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
 func GetLoadBalancerName(service *v1.Service) string {
-        // Check if annotation for custom loadbalancer name is defined
-        lbname, ok := service.Annotations["load-balancer-name"]
-	if ok {
-                //AWS requires that the name of a load balancer is shorter than 32 bytes.
-	        if len(lbname) > 32 {
-		  lbname = lbname[:32]
-	        }
-		return lbname
-	}
-
 	//GCE requires that the name of a load balancer starts with a lower case letter.
 	ret := "a" + string(service.UID)
 	ret = strings.Replace(ret, "-", "", -1)
+	// Check if annotation for custom loadbalancer name is defined
+	lbname, ok := service.Annotations["kubernetes.io/load-balancer-name"]
+	if ok {
+		ret = lbname
+	}
 	//AWS requires that the name of a load balancer is shorter than 32 bytes.
 	if len(ret) > 32 {
 		ret = ret[:32]

--- a/pkg/cloudprovider/cloud.go
+++ b/pkg/cloudprovider/cloud.go
@@ -66,6 +66,16 @@ type Clusters interface {
 // TODO(#6812): Use a shorter name that's less likely to be longer than cloud
 // providers' name length limits.
 func GetLoadBalancerName(service *v1.Service) string {
+        // Check if annotation for custom loadbalancer name is defined
+        lbname, ok := service.Annotations["load-balancer-name"]
+	if ok {
+                //AWS requires that the name of a load balancer is shorter than 32 bytes.
+	        if len(lbname) > 32 {
+		  lbname = lbname[:32]
+	        }
+		return lbname
+	}
+
 	//GCE requires that the name of a load balancer starts with a lower case letter.
 	ret := "a" + string(service.UID)
 	ret = strings.Replace(ret, "-", "", -1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In our company environment we need to match loadbalancer name with service name for auditing and debugging purpose, current implementation use clusterid as loadbalancer name that's its make hard to do auditing and debugging in our env.
I'm propose to add annotation in Service API to allow custom name for loadbalancer name, as example : 
```
apiVersion: v1
kind: Service
metadata:
  name: 'testlb2'
  annotations:
    cloud.google.com/load-balancer-type: "Internal"
    load-balancer-name: "testlb2"
  labels:
    app: webapp
spec:
  type: LoadBalancer
  ports:
  - port: 9020
    protocol: TCP
  selector:
    app: webapp-backend
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Custom loadbalancer name via service annotation "load-balancer-name"
```
