### PR TITLE
Add option to run nettest server in stand-alone

### DIFF
--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -48,6 +48,7 @@ func testPreStop(c clientset.Interface, ns string) {
 				{
 					Name:  "server",
 					Image: imageutils.GetE2EImage(imageutils.Nettest),
+					Args:  []string{"-peers=0"},
 					Ports: []v1.ContainerPort{{ContainerPort: 8080}},
 				},
 			},

--- a/test/images/nettest/nettest.go
+++ b/test/images/nettest/nettest.go
@@ -52,7 +52,7 @@ import (
 
 var (
 	port          = flag.Int("port", 8080, "Port number to serve at.")
-	peerCount     = flag.Int("peers", 8, "Must find at least this many peers for the test to pass.")
+	peerCount     = flag.Int("peers", 8, "Must find at least this many peers for the test to pass. A zero or negative value will run the server in stand-alone mode.")
 	service       = flag.String("service", "nettest", "Service to find other network test pods in.")
 	namespace     = flag.String("namespace", "default", "Namespace of this pod. TODO: kubernetes should make this discoverable.")
 	delayShutdown = flag.Int("delay-shutdown", 0, "Number of seconds to delay shutdown when receiving SIGTERM.")
@@ -231,6 +231,11 @@ func contactOthers(state *State) {
 		timeout = time.Duration(*peerCount) * time.Second
 	}
 	defer state.doneContactingPeers()
+
+	if *peerCount <= 0 {
+		// Server is running in stand-alone mode; No expected peers to contact.
+		return
+	}
 
 	config, err := restclient.InClusterConfig()
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

To be used with the PreStop e2e conformance test. With this change, the test can pass even when the cluster does not provide pods with a default service account token.

**Which issue(s) this PR fixes**:

Fixes #56897 


