### PR TITLE
Update the comments on webhook failure policy

### DIFF
--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -106,11 +106,9 @@ type Rule struct {
 type FailurePolicyType string
 
 const (
-	// Ignore means the initializer is removed from the initializers list of an
-	// object if the initializer is timed out.
+	// Ignore means that an error calling the webhook is ignored.
 	Ignore FailurePolicyType = "Ignore"
-	// For 1.7, only "Ignore" is allowed. "Fail" will be allowed when the
-	// extensible admission feature is beta.
+	// Fail means that an error calling the webhook causes the admission to fail.
 	Fail FailurePolicyType = "Fail"
 )
 

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -54,11 +54,9 @@ type Rule struct {
 type FailurePolicyType string
 
 const (
-	// Ignore means the initializer is removed from the initializers list of an
-	// object if the initializer is timed out.
+	// Ignore means that an error calling the webhook is ignored.
 	Ignore FailurePolicyType = "Ignore"
-	// For 1.7, only "Ignore" is allowed. "Fail" will be allowed when the
-	// extensible admission feature is beta.
+	// Fail means that an error calling the webhook causes the admission to fail.
 	Fail FailurePolicyType = "Fail"
 )
 


### PR DESCRIPTION
ref: kubernetes/features#492

Note that comments on constants aren't reflected in the user docs