### PR TITLE
-Add scheduler optimization options, short circuit all predicates if …

### DIFF
--- a/examples/scheduler-policy-config-with-extender.json
+++ b/examples/scheduler-policy-config-with-extender.json
@@ -26,5 +26,6 @@
         "nodeCacheCapable": false
 	}
     ],
-"hardPodAffinitySymmetricWeight" : 10
+"hardPodAffinitySymmetricWeight" : 10,
+"alwaysCheckAllPredicates" : false
 }

--- a/examples/scheduler-policy-config.json
+++ b/examples/scheduler-policy-config.json
@@ -15,5 +15,6 @@
 	{"name" : "ServiceSpreadingPriority", "weight" : 1},
 	{"name" : "EqualPriority", "weight" : 1}
 	],
-"hardPodAffinitySymmetricWeight" : 10
+"hardPodAffinitySymmetricWeight" : 10,
+"alwaysCheckAllPredicates" : false
 }

--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -47,6 +47,12 @@ type Policy struct {
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
 	HardPodAffinitySymmetricWeight int32
+
+	// When AlwaysCheckAllPredicates is set to true, scheduler checks all
+	// the configured predicates even after one or more of them fails.
+	// When the flag is set to false, scheduler skips checking the rest
+	// of the predicates after it finds one predicate that failed.
+	AlwaysCheckAllPredicates bool
 }
 
 type PredicatePolicy struct {

--- a/pkg/scheduler/api/v1/types.go
+++ b/pkg/scheduler/api/v1/types.go
@@ -39,6 +39,12 @@ type Policy struct {
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 1-100.
 	HardPodAffinitySymmetricWeight int `json:"hardPodAffinitySymmetricWeight"`
+
+	// When AlwaysCheckAllPredicates is set to true, scheduler checks all
+	// the configured predicates even after one or more of them fails.
+	// When the flag is set to false, scheduler skips checking the rest
+	// of the predicates after it finds one predicate that failed.
+	AlwaysCheckAllPredicates bool `json:"alwaysCheckAllPredicates"`
 }
 
 type PredicatePolicy struct {

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -317,7 +317,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		}
 		queue := NewSchedulingQueue()
 		scheduler := NewGenericScheduler(
-			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{})
+			cache, nil, queue, test.predicates, algorithm.EmptyPredicateMetadataProducer, test.prioritizers, algorithm.EmptyMetadataProducer, extenders, nil, schedulertesting.FakePersistentVolumeClaimLister{}, false)
 		podIgnored := &v1.Pod{}
 		machine, err := scheduler.Schedule(podIgnored, schedulertesting.FakeNodeLister(makeNodeList(test.nodes)))
 		if test.expectsErr {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -533,7 +533,8 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache schedulercache.
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
 		nil,
-		schedulertesting.FakePersistentVolumeClaimLister{})
+		schedulertesting.FakePersistentVolumeClaimLister{},
+		false)
 	bindingChan := make(chan *v1.Binding, 1)
 	errChan := make(chan error, 1)
 	configurator := &FakeConfigurator{
@@ -577,7 +578,8 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		algorithm.EmptyMetadataProducer,
 		[]algorithm.SchedulerExtender{},
 		nil,
-		schedulertesting.FakePersistentVolumeClaimLister{})
+		schedulertesting.FakePersistentVolumeClaimLister{},
+		false)
 	bindingChan := make(chan *v1.Binding, 2)
 	configurator := &FakeConfigurator{
 		Config: &Config{


### PR DESCRIPTION
…one predicate fails

Signed-off-by: Wang Guoliang <iamwgliang@gmail.com>

**What this PR does / why we need it**:
Short circuit all predicates if one predicate fails. 

I think we can add a switch to control it, maybe some scenes do not need to know all the causes of failure, but also can get a great performance improvement; if you need to fully understand the reasons for the failure, and accept the current performance requirements, can maintain the current logic. It should expose this switch to the user.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #56889 and #48186

**Special notes for your reviewer**:
@davidopp

**Release note**:

```
Allow scheduler set AlwaysCheckAllPredicates, short circuit all predicates if one predicate fails can greatly improve the scheduling performance.
```
  
  