### PR TITLE
GCE: Parse comma-separated values in the config file

### DIFF
--- a/pkg/cloudprovider/providers/gce/gce_test.go
+++ b/pkg/cloudprovider/providers/gce/gce_test.go
@@ -42,6 +42,8 @@ secondary-range-name = my-secondary-range
 node-tags = my-node-tag1
 node-instance-prefix = my-prefix
 multizone = true
+alpha-features = feature1,feature2
+alpha-features = feature3
    `
 	reader := strings.NewReader(s)
 	config, err := readConfig(reader)
@@ -60,6 +62,7 @@ multizone = true
 		NodeTags:           []string{"my-node-tag1"},
 		NodeInstancePrefix: "my-prefix",
 		Multizone:          true,
+		AlphaFeatures:      []string{"feature1", "feature2", "feature3"},
 	}}
 
 	if !reflect.DeepEqual(expected, config) {


### PR DESCRIPTION
This is necessary to support fields such as AlphaFeatures, which is
usually populated through an environment variable.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56833

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[GCE] Parse comma-separated values in the config file
```
