### PR TITLE
Harden kube-proxy for unmatched IP versions

### DIFF
--- a/pkg/kubelet/network/hostport/BUILD
+++ b/pkg/kubelet/network/hostport/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/proxy/iptables:go_default_library",
         "//pkg/util/conntrack:go_default_library",
         "//pkg/util/iptables:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/pkg/kubelet/network/hostport/hostport_manager.go
+++ b/pkg/kubelet/network/hostport/hostport_manager.go
@@ -31,6 +31,7 @@ import (
 	iptablesproxy "k8s.io/kubernetes/pkg/proxy/iptables"
 	"k8s.io/kubernetes/pkg/util/conntrack"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	"k8s.io/utils/exec"
 )
 
@@ -165,7 +166,7 @@ func (hm *hostportManager) Add(id string, podPortMapping *PodPortMapping, natInt
 		// clean up opened host port if encounter any error
 		return utilerrors.NewAggregate([]error{err, hm.closeHostports(hostportMappings)})
 	}
-	isIpv6 := conntrack.IsIPv6(podPortMapping.IP)
+	isIpv6 := utilnet.IsIPv6(podPortMapping.IP)
 
 	// Remove conntrack entries just after adding the new iptables rules. If the conntrack entry is removed along with
 	// the IP tables rule, it can be the case that the packets received by the node after iptables rule removal will

--- a/pkg/proxy/BUILD
+++ b/pkg/proxy/BUILD
@@ -16,11 +16,15 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/proxy",
     deps = [
+        "//pkg/api/service:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/helper:go_default_library",
         "//pkg/proxy/util:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )
 
@@ -57,7 +61,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/api/service:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -52,7 +52,7 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		// Case[1]: unnamed port
 		endpointsMap: EndpointsMap{
 			makeServicePortName("ns1", "ep1", ""): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expected: map[types.NamespacedName]sets.String{},
@@ -60,7 +60,7 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		// Case[2]: unnamed port local
 		endpointsMap: EndpointsMap{
 			makeServicePortName("ns1", "ep1", ""): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expected: map[types.NamespacedName]sets.String{
@@ -70,12 +70,12 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		// Case[3]: named local and non-local ports for the same IP.
 		endpointsMap: EndpointsMap{
 			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false},
-				&EndpointInfoCommon{Endpoint: "1.1.1.2:11", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: false},
-				&EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expected: map[types.NamespacedName]sets.String{
@@ -85,21 +85,21 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 		// Case[4]: named local and non-local ports for different IPs.
 		endpointsMap: EndpointsMap{
 			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "2.2.2.2:22", IsLocal: true},
-				&EndpointInfoCommon{Endpoint: "2.2.2.22:22", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p23"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "2.2.2.3:23", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
 			makeServicePortName("ns4", "ep4", "p44"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "4.4.4.4:44", IsLocal: true},
-				&EndpointInfoCommon{Endpoint: "4.4.4.5:44", IsLocal: false},
+				&BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: false},
 			},
 			makeServicePortName("ns4", "ep4", "p45"): []Endpoint{
-				&EndpointInfoCommon{Endpoint: "4.4.4.6:45", IsLocal: true},
+				&BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
 		expected: map[types.NamespacedName]sets.String{
@@ -139,13 +139,13 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		newEndpoints *api.Endpoints
-		expected     map[ServicePortName][]*EndpointInfoCommon
+		expected     map[ServicePortName][]*BaseEndpointInfo
 		isIPv6Mode   *bool
 	}{
 		{
 			desc:         "nothing",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {}),
-			expected:     map[ServicePortName][]*EndpointInfoCommon{},
+			expected:     map[ServicePortName][]*BaseEndpointInfo{},
 		},
 		{
 			desc: "no changes, unnamed port",
@@ -162,7 +162,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", ""): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -183,7 +183,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "port"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -203,7 +203,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", ""): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -212,7 +212,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 		{
 			desc:         "remove port",
 			newEndpoints: makeTestEndpoints("ns1", "ep1", func(ept *api.Endpoints) {}),
-			expected:     map[ServicePortName][]*EndpointInfoCommon{},
+			expected:     map[ServicePortName][]*BaseEndpointInfo{},
 		},
 		{
 			desc: "new IP and port",
@@ -234,7 +234,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 					{Endpoint: "2.2.2.2:11", IsLocal: false},
@@ -260,7 +260,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -281,7 +281,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p2"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -302,7 +302,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 				},
@@ -328,7 +328,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p1"): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
@@ -358,7 +358,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 					},
 				}
 			}),
-			expected: map[ServicePortName][]*EndpointInfoCommon{
+			expected: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "ep1", "p1"): {
 					{Endpoint: "[2001:db8:85a3:0:0:8a2e:370:7334]:11", IsLocal: false},
 				},
@@ -383,7 +383,7 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 				t.Errorf("[%s] expected %d endpoints for %v, got %d", tc.desc, len(tc.expected[x]), x, len(newEndpoints[x]))
 			} else {
 				for i := range newEndpoints[x] {
-					ep := newEndpoints[x][i].(*EndpointInfoCommon)
+					ep := newEndpoints[x][i].(*BaseEndpointInfo)
 					if *ep != *(tc.expected[x][i]) {
 						t.Errorf("[%s] expected new[%v][%d] to be %v, got %v", tc.desc, x, i, tc.expected[x][i], *ep)
 					}
@@ -705,15 +705,15 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// or non-nil) and must be of equal length.
 		previousEndpoints         []*api.Endpoints
 		currentEndpoints          []*api.Endpoints
-		oldEndpoints              map[ServicePortName][]*EndpointInfoCommon
-		expectedResult            map[ServicePortName][]*EndpointInfoCommon
+		oldEndpoints              map[ServicePortName][]*BaseEndpointInfo
+		expectedResult            map[ServicePortName][]*BaseEndpointInfo
 		expectedStaleEndpoints    []ServiceEndpoint
 		expectedStaleServiceNames map[ServicePortName]bool
 		expectedHealthchecks      map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		oldEndpoints:              map[ServicePortName][]*EndpointInfoCommon{},
-		expectedResult:            map[ServicePortName][]*EndpointInfoCommon{},
+		oldEndpoints:              map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult:            map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -725,12 +725,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -746,12 +746,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
@@ -769,7 +769,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -777,7 +777,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -796,7 +796,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
@@ -807,7 +807,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
@@ -833,7 +833,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
@@ -859,7 +859,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
@@ -899,8 +899,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
@@ -920,12 +920,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			nil,
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{},
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
 			ServicePortName: makeServicePortName("ns1", "ep1", ""),
@@ -940,12 +940,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
@@ -970,7 +970,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
@@ -980,7 +980,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1005,12 +1005,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1033,7 +1033,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1041,7 +1041,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1060,12 +1060,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11-2"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1086,12 +1086,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
@@ -1116,7 +1116,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns3", "ep3", complexAfter3),
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1135,7 +1135,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.11:11", IsLocal: false},
@@ -1185,8 +1185,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
-		oldEndpoints: map[ServicePortName][]*EndpointInfoCommon{},
-		expectedResult: map[ServicePortName][]*EndpointInfoCommon{
+		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
+		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
 			makeServicePortName("ns1", "ep1", ""): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
@@ -1268,7 +1268,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 	}
 }
 
-func compareEndpointsMaps(t *testing.T, tci int, newMap EndpointsMap, expected map[ServicePortName][]*EndpointInfoCommon) {
+func compareEndpointsMaps(t *testing.T, tci int, newMap EndpointsMap, expected map[ServicePortName][]*BaseEndpointInfo) {
 	if len(newMap) != len(expected) {
 		t.Errorf("[%d] expected %d results, got %d: %v", tci, len(expected), len(newMap), newMap)
 	}
@@ -1277,7 +1277,7 @@ func compareEndpointsMaps(t *testing.T, tci int, newMap EndpointsMap, expected m
 			t.Errorf("[%d] expected %d endpoints for %v, got %d", tci, len(expected[x]), x, len(newMap[x]))
 		} else {
 			for i := range expected[x] {
-				newEp, ok := newMap[x][i].(*EndpointInfoCommon)
+				newEp, ok := newMap[x][i].(*BaseEndpointInfo)
 				if !ok {
 					t.Errorf("Failed to cast endpointsInfo")
 					continue

--- a/pkg/proxy/iptables/BUILD
+++ b/pkg/proxy/iptables/BUILD
@@ -13,9 +13,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/proxy/iptables",
     deps = [
-        "//pkg/api/service:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/core/helper:go_default_library",
         "//pkg/proxy:go_default_library",
         "//pkg/proxy/healthcheck:go_default_library",
         "//pkg/proxy/metrics:go_default_library",
@@ -23,6 +21,7 @@ go_library(
         "//pkg/util/async:go_default_library",
         "//pkg/util/conntrack:go_default_library",
         "//pkg/util/iptables:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//pkg/util/sysctl:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -309,6 +309,8 @@ func NewProxier(ipt utiliptables.Interface,
 
 	if len(clusterCIDR) == 0 {
 		glog.Warningf("clusterCIDR not specified, unable to distinguish between internal and external traffic")
+	} else if utilnet.IsIPv6CIDR(clusterCIDR) != ipt.IsIpv6() {
+		return nil, fmt.Errorf("clusterCIDR %s has incorrect IP version: expect isIPv6=%t", clusterCIDR, ipt.IsIpv6())
 	}
 
 	healthChecker := healthcheck.NewServer(hostname, recorder, nil, nil) // use default implementations of deps

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -46,6 +46,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/async"
 	"k8s.io/kubernetes/pkg/util/conntrack"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilversion "k8s.io/kubernetes/pkg/util/version"
 	utilexec "k8s.io/utils/exec"
@@ -758,7 +759,7 @@ func (proxier *Proxier) syncProxyRules() {
 			glog.Errorf("Failed to cast serviceInfo %q", svcName.String())
 			continue
 		}
-		isIPv6 := conntrack.IsIPv6(svcInfo.ClusterIP)
+		isIPv6 := utilnet.IsIPv6(svcInfo.ClusterIP)
 		protocol := strings.ToLower(string(svcInfo.Protocol))
 		svcNameString := svcInfo.serviceNameString
 		hasEndpoints := len(proxier.endpointsMap[svcName]) > 0
@@ -1223,7 +1224,7 @@ func (proxier *Proxier) syncProxyRules() {
 				break
 			}
 			// Ignore IP addresses with incorrect version
-			if isIPv6 && !conntrack.IsIPv6String(address) || !isIPv6 && conntrack.IsIPv6String(address) {
+			if isIPv6 && !utilnet.IsIPv6String(address) || !isIPv6 && utilnet.IsIPv6String(address) {
 				glog.Errorf("IP address %s has incorrect IP version", address)
 				continue
 			}

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -179,12 +179,14 @@ func TestGetChainLinesMultipleTables(t *testing.T) {
 
 func newFakeServiceInfo(service proxy.ServicePortName, ip net.IP, port int, protocol api.Protocol, onlyNodeLocalEndpoints bool) *serviceInfo {
 	return &serviceInfo{
-		sessionAffinityType:    api.ServiceAffinityNone,                        // default
-		stickyMaxAgeSeconds:    int(api.DefaultClientIPServiceAffinitySeconds), // default
-		clusterIP:              ip,
-		port:                   port,
-		protocol:               protocol,
-		onlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
+		ServiceInfoCommon: &proxy.ServiceInfoCommon{
+			SessionAffinityType:    api.ServiceAffinityNone,                        // default
+			StickyMaxAgeSeconds:    int(api.DefaultClientIPServiceAffinitySeconds), // default
+			ClusterIP:              ip,
+			Port:                   port,
+			Protocol:               protocol,
+			OnlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
+		},
 	}
 }
 
@@ -391,9 +393,9 @@ func NewFakeProxier(ipt utiliptables.Interface) *Proxier {
 	p := &Proxier{
 		exec:                     &fakeexec.FakeExec{},
 		serviceMap:               make(proxy.ServiceMap),
-		serviceChanges:           proxy.NewServiceChangeTracker(),
+		serviceChanges:           proxy.NewServiceChangeTracker(customizeServiceInfo, nil, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
-		endpointsChanges:         proxy.NewEndpointChangeTracker(testHostname),
+		endpointsChanges:         proxy.NewEndpointChangeTracker(testHostname, customizeEndpointInfo, nil, nil),
 		iptables:                 ipt,
 		clusterCIDR:              "10.0.0.0/24",
 		hostname:                 testHostname,
@@ -821,7 +823,7 @@ func TestExternalIPsReject(t *testing.T) {
 
 	kubeSvcRules := ipt.GetRules(string(kubeExternalServicesChain))
 	if !hasJump(kubeSvcRules, iptablestest.Reject, svcExternalIPs, svcPort) {
-		errorf(fmt.Sprintf("Failed to a %v rule for externalIP %v with no endpoints", iptablestest.Reject, svcPortName), kubeSvcRules, t)
+		errorf(fmt.Sprintf("Failed to find a %v rule for externalIP %v with no endpoints", iptablestest.Reject, svcPortName), kubeSvcRules, t)
 	}
 }
 
@@ -1379,7 +1381,10 @@ func compareEndpointsMaps(t *testing.T, tci int, newMap proxy.EndpointsMap, expe
 					t.Errorf("Failed to cast endpointsInfo")
 					continue
 				}
-				if *newEp != *(expected[x][i]) {
+				if newEp.Endpoint != expected[x][i].Endpoint ||
+					newEp.IsLocal != expected[x][i].IsLocal ||
+					newEp.protocol != expected[x][i].protocol ||
+					newEp.chainName != expected[x][i].chainName {
 					t.Errorf("[%d] expected new[%v][%d] to be %v, got %v", tci, x, i, expected[x][i], newEp)
 				}
 			}
@@ -1721,12 +1726,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1742,12 +1747,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1765,18 +1770,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1792,24 +1797,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1829,54 +1834,54 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
-				{endpoint: "1.1.1.4:13", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:13", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p14"): {
-				{endpoint: "1.1.1.3:14", isLocal: false},
-				{endpoint: "1.1.1.4:14", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:14", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
 			makeServicePortName("ns2", "ep2", "p21"): {
-				{endpoint: "2.2.2.1:21", isLocal: false},
-				{endpoint: "2.2.2.2:21", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.1:21", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.1:22", isLocal: false},
-				{endpoint: "2.2.2.2:22", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.1:22", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
-				{endpoint: "1.1.1.4:13", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:13", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p14"): {
-				{endpoint: "1.1.1.3:14", isLocal: false},
-				{endpoint: "1.1.1.4:14", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.3:14", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
 			makeServicePortName("ns2", "ep2", "p21"): {
-				{endpoint: "2.2.2.1:21", isLocal: false},
-				{endpoint: "2.2.2.2:21", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.1:21", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.1:22", isLocal: false},
-				{endpoint: "2.2.2.2:22", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.1:22", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1896,7 +1901,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -1916,7 +1921,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{},
@@ -1936,17 +1941,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -1966,17 +1971,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:12", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2001,15 +2006,15 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -2029,15 +2034,15 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2056,12 +2061,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11-2"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2082,12 +2087,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:22", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:22", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2112,39 +2117,39 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.2:22", isLocal: true},
-				{endpoint: "2.2.2.22:22", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.2:22", IsLocal: true}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.22:22", IsLocal: true}},
 			},
 			makeServicePortName("ns2", "ep2", "p23"): {
-				{endpoint: "2.2.2.3:23", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "2.2.2.3:23", IsLocal: true}},
 			},
 			makeServicePortName("ns4", "ep4", "p44"): {
-				{endpoint: "4.4.4.4:44", isLocal: true},
-				{endpoint: "4.4.4.5:44", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "4.4.4.4:44", IsLocal: true}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "4.4.4.5:44", IsLocal: true}},
 			},
 			makeServicePortName("ns4", "ep4", "p45"): {
-				{endpoint: "4.4.4.6:45", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "4.4.4.6:45", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.11:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.11:11", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 			makeServicePortName("ns1", "ep1", "p122"): {
-				{endpoint: "1.1.1.2:122", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.2:122", IsLocal: false}},
 			},
 			makeServicePortName("ns3", "ep3", "p33"): {
-				{endpoint: "3.3.3.3:33", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "3.3.3.3:33", IsLocal: false}},
 			},
 			makeServicePortName("ns4", "ep4", "p44"): {
-				{endpoint: "4.4.4.4:44", isLocal: true},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "4.4.4.4:44", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2182,7 +2187,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{EndpointInfoCommon: &proxy.EndpointInfoCommon{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},

--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -78,9 +78,7 @@ go_library(
     }),
     importpath = "k8s.io/kubernetes/pkg/proxy/ipvs",
     deps = [
-        "//pkg/api/service:go_default_library",
         "//pkg/apis/core:go_default_library",
-        "//pkg/apis/core/helper:go_default_library",
         "//pkg/proxy:go_default_library",
         "//pkg/proxy/healthcheck:go_default_library",
         "//pkg/proxy/metrics:go_default_library",
@@ -90,6 +88,7 @@ go_library(
         "//pkg/util/ipset:go_default_library",
         "//pkg/util/iptables:go_default_library",
         "//pkg/util/ipvs:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//pkg/util/sysctl:go_default_library",
         "//pkg/util/version:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -296,6 +296,8 @@ func NewProxier(ipt utiliptables.Interface,
 
 	if len(clusterCIDR) == 0 {
 		glog.Warningf("clusterCIDR not specified, unable to distinguish between internal and external traffic")
+	} else if utilnet.IsIPv6CIDR(clusterCIDR) != isIPv6 {
+		return nil, fmt.Errorf("clusterCIDR %s has incorrect IP version: expect isIPv6=%t", clusterCIDR, isIPv6)
 	}
 
 	if len(scheduler) == 0 {

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -47,6 +47,7 @@ import (
 	utilipset "k8s.io/kubernetes/pkg/util/ipset"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
 	utilipvs "k8s.io/kubernetes/pkg/util/ipvs"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 	utilsysctl "k8s.io/kubernetes/pkg/util/sysctl"
 	utilexec "k8s.io/utils/exec"
 )
@@ -289,7 +290,7 @@ func NewProxier(ipt utiliptables.Interface,
 		nodeIP = net.ParseIP("127.0.0.1")
 	}
 
-	isIPv6 := conntrack.IsIPv6(nodeIP)
+	isIPv6 := utilnet.IsIPv6(nodeIP)
 
 	glog.V(2).Infof("nodeIP: %v, isIPv6: %v", nodeIP, isIPv6)
 
@@ -1006,7 +1007,7 @@ func (proxier *Proxier) syncProxyRules() {
 					continue
 				}
 				if lp.Protocol == "udp" {
-					isIPv6 := conntrack.IsIPv6(svcInfo.ClusterIP)
+					isIPv6 := utilnet.IsIPv6(svcInfo.ClusterIP)
 					conntrack.ClearEntriesForPort(proxier.exec, lp.Port, isIPv6, clientv1.ProtocolUDP)
 				}
 				replacementPortsMap[lp] = socket

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -33,7 +33,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	netlinktest "k8s.io/kubernetes/pkg/proxy/ipvs/testing"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
+	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
 	utilipset "k8s.io/kubernetes/pkg/util/ipset"
 	ipsettest "k8s.io/kubernetes/pkg/util/ipset/testing"
@@ -67,12 +67,12 @@ func newFakeHealthChecker() *fakeHealthChecker {
 
 // fakePortOpener implements portOpener.
 type fakePortOpener struct {
-	openPorts []*proxyutil.LocalPort
+	openPorts []*utilproxy.LocalPort
 }
 
 // OpenLocalPort fakes out the listen() and bind() used by syncProxyRules
 // to lock a local port.
-func (f *fakePortOpener) OpenLocalPort(lp *proxyutil.LocalPort) (proxyutil.Closeable, error) {
+func (f *fakePortOpener) OpenLocalPort(lp *utilproxy.LocalPort) (utilproxy.Closeable, error) {
 	f.openPorts = append(f.openPorts, lp)
 	return nil, nil
 }
@@ -121,16 +121,16 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 	return &Proxier{
 		exec:               fexec,
 		serviceMap:         make(proxy.ServiceMap),
-		serviceChanges:     proxy.NewServiceChangeTracker(),
+		serviceChanges:     proxy.NewServiceChangeTracker(customizeServiceInfo, nil, nil),
 		endpointsMap:       make(proxy.EndpointsMap),
-		endpointsChanges:   proxy.NewEndpointChangeTracker(testHostname),
+		endpointsChanges:   proxy.NewEndpointChangeTracker(testHostname, nil, nil, nil),
 		iptables:           ipt,
 		ipvs:               ipvs,
 		ipset:              ipset,
 		clusterCIDR:        "10.0.0.0/24",
 		hostname:           testHostname,
-		portsMap:           make(map[proxyutil.LocalPort]proxyutil.Closeable),
-		portMapper:         &fakePortOpener{[]*proxyutil.LocalPort{}},
+		portsMap:           make(map[utilproxy.LocalPort]utilproxy.Closeable),
+		portMapper:         &fakePortOpener{[]*utilproxy.LocalPort{}},
 		healthChecker:      newFakeHealthChecker(),
 		ipvsScheduler:      DefaultScheduler,
 		ipGetter:           &fakeIPGetter{nodeIPs: nodeIPs},
@@ -1581,15 +1581,15 @@ func Test_updateEndpointsMap(t *testing.T) {
 		// or non-nil) and must be of equal length.
 		previousEndpoints         []*api.Endpoints
 		currentEndpoints          []*api.Endpoints
-		oldEndpoints              map[proxy.ServicePortName][]*endpointsInfo
-		expectedResult            map[proxy.ServicePortName][]*endpointsInfo
+		oldEndpoints              map[proxy.ServicePortName][]*proxy.EndpointInfoCommon
+		expectedResult            map[proxy.ServicePortName][]*proxy.EndpointInfoCommon
 		expectedStaleEndpoints    []proxy.ServiceEndpoint
 		expectedStaleServiceNames map[proxy.ServicePortName]bool
 		expectedHealthchecks      map[types.NamespacedName]int
 	}{{
 		// Case[0]: nothing
-		oldEndpoints:              map[proxy.ServicePortName][]*endpointsInfo{},
-		expectedResult:            map[proxy.ServicePortName][]*endpointsInfo{},
+		oldEndpoints:              map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{},
+		expectedResult:            map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -1601,14 +1601,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1622,14 +1622,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1645,20 +1645,20 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1672,26 +1672,26 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
+				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
+				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1709,56 +1709,56 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
+				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
-				{endpoint: "1.1.1.4:13", isLocal: true},
+				{Endpoint: "1.1.1.3:13", IsLocal: false},
+				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p14"): {
-				{endpoint: "1.1.1.3:14", isLocal: false},
-				{endpoint: "1.1.1.4:14", isLocal: true},
+				{Endpoint: "1.1.1.3:14", IsLocal: false},
+				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p21"): {
-				{endpoint: "2.2.2.1:21", isLocal: false},
-				{endpoint: "2.2.2.2:21", isLocal: true},
+				{Endpoint: "2.2.2.1:21", IsLocal: false},
+				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.1:22", isLocal: false},
-				{endpoint: "2.2.2.2:22", isLocal: true},
+				{Endpoint: "2.2.2.1:22", IsLocal: false},
+				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
+				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p13"): {
-				{endpoint: "1.1.1.3:13", isLocal: false},
-				{endpoint: "1.1.1.4:13", isLocal: true},
+				{Endpoint: "1.1.1.3:13", IsLocal: false},
+				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p14"): {
-				{endpoint: "1.1.1.3:14", isLocal: false},
-				{endpoint: "1.1.1.4:14", isLocal: true},
+				{Endpoint: "1.1.1.3:14", IsLocal: false},
+				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p21"): {
-				{endpoint: "2.2.2.1:21", isLocal: false},
-				{endpoint: "2.2.2.2:21", isLocal: true},
+				{Endpoint: "2.2.2.1:21", IsLocal: false},
+				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.1:22", isLocal: false},
-				{endpoint: "2.2.2.2:22", isLocal: true},
+				{Endpoint: "2.2.2.1:22", IsLocal: false},
+				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints:    []proxy.ServiceEndpoint{},
@@ -1775,10 +1775,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{},
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -1796,12 +1796,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			nil,
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{},
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
 			ServicePortName: makeServicePortName("ns1", "ep1", ""),
@@ -1816,19 +1816,19 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
+				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -1846,19 +1846,19 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.2:11", isLocal: true},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
+				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.1:12", isLocal: false},
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{Endpoint: "1.1.1.1:12", IsLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -1881,17 +1881,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: true},
+				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -1909,17 +1909,17 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -1936,14 +1936,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11-2"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -1962,14 +1962,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:22", isLocal: false},
+				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -1992,41 +1992,41 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns3", "ep3", complexAfter3),
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 			makeServicePortName("ns2", "ep2", "p22"): {
-				{endpoint: "2.2.2.2:22", isLocal: true},
-				{endpoint: "2.2.2.22:22", isLocal: true},
+				{Endpoint: "2.2.2.2:22", IsLocal: true},
+				{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
 			makeServicePortName("ns2", "ep2", "p23"): {
-				{endpoint: "2.2.2.3:23", isLocal: true},
+				{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
 			makeServicePortName("ns4", "ep4", "p44"): {
-				{endpoint: "4.4.4.4:44", isLocal: true},
-				{endpoint: "4.4.4.5:44", isLocal: true},
+				{Endpoint: "4.4.4.4:44", IsLocal: true},
+				{Endpoint: "4.4.4.5:44", IsLocal: true},
 			},
 			makeServicePortName("ns4", "ep4", "p45"): {
-				{endpoint: "4.4.4.6:45", isLocal: true},
+				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", "p11"): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
-				{endpoint: "1.1.1.11:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
+				{Endpoint: "1.1.1.11:11", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p12"): {
-				{endpoint: "1.1.1.2:12", isLocal: false},
+				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 			makeServicePortName("ns1", "ep1", "p122"): {
-				{endpoint: "1.1.1.2:122", isLocal: false},
+				{Endpoint: "1.1.1.2:122", IsLocal: false},
 			},
 			makeServicePortName("ns3", "ep3", "p33"): {
-				{endpoint: "3.3.3.3:33", isLocal: false},
+				{Endpoint: "3.3.3.3:33", IsLocal: false},
 			},
 			makeServicePortName("ns4", "ep4", "p44"): {
-				{endpoint: "4.4.4.4:44", isLocal: true},
+				{Endpoint: "4.4.4.4:44", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
@@ -2061,10 +2061,10 @@ func Test_updateEndpointsMap(t *testing.T) {
 		currentEndpoints: []*api.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
-		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
-		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
+		oldEndpoints: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{},
+		expectedResult: map[proxy.ServicePortName][]*proxy.EndpointInfoCommon{
 			makeServicePortName("ns1", "ep1", ""): {
-				{endpoint: "1.1.1.1:11", isLocal: false},
+				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
@@ -2148,7 +2148,7 @@ func Test_updateEndpointsMap(t *testing.T) {
 	}
 }
 
-func compareEndpointsMaps(t *testing.T, tci int, newMap proxy.EndpointsMap, expected map[proxy.ServicePortName][]*endpointsInfo) {
+func compareEndpointsMaps(t *testing.T, tci int, newMap proxy.EndpointsMap, expected map[proxy.ServicePortName][]*proxy.EndpointInfoCommon) {
 	if len(newMap) != len(expected) {
 		t.Errorf("[%d] expected %d results, got %d: %v", tci, len(expected), len(newMap), newMap)
 	}
@@ -2157,9 +2157,9 @@ func compareEndpointsMaps(t *testing.T, tci int, newMap proxy.EndpointsMap, expe
 			t.Errorf("[%d] expected %d endpoints for %v, got %d", tci, len(expected[x]), x, len(newMap[x]))
 		} else {
 			for i := range expected[x] {
-				newEp, ok := newMap[x][i].(*endpointsInfo)
+				newEp, ok := newMap[x][i].(*proxy.EndpointInfoCommon)
 				if !ok {
-					t.Errorf("Failed to cast endpointsInfo")
+					t.Errorf("Failed to cast proxy.EndpointInfoCommon")
 					continue
 				}
 				if *newEp != *(expected[x][i]) {

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -17,6 +17,8 @@ limitations under the License.
 package proxy
 
 import (
+	"fmt"
+	"net"
 	"reflect"
 	"sync"
 
@@ -24,9 +26,90 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/tools/record"
+	apiservice "k8s.io/kubernetes/pkg/api/service"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
+	"k8s.io/kubernetes/pkg/apis/core/helper"
+	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 )
+
+// ServiceInfoCommon contains common service information.
+type ServiceInfoCommon struct {
+	ClusterIP                net.IP
+	Port                     int
+	Protocol                 api.Protocol
+	NodePort                 int
+	LoadBalancerStatus       api.LoadBalancerStatus
+	SessionAffinityType      api.ServiceAffinity
+	StickyMaxAgeSeconds      int
+	ExternalIPs              []string
+	LoadBalancerSourceRanges []string
+	HealthCheckNodePort      int
+	OnlyNodeLocalEndpoints   bool
+}
+
+var _ ServicePort = &ServiceInfoCommon{}
+
+// String is part of ServicePort interface.
+func (info *ServiceInfoCommon) String() string {
+	return fmt.Sprintf("%s:%d/%s", info.ClusterIP, info.Port, info.Protocol)
+}
+
+// GetClusterIP is part of ServicePort interface.
+func (info *ServiceInfoCommon) GetClusterIP() string {
+	return info.ClusterIP.String()
+}
+
+// GetProtocol is part of ServicePort interface.
+func (info *ServiceInfoCommon) GetProtocol() api.Protocol {
+	return info.Protocol
+}
+
+// GetHealthCheckNodePort is part of ServicePort interface.
+func (info *ServiceInfoCommon) GetHealthCheckNodePort() int {
+	return info.HealthCheckNodePort
+}
+
+func (sct *ServiceChangeTracker) newServiceInfoCommon(port *api.ServicePort, service *api.Service) *ServiceInfoCommon {
+	onlyNodeLocalEndpoints := false
+	if apiservice.RequestsOnlyLocalTraffic(service) {
+		onlyNodeLocalEndpoints = true
+	}
+	var stickyMaxAgeSeconds int
+	if service.Spec.SessionAffinity == api.ServiceAffinityClientIP {
+		// Kube-apiserver side guarantees SessionAffinityConfig won't be nil when session affinity type is ClientIP
+		stickyMaxAgeSeconds = int(*service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
+	}
+	info := &ServiceInfoCommon{
+		ClusterIP: net.ParseIP(service.Spec.ClusterIP),
+		Port:      int(port.Port),
+		Protocol:  port.Protocol,
+		NodePort:  int(port.NodePort),
+		// Deep-copy in case the service instance changes
+		LoadBalancerStatus:     *helper.LoadBalancerStatusDeepCopy(&service.Status.LoadBalancer),
+		SessionAffinityType:    service.Spec.SessionAffinity,
+		StickyMaxAgeSeconds:    stickyMaxAgeSeconds,
+		OnlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
+	}
+
+	info.ExternalIPs = make([]string, len(service.Spec.ExternalIPs))
+	info.LoadBalancerSourceRanges = make([]string, len(service.Spec.LoadBalancerSourceRanges))
+	copy(info.LoadBalancerSourceRanges, service.Spec.LoadBalancerSourceRanges)
+	copy(info.ExternalIPs, service.Spec.ExternalIPs)
+
+	if apiservice.NeedsHealthCheck(service) {
+		p := service.Spec.HealthCheckNodePort
+		if p == 0 {
+			glog.Errorf("Service %s/%s has no healthcheck nodeport", service.Namespace, service.Name)
+		} else {
+			info.HealthCheckNodePort = int(p)
+		}
+	}
+
+	return info
+}
+
+type customizeServiceInfoFunc func(*api.ServicePort, *api.Service, *ServiceInfoCommon) ServicePort
 
 // serviceChange contains all changes to services that happened since proxy rules were synced.  For a single object,
 // changes are accumulated, i.e. previous is state from before applying the changes,
@@ -43,12 +126,20 @@ type ServiceChangeTracker struct {
 	lock sync.Mutex
 	// items maps a service to its serviceChange.
 	items map[types.NamespacedName]*serviceChange
+	// customizeServiceInfo allows proxier to inject customized infomation when processing service.
+	customizeServiceInfo customizeServiceInfoFunc
+	// isIPv6Mode indicates if change tracker is under IPv6/IPv4 mode. Nil means not applicable.
+	isIPv6Mode *bool
+	recorder   record.EventRecorder
 }
 
 // NewServiceChangeTracker initializes a ServiceChangeTracker
-func NewServiceChangeTracker() *ServiceChangeTracker {
+func NewServiceChangeTracker(customizeServiceInfo customizeServiceInfoFunc, isIPv6Mode *bool, recorder record.EventRecorder) *ServiceChangeTracker {
 	return &ServiceChangeTracker{
-		items: make(map[types.NamespacedName]*serviceChange),
+		items:                make(map[types.NamespacedName]*serviceChange),
+		customizeServiceInfo: customizeServiceInfo,
+		isIPv6Mode:           isIPv6Mode,
+		recorder:             recorder,
 	}
 }
 
@@ -60,10 +151,7 @@ func NewServiceChangeTracker() *ServiceChangeTracker {
 //   - pass <oldService, service> as the <previous, current> pair.
 // Delete item
 //   - pass <service, nil> as the <previous, current> pair.
-//
-// makeServicePort() return a proxy.ServicePort based on the given Service and its ServicePort.  We inject makeServicePort()
-// so that giving caller side a chance to initialize proxy.ServicePort interface.
-func (sct *ServiceChangeTracker) Update(previous, current *api.Service, makeServicePort func(servicePort *api.ServicePort, service *api.Service) ServicePort) bool {
+func (sct *ServiceChangeTracker) Update(previous, current *api.Service) bool {
 	svc := current
 	if svc == nil {
 		svc = previous
@@ -80,10 +168,10 @@ func (sct *ServiceChangeTracker) Update(previous, current *api.Service, makeServ
 	change, exists := sct.items[namespacedName]
 	if !exists {
 		change = &serviceChange{}
-		change.previous = serviceToServiceMap(previous, makeServicePort)
+		change.previous = sct.serviceToServiceMap(previous)
 		sct.items[namespacedName] = change
 	}
-	change.current = serviceToServiceMap(current, makeServicePort)
+	change.current = sct.serviceToServiceMap(current)
 	// if change.previous equal to change.current, it means no change
 	if reflect.DeepEqual(change.previous, change.current) {
 		delete(sct.items, namespacedName)
@@ -110,28 +198,26 @@ func UpdateServiceMap(serviceMap ServiceMap, changes *ServiceChangeTracker) (res
 	// computing this incrementally similarly to serviceMap.
 	result.HCServiceNodePorts = make(map[types.NamespacedName]uint16)
 	for svcPortName, info := range serviceMap {
-		if info.HealthCheckNodePort() != 0 {
-			result.HCServiceNodePorts[svcPortName.NamespacedName] = uint16(info.HealthCheckNodePort())
+		if info.GetHealthCheckNodePort() != 0 {
+			result.HCServiceNodePorts[svcPortName.NamespacedName] = uint16(info.GetHealthCheckNodePort())
 		}
 	}
 
 	return result
 }
 
-// ServiceMap maps a service to its ServicePort information.
+// ServiceMap maps a service to its ServicePort.
 type ServiceMap map[ServicePortName]ServicePort
 
 // serviceToServiceMap translates a single Service object to a ServiceMap.
-// makeServicePort() return a proxy.ServicePort based on the given Service and its ServicePort.  We inject makeServicePort()
-// so that giving caller side a chance to initialize proxy.ServicePort interface.
 //
 // NOTE: service object should NOT be modified.
-func serviceToServiceMap(service *api.Service, makeServicePort func(servicePort *api.ServicePort, service *api.Service) ServicePort) ServiceMap {
+func (sct *ServiceChangeTracker) serviceToServiceMap(service *api.Service) ServiceMap {
 	if service == nil {
 		return nil
 	}
 	svcName := types.NamespacedName{Namespace: service.Namespace, Name: service.Name}
-	if proxyutil.ShouldSkipService(svcName, service) {
+	if utilproxy.ShouldSkipService(svcName, service) {
 		return nil
 	}
 
@@ -139,7 +225,12 @@ func serviceToServiceMap(service *api.Service, makeServicePort func(servicePort 
 	for i := range service.Spec.Ports {
 		servicePort := &service.Spec.Ports[i]
 		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name}
-		serviceMap[svcPortName] = makeServicePort(servicePort, service)
+		svcInfoCommon := sct.newServiceInfoCommon(servicePort, service)
+		if sct.customizeServiceInfo != nil {
+			serviceMap[svcPortName] = sct.customizeServiceInfo(servicePort, service, svcInfoCommon)
+		} else {
+			serviceMap[svcPortName] = svcInfoCommon
+		}
 	}
 	return serviceMap
 }
@@ -213,8 +304,8 @@ func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
 		info, exists := (*sm)[svcPortName]
 		if exists {
 			glog.V(1).Infof("Removing service port %q", svcPortName)
-			if info.Protocol() == api.ProtocolUDP {
-				UDPStaleClusterIP.Insert(info.ClusterIP())
+			if info.GetProtocol() == api.ProtocolUDP {
+				UDPStaleClusterIP.Insert(info.GetClusterIP())
 			}
 			delete(*sm, svcPortName)
 		} else {

--- a/pkg/proxy/service_test.go
+++ b/pkg/proxy/service_test.go
@@ -25,12 +25,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 const testHostname = "test-hostname"
 
-func makeTestServiceInfo(clusterIP string, port int, protocol string, healthcheckNodePort int) *ServiceInfoCommon {
+func makeTestServiceInfo(clusterIP string, port int, protocol string, healthcheckNodePort int, svcInfoFuncs ...func(*ServiceInfoCommon)) *ServiceInfoCommon {
 	info := &ServiceInfoCommon{
 		ClusterIP: net.ParseIP(clusterIP),
 		Port:      port,
@@ -38,6 +39,9 @@ func makeTestServiceInfo(clusterIP string, port int, protocol string, healthchec
 	}
 	if healthcheckNodePort != 0 {
 		info.HealthCheckNodePort = healthcheckNodePort
+	}
+	for _, svcInfoFunc := range svcInfoFuncs {
+		svcInfoFunc(info)
 	}
 	return info
 }
@@ -81,17 +85,28 @@ func makeServicePortName(ns, name, port string) ServicePortName {
 func TestServiceToServiceMap(t *testing.T) {
 	svcTracker := NewServiceChangeTracker(nil, nil, nil)
 
+	trueVal := true
+	falseVal := false
+	testClusterIPv4 := "10.0.0.1"
+	testExternalIPv4 := "8.8.8.8"
+	testSourceRangeIPv4 := "0.0.0.0/1"
+	testClusterIPv6 := "2001:db8:85a3:0:0:8a2e:370:7334"
+	testExternalIPv6 := "2001:db8:85a3:0:0:8a2e:370:7335"
+	testSourceRangeIPv6 := "2001:db8::/32"
+
 	testCases := []struct {
-		service  *api.Service
-		expected map[ServicePortName]*ServiceInfoCommon
+		desc       string
+		service    *api.Service
+		expected   map[ServicePortName]*ServiceInfoCommon
+		isIPv6Mode *bool
 	}{
 		{
-			// Case[0]: nothing
+			desc:     "nothing",
 			service:  nil,
 			expected: map[ServicePortName]*ServiceInfoCommon{},
 		},
 		{
-			// Case[1]: headless service
+			desc: "headless service",
 			service: makeTestService("ns2", "headless", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = api.ClusterIPNone
@@ -100,7 +115,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			expected: map[ServicePortName]*ServiceInfoCommon{},
 		},
 		{
-			// Case[2]: headless service without port
+			desc: "headless service without port",
 			service: makeTestService("ns2", "headless-without-port", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = api.ClusterIPNone
@@ -108,7 +123,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			expected: map[ServicePortName]*ServiceInfoCommon{},
 		},
 		{
-			// Case[3]: cluster ip service
+			desc: "cluster ip service",
 			service: makeTestService("ns2", "cluster-ip", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeClusterIP
 				svc.Spec.ClusterIP = "172.16.55.4"
@@ -121,7 +136,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			},
 		},
 		{
-			// Case[4]: nodeport service
+			desc: "nodeport service",
 			service: makeTestService("ns2", "node-port", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeNodePort
 				svc.Spec.ClusterIP = "172.16.55.10"
@@ -134,7 +149,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			},
 		},
 		{
-			// Case[5]: load balancer service
+			desc: "load balancer service",
 			service: makeTestService("ns1", "load-balancer", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeLoadBalancer
 				svc.Spec.ClusterIP = "172.16.55.11"
@@ -153,7 +168,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			},
 		},
 		{
-			// Case[6]: load balancer service with only local traffic policy
+			desc: "load balancer service with only local traffic policy",
 			service: makeTestService("ns1", "only-local-load-balancer", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeLoadBalancer
 				svc.Spec.ClusterIP = "172.16.55.12"
@@ -174,7 +189,7 @@ func TestServiceToServiceMap(t *testing.T) {
 			},
 		},
 		{
-			// Case[7]: external name service
+			desc: "external name service",
 			service: makeTestService("ns2", "external-name", func(svc *api.Service) {
 				svc.Spec.Type = api.ServiceTypeExternalName
 				svc.Spec.ClusterIP = "172.16.55.4" // Should be ignored
@@ -183,22 +198,177 @@ func TestServiceToServiceMap(t *testing.T) {
 			}),
 			expected: map[ServicePortName]*ServiceInfoCommon{},
 		},
+		{
+			desc: "service with ipv6 clusterIP under ipv4 mode, service should be filtered",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalidIPv6InIPV4Mode",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP: testClusterIPv6,
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			isIPv6Mode: &falseVal,
+		},
+		{
+			desc: "service with ipv4 clusterIP under ipv6 mode, service should be filtered",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "invalidIPv4InIPV6Mode",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP: testClusterIPv4,
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			isIPv6Mode: &trueVal,
+		},
+		{
+			desc: "service with ipv4 configurations under ipv4 mode",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "validIPv4",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP:                testClusterIPv4,
+					ExternalIPs:              []string{testExternalIPv4},
+					LoadBalancerSourceRanges: []string{testSourceRangeIPv4},
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expected: map[ServicePortName]*ServiceInfoCommon{
+				makeServicePortName("test", "validIPv4", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *ServiceInfoCommon) {
+					info.ExternalIPs = []string{testExternalIPv4}
+					info.LoadBalancerSourceRanges = []string{testSourceRangeIPv4}
+				}),
+			},
+			isIPv6Mode: &falseVal,
+		},
+		{
+			desc: "service with ipv6 configurations under ipv6 mode",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "validIPv6",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP:                testClusterIPv6,
+					ExternalIPs:              []string{testExternalIPv6},
+					LoadBalancerSourceRanges: []string{testSourceRangeIPv6},
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expected: map[ServicePortName]*ServiceInfoCommon{
+				makeServicePortName("test", "validIPv6", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *ServiceInfoCommon) {
+					info.ExternalIPs = []string{testExternalIPv6}
+					info.LoadBalancerSourceRanges = []string{testSourceRangeIPv6}
+				}),
+			},
+			isIPv6Mode: &trueVal,
+		},
+		{
+			desc: "service with both ipv4 and ipv6 configurations under ipv4 mode, ipv6 fields should be filtered",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "filterIPv6InIPV4Mode",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP:                testClusterIPv4,
+					ExternalIPs:              []string{testExternalIPv4, testExternalIPv6},
+					LoadBalancerSourceRanges: []string{testSourceRangeIPv4, testSourceRangeIPv6},
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expected: map[ServicePortName]*ServiceInfoCommon{
+				makeServicePortName("test", "filterIPv6InIPV4Mode", "testPort"): makeTestServiceInfo(testClusterIPv4, 12345, "TCP", 0, func(info *ServiceInfoCommon) {
+					info.ExternalIPs = []string{testExternalIPv4}
+					info.LoadBalancerSourceRanges = []string{testSourceRangeIPv4}
+				}),
+			},
+			isIPv6Mode: &falseVal,
+		},
+		{
+			desc: "service with both ipv4 and ipv6 configurations under ipv6 mode, ipv4 fields should be filtered",
+			service: &api.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "filterIPv4InIPV6Mode",
+					Namespace: "test",
+				},
+				Spec: api.ServiceSpec{
+					ClusterIP:                testClusterIPv6,
+					ExternalIPs:              []string{testExternalIPv4, testExternalIPv6},
+					LoadBalancerSourceRanges: []string{testSourceRangeIPv4, testSourceRangeIPv6},
+					Ports: []api.ServicePort{
+						{
+							Name:     "testPort",
+							Port:     int32(12345),
+							Protocol: api.ProtocolTCP,
+						},
+					},
+				},
+			},
+			expected: map[ServicePortName]*ServiceInfoCommon{
+				makeServicePortName("test", "filterIPv4InIPV6Mode", "testPort"): makeTestServiceInfo(testClusterIPv6, 12345, "TCP", 0, func(info *ServiceInfoCommon) {
+					info.ExternalIPs = []string{testExternalIPv6}
+					info.LoadBalancerSourceRanges = []string{testSourceRangeIPv6}
+				}),
+			},
+			isIPv6Mode: &trueVal,
+		},
 	}
 
-	for tci, tc := range testCases {
+	for _, tc := range testCases {
+		svcTracker.isIPv6Mode = tc.isIPv6Mode
 		// outputs
 		newServices := svcTracker.serviceToServiceMap(tc.service)
 
 		if len(newServices) != len(tc.expected) {
-			t.Errorf("[%d] expected %d new, got %d: %v", tci, len(tc.expected), len(newServices), spew.Sdump(newServices))
+			t.Errorf("[%s] expected %d new, got %d: %v", tc.desc, len(tc.expected), len(newServices), spew.Sdump(newServices))
 		}
-		for x := range tc.expected {
-			svcInfo := newServices[x].(*ServiceInfoCommon)
-			if !svcInfo.ClusterIP.Equal(tc.expected[x].ClusterIP) ||
-				svcInfo.Port != tc.expected[x].Port ||
-				svcInfo.Protocol != tc.expected[x].Protocol ||
-				svcInfo.HealthCheckNodePort != tc.expected[x].HealthCheckNodePort {
-				t.Errorf("[%d] expected new[%v]to be %v, got %v", tci, x, tc.expected[x], *svcInfo)
+		for svcKey, expectedInfo := range tc.expected {
+			svcInfo := newServices[svcKey].(*ServiceInfoCommon)
+			if !svcInfo.ClusterIP.Equal(expectedInfo.ClusterIP) ||
+				svcInfo.Port != expectedInfo.Port ||
+				svcInfo.Protocol != expectedInfo.Protocol ||
+				svcInfo.HealthCheckNodePort != expectedInfo.HealthCheckNodePort ||
+				!sets.NewString(svcInfo.ExternalIPs...).Equal(sets.NewString(expectedInfo.ExternalIPs...)) ||
+				!sets.NewString(svcInfo.LoadBalancerSourceRanges...).Equal(sets.NewString(expectedInfo.LoadBalancerSourceRanges...)) {
+				t.Errorf("[%s] expected new[%v]to be %v, got %v", tc.desc, svcKey, expectedInfo, *svcInfo)
 			}
 		}
 	}

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -48,8 +48,8 @@ func (spn ServicePortName) String() string {
 type ServicePort interface {
 	// String returns service string.  An example format can be: `IP:Port/Protocol`.
 	String() string
-	// GetClusterIP returns service cluster IP.
-	GetClusterIP() string
+	// ClusterIPString returns service cluster IP in string format.
+	ClusterIPString() string
 	// GetProtocol returns service protocol.
 	GetProtocol() api.Protocol
 	// GetHealthCheckNodePort returns service health check node port if present.  If return 0, it means not present.

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -48,23 +48,26 @@ func (spn ServicePortName) String() string {
 type ServicePort interface {
 	// String returns service string.  An example format can be: `IP:Port/Protocol`.
 	String() string
-	// ClusterIP returns service cluster IP.
-	ClusterIP() string
-	// Protocol returns service protocol.
-	Protocol() api.Protocol
-	// HealthCheckNodePort returns service health check node port if present.  If return 0, it means not present.
-	HealthCheckNodePort() int
+	// GetClusterIP returns service cluster IP.
+	GetClusterIP() string
+	// GetProtocol returns service protocol.
+	GetProtocol() api.Protocol
+	// GetHealthCheckNodePort returns service health check node port if present.  If return 0, it means not present.
+	GetHealthCheckNodePort() int
 }
 
 // Endpoint in an interface which abstracts information about an endpoint.
+// TODO: Rename functions to be consistent with ServicePort.
 type Endpoint interface {
 	// String returns endpoint string.  An example format can be: `IP:Port`.
 	// We take the returned value as ServiceEndpoint.Endpoint.
 	String() string
-	// IsLocal returns true if the endpoint is running in same host as kube-proxy, otherwise returns false.
-	IsLocal() bool
-	// IP returns IP part of endpoints.
+	// GetIsLocal returns true if the endpoint is running in same host as kube-proxy, otherwise returns false.
+	GetIsLocal() bool
+	// IP returns IP part of the endpoint.
 	IP() string
+	// Port returns the Port part of the endpoint.
+	Port() (int, error)
 	// Equal checks if two endpoints are equal.
 	Equal(Endpoint) bool
 }

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -36,7 +36,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	proxyutil "k8s.io/kubernetes/pkg/proxy/util"
+	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 	"k8s.io/kubernetes/pkg/util/conntrack"
 	"k8s.io/kubernetes/pkg/util/iptables"
 	utilexec "k8s.io/utils/exec"
@@ -588,7 +588,7 @@ func (proxier *Proxier) openPortal(service proxy.ServicePortName, info *ServiceI
 }
 
 func (proxier *Proxier) openOnePortal(portal portal, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) error {
-	if local, err := proxyutil.IsLocalIP(portal.ip.String()); err != nil {
+	if local, err := utilproxy.IsLocalIP(portal.ip.String()); err != nil {
 		return fmt.Errorf("can't determine if IP %s is local, assuming not: %v", portal.ip, err)
 	} else if local {
 		err := proxier.claimNodePort(portal.ip, portal.port, protocol, name)
@@ -767,7 +767,7 @@ func (proxier *Proxier) closePortal(service proxy.ServicePortName, info *Service
 func (proxier *Proxier) closeOnePortal(portal portal, protocol api.Protocol, proxyIP net.IP, proxyPort int, name proxy.ServicePortName) []error {
 	el := []error{}
 
-	if local, err := proxyutil.IsLocalIP(portal.ip.String()); err != nil {
+	if local, err := utilproxy.IsLocalIP(portal.ip.String()); err != nil {
 		el = append(el, fmt.Errorf("can't determine if IP %s is local, assuming not: %v", portal.ip, err))
 	} else if local {
 		if err := proxier.releaseNodePort(portal.ip, portal.port, protocol, name); err != nil {
@@ -967,7 +967,7 @@ func iptablesCommonPortalArgs(destIP net.IP, addPhysicalInterfaceMatch bool, add
 	}
 
 	if destIP != nil {
-		args = append(args, "-d", proxyutil.ToCIDR(destIP))
+		args = append(args, "-d", utilproxy.ToCIDR(destIP))
 	}
 
 	if addPhysicalInterfaceMatch {

--- a/pkg/proxy/util/BUILD
+++ b/pkg/proxy/util/BUILD
@@ -13,10 +13,12 @@ go_library(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/helper:go_default_library",
-        "//pkg/util/conntrack:go_default_library",
+        "//pkg/util/net:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/k8s.io/client-go/tools/record:go_default_library",
     ],
 )
 

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
-	"k8s.io/kubernetes/pkg/util/conntrack"
+	utilnet "k8s.io/kubernetes/pkg/util/net"
 
 	"github.com/golang/glog"
 )
@@ -117,10 +117,10 @@ func GetNodeAddresses(cidrs []string, nw NetworkInterfacer) (sets.String, error)
 					return nil, fmt.Errorf("error parsing CIDR for interface %s, error: %v", itf.Name, err)
 				}
 				if ipNet.Contains(ip) {
-					if conntrack.IsIPv6(ip) && !uniqueAddressList.Has(IPv6ZeroCIDR) {
+					if utilnet.IsIPv6(ip) && !uniqueAddressList.Has(IPv6ZeroCIDR) {
 						uniqueAddressList.Insert(ip.String())
 					}
-					if !conntrack.IsIPv6(ip) && !uniqueAddressList.Has(IPv4ZeroCIDR) {
+					if !utilnet.IsIPv6(ip) && !uniqueAddressList.Has(IPv4ZeroCIDR) {
 						uniqueAddressList.Insert(ip.String())
 					}
 				}

--- a/pkg/util/conntrack/BUILD
+++ b/pkg/util/conntrack/BUILD
@@ -8,6 +8,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/util/conntrack",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/net:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
@@ -20,6 +21,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/util/net:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",

--- a/pkg/util/net/BUILD
+++ b/pkg/util/net/BUILD
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
 package(default_visibility = ["//visibility:public"])
 
 filegroup(
@@ -14,4 +16,16 @@ filegroup(
         "//pkg/util/net/sets:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["net.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/net",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["net_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/util/net/OWNERS
+++ b/pkg/util/net/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+  - sig-network-reviewers
+approvers:
+  - sig-network-approvers

--- a/pkg/util/net/net.go
+++ b/pkg/util/net/net.go
@@ -30,3 +30,32 @@ func IsIPv6String(ip string) bool {
 	netIP := net.ParseIP(ip)
 	return IsIPv6(netIP)
 }
+
+// IsIPv6CIDR returns if cidr is IPv6.
+// This assumes cidr is a valid CIDR.
+func IsIPv6CIDR(cidr string) bool {
+	ip, _, _ := net.ParseCIDR(cidr)
+	return IsIPv6(ip)
+}
+
+// FilterIncorrectIPVersion filters out the incorrect IP version case from a slice of IP strings.
+func FilterIncorrectIPVersion(ipStrings []string, isIPv6Mode bool) ([]string, []string) {
+	return filterWithCondition(ipStrings, isIPv6Mode, IsIPv6String)
+}
+
+// FilterIncorrectCIDRVersion filters out the incorrect IP version case from a slice of CIDR strings.
+func FilterIncorrectCIDRVersion(ipStrings []string, isIPv6Mode bool) ([]string, []string) {
+	return filterWithCondition(ipStrings, isIPv6Mode, IsIPv6CIDR)
+}
+
+func filterWithCondition(strs []string, expectedCondition bool, conditionFunc func(string) bool) ([]string, []string) {
+	var corrects, incorrects []string
+	for _, str := range strs {
+		if conditionFunc(str) != expectedCondition {
+			incorrects = append(incorrects, str)
+		} else {
+			corrects = append(corrects, str)
+		}
+	}
+	return corrects, incorrects
+}

--- a/pkg/util/net/net.go
+++ b/pkg/util/net/net.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+)
+
+// IsIPv6 returns if netIP is IPv6.
+func IsIPv6(netIP net.IP) bool {
+	return netIP != nil && netIP.To4() == nil
+}
+
+// IsIPv6String returns if ip is IPv6.
+func IsIPv6String(ip string) bool {
+	netIP := net.ParseIP(ip)
+	return IsIPv6(netIP)
+}

--- a/pkg/util/net/net_test.go
+++ b/pkg/util/net/net_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package net
+
+import (
+	"net"
+	"testing"
+)
+
+func TestIsIPv6String(t *testing.T) {
+	testCases := []struct {
+		ip         string
+		expectIPv6 bool
+	}{
+		{
+			ip:         "127.0.0.1",
+			expectIPv6: false,
+		},
+		{
+			ip:         "192.168.0.0",
+			expectIPv6: false,
+		},
+		{
+			ip:         "1.2.3.4",
+			expectIPv6: false,
+		},
+		{
+			ip:         "bad ip",
+			expectIPv6: false,
+		},
+		{
+			ip:         "::1",
+			expectIPv6: true,
+		},
+		{
+			ip:         "fd00::600d:f00d",
+			expectIPv6: true,
+		},
+		{
+			ip:         "2001:db8::5",
+			expectIPv6: true,
+		},
+	}
+	for i := range testCases {
+		isIPv6 := IsIPv6String(testCases[i].ip)
+		if isIPv6 != testCases[i].expectIPv6 {
+			t.Errorf("[%d] Expect ipv6 %v, got %v", i+1, testCases[i].expectIPv6, isIPv6)
+		}
+	}
+}
+
+func TestIsIPv6(t *testing.T) {
+	testCases := []struct {
+		ip         net.IP
+		expectIPv6 bool
+	}{
+		{
+			ip:         net.IPv4zero,
+			expectIPv6: false,
+		},
+		{
+			ip:         net.IPv4bcast,
+			expectIPv6: false,
+		},
+		{
+			ip:         net.ParseIP("127.0.0.1"),
+			expectIPv6: false,
+		},
+		{
+			ip:         net.ParseIP("10.20.40.40"),
+			expectIPv6: false,
+		},
+		{
+			ip:         net.ParseIP("172.17.3.0"),
+			expectIPv6: false,
+		},
+		{
+			ip:         nil,
+			expectIPv6: false,
+		},
+		{
+			ip:         net.IPv6loopback,
+			expectIPv6: true,
+		},
+		{
+			ip:         net.IPv6zero,
+			expectIPv6: true,
+		},
+		{
+			ip:         net.ParseIP("fd00::600d:f00d"),
+			expectIPv6: true,
+		},
+		{
+			ip:         net.ParseIP("2001:db8::5"),
+			expectIPv6: true,
+		},
+	}
+	for i := range testCases {
+		isIPv6 := IsIPv6(testCases[i].ip)
+		if isIPv6 != testCases[i].expectIPv6 {
+			t.Errorf("[%d] Expect ipv6 %v, got %v", i+1, testCases[i].expectIPv6, isIPv6)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes kube-proxy omits & logs & emits event for unmatched IP versions configuration (IPv6 address in IPv4 mode or IPv4 address in IPv6 mode). 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57219

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix the issue in kube-proxy iptables/ipvs mode to properly handle incorrect IP version.
```
