### PR TITLE
Add PostStartHooks to webhook admission controllers to detect disabled configuration API

### DIFF
--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -328,6 +328,20 @@ else
   ADMISSION_CONTROL=${KUBE_ADMISSION_CONTROL}
 fi
 
+if [[ ${ADMISSION_CONTROL} == *"Initializers"* ]]; then
+    if [[ -n "${RUNTIME_CONFIG}" ]]; then
+      RUNTIME_CONFIG+=","
+    fi
+    RUNTIME_CONFIG+="admissionregistration.k8s.io/v1alpha1"
+fi
+
+if [[ ${ADMISSION_CONTROL} == *"AdmissionWebhook"* ]]; then
+    if [[ -n "${RUNTIME_CONFIG}" ]]; then
+      RUNTIME_CONFIG+=","
+    fi
+    RUNTIME_CONFIG+="admissionregistration.k8s.io/v1beta1"
+fi
+
 # Optional: if set to true kube-up will automatically check for existing resources and clean them up.
 KUBE_UP_AUTOMATIC_CLEANUP=${KUBE_UP_AUTOMATIC_CLEANUP:-false}
 

--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -72,6 +72,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/etcd3/preflight:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -35,6 +35,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/server/types"
 	kubeexternalinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
@@ -107,7 +108,7 @@ func createAggregatorServer(aggregatorConfig *aggregatorapiserver.Config, delega
 		apiExtensionInformers.Apiextensions().InternalVersion().CustomResourceDefinitions(),
 		autoRegistrationController)
 
