### PR TITLE
Limit number of pods listed as master liveness check.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1532,7 +1532,7 @@ function check-cluster() {
           -H "Authorization: Bearer ${KUBE_BEARER_TOKEN}" \
           ${secure} \
           --max-time 5 --fail \
-          "https://${KUBE_MASTER_IP}/api/v1/pods" > "${curl_out}" 2>&1; do
+          "https://${KUBE_MASTER_IP}/api/v1/pods?limit=100" > "${curl_out}" 2>&1; do
       local elapsed=$(($(date +%s) - ${start_time}))
       if [[ ${elapsed} -gt ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} ]]; then
           echo -e "${color_red}Cluster failed to initialize within ${KUBE_CLUSTER_INITIALIZATION_TIMEOUT} seconds.${color_norm}" >&2


### PR DESCRIPTION
**What this PR does / why we need it**:

Another step in making #55686 less likely.

**Release note**:
```release-note
NONE
```