### PR TITLE
Improve etcd-version-monitor metrics proxying, add etcd 3.1 gprc metr…

### DIFF
--- a/cluster/images/etcd-version-monitor/BUILD
+++ b/cluster/images/etcd-version-monitor/BUILD
@@ -19,6 +19,8 @@ go_library(
     deps = [
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/prometheus/common/expfmt:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],

--- a/cluster/images/etcd-version-monitor/Makefile
+++ b/cluster/images/etcd-version-monitor/Makefile
@@ -20,7 +20,7 @@
 ARCH:=amd64
 GOLANG_VERSION?=1.8.3
 REGISTRY?=gcr.io/google-containers
-TAG?=0.1.0
+TAG?=0.1.1
 IMAGE:=$(REGISTRY)/etcd-version-monitor:$(TAG)
 CURRENT_DIR:=$(pwd)
 TEMP_DIR:=$(shell mktemp -d)

--- a/cluster/images/etcd-version-monitor/README.md
+++ b/cluster/images/etcd-version-monitor/README.md
@@ -1,10 +1,18 @@
 # etcd-version-monitor
 
-This is a tool for exporting metrics related to etcd version, like etcd
-server's binary version, cluster version, and counts of different kinds of
-gRPC calls (which is a characteristic of v3), etc. These metrics are in
+This is a tool for exporting etcd metrics and supplementing them with etcd
+server binary version and cluster version. These metrics are in
 prometheus format and can be scraped by a prometheus server.
 The metrics are exposed at the http://localhost:9101/metrics endpoint.
+
+For etcd 3.1+, the
+[go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus)
+metrics format, which backward incompatibly replaces the 3.0 legacy grpc metric
+format, is exposed in both the 3.1 format and in the 3.0. This preserves
+backward compatiblity.
+
+For etcd 3.1+, the `--metrics=extensive` must be set on etcd for grpc request
+latency metrics (`etcd_grpc_unary_requests_duration_seconds`) to be exposed.
 
 **RUNNING THE TOOL**
 


### PR DESCRIPTION
Partially addresses https://github.com/kubernetes/kubernetes/issues/56869:

- Fix `etcd-version-monitor` to support etcd 3.1: Add support for the etcd 3.1+ [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) metrics format, which backward incompatibly replaces  the 3.0 legacy grpc metric format. Expose the go-grpc-prometheus metrics both in the 3.1 format and in the 3.0 format so systems consuming `etcd-version-monitor` metrics have a clean, simple upgrade path.
- Expose *all* etcd metrics by default, making this a one stop shop for all etcd metrics.
- Expose grpc request latency histogram metrics (`grpc_server_handling_seconds` from [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) metrics format). Rewrite etcd 3.0 legacy metric for latency histograms to the etcd 3.1+ `go-grpc-prometheus` format so there is a single format exported for all etcd versions.

etcd 3.0 to 3.1 upgrade path:  Continue to use the `etcd_grpc_requests_total`. Once the upgrade is complete and all etcd nodes are running 3.1, migrate to the `grpc_server_handled_total` metric at your leisure.

This PR reorganizes the code substantially. Previously, the code to proxy etcd metrics was hard coded and limited to a single counter metric. This has been entirely replaced with code that generically filters, rewrites proxied etcd metrics and then aggregates them with custom metrics such as the etcd version metric.

cc @wojtek-t @mml @shyamjvs @cheftako 

```release-note
Fix `etcd-version-monitor` to backward compatibly support etcd 3.1 [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) metrics format.
```