### PR TITLE
Fix a comment in hack/lib/version.sh about which tags are used to get the version

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -62,7 +62,7 @@ kube::version::get_version_vars() {
       fi
     fi
 
-    # Use git describe to find the version based on annotated tags.
+    # Use git describe to find the version based on tags.
     if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
       # This translates the "git describe" to an actual semver.org
       # compatible semantic version that looks something like this:


### PR DESCRIPTION
The `--tags` flag to `git describe` specifically adds in lightweight tags. This just makes the comment correct.

Alternatively, that flag could be removed from the command, but I think that requires more detailed thinking.

**Release note**:
```release-note
NONE
```
