### PR TITLE
enable flexvolume on Windows node

### DIFF
--- a/pkg/kubelet/volume_host.go
+++ b/pkg/kubelet/volume_host.go
@@ -19,6 +19,7 @@ package kubelet
 import (
 	"fmt"
 	"net"
+	"runtime"
 
 	"github.com/golang/glog"
 
@@ -91,7 +92,11 @@ func (kvh *kubeletVolumeHost) GetVolumeDevicePluginDir(pluginName string) string
 }
 
 func (kvh *kubeletVolumeHost) GetPodVolumeDir(podUID types.UID, pluginName string, volumeName string) string {
-	return kvh.kubelet.getPodVolumeDir(podUID, pluginName, volumeName)
+	dir := kvh.kubelet.getPodVolumeDir(podUID, pluginName, volumeName)
+	if runtime.GOOS == "windows" {
+		dir = volume.GetWindowsPath(dir)
+	}
+	return dir
 }
 
 func (kvh *kubeletVolumeHost) GetPodVolumeDeviceDir(podUID types.UID, pluginName string) string {

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -19,6 +19,7 @@ package flexvolume
 import (
 	"fmt"
 	"path"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -100,7 +101,11 @@ func (plugin *flexVolumePlugin) Init(host volume.VolumeHost) error {
 func (plugin *flexVolumePlugin) getExecutable() string {
 	parts := strings.Split(plugin.driverName, "/")
 	execName := parts[len(parts)-1]
-	return path.Join(plugin.execPath, execName)
+	execPath := path.Join(plugin.execPath, execName)
+	if runtime.GOOS == "windows" {
+		execPath = volume.GetWindowsPath(execPath)
+	}
+	return execPath
 }
 
 // Name is part of the volume.VolumePlugin interface.

--- a/pkg/volume/util.go
+++ b/pkg/volume/util.go
@@ -495,3 +495,12 @@ func AccessModesContainedInAll(indexedModes []v1.PersistentVolumeAccessMode, req
 	}
 	return true
 }
+
+// GetWindowsPath get a windows path
+func GetWindowsPath(path string) string {
+	windowsPath := strings.Replace(path, "/", "\\", -1)
+	if strings.HasPrefix(windowsPath, "\\") {
+		windowsPath = "c:" + windowsPath
+	}
+	return windowsPath
+}

--- a/pkg/volume/util_test.go
+++ b/pkg/volume/util_test.go
@@ -869,3 +869,34 @@ func TestValidateZone(t *testing.T) {
 		}
 	}
 }
+
+func TestGetWindowsPath(t *testing.T) {
+	tests := []struct {
+		path         string
+		expectedPath string
+	}{
+		{
+			path:         `/var/lib/kubelet/pods/146f8428-83e7-11e7-8dd4-000d3a31dac4/volumes/kubernetes.io~disk`,
+			expectedPath: `c:\var\lib\kubelet\pods\146f8428-83e7-11e7-8dd4-000d3a31dac4\volumes\kubernetes.io~disk`,
+		},
+		{
+			path:         `\var/lib/kubelet/pods/146f8428-83e7-11e7-8dd4-000d3a31dac4\volumes\kubernetes.io~disk`,
+			expectedPath: `c:\var\lib\kubelet\pods\146f8428-83e7-11e7-8dd4-000d3a31dac4\volumes\kubernetes.io~disk`,
+		},
+		{
+			path:         `/`,
+			expectedPath: `c:\`,
+		},
+		{
+			path:         ``,
+			expectedPath: ``,
+		},
+	}
+
+	for _, test := range tests {
+		result := GetWindowsPath(test.path)
+		if result != test.expectedPath {
+			t.Errorf("GetWindowsPath(%v) returned (%v), want (%v)", test.path, result, test.expectedPath)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
enable flexvolume on Windows node:
current PodVolumeDir is like 
`\var\lib\kubelet\pods\f54c5a74-da63-11e7-b71a-000d3a02c330\volumes\test~hostpath.cmd\flextest`
which is a unix path, with this PR, PodVolumeDir in **windows** kubelet  will be converted into like
`c:\var\lib\kubelet\pods\f54c5a74-da63-11e7-b71a-000d3a02c330\volumes\test~hostpath.cmd\flextest` 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56875

**Special notes for your reviewer**:
Detailed steps about how to use flexvolume on Windows with this PR:
https://github.com/andyzhangx/Demo/tree/master/windows/flexvolume

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
enable flexvolume on Windows node
```

/sig windows