-	aggregatorServer.GenericAPIServer.AddPostStartHook("kube-apiserver-autoregistration", func(context genericapiserver.PostStartHookContext) error {
+	aggregatorServer.GenericAPIServer.AddPostStartHook("kube-apiserver-autoregistration", func(context types.PostStartHookContext) error {
 		go crdRegistrationController.Run(5, context.StopCh)
 		go func() {
 			// let the CRD controller process the initial set of CRDs before starting the autoregistration controller.

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -52,6 +52,7 @@ import (
 	serveroptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/apiserver/pkg/server/options/encryptionconfig"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	"k8s.io/apiserver/pkg/server/types"
 	aggregatorapiserver "k8s.io/kube-aggregator/pkg/apiserver"
 	openapi "k8s.io/kube-openapi/pkg/common"
 
@@ -204,7 +205,7 @@ func CreateKubeAPIServer(kubeAPIServerConfig *master.Config, delegateAPIServer g
 	if err != nil {
 		return nil, err
 	}
-	kubeAPIServer.GenericAPIServer.AddPostStartHook("start-kube-apiserver-informers", func(context genericapiserver.PostStartHookContext) error {
+	kubeAPIServer.GenericAPIServer.AddPostStartHook("start-kube-apiserver-informers", func(context types.PostStartHookContext) error {
 		sharedInformers.Start(context.StopCh)
 		return nil
 	})

--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -103,6 +103,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend/factory:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",

--- a/pkg/master/client_ca_hook.go
+++ b/pkg/master/client_ca_hook.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/types"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 )
@@ -40,7 +40,7 @@ type ClientCARegistrationHook struct {
 	RequestHeaderAllowedNames        []string
 }
 
-func (h ClientCARegistrationHook) PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
+func (h ClientCARegistrationHook) PostStartHook(hookContext types.PostStartHookContext) error {
 	// no work to do
 	if len(h.ClientCA) == 0 && len(h.RequestHeaderCA) == 0 {
 		return nil

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -28,7 +28,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
-	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/types"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	coreclient "k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/typed/core/internalversion"
 	"k8s.io/kubernetes/pkg/master/reconcilers"
@@ -107,7 +107,7 @@ func (c *completedConfig) NewBootstrapController(legacyRESTStorage corerest.Lega
 	}
 }
 
-func (c *Controller) PostStartHook(hookContext genericapiserver.PostStartHookContext) error {
+func (c *Controller) PostStartHook(hookContext types.PostStartHookContext) error {
 	c.Start()
 	return nil
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -52,6 +52,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
+	"k8s.io/apiserver/pkg/server/types"
 	storagefactory "k8s.io/apiserver/pkg/storage/storagebackend/factory"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -416,7 +417,7 @@ func (m *Master) InstallAPIs(apiResourceConfigSource serverstorage.APIResourceCo
 		}
 		glog.V(1).Infof("Enabling API group %q.", groupName)
 
-		if postHookProvider, ok := restStorageBuilder.(genericapiserver.PostStartHookProvider); ok {
+		if postHookProvider, ok := restStorageBuilder.(types.PostStartHookProvider); ok {
 			name, hook, err := postHookProvider.PostStartHook()
 			if err != nil {
 				glog.Fatalf("Error building PostStartHook: %v", err)

--- a/pkg/registry/rbac/rest/BUILD
+++ b/pkg/registry/rbac/rest/BUILD
@@ -43,6 +43,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/storage:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/client-go/util/retry:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/apiserver.go
@@ -35,6 +35,7 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/types"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
@@ -199,11 +200,11 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		crdHandler,
 	)
 
-	s.GenericAPIServer.AddPostStartHook("start-apiextensions-informers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("start-apiextensions-informers", func(context types.PostStartHookContext) error {
 		s.Informers.Start(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("start-apiextensions-controllers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("start-apiextensions-controllers", func(context types.PostStartHookContext) error {
 		go crdController.Run(context.StopCh)
 		go namingController.Run(context.StopCh)
 		go finalizingController.Run(5, context.StopCh)

--- a/staging/src/k8s.io/apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiserver/Godeps/Godeps.json
@@ -1703,6 +1703,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/client-go/informers/admissionregistration/v1beta1",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
@@ -1724,6 +1728,10 @@
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
+			"ImportPath": "k8s.io/client-go/listers/admissionregistration/v1beta1",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{

--- a/staging/src/k8s.io/apiserver/pkg/admission/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/apis/apiserver:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
@@ -21,9 +21,12 @@ go_test(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/listers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 
@@ -42,8 +45,13 @@ go_library(
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/informers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/listers/admissionregistration/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -18,84 +18,82 @@ package configuration
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
-
-	"github.com/golang/glog"
+	"sync/atomic"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	admissionregistrationinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
-
-type MutatingWebhookConfigurationLister interface {
-	List(opts metav1.ListOptions) (*v1beta1.MutatingWebhookConfigurationList, error)
-}
 
 // MutatingWebhookConfigurationManager collects the mutating webhook objects so that they can be called.
 type MutatingWebhookConfigurationManager struct {
-	*poller
+	ready         int32
+	configuration *atomic.Value
+	hasSynced     func() bool
+	lister        admissionregistrationlisters.MutatingWebhookConfigurationLister
 }
 
-func NewMutatingWebhookConfigurationManager(c MutatingWebhookConfigurationLister) *MutatingWebhookConfigurationManager {
-	getFn := func() (runtime.Object, error) {
-		list, err := c.List(metav1.ListOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) || errors.IsForbidden(err) {
-				glog.V(5).Infof("MutatingWebhookConfiguration are disabled due to an error: %v", err)
-				return nil, ErrDisabled
-			}
-			return nil, err
-		}
-		return mergeMutatingWebhookConfigurations(list), nil
+func NewMutatingWebhookConfigurationManager(informer admissionregistrationinformers.MutatingWebhookConfigurationInformer) *MutatingWebhookConfigurationManager {
+	manager := &MutatingWebhookConfigurationManager{
+		ready:         0,
+		configuration: &atomic.Value{},
+		hasSynced:     informer.Informer().HasSynced,
+		lister:        informer.Lister(),
 	}
 
-	return &MutatingWebhookConfigurationManager{
-		newPoller(getFn),
-	}
+	// Start with an empty list
+	manager.configuration.Store(&v1beta1.MutatingWebhookConfiguration{})
+
+	// On any change, rebuild the config
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+	})
+
+	return manager
 }
 
 // Webhooks returns the merged MutatingWebhookConfiguration.
-func (im *MutatingWebhookConfigurationManager) Webhooks() (*v1beta1.MutatingWebhookConfiguration, error) {
-	configuration, err := im.poller.configuration()
+func (m *MutatingWebhookConfigurationManager) Webhooks() (*v1beta1.MutatingWebhookConfiguration, error) {
+	if atomic.LoadInt32(&m.ready) == 0 {
+		if !m.hasSynced() {
+			// Return an error until we've synced
+			return nil, fmt.Errorf("mutating webhook configuration is not ready")
+		}
+		// Remember we're ready
+		atomic.StoreInt32(&m.ready, 1)
+	}
+	return m.configuration.Load().(*v1beta1.MutatingWebhookConfiguration), nil
+}
+
+func (m *MutatingWebhookConfigurationManager) updateConfiguration() {
+	configurations, err := m.lister.List(labels.Everything())
 	if err != nil {
-		return nil, err
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		return
 	}
-	mutatingWebhookConfiguration, ok := configuration.(*v1beta1.MutatingWebhookConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("expected type %v, got type %v", reflect.TypeOf(mutatingWebhookConfiguration), reflect.TypeOf(configuration))
-	}
-	return mutatingWebhookConfiguration, nil
+	m.configuration.Store(mergeMutatingWebhookConfigurations(configurations))
 }
 
-func (im *MutatingWebhookConfigurationManager) Run(stopCh <-chan struct{}) {
-	im.poller.Run(stopCh)
-}
-
-func mergeMutatingWebhookConfigurations(
-	list *v1beta1.MutatingWebhookConfigurationList,
-) *v1beta1.MutatingWebhookConfiguration {
-	configurations := append([]v1beta1.MutatingWebhookConfiguration{}, list.Items...)
+func mergeMutatingWebhookConfigurations(configurations []*v1beta1.MutatingWebhookConfiguration) *v1beta1.MutatingWebhookConfiguration {
 	var ret v1beta1.MutatingWebhookConfiguration
 	// The internal order of webhooks for each configuration is provided by the user
 	// but configurations themselves can be in any order. As we are going to run these
 	// webhooks in serial, they are sorted here to have a deterministic order.
-	sort.Sort(byName(configurations))
+	sort.SliceStable(configurations, MutatingWebhookConfigurationSorter(configurations).ByName)
 	for _, c := range configurations {
 		ret.Webhooks = append(ret.Webhooks, c.Webhooks...)
 	}
 	return &ret
 }
 
-// byName sorts MutatingWebhookConfiguration by name. These objects are all in
-// cluster namespace (aka no namespace) thus they all have unique names.
-type byName []v1beta1.MutatingWebhookConfiguration
+type MutatingWebhookConfigurationSorter []*v1beta1.MutatingWebhookConfiguration
 
-func (x byName) Len() int { return len(x) }
-
-func (x byName) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
-
-func (x byName) Less(i, j int) bool {
-	return x[i].ObjectMeta.Name < x[j].ObjectMeta.Name
+func (a MutatingWebhookConfigurationSorter) ByName(i, j int) bool {
+	return a[i].Name < a[j].Name
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -17,24 +17,118 @@ limitations under the License.
 package configuration
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/labels"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
-type disabledMutatingWebhookConfigLister struct{}
-
-func (l *disabledMutatingWebhookConfigLister) List(options metav1.ListOptions) (*v1beta1.MutatingWebhookConfigurationList, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: "admissionregistration", Resource: "MutatingWebhookConfigurations"}, "")
+type fakeMutatingWebhookConfigSharedInformer struct {
+	informer *fakeMutatingWebhookConfigInformer
+	lister   *fakeMutatingWebhookConfigLister
 }
-func TestMutatingWebhookConfigDisabled(t *testing.T) {
-	manager := NewMutatingWebhookConfigurationManager(&disabledMutatingWebhookConfigLister{})
-	manager.sync()
-	_, err := manager.Webhooks()
-	if err.Error() != ErrDisabled.Error() {
-		t.Errorf("expected %v, got %v", ErrDisabled, err)
+
+func (f *fakeMutatingWebhookConfigSharedInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+func (f *fakeMutatingWebhookConfigSharedInformer) Lister() admissionregistrationlisters.MutatingWebhookConfigurationLister {
+	return f.lister
+}
+
+type fakeMutatingWebhookConfigInformer struct {
+	eventHandler cache.ResourceEventHandler
+	hasSynced    bool
+}
+
+func (f *fakeMutatingWebhookConfigInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	fmt.Println("added handler")
+	f.eventHandler = handler
+}
+func (f *fakeMutatingWebhookConfigInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetStore() cache.Store {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetController() cache.Controller {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) Run(stopCh <-chan struct{}) {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) HasSynced() bool {
+	return f.hasSynced
+}
+func (f *fakeMutatingWebhookConfigInformer) LastSyncResourceVersion() string {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) AddIndexers(indexers cache.Indexers) error {
+	panic("unsupported")
+}
+func (f *fakeMutatingWebhookConfigInformer) GetIndexer() cache.Indexer { panic("unsupported") }
+
+type fakeMutatingWebhookConfigLister struct {
+	list []*v1beta1.MutatingWebhookConfiguration
+	err  error
+}
+
+func (f *fakeMutatingWebhookConfigLister) List(selector labels.Selector) (ret []*v1beta1.MutatingWebhookConfiguration, err error) {
+	return f.list, f.err
+}
+
+func (f *fakeMutatingWebhookConfigLister) Get(name string) (*v1beta1.MutatingWebhookConfiguration, error) {
+	panic("unsupported")
+}
+
+func TestGetMutatingWebhookConfig(t *testing.T) {
+	informer := &fakeMutatingWebhookConfigSharedInformer{
+		informer: &fakeMutatingWebhookConfigInformer{},
+		lister:   &fakeMutatingWebhookConfigLister{},
+	}
+
+	// unsynced, error retrieving list
+	informer.informer.hasSynced = false
+	informer.lister.list = nil
+	informer.lister.err = fmt.Errorf("mutating webhook configuration is not ready")
+	manager := NewMutatingWebhookConfigurationManager(informer)
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// list found, still unsynced
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.MutatingWebhookConfiguration{}
+	informer.lister.err = nil
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// items populated, still unsynced
+	webhookContainer := &v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+		Webhooks:   []v1beta1.Webhook{{Name: "webhook1.1"}},
+	}
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.MutatingWebhookConfiguration{webhookContainer.DeepCopy()}
+	informer.lister.err = nil
+	informer.informer.eventHandler.OnAdd(webhookContainer.DeepCopy())
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// sync completed
+	informer.informer.hasSynced = true
+	hooks, err := manager.Webhooks()
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	if !reflect.DeepEqual(hooks.Webhooks, webhookContainer.Webhooks) {
+		t.Errorf("Expected\n%#v\ngot\n%#v", webhookContainer.Webhooks, hooks.Webhooks)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -18,67 +18,81 @@ package configuration
 
 import (
 	"fmt"
-	"reflect"
-
-	"github.com/golang/glog"
+	"sort"
+	"sync/atomic"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/labels"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	admissionregistrationinformers "k8s.io/client-go/informers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
-
-type ValidatingWebhookConfigurationLister interface {
-	List(opts metav1.ListOptions) (*v1beta1.ValidatingWebhookConfigurationList, error)
-}
 
 // ValidatingWebhookConfigurationManager collects the validating webhook objects so that they can be called.
 type ValidatingWebhookConfigurationManager struct {
-	*poller
+	ready         int32
+	configuration *atomic.Value
+	hasSynced     func() bool
+	lister        admissionregistrationlisters.ValidatingWebhookConfigurationLister
 }
 
-func NewValidatingWebhookConfigurationManager(c ValidatingWebhookConfigurationLister) *ValidatingWebhookConfigurationManager {
-	getFn := func() (runtime.Object, error) {
-		list, err := c.List(metav1.ListOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) || errors.IsForbidden(err) {
-				glog.V(5).Infof("ValidatingWebhookConfiguration are disabled due to an error: %v", err)
-				return nil, ErrDisabled
-			}
-			return nil, err
-		}
-		return mergeValidatingWebhookConfigurations(list), nil
+func NewValidatingWebhookConfigurationManager(informer admissionregistrationinformers.ValidatingWebhookConfigurationInformer) *ValidatingWebhookConfigurationManager {
+	manager := &ValidatingWebhookConfigurationManager{
+		ready:         0,
+		configuration: &atomic.Value{},
+		hasSynced:     informer.Informer().HasSynced,
+		lister:        informer.Lister(),
 	}
 
-	return &ValidatingWebhookConfigurationManager{
-		newPoller(getFn),
-	}
+	// Start with an empty list
+	manager.configuration.Store(&v1beta1.ValidatingWebhookConfiguration{})
+
+	// On any change, rebuild the config
+	informer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(_ interface{}) { manager.updateConfiguration() },
+		UpdateFunc: func(_, _ interface{}) { manager.updateConfiguration() },
+		DeleteFunc: func(_ interface{}) { manager.updateConfiguration() },
+	})
+
+	return manager
 }
 
 // Webhooks returns the merged ValidatingWebhookConfiguration.
-func (im *ValidatingWebhookConfigurationManager) Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error) {
-	configuration, err := im.poller.configuration()
-	if err != nil {
-		return nil, err
+func (v *ValidatingWebhookConfigurationManager) Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error) {
+	if atomic.LoadInt32(&v.ready) == 0 {
+		if !v.hasSynced() {
+			// Return an error until we've synced
+			return nil, fmt.Errorf("validating webhook configuration is not ready")
+		}
+		// Remember we're ready
+		atomic.StoreInt32(&v.ready, 1)
 	}
-	validatingWebhookConfiguration, ok := configuration.(*v1beta1.ValidatingWebhookConfiguration)
-	if !ok {
-		return nil, fmt.Errorf("expected type %v, got type %v", reflect.TypeOf(validatingWebhookConfiguration), reflect.TypeOf(configuration))
-	}
-	return validatingWebhookConfiguration, nil
+	return v.configuration.Load().(*v1beta1.ValidatingWebhookConfiguration), nil
 }
 
-func (im *ValidatingWebhookConfigurationManager) Run(stopCh <-chan struct{}) {
-	im.poller.Run(stopCh)
+func (v *ValidatingWebhookConfigurationManager) updateConfiguration() {
+	configurations, err := v.lister.List(labels.Everything())
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error updating configuration: %v", err))
+		return
+	}
+	v.configuration.Store(mergeValidatingWebhookConfigurations(configurations))
 }
 
 func mergeValidatingWebhookConfigurations(
-	list *v1beta1.ValidatingWebhookConfigurationList,
+	configurations []*v1beta1.ValidatingWebhookConfiguration,
 ) *v1beta1.ValidatingWebhookConfiguration {
-	configurations := list.Items
+	sort.SliceStable(configurations, ValidatingWebhookConfigurationSorter(configurations).ByName)
 	var ret v1beta1.ValidatingWebhookConfiguration
 	for _, c := range configurations {
 		ret.Webhooks = append(ret.Webhooks, c.Webhooks...)
 	}
 	return &ret
+}
+
+type ValidatingWebhookConfigurationSorter []*v1beta1.ValidatingWebhookConfiguration
+
+func (a ValidatingWebhookConfigurationSorter) ByName(i, j int) bool {
+	return a[i].Name < a[j].Name
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -17,24 +17,118 @@ limitations under the License.
 package configuration
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
+	"time"
 
 	"k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/labels"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	"k8s.io/client-go/tools/cache"
 )
 
-type disabledValidatingWebhookConfigLister struct{}
-
-func (l *disabledValidatingWebhookConfigLister) List(options metav1.ListOptions) (*v1beta1.ValidatingWebhookConfigurationList, error) {
-	return nil, errors.NewNotFound(schema.GroupResource{Group: "admissionregistration", Resource: "ValidatingWebhookConfigurations"}, "")
+type fakeValidatingWebhookConfigSharedInformer struct {
+	informer *fakeValidatingWebhookConfigInformer
+	lister   *fakeValidatingWebhookConfigLister
 }
-func TestWebhookConfigDisabled(t *testing.T) {
-	manager := NewValidatingWebhookConfigurationManager(&disabledValidatingWebhookConfigLister{})
-	manager.sync()
-	_, err := manager.Webhooks()
-	if err.Error() != ErrDisabled.Error() {
-		t.Errorf("expected %v, got %v", ErrDisabled, err)
+
+func (f *fakeValidatingWebhookConfigSharedInformer) Informer() cache.SharedIndexInformer {
+	return f.informer
+}
+func (f *fakeValidatingWebhookConfigSharedInformer) Lister() admissionregistrationlisters.ValidatingWebhookConfigurationLister {
+	return f.lister
+}
+
+type fakeValidatingWebhookConfigInformer struct {
+	eventHandler cache.ResourceEventHandler
+	hasSynced    bool
+}
+
+func (f *fakeValidatingWebhookConfigInformer) AddEventHandler(handler cache.ResourceEventHandler) {
+	fmt.Println("added handler")
+	f.eventHandler = handler
+}
+func (f *fakeValidatingWebhookConfigInformer) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetStore() cache.Store {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetController() cache.Controller {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) Run(stopCh <-chan struct{}) {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) HasSynced() bool {
+	return f.hasSynced
+}
+func (f *fakeValidatingWebhookConfigInformer) LastSyncResourceVersion() string {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) AddIndexers(indexers cache.Indexers) error {
+	panic("unsupported")
+}
+func (f *fakeValidatingWebhookConfigInformer) GetIndexer() cache.Indexer { panic("unsupported") }
+
+type fakeValidatingWebhookConfigLister struct {
+	list []*v1beta1.ValidatingWebhookConfiguration
+	err  error
+}
+
+func (f *fakeValidatingWebhookConfigLister) List(selector labels.Selector) (ret []*v1beta1.ValidatingWebhookConfiguration, err error) {
+	return f.list, f.err
+}
+
+func (f *fakeValidatingWebhookConfigLister) Get(name string) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	panic("unsupported")
+}
+
+func TestGettValidatingWebhookConfig(t *testing.T) {
+	informer := &fakeValidatingWebhookConfigSharedInformer{
+		informer: &fakeValidatingWebhookConfigInformer{},
+		lister:   &fakeValidatingWebhookConfigLister{},
+	}
+
+	// unsynced, error retrieving list
+	informer.informer.hasSynced = false
+	informer.lister.list = nil
+	informer.lister.err = fmt.Errorf("validating webhook configuration is not ready")
+	manager := NewValidatingWebhookConfigurationManager(informer)
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// list found, still unsynced
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.ValidatingWebhookConfiguration{}
+	informer.lister.err = nil
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// items populated, still unsynced
+	webhookContainer := &v1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
+		Webhooks:   []v1beta1.Webhook{{Name: "webhook1.1"}},
+	}
+	informer.informer.hasSynced = false
+	informer.lister.list = []*v1beta1.ValidatingWebhookConfiguration{webhookContainer.DeepCopy()}
+	informer.lister.err = nil
+	informer.informer.eventHandler.OnAdd(webhookContainer.DeepCopy())
+	if _, err := manager.Webhooks(); err == nil {
+		t.Errorf("expected err, but got none")
+	}
+
+	// sync completed
+	informer.informer.hasSynced = true
+	hooks, err := manager.Webhooks()
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+	if !reflect.DeepEqual(hooks.Webhooks, webhookContainer.Webhooks) {
+		t.Errorf("Expected\n%#v\ngot\n%#v", webhookContainer.Webhooks, hooks.Webhooks)
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
@@ -29,8 +30,10 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/rules:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/versioned:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/request"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/rules"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/versioned"
+	"k8s.io/apiserver/pkg/server/types"
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	admissionregistrationv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/admission.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/configuration"
 	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
@@ -69,7 +68,6 @@ func Register(plugins *admission.Plugins) {
 
 // WebhookSource can list dynamic webhook plugins.
 type WebhookSource interface {
-	Run(stopCh <-chan struct{})
 	Webhooks() (*v1beta1.MutatingWebhookConfiguration, error)
 }
 
@@ -144,7 +142,6 @@ func (a *MutatingWebhook) SetScheme(scheme *runtime.Scheme) {
 // WantsExternalKubeClientSet defines a function which sets external ClientSet for admission plugins that need it
 func (a *MutatingWebhook) SetExternalKubeClientSet(client clientset.Interface) {
 	a.namespaceMatcher.Client = client
-	a.hookSource = configuration.NewMutatingWebhookConfigurationManager(client.AdmissionregistrationV1beta1().MutatingWebhookConfigurations())
 }
 
 // SetExternalKubeInformerFactory implements the WantsExternalKubeInformerFactory interface.
@@ -152,6 +149,7 @@ func (a *MutatingWebhook) SetExternalKubeInformerFactory(f informers.SharedInfor
 	namespaceInformer := f.Core().V1().Namespaces()
 	a.namespaceMatcher.NamespaceLister = namespaceInformer.Lister()
 	a.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+	a.hookSource = configuration.NewMutatingWebhookConfigurationManager(f.Admissionregistration().V1beta1().MutatingWebhookConfigurations())
 }
 
 // ValidateInitialization implements the InitializationValidator interface.
@@ -171,16 +169,11 @@ func (a *MutatingWebhook) ValidateInitialization() error {
 	if err := a.convertor.Validate(); err != nil {
 		return fmt.Errorf("MutatingWebhook.convertor is not properly setup: %v", err)
 	}
-	go a.hookSource.Run(wait.NeverStop)
 	return nil
 }
 
 func (a *MutatingWebhook) loadConfiguration(attr admission.Attributes) (*v1beta1.MutatingWebhookConfiguration, error) {
 	hookConfig, err := a.hookSource.Webhooks()
-	// if Webhook configuration is disabled, fail open
-	if err == configuration.ErrDisabled {
-		return &v1beta1.MutatingWebhookConfiguration{}, nil
-	}
 	if err != nil {
 		e := apierrors.NewServerTimeout(attr.GetResource().GroupResource(), string(attr.GetOperation()), 1)
 		e.ErrStatus.Message = fmt.Sprintf("Unable to refresh the Webhook configuration: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/configuration:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
@@ -29,8 +30,10 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/rules:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/versioned:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/admission.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/configuration"
 	genericadmissioninit "k8s.io/apiserver/pkg/admission/initializer"
@@ -73,7 +72,6 @@ func Register(plugins *admission.Plugins) {
 
 // WebhookSource can list dynamic webhook plugins.
 type WebhookSource interface {
-	Run(stopCh <-chan struct{})
 	Webhooks() (*v1beta1.ValidatingWebhookConfiguration, error)
 }
 
@@ -146,7 +144,6 @@ func (a *ValidatingAdmissionWebhook) SetScheme(scheme *runtime.Scheme) {
 // WantsExternalKubeClientSet defines a function which sets external ClientSet for admission plugins that need it
 func (a *ValidatingAdmissionWebhook) SetExternalKubeClientSet(client clientset.Interface) {
 	a.namespaceMatcher.Client = client
-	a.hookSource = configuration.NewValidatingWebhookConfigurationManager(client.AdmissionregistrationV1beta1().ValidatingWebhookConfigurations())
 }
 
 // SetExternalKubeInformerFactory implements the WantsExternalKubeInformerFactory interface.
@@ -154,12 +151,13 @@ func (a *ValidatingAdmissionWebhook) SetExternalKubeInformerFactory(f informers.
 	namespaceInformer := f.Core().V1().Namespaces()
 	a.namespaceMatcher.NamespaceLister = namespaceInformer.Lister()
 	a.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+	a.hookSource = configuration.NewValidatingWebhookConfigurationManager(f.Admissionregistration().V1beta1().ValidatingWebhookConfigurations())
 }
 
 // ValidateInitialization implements the InitializationValidator interface.
 func (a *ValidatingAdmissionWebhook) ValidateInitialization() error {
 	if a.hookSource == nil {
-		return fmt.Errorf("ValidatingAdmissionWebhook admission plugin requires a Kubernetes client to be provided")
+		return fmt.Errorf("ValidatingAdmissionWebhook admission plugin requires a Kubernetes informer to be provided")
 	}
 	if err := a.namespaceMatcher.Validate(); err != nil {
 		return fmt.Errorf("ValidatingAdmissionWebhook.namespaceMatcher is not properly setup: %v", err)
@@ -170,16 +168,11 @@ func (a *ValidatingAdmissionWebhook) ValidateInitialization() error {
 	if err := a.convertor.Validate(); err != nil {
 		return fmt.Errorf("ValidatingAdmissionWebhook.convertor is not properly setup: %v", err)
 	}
-	go a.hookSource.Run(wait.NeverStop)
 	return nil
 }
 
 func (a *ValidatingAdmissionWebhook) loadConfiguration(attr admission.Attributes) (*v1beta1.ValidatingWebhookConfiguration, error) {
 	hookConfig, err := a.hookSource.Webhooks()
-	// if Webhook configuration is disabled, fail open
-	if err == configuration.ErrDisabled {
-		return &v1beta1.ValidatingWebhookConfiguration{}, nil
-	}
 	if err != nil {
 		e := apierrors.NewServerTimeout(attr.GetResource().GroupResource(), string(attr.GetOperation()), 1)
 		e.ErrStatus.Message = fmt.Sprintf("Unable to refresh the Webhook configuration: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/server"
 
 	"github.com/golang/glog"
 )
@@ -132,10 +133,16 @@ func splitStream(config io.Reader) (io.Reader, io.Reader, error) {
 
 type Decorator func(handler Interface, name string) Interface
 
+type PostStartHookFuncAndName struct {
+	Func server.PostStartHookFunc
+	Name string
+}
+
 // NewFromPlugins returns an admission.Interface that will enforce admission control decisions of all
 // the given plugins.
-func (ps *Plugins) NewFromPlugins(pluginNames []string, configProvider ConfigProvider, pluginInitializer PluginInitializer, decorator Decorator) (Interface, error) {
+func (ps *Plugins) NewFromPlugins(pluginNames []string, configProvider ConfigProvider, pluginInitializer PluginInitializer, decorator Decorator) (Interface, []PostStartHookFuncAndName, error) {
 	handlers := []Interface{}
+	var hooks []PostStartHookFuncAndName
 	for _, pluginName := range pluginNames {
 		pluginConfig, err := configProvider.ConfigFor(pluginName)
 		if err != nil {
@@ -153,8 +160,18 @@ func (ps *Plugins) NewFromPlugins(pluginNames []string, configProvider ConfigPro
 				handlers = append(handlers, plugin)
 			}
 		}
+		if postHookProvider, ok := plugin.(server.PostStartHookProvider); ok {
+			name, hook, err := postHookProvider.PostStartHook()
+			if err != nil {
+				glog.Fatalf("Error building PostStartHook: %v", err)
+			}
+			hooks = append(hooks, PostStartHookFuncAndName{
+				Name: name,
+				Func: hook,
+			})
+		}
 	}
-	return chainAdmissionHandler(handlers), nil
+	return chainAdmissionHandler(handlers), hooks, nil
 }
 
 // InitPlugin creates an instance of the named interface.

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugins.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/types"
 
 	"github.com/golang/glog"
 )
@@ -134,7 +134,7 @@ func splitStream(config io.Reader) (io.Reader, io.Reader, error) {
 type Decorator func(handler Interface, name string) Interface
 
 type PostStartHookFuncAndName struct {
-	Func server.PostStartHookFunc
+	Func types.PostStartHookFunc
 	Name string
 }
 
@@ -146,12 +146,12 @@ func (ps *Plugins) NewFromPlugins(pluginNames []string, configProvider ConfigPro
 	for _, pluginName := range pluginNames {
 		pluginConfig, err := configProvider.ConfigFor(pluginName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		plugin, err := ps.InitPlugin(pluginName, pluginConfig, pluginInitializer)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if plugin != nil {
 			if decorator != nil {
@@ -160,7 +160,7 @@ func (ps *Plugins) NewFromPlugins(pluginNames []string, configProvider ConfigPro
 				handlers = append(handlers, plugin)
 			}
 		}
-		if postHookProvider, ok := plugin.(server.PostStartHookProvider); ok {
+		if postHookProvider, ok := plugin.(types.PostStartHookProvider); ok {
 			name, hook, err := postHookProvider.PostStartHook()
 			if err != nil {
 				glog.Fatalf("Error building PostStartHook: %v", err)

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -112,6 +112,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/mux:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/routes:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
@@ -138,6 +139,7 @@ filegroup(
         "//staging/src/k8s.io/apiserver/pkg/server/options:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/server/routes:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/server/types:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -94,8 +94,9 @@ type Config struct {
 	RuleResolver authorizer.RuleResolver
 	// AdmissionControl performs deep inspection of a given request (including content)
 	// to set values and determine whether its allowed
-	AdmissionControl      admission.Interface
-	CorsAllowedOriginList []string
+	AdmissionControl        admission.Interface
+	AdmissionPostStartHooks []admission.PostStartHookFuncAndName
+	CorsAllowedOriginList   []string
 
 	EnableSwaggerUI bool
 	EnableIndex     bool
@@ -489,6 +490,14 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 		})
 		if err != nil {
 			return nil, err
+		}
+	}
+
+	for _, hook := range c.AdmissionPostStartHooks {
+		if !s.isPostStartHookRegistered(hook.Name) {
+			if err := s.AddPostStartHook(hook.Name, hook.Func); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -57,6 +57,7 @@ import (
 	genericfilters "k8s.io/apiserver/pkg/server/filters"
 	"k8s.io/apiserver/pkg/server/healthz"
 	"k8s.io/apiserver/pkg/server/routes"
+	"k8s.io/apiserver/pkg/server/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	restclient "k8s.io/client-go/rest"
@@ -484,7 +485,7 @@ func (c completedConfig) New(name string, delegationTarget DelegationTarget) (*G
 
 	genericApiServerHookName := "generic-apiserver-start-informers"
 	if c.SharedInformerFactory != nil && !s.isPostStartHookRegistered(genericApiServerHookName) {
-		err := s.AddPostStartHook(genericApiServerHookName, func(context PostStartHookContext) error {
+		err := s.AddPostStartHook(genericApiServerHookName, func(context types.PostStartHookContext) error {
 			c.SharedInformerFactory.Start(context.StopCh)
 			return nil
 		})

--- a/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/admission.go
@@ -119,12 +119,13 @@ func (a *AdmissionOptions) ApplyTo(
 	pluginInitializers = append(pluginInitializers, genericInitializer)
 	initializersChain = append(initializersChain, pluginInitializers...)
 
-	admissionChain, err := a.Plugins.NewFromPlugins(pluginNames, pluginsConfigProvider, initializersChain, admissionmetrics.WithControllerMetrics)
+	admissionChain, postStartHooks, err := a.Plugins.NewFromPlugins(pluginNames, pluginsConfigProvider, initializersChain, admissionmetrics.WithControllerMetrics)
 	if err != nil {
 		return err
 	}
 
 	c.AdmissionControl = admissionmetrics.WithStepMetrics(admissionChain)
+	c.AdmissionPostStartHooks = postStartHooks
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/types/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/types/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hooks.go"],
+    importpath = "k8s.io/apiserver/pkg/server/types",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/k8s.io/client-go/rest:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/server/types/hooks.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/types/hooks.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	restclient "k8s.io/client-go/rest"
+)
+
+// PostStartHookFunc is a function that is called after the server has started.
+// It must properly handle cases like:
+//  1. asynchronous start in multiple API server processes
+//  2. conflicts between the different processes all trying to perform the same action
+//  3. partially complete work (API server crashes while running your hook)
+//  4. API server access **BEFORE** your hook has completed
+// Think of it like a mini-controller that is super privileged and gets to run in-process
+// If you use this feature, tag @deads2k on github who has promised to review code for anyone's PostStartHook
+// until it becomes easier to use.
+type PostStartHookFunc func(context PostStartHookContext) error
+
+// PreShutdownHookFunc is a function that can be added to the shutdown logic.
+type PreShutdownHookFunc func() error
+
+// PostStartHookContext provides information about this API server to a PostStartHookFunc
+type PostStartHookContext struct {
+	// LoopbackClientConfig is a config for a privileged loopback connection to the API server
+	LoopbackClientConfig *restclient.Config
+	// StopCh is the channel that will be closed when the server stops
+	StopCh <-chan struct{}
+}
+
+// PostStartHookProvider is an interface in addition to provide a post start hook for the api server
+type PostStartHookProvider interface {
+	PostStartHook() (string, PostStartHookFunc, error)
+}
+
+type postStartHookEntry struct {
+	hook PostStartHookFunc
+
+	// done will be closed when the postHook is finished
+	done chan struct{}
+}
+
+type preShutdownHookEntry struct {
+	hook PreShutdownHookFunc
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/BUILD
@@ -62,6 +62,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/features:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/proxy:go_default_library",
         "//vendor/k8s.io/client-go/informers/core/v1:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/apiserver.go
@@ -30,6 +30,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/apiserver/pkg/server/types"
 	"k8s.io/client-go/pkg/version"
 
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
@@ -211,16 +212,16 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		s.serviceResolver,
 	)
 
-	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("start-kube-aggregator-informers", func(context types.PostStartHookContext) error {
 		informerFactory.Start(context.StopCh)
 		c.GenericConfig.SharedInformerFactory.Start(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("apiservice-registration-controller", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("apiservice-registration-controller", func(context types.PostStartHookContext) error {
 		go apiserviceRegistrationController.Run(context.StopCh)
 		return nil
 	})
-	s.GenericAPIServer.AddPostStartHook("apiservice-status-available-controller", func(context genericapiserver.PostStartHookContext) error {
+	s.GenericAPIServer.AddPostStartHook("apiservice-status-available-controller", func(context types.PostStartHookContext) error {
 		// if we end up blocking for long periods of time, we may need to increase threadiness.
 		go availableController.Run(5, context.StopCh)
 		return nil
@@ -239,7 +240,7 @@ func (c completedConfig) NewWithDelegate(delegationTarget genericapiserver.Deleg
 		}
 		s.openAPIAggregationController = openapicontroller.NewAggregationController(&specDownloader, openAPIAggregator)
 
-		s.GenericAPIServer.AddPostStartHook("apiservice-openapi-controller", func(context genericapiserver.PostStartHookContext) error {
+		s.GenericAPIServer.AddPostStartHook("apiservice-openapi-controller", func(context types.PostStartHookContext) error {
 			go s.openAPIAggregationController.Run(context.StopCh)
 			return nil
 		})

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/BUILD
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/options:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/server/types:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/admission/plugin/banflunder:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/admission/wardleinitializer:go_default_library",
         "//vendor/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1:go_default_library",

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -26,6 +26,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	genericoptions "k8s.io/apiserver/pkg/server/options"
+	"k8s.io/apiserver/pkg/server/types"
 	"k8s.io/sample-apiserver/pkg/admission/plugin/banflunder"
 	"k8s.io/sample-apiserver/pkg/admission/wardleinitializer"
 	"k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"
@@ -141,7 +142,7 @@ func (o WardleServerOptions) RunWardleServer(stopCh <-chan struct{}) error {
 		return err
 	}
 
-	server.GenericAPIServer.AddPostStartHook("start-sample-server-informers", func(context genericapiserver.PostStartHookContext) error {
+	server.GenericAPIServer.AddPostStartHook("start-sample-server-informers", func(context types.PostStartHookContext) error {
 		config.GenericConfig.SharedInformerFactory.Start(context.StopCh)
 		return nil
 	})


### PR DESCRIPTION
ref: kubernetes/features#492

Follow-up of #56478 

Please review the commit "add post start hook to admission plugins".

We want to fail the start of an apiserver with a clear error message if the webhook admission controllers are enabled but the `admissionregistration/v1beta1` API is not. The check of the API should run after the APIs are installed to avoid false negative, so writing the check as a `PostStartHook` seems to be the right mechanism.

@liggitt @deads2k @hzxuzhonghu 