### PR TITLE
Check both name and ports for azure health probes

### DIFF
--- a/pkg/cloudprovider/providers/azure/BUILD
+++ b/pkg/cloudprovider/providers/azure/BUILD
@@ -59,6 +59,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "azure_loadbalancer_test.go",
         "azure_test.go",
         "azure_util_test.go",
     ],

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer.go
@@ -1193,7 +1193,7 @@ func (az *Cloud) reconcilePublicIP(clusterName string, service *v1.Service, want
 
 func findProbe(probes []network.Probe, probe network.Probe) bool {
 	for _, existingProbe := range probes {
-		if strings.EqualFold(*existingProbe.Name, *probe.Name) {
+		if strings.EqualFold(*existingProbe.Name, *probe.Name) && *existingProbe.Port == *probe.Port {
 			return true
 		}
 	}

--- a/pkg/cloudprovider/providers/azure/azure_loadbalancer_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_loadbalancer_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azure
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindProbe(t *testing.T) {
+	tests := []struct {
+		msg           string
+		existingProbe []network.Probe
+		curProbe      network.Probe
+		expected      bool
+	}{
+		{
+			msg:      "empty existing probes should return false",
+			expected: false,
+		},
+		{
+			msg: "probe names match while ports unmatch should return false",
+			existingProbe: []network.Probe{
+				{
+					Name: to.StringPtr("httpProbe"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port: to.Int32Ptr(1),
+					},
+				},
+			},
+			curProbe: network.Probe{
+				Name: to.StringPtr("httpProbe"),
+				ProbePropertiesFormat: &network.ProbePropertiesFormat{
+					Port: to.Int32Ptr(2),
+				},
+			},
+			expected: false,
+		},
+		{
+			msg: "probe ports match while names unmatch should return false",
+			existingProbe: []network.Probe{
+				{
+					Name: to.StringPtr("probe1"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port: to.Int32Ptr(1),
+					},
+				},
+			},
+			curProbe: network.Probe{
+				Name: to.StringPtr("probe2"),
+				ProbePropertiesFormat: &network.ProbePropertiesFormat{
+					Port: to.Int32Ptr(1),
+				},
+			},
+			expected: false,
+		},
+		{
+			msg: "both probe ports and names match should return true",
+			existingProbe: []network.Probe{
+				{
+					Name: to.StringPtr("matchName"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port: to.Int32Ptr(1),
+					},
+				},
+			},
+			curProbe: network.Probe{
+				Name: to.StringPtr("matchName"),
+				ProbePropertiesFormat: &network.ProbePropertiesFormat{
+					Port: to.Int32Ptr(1),
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for i, test := range tests {
+		findResult := findProbe(test.existingProbe, test.curProbe)
+		assert.Equal(t, test.expected, findResult, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Check both name and ports for azure health probes, so that probe ports could follow nodePorts changes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56898

**Special notes for your reviewer**:

Should be cherry-picked in 1.7, 1.8, 1.9.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BUG FIX: Check both name and ports for azure health probes
```