### PR TITLE
Update kube-up.sh; fixed a typo!

### DIFF
--- a/cluster/kube-up.sh
+++ b/cluster/kube-up.sh
@@ -34,7 +34,7 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 DEPRECATED_PROVIDERS=(
   "centos"
-  "libvert-coreos"
+  "libvirt-coreos"
   "local"
   "openstack-heat"
   "photon-controller"


### PR DESCRIPTION
fixed a typo in kube-up.sh; ```libvert-coreos``` should be ```libvirt-coreos```