### PR TITLE
sink errors if statefulset pods already exist

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -80,7 +80,7 @@ func (spc *realStatefulPodControl) CreateStatefulPod(set *apps.StatefulSet, pod 
 	_, err := spc.client.CoreV1().Pods(set.Namespace).Create(pod)
 	// sink already exists errors
 	if apierrors.IsAlreadyExists(err) {
-		return err
+		return nil
 	}
 	spc.recordPodEvent("create", set, pod, err)
 	return err

--- a/pkg/controller/statefulset/stateful_pod_control_test.go
+++ b/pkg/controller/statefulset/stateful_pod_control_test.go
@@ -88,7 +88,7 @@ func TestStatefulPodControlCreatePodExists(t *testing.T) {
 	fakeClient.AddReactor("create", "pods", func(action core.Action) (bool, runtime.Object, error) {
 		return true, pod, apierrors.NewAlreadyExists(action.GetResource().GroupResource(), pod.Name)
 	})
-	if err := control.CreateStatefulPod(set, pod); !apierrors.IsAlreadyExists(err) {
+	if err := control.CreateStatefulPod(set, pod); err != nil {
 		t.Errorf("Failed to create Pod error: %s", err)
 	}
 	events := collectEvents(recorder.Events)


### PR DESCRIPTION
if the statefulset pods have already existed, should return no errors when CreateStatefulPod