### PR TITLE
[Test Fix] Fix Broken LocalStorageEviction test

### DIFF
--- a/test/e2e_node/eviction_test.go
+++ b/test/e2e_node/eviction_test.go
@@ -227,7 +227,7 @@ var _ = framework.KubeDescribe("LocalStorageCapacityIsolationEviction [Slow] [Se
 			},
 			{
 				evictionPriority: 0, // This pod should not be evicted because it uses less than its limit
-				pod:              diskConsumingPod("emptydir-disk-below-sizelimit", useUnderLimit, nil, v1.ResourceRequirements{Limits: containerLimit}),
+				pod:              diskConsumingPod("container-disk-below-sizelimit", useUnderLimit, nil, v1.ResourceRequirements{Limits: containerLimit}),
 			},
 		})
 	})


### PR DESCRIPTION
**What this PR does / why we need it**:
In #56643, I added a new test case, but did not rename the pod.  The test failed because the new pod can not be created since there is a name collision.
It fixes these new test failures: https://k8s-testgrid.appspot.com/sig-node-kubelet#kubelet-flaky-gce-e2e&include-filter-by-regex=LocalStorageCapacityIsolationEviction

**Special notes for your reviewer**:
I tested it this time

**Release note**:
```release-note
NONE
```

/assign @yujuhong 
/sig node
/kind bug
/priority critical-urgent