### PR TITLE
Add Cinder e2e tests

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -696,6 +696,7 @@ test/e2e/lifecycle
 test/e2e/lifecycle/bootstrap
 test/e2e/network
 test/e2e/node
+test/e2e/storage/openstack
 test/e2e/scalability
 test/e2e/scheduling
 test/e2e/servicecatalog

--- a/pkg/cloudprovider/providers/openstack/openstack.go
+++ b/pkg/cloudprovider/providers/openstack/openstack.go
@@ -164,7 +164,7 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		return newOpenStack(cfg)
+		return NewOpenStack(cfg)
 	})
 }
 
@@ -198,7 +198,7 @@ func (cfg Config) toAuth3Options() tokens3.AuthOptions {
 
 // configFromEnv allows setting up credentials etc using the
 // standard OS_* OpenStack client environment variables.
-func configFromEnv() (cfg Config, ok bool) {
+func ConfigFromEnv() (cfg Config, ok bool) {
 	cfg.Global.AuthURL = os.Getenv("OS_AUTH_URL")
 	cfg.Global.Username = os.Getenv("OS_USERNAME")
 	cfg.Global.Password = os.Getenv("OS_PASSWORD")
@@ -243,7 +243,7 @@ func readConfig(config io.Reader) (Config, error) {
 		return Config{}, fmt.Errorf("no OpenStack cloud provider config file given")
 	}
 
-	cfg, _ := configFromEnv()
+	cfg, _ := ConfigFromEnv()
 
 	// Set default values for config params
 	cfg.BlockStorage.BSVersion = "auto"
@@ -310,7 +310,7 @@ func checkOpenStackOpts(openstackOpts *OpenStack) error {
 	return checkMetadataSearchOrder(openstackOpts.metadataOpts.SearchOrder)
 }
 
-func newOpenStack(cfg Config) (*OpenStack, error) {
+func NewOpenStack(cfg Config) (*OpenStack, error) {
 	provider, err := openstack.NewClient(cfg.Global.AuthURL)
 	if err != nil {
 		return nil, err

--- a/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_routes_test.go
@@ -30,12 +30,12 @@ import (
 func TestRoutes(t *testing.T) {
 	const clusterName = "ignored"
 
-	cfg, ok := configFromEnv()
+	cfg, ok := ConfigFromEnv()
 	if !ok {
 		t.Skipf("No config found in environment")
 	}
 
-	os, err := newOpenStack(cfg)
+	os, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_test.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_test.go
@@ -460,19 +460,19 @@ func TestNodeAddresses(t *testing.T) {
 }
 
 func TestNewOpenStack(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := ConfigFromEnv()
 	if !ok {
 		t.Skip("No config found in environment")
 	}
 
-	_, err := newOpenStack(cfg)
+	_, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}
 }
 
 func TestLoadBalancer(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := ConfigFromEnv()
 	if !ok {
 		t.Skip("No config found in environment")
 	}
@@ -483,7 +483,7 @@ func TestLoadBalancer(t *testing.T) {
 		t.Logf("Trying LBVersion = '%s'\n", v)
 		cfg.LoadBalancer.LBVersion = v
 
-		os, err := newOpenStack(cfg)
+		os, err := NewOpenStack(cfg)
 		if err != nil {
 			t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 		}
@@ -536,12 +536,12 @@ func TestZones(t *testing.T) {
 var diskPathRegexp = regexp.MustCompile("/dev/disk/(?:by-id|by-path)/")
 
 func TestVolumes(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := ConfigFromEnv()
 	if !ok {
 		t.Skip("No config found in environment")
 	}
 
-	os, err := newOpenStack(cfg)
+	os, err := NewOpenStack(cfg)
 	if err != nil {
 		t.Fatalf("Failed to construct/authenticate OpenStack: %s", err)
 	}

--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -441,6 +441,14 @@ func (os *OpenStack) getVolume(volumeID string) (Volume, error) {
 	return volumes.getVolume(volumeID)
 }
 
+func (os *OpenStack) GetVolume(volumeID string) (Volume, error) {
+	volumes, err := os.volumeService("")
+	if err != nil {
+		return Volume{}, fmt.Errorf("unable to initialize cinder client for region: %s, err: %v", os.region, err)
+	}
+	return volumes.getVolume(volumeID)
+}
+
 // CreateVolume creates a volume of given size (in GiB)
 func (os *OpenStack) CreateVolume(name string, size int, vtype, availability string, tags *map[string]string) (string, string, bool, error) {
 	volumes, err := os.volumeService("")

--- a/test/e2e/storage/BUILD
+++ b/test/e2e/storage/BUILD
@@ -91,6 +91,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//test/e2e/storage/openstack:all-srcs",
         "//test/e2e/storage/utils:all-srcs",
         "//test/e2e/storage/vsphere:all-srcs",
     ],

--- a/test/e2e/storage/openstack/BUILD
+++ b/test/e2e/storage/openstack/BUILD
@@ -1,0 +1,60 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "openstack_common.go",
+        "openstack_scale.go",
+        "openstack_statefulsets.go",
+        "openstack_stress.go",
+        "openstack_utils.go",
+        "openstack_volume_cluster_ds.go",
+        "openstack_volume_datastore.go",
+        "openstack_volume_disksize.go",
+        "openstack_volume_fstype.go",
+        "openstack_volume_master_restart.go",
+        "openstack_volume_ops_storm.go",
+        "openstack_volume_perf.go",
+        "openstack_volume_placement.go",
+        "persistent_volumes-openstack.go",
+        "pv_reclaimpolicy.go",
+        "pvc_label_selector.go",
+    ],
+    importpath = "k8s.io/kubernetes/test/e2e/storage/openstack",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/cloudprovider/providers/openstack:go_default_library",
+        "//pkg/volume/util:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/storage/utils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/storage/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/storage/openstack/openstack_common.go
+++ b/test/e2e/storage/openstack/openstack_common.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	. "github.com/onsi/gomega"
+	"os"
+	"strconv"
+)
+
+const (
+	SPBMPolicyName            = "OPENSTACK_SPBM_POLICY_NAME"
+	StorageClassDatastoreName = "OPENSTACK_DATASTORE"
+	SecondSharedDatastore     = "OPENSTACK_SECOND_SHARED_DATASTORE"
+	KubernetesClusterName     = "OPENSTACK_KUBERNETES_CLUSTER"
+	SPBMTagPolicy             = "OPENSTACK_SPBM_TAG_POLICY"
+)
+
+const (
+	OSPClusterDatastore        = "CLUSTER_DATASTORE"
+	SPBMPolicyDataStoreCluster = "OPENSTACK_SPBM_POLICY_DS_CLUSTER"
+)
+
+const (
+	OSPScaleVolumeCount   = "OSP_SCALE_VOLUME_COUNT"
+	OSPScaleVolumesPerPod = "OSP_SCALE_VOLUME_PER_POD"
+	OSPScaleInstances     = "OSP_SCALE_INSTANCES"
+)
+
+const (
+	OSPStressInstances  = "OSP_STRESS_INSTANCES"
+	OSPStressIterations = "OSP_STRESS_ITERATIONS"
+)
+
+const (
+	OSPPerfVolumeCount   = "OSP_PERF_VOLUME_COUNT"
+	OSPPerfVolumesPerPod = "OSP_PERF_VOLUME_PER_POD"
+	OSPPerfIterations    = "OSP_PERF_ITERATIONS"
+)
+
+func GetAndExpectStringEnvVar(varName string) string {
+	varValue := os.Getenv(varName)
+	Expect(varValue).NotTo(BeEmpty(), "ENV "+varName+" is not set")
+	return varValue
+}
+
+func GetAndExpectIntEnvVar(varName string) int {
+	varValue := GetAndExpectStringEnvVar(varName)
+	varIntValue, err := strconv.Atoi(varValue)
+	Expect(err).NotTo(HaveOccurred(), "Error Parsing "+varName)
+	return varIntValue
+}

--- a/test/e2e/storage/openstack/openstack_scale.go
+++ b/test/e2e/storage/openstack/openstack_scale.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stypes "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// NodeLabeKey name
+const (
+	NodeLabelKey = "openstack_e2e_label"
+)
+
+// NodeSelector holds
+type NodeSelector struct {
+	labelKey   string
+	labelValue string
+}
+
+var _ = utils.SIGDescribe("osp at scale [Feature:openstack] ", func() {
+	f := framework.NewDefaultFramework("osp-at-scale")
+
+	var (
+		client            clientset.Interface
+		namespace         string
+		nodeSelectorList  []*NodeSelector
+		volumeCount       int
+		numberOfInstances int
+		volumesPerPod     int
+		nodeVolumeMapChan chan map[string][]string
+		nodes             *v1.NodeList
+		policyName        string
+		datastoreName     string
+		scNames           = []string{storageclass1, storageclass2, storageclass3, storageclass4}
+		err               error
+	)
+
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeVolumeMapChan = make(chan map[string][]string)
+
+		// Read the environment variables
+		volumeCountStr := os.Getenv("OSP_SCALE_VOLUME_COUNT")
+		Expect(volumeCountStr).NotTo(BeEmpty(), "ENV OSP_SCALE_VOLUME_COUNT is not set")
+		volumeCount, err = strconv.Atoi(volumeCountStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing OSP_SCALE_VOLUME_COUNT")
+
+		volumesPerPodStr := os.Getenv("OSP_SCALE_VOLUME_PER_POD")
+		Expect(volumesPerPodStr).NotTo(BeEmpty(), "ENV OSP_SCALE_VOLUME_PER_POD is not set")
+		volumesPerPod, err = strconv.Atoi(volumesPerPodStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing OSP_SCALE_VOLUME_PER_POD")
+
+		numberOfInstancesStr := os.Getenv("OSP_SCALE_INSTANCES")
+		Expect(numberOfInstancesStr).NotTo(BeEmpty(), "ENV OSP_SCALE_INSTANCES is not set")
+		numberOfInstances, err = strconv.Atoi(numberOfInstancesStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing OSP_SCALE_INSTANCES")
+		Expect(numberOfInstances > 5).NotTo(BeTrue(), "Maximum allowed instances are 5")
+		Expect(numberOfInstances > volumeCount).NotTo(BeTrue(), "Number of instances should be less than the total volume count")
+
+		policyName = os.Getenv("OPENSTACK_SPBM_POLICY_NAME")
+		datastoreName = os.Getenv("OPENSTACK_DATASTORE")
+		Expect(policyName).NotTo(BeEmpty(), "ENV OPENSTACK_SPBM_POLICY_NAME is not set")
+		Expect(datastoreName).NotTo(BeEmpty(), "ENV OPENSTACK_DATASTORE is not set")
+
+		nodes = framework.GetReadySchedulableNodesOrDie(client)
+		if len(nodes.Items) < 2 {
+			framework.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+		}
+		// Verify volume count specified by the user can be satisfied
+		if volumeCount > volumesPerNode*len(nodes.Items) {
+			framework.Skipf("Cannot attach %d volumes to %d nodes. Maximum volumes that can be attached on %d nodes is %d", volumeCount, len(nodes.Items), len(nodes.Items), volumesPerNode*len(nodes.Items))
+		}
+		nodeSelectorList = createOSNodeLabels(client, namespace, nodes)
+	})
+
+	framework.AddCleanupAction(func() {
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(namespace) > 0 {
+			for _, node := range nodes.Items {
+				framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
+			}
+		}
+	})
+
+	It("openstack scale tests", func() {
+		var pvcClaimList []string
+		nodeVolumeMap := make(map[k8stypes.NodeName][]string)
+		// Volumes will be provisioned with each different types of Storage Class
+		scArrays := make([]*storageV1.StorageClass, len(scNames))
+		for index, scname := range scNames {
+			// Create openstack Storage Class
+			By(fmt.Sprintf("Creating Storage Class : %q", scname))
+			var sc *storageV1.StorageClass
+			scParams := make(map[string]string)
+			var err error
+			switch scname {
+			case storageclass1:
+				scParams = nil
+			case storageclass2:
+				scParams[PolicyHostFailuresToTolerate] = "1"
+			case storageclass3:
+				scParams[SpbmStoragePolicy] = policyName
+			case storageclass4:
+				scParams[Datastore] = datastoreName
+			}
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(scname, scParams))
+			Expect(sc).NotTo(BeNil(), "Storage class is empty")
+			Expect(err).NotTo(HaveOccurred(), "Failed to create storage class")
+			defer client.StorageV1().StorageClasses().Delete(scname, nil)
+			scArrays[index] = sc
+		}
+
+		volumeCountPerInstance := volumeCount / numberOfInstances
+		for instanceCount := 0; instanceCount < numberOfInstances; instanceCount++ {
+			if instanceCount == numberOfInstances-1 {
+				volumeCountPerInstance = volumeCount
+			}
+			volumeCount = volumeCount - volumeCountPerInstance
+			go VolumeCreateAndAttach(client, namespace, scArrays, volumeCountPerInstance, volumesPerPod, nodeSelectorList, nodeVolumeMapChan, id, osp)
+		}
+
+		// Get the list of all volumes attached to each node from the go routines by reading the data from the channel
+		for instanceCount := 0; instanceCount < numberOfInstances; instanceCount++ {
+			for node, volumeList := range <-nodeVolumeMapChan {
+				nodeVolumeMap[k8stypes.NodeName(node)] = append(nodeVolumeMap[k8stypes.NodeName(node)], volumeList...)
+			}
+		}
+		podList, err := client.CoreV1().Pods(namespace).List(metav1.ListOptions{})
+		for _, pod := range podList.Items {
+			pvcClaimList = append(pvcClaimList, getClaimsForPod(&pod, volumesPerPod)...)
+			By("Deleting pod")
+			err = framework.DeletePodWithWait(f, client, &pod)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		for _, pvcClaim := range pvcClaimList {
+			err = framework.DeletePersistentVolumeClaim(client, pvcClaim, namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+})
+
+// Get PVC claims for the pod
+func getClaimsForPod(pod *v1.Pod, volumesPerPod int) []string {
+	pvcClaimList := make([]string, volumesPerPod)
+	for i, volumespec := range pod.Spec.Volumes {
+		if volumespec.PersistentVolumeClaim != nil {
+			pvcClaimList[i] = volumespec.PersistentVolumeClaim.ClaimName
+		}
+	}
+	return pvcClaimList
+}
+
+// VolumeCreateAndAttach peforms create and attach operations of openstack persistent volumes at scale
+func VolumeCreateAndAttach(client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumeCountPerInstance int, volumesPerPod int, nodeSelectorList []*NodeSelector, nodeVolumeMapChan chan map[string][]string, instanceID string, osp *openstack.OpenStack) {
+	defer GinkgoRecover()
+	nodeVolumeMap := make(map[string][]string)
+	nodeSelectorIndex := 0
+	for index := 0; index < volumeCountPerInstance; index = index + volumesPerPod {
+		if (volumeCountPerInstance - index) < volumesPerPod {
+			volumesPerPod = volumeCountPerInstance - index
+		}
+		pvclaims := make([]*v1.PersistentVolumeClaim, volumesPerPod)
+		for i := 0; i < volumesPerPod; i++ {
+			By("Creating PVC using the Storage Class")
+			pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", sc[index%len(sc)]))
+			Expect(err).NotTo(HaveOccurred())
+			pvclaims[i] = pvclaim
+		}
+
+		By("Waiting for claim to be in bound phase")
+		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating pod to attach PV to the node")
+		nodeSelector := nodeSelectorList[nodeSelectorIndex%len(nodeSelectorList)]
+		// Create pod to attach Volume to Node
+		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		for _, pv := range persistentvolumes {
+			nodeVolumeMap[pod.Spec.NodeName] = append(nodeVolumeMap[pod.Spec.NodeName], pv.Spec.Cinder.VolumeID)
+		}
+		By("Verify the volume is accessible and available in the pod")
+		verifyOpenstackVolumesAccessible(client, pod, persistentvolumes, instanceID, osp)
+		nodeSelectorIndex++
+	}
+	nodeVolumeMapChan <- nodeVolumeMap
+	close(nodeVolumeMapChan)
+}
+
+func createOSNodeLabels(client clientset.Interface, namespace string, nodes *v1.NodeList) []*NodeSelector {
+	var nodeSelectorList []*NodeSelector
+	for i, node := range nodes.Items {
+		labelVal := "openstack_e2e_" + strconv.Itoa(i)
+		nodeSelector := &NodeSelector{
+			labelKey:   NodeLabelKey,
+			labelValue: labelVal,
+		}
+		nodeSelectorList = append(nodeSelectorList, nodeSelector)
+		framework.AddOrUpdateLabelOnNode(client, node.Name, NodeLabelKey, labelVal)
+	}
+	return nodeSelectorList
+}

--- a/test/e2e/storage/openstack/openstack_statefulsets.go
+++ b/test/e2e/storage/openstack/openstack_statefulsets.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+const (
+	manifestPath     = "test/e2e/testing-manifests/statefulset/nginx"
+	mountPath        = "/usr/share/nginx/html"
+	storageclassname = "nginx-sc"
+)
+
+var _ = utils.SIGDescribe("openstack statefulset", func() {
+	f := framework.NewDefaultFramework("openstack-statefulset")
+	var (
+		namespace string
+		client    clientset.Interface
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		namespace = f.Namespace.Name
+		client = f.ClientSet
+	})
+	AfterEach(func() {
+		framework.Logf("Deleting all statefulset in namespace: %v", namespace)
+		framework.DeleteAllStatefulSets(client, namespace)
+	})
+
+	It("openstack statefulset testing", func(t *testing.T) {
+		By("Creating StorageClass for Statefulset")
+		scParameters := make(map[string]string)
+		scParameters["diskformat"] = "thin"
+		scSpec := getOpenstackStorageClassSpec(storageclassname, scParameters)
+		sc, err := client.StorageV1().StorageClasses().Create(scSpec)
+		Expect(err).NotTo(HaveOccurred())
+		defer client.StorageV1().StorageClasses().Delete(sc.Name, nil)
+
+		By("Creating statefulset")
+		statefulsetTester := framework.NewStatefulSetTester(client)
+		statefulset := statefulsetTester.CreateStatefulSet(manifestPath, namespace)
+		replicas := *(statefulset.Spec.Replicas)
+		// Waiting for pods status to be Ready
+		statefulsetTester.WaitForStatusReadyReplicas(statefulset, replicas)
+		Expect(statefulsetTester.CheckMount(statefulset, mountPath)).NotTo(HaveOccurred())
+		ssPodsBeforeScaleDown := statefulsetTester.GetPodList(statefulset)
+		Expect(ssPodsBeforeScaleDown.Items).NotTo(BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		Expect(len(ssPodsBeforeScaleDown.Items) == int(replicas)).To(BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+
+		// Get the list of Volumes attached to Pods before scale down
+		volumesBeforeScaleDown := make(map[string]string)
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(sspod.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, volumespec := range sspod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					volumeID := getopenStackVolumeIDFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					volumesBeforeScaleDown[volumeID] = volumespec.PersistentVolumeClaim.ClaimName
+				}
+			}
+		}
+
+		By(fmt.Sprintf("Scaling down statefulsets to number of Replica: %v", replicas-1))
+		_, scaledownErr := statefulsetTester.Scale(statefulset, replicas-1)
+		Expect(scaledownErr).NotTo(HaveOccurred())
+		statefulsetTester.WaitForStatusReadyReplicas(statefulset, replicas-1)
+
+		osp, instanceID, err := getOpenstack(client)
+		Expect(err).NotTo(HaveOccurred())
+
+		// After scale down, verify openstack volumes are detached from deleted pods
+		By("Verify Volumes are detached from Nodes after Statefulsets is scaled down")
+		for _, sspod := range ssPodsBeforeScaleDown.Items {
+			_, err := client.CoreV1().Pods(namespace).Get(sspod.Name, metav1.GetOptions{})
+			if err != nil {
+				Expect(apierrs.IsNotFound(err), BeTrue())
+				for _, volumespec := range sspod.Spec.Volumes {
+					if volumespec.PersistentVolumeClaim != nil {
+						osVolumeID := getopenStackVolumeIDFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+						framework.Logf("Waiting for Volume: %q to detach from Node: %q", osVolumeID, sspod.Spec.NodeName)
+						WaitForVolumeStatus(osp, osVolumeID, VolumeAvailableStatus)
+					}
+				}
+			}
+		}
+
+		By(fmt.Sprintf("Scaling up statefulsets to number of Replica: %v", replicas))
+		_, scaleupErr := statefulsetTester.Scale(statefulset, replicas)
+		Expect(scaleupErr).NotTo(HaveOccurred())
+		statefulsetTester.WaitForStatusReplicas(statefulset, replicas)
+		statefulsetTester.WaitForStatusReadyReplicas(statefulset, replicas)
+
+		ssPodsAfterScaleUp := statefulsetTester.GetPodList(statefulset)
+		Expect(ssPodsAfterScaleUp.Items).NotTo(BeEmpty(), fmt.Sprintf("Unable to get list of Pods from the Statefulset: %v", statefulset.Name))
+		Expect(len(ssPodsAfterScaleUp.Items) == int(replicas)).To(BeTrue(), "Number of Pods in the statefulset should match with number of replicas")
+
+		// After scale up, verify all openstack volumes are attached to node VMs.
+		By("Verify all volumes are attached to Nodes after Statefulsets is scaled up")
+		for _, sspod := range ssPodsAfterScaleUp.Items {
+			err := framework.WaitForPodsReady(client, statefulset.Namespace, sspod.Name, 0)
+			Expect(err).NotTo(HaveOccurred())
+			pod, err := client.CoreV1().Pods(namespace).Get(sspod.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			for _, volumespec := range pod.Spec.Volumes {
+				if volumespec.PersistentVolumeClaim != nil {
+					osVolumeID := getopenStackVolumeIDFromClaim(client, statefulset.Namespace, volumespec.PersistentVolumeClaim.ClaimName)
+					framework.Logf("Verify Volume: %q is attached to the Node: %q", osVolumeID, sspod.Spec.NodeName)
+					isVolumeAttached, verifyDiskAttachedError := osp.DiskIsAttached(instanceID, osVolumeID)
+					Expect(isVolumeAttached).To(BeTrue())
+					Expect(verifyDiskAttachedError).NotTo(HaveOccurred())
+				}
+			}
+		}
+	})
+})

--- a/test/e2e/storage/openstack/openstack_stress.go
+++ b/test/e2e/storage/openstack/openstack_stress.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"sync"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("openstack cloud provider stress [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("osp-stress")
+	var (
+		client        clientset.Interface
+		namespace     string
+		instances     int
+		iterations    int
+		err           error
+		scNames       = []string{storageclass1, storageclass2, storageclass3, storageclass4}
+		policyName    string
+		datastoreName string
+	)
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		Expect(nodeList.Items).NotTo(BeEmpty(), "Unable to find ready and schedulable Node")
+
+		instancesStr := os.Getenv("OSP_STRESS_INSTANCES")
+		Expect(instancesStr).NotTo(BeEmpty(), "ENV OSP_STRESS_INSTANCES is not set")
+		instances, err = strconv.Atoi(instancesStr)
+		Expect(err).NotTo(HaveOccurred(), "error parsing OSP-STRESS-INSTANCES: %v", err)
+		Expect(instances <= volumesPerNode*len(nodeList.Items)).To(BeTrue(), fmt.Sprintf("number of Instances (%d) should be less or equal: %v", instances, volumesPerNode*len(nodeList.Items)))
+		Expect(instances > len(scNames)).To(BeTrue(), "OSP_STRESS_INSTANCES should be less or equal: %v to utilize all 4 types of storage classes", volumesPerNode*len(nodeList.Items))
+
+		iterationStr := os.Getenv("OSP_STRESS_ITERATIONS")
+		Expect(instancesStr).NotTo(BeEmpty(), "ENV OSP_STRESS_ITERATIONS is not set")
+		iterations, err = strconv.Atoi(iterationStr)
+		Expect(err).NotTo(HaveOccurred(), "error parsing OSP_STRESS_ITERATIONS: %v", err)
+		Expect(iterations > 0).To(BeTrue(), "OSP_STRESS_ITERATIONS should be greater than 0")
+
+		policyName = os.Getenv("OPENSTACK_SPBM_POLICY_NAME")
+		datastoreName = os.Getenv("OPENSTACK_DATASTORE")
+		Expect(policyName).NotTo(BeEmpty(), "ENV OPENSTACK_SPBM_POLICY_NAME is not set")
+		Expect(datastoreName).NotTo(BeEmpty(), "ENV OPENSTACK_DATASTORE is not set")
+	})
+
+	It("openstack stress tests", func() {
+		scArrays := make([]*storageV1.StorageClass, len(scNames))
+		for index, scname := range scNames {
+			// Create openstack Storage Class
+			By(fmt.Sprintf("Creating Storage Class : %v", scname))
+			var sc *storageV1.StorageClass
+			var err error
+			switch scname {
+			case storageclass1:
+				sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass1, nil))
+			case storageclass2:
+				var scOSanParameters map[string]string
+				scOSanParameters = make(map[string]string)
+				scOSanParameters[PolicyHostFailuresToTolerate] = "1"
+				sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass2, scOSanParameters))
+			case storageclass3:
+				var scSPBMPolicyParameters map[string]string
+				scSPBMPolicyParameters = make(map[string]string)
+				scSPBMPolicyParameters[SpbmStoragePolicy] = policyName
+				sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass3, scSPBMPolicyParameters))
+			case storageclass4:
+				var scWithDSParameters map[string]string
+				scWithDSParameters = make(map[string]string)
+				scWithDSParameters[Datastore] = datastoreName
+				scWithDatastoreSpec := getOpenstackStorageClassSpec(storageclass4, scWithDSParameters)
+				sc, err = client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+			}
+			Expect(sc).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+			defer client.StorageV1().StorageClasses().Delete(scname, nil)
+			scArrays[index] = sc
+		}
+
+		var wg sync.WaitGroup
+		wg.Add(instances)
+		for instanceCount := 0; instanceCount < instances; instanceCount++ {
+			instanceID := fmt.Sprintf("Thread:%v", instanceCount+1)
+			go PerformVolumeLifeCycleInParallel(f, client, namespace, instanceID, scArrays[instanceCount%len(scArrays)], iterations, &wg)
+		}
+		wg.Wait()
+	})
+
+})
+
+// PerformVolumeLifeCycleInParallel performs volume lifecycle operations in parallel
+func PerformVolumeLifeCycleInParallel(f *framework.Framework, client clientset.Interface, namespace string, instanceID string, sc *storageV1.StorageClass, iterations int, wg *sync.WaitGroup) {
+	defer wg.Done()
+	defer GinkgoRecover()
+	osp, _, err := getOpenstack(f.ClientSet)
+	Expect(err).NotTo(HaveOccurred())
+	for iterationCount := 0; iterationCount < iterations; iterationCount++ {
+		logPrefix := fmt.Sprintf("Instance: [%v], Iteration: [%v] :", instanceID, iterationCount+1)
+		By(fmt.Sprintf("%v Creating PVC using the Storage Class: %v", logPrefix, sc.Name))
+		pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "1Gi", sc))
+		Expect(err).NotTo(HaveOccurred())
+		defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+		var pvclaims []*v1.PersistentVolumeClaim
+		pvclaims = append(pvclaims, pvclaim)
+		By(fmt.Sprintf("%v Waiting for claim: %v to be in bound phase", logPrefix, pvclaim.Name))
+		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("%v Creating Pod using the claim: %v", logPrefix, pvclaim.Name))
+		// Create pod to attach Volume to Node
+		pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("%v Waiting for the Pod: %v to be in the running state", logPrefix, pod.Name))
+		Expect(f.WaitForPodRunningSlow(pod.Name)).NotTo(HaveOccurred())
+
+		// Get the copy of the Pod to know the assigned node name.
+		pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("%v Verifing the volume: %v is attached to the node VM: %v", logPrefix, persistentvolumes[0].Spec.Cinder.VolumeID, pod.Spec.NodeName))
+		isVolumeAttached, verifyDiskAttachedError := verifyOpenstackDiskAttached(client, osp, instanceID, persistentvolumes[0].Spec.Cinder.VolumeID, types.NodeName(pod.Spec.NodeName))
+		Expect(isVolumeAttached).To(BeTrue())
+		Expect(verifyDiskAttachedError).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("%v Verifing the volume: %v is accessible in the pod: %v", logPrefix, persistentvolumes[0].Spec.Cinder.VolumeID, pod.Name))
+		verifyOpenstackVolumesAccessible(client, pod, persistentvolumes, instanceID, osp)
+
+		By(fmt.Sprintf("%v Deleting pod: %v", logPrefix, pod.Name))
+		err = framework.DeletePodWithWait(f, client, pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("%v Waiting for volume: %v to be detached from the node: %v", logPrefix, persistentvolumes[0].Spec.Cinder.VolumeID, pod.Spec.NodeName))
+		WaitForVolumeStatus(osp, persistentvolumes[0].Spec.Cinder.VolumeID, VolumeAvailableStatus)
+
+		By(fmt.Sprintf("%v Deleting the Claim: %v", logPrefix, pvclaim.Name))
+		Expect(framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)).NotTo(HaveOccurred())
+	}
+}

--- a/test/e2e/storage/openstack/openstack_utils.go
+++ b/test/e2e/storage/openstack/openstack_utils.go
@@ -1,0 +1,593 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/util/rand"
+	clientset "k8s.io/client-go/kubernetes"
+	openstack "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+
+	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8stype "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/kubernetes/pkg/volume/util"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+const (
+	volumesPerNode = 55
+	storageclass1  = "sc-default"
+	storageclass2  = "sc-vsan"
+	storageclass3  = "sc-spbm"
+	storageclass4  = "sc-user-specified-ds"
+)
+
+// volumeState represents the state of a volume.
+type volumeState int32
+
+const (
+	volumeStateDetached volumeState = 1
+	volumeStateAttached volumeState = 2
+)
+
+// volume constants.
+const (
+	VmfsDatastore                              = "sharedVmfs-0"
+	VsanDatastore                              = "vsanDatastore"
+	Datastore                                  = "datastore"
+	PolicyDiskStripes                          = "diskStripes"
+	PolicyHostFailuresToTolerate               = "hostFailuresToTolerate"
+	PolicyCacheReservation                     = "cacheReservation"
+	PolicyObjectSpaceReservation               = "objectSpaceReservation"
+	PolicyIopsLimit                            = "iopsLimit"
+	DiskFormat                                 = "diskformat"
+	ThinDisk                                   = "thin"
+	SpbmStoragePolicy                          = "storagepolicyname"
+	BronzeStoragePolicy                        = "bronze"
+	HostFailuresToTolerateCapabilityVal        = "0"
+	CacheReservationCapabilityVal              = "20"
+	DiskStripesCapabilityVal                   = "1"
+	ObjectSpaceReservationCapabilityVal        = "30"
+	IopsLimitCapabilityVal                     = "100"
+	StripeWidthCapabilityVal                   = "2"
+	DiskStripesCapabilityInvalidVal            = "14"
+	HostFailuresToTolerateCapabilityInvalidVal = "4"
+	DummyVMPrefixName                          = "openstack-k8s"
+	DiskStripesCapabilityMaxVal                = "11"
+)
+
+// volume status constants
+const (
+	VolumeAvailableStatus = "available"
+	volumeInUseStatus     = "in-use"
+	testClusterName       = "testCluster"
+
+	volumeStatusTimeoutSeconds = 30
+	// volumeStatus* is configuration of exponential backoff for
+	// waiting for specified volume status. Starting with 1
+	// seconds, multiplying by 1.2 with each step and taking 13 steps at maximum
+	// it will time out after 32s, which roughly corresponds to 30s
+	volumeStatusInitDealy = 1 * time.Second
+	volumeStatusFactor    = 1.2
+	volumeStatusSteps     = 13
+)
+
+func verifyOpenstackDiskAttached(c clientset.Interface, os *openstack.OpenStack, instanceID string, volumeID string, nodeName types.NodeName) (bool, error) {
+	var (
+		isAttached bool
+		err        error
+	)
+
+	isAttached, err = os.DiskIsAttached(instanceID, volumeID)
+	return isAttached, err
+}
+
+// Wait until openstack volumes are detached from the list of nodes or time out after 5 minutes
+func waitForOpenstackDisksToDetach(c clientset.Interface, instanceId string, osp *openstack.OpenStack, nodeVolumes map[k8stype.NodeName][]string) error {
+	var (
+		err            error
+		disksAttached  = true
+		detachTimeout  = 5 * time.Minute
+		detachPollTime = 10 * time.Second
+	)
+	if osp == nil {
+		osp, _, err = getOpenstack(c)
+		if err != nil {
+			return err
+		}
+	}
+	err = wait.Poll(detachPollTime, detachTimeout, func() (bool, error) {
+		for _, volumeids := range nodeVolumes {
+			attachedResult, err := osp.DisksAreAttached(instanceId, volumeids)
+			if err != nil {
+				return false, err
+			}
+			for volumeID, attached := range attachedResult {
+				if attached {
+					framework.Logf("Waiting for volumes %q to detach from %v.", volumeID, attached)
+					return false, nil
+				}
+			}
+		}
+
+		disksAttached = false
+		framework.Logf("Volume are successfully detached from all the nodes: %+v", nodeVolumes)
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+	if disksAttached {
+		return fmt.Errorf("Gave up waiting for volumes to detach after %v", detachTimeout)
+	}
+	return nil
+}
+
+func createOpenstackVolume(os *openstack.OpenStack) (string, error) {
+
+	tags := map[string]string{
+		"test": "value",
+	}
+	vol, _, _, err := os.CreateVolume("kubernetes-test-volume-"+rand.String(10), 1, "", "", &tags)
+
+	return vol, err
+}
+
+func getTestStorageClasses(client clientset.Interface, policyName, datastoreName string) []*storage.StorageClass {
+	const (
+		storageclass1 = "sc-default"
+		storageclass2 = "sc-vsan"
+		storageclass3 = "sc-spbm"
+		storageclass4 = "sc-user-specified-ds"
+	)
+	scNames := []string{storageclass1, storageclass2, storageclass3, storageclass4}
+	scArrays := make([]*storage.StorageClass, len(scNames))
+	for index, scname := range scNames {
+		// Create openstack Storage Class
+		var sc *storage.StorageClass
+		var err error
+		switch scname {
+		case storageclass1:
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass1, nil))
+		case storageclass2:
+			var scVSanParameters map[string]string
+			scVSanParameters = make(map[string]string)
+			scVSanParameters[PolicyHostFailuresToTolerate] = "1"
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass2, scVSanParameters))
+		case storageclass3:
+			var scSPBMPolicyParameters map[string]string
+			scSPBMPolicyParameters = make(map[string]string)
+			scSPBMPolicyParameters[SpbmStoragePolicy] = policyName
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass3, scSPBMPolicyParameters))
+		case storageclass4:
+			var scWithDSParameters map[string]string
+			scWithDSParameters = make(map[string]string)
+			scWithDSParameters[Datastore] = datastoreName
+			scWithDatastoreSpec := getOpenstackStorageClassSpec(storageclass4, scWithDSParameters)
+			sc, err = client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+		}
+		Expect(sc).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		scArrays[index] = sc
+	}
+	return scArrays
+}
+
+func getOpenstackStorageClassSpec(name string, scParameters map[string]string) *storage.StorageClass {
+	var sc *storage.StorageClass
+
+	sc = &storage.StorageClass{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "StorageClass",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Provisioner: "kubernetes.io/openstack-volume",
+	}
+	if scParameters != nil {
+		sc.Parameters = scParameters
+	}
+	return sc
+}
+
+func getOpenstackClaimSpecWithStorageClassAnnotation(ns string, diskSize string, storageclass *storage.StorageClass) *v1.PersistentVolumeClaim {
+	scAnnotation := make(map[string]string)
+	scAnnotation[v1.BetaStorageClassAnnotation] = storageclass.Name
+
+	claim := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pvc-",
+			Namespace:    ns,
+			Annotations:  scAnnotation,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse(diskSize),
+				},
+			},
+		},
+	}
+	return claim
+}
+
+func getOpenstack(client clientset.Interface) (*openstack.OpenStack, string, error) {
+	cfg, _ := openstack.ConfigFromEnv()
+	osp, err := openstack.NewOpenStack(cfg)
+
+	id, err := osp.InstanceID()
+	if err != nil {
+		return nil, id, err
+	}
+	return osp, id, err
+}
+
+// Get openstack Volume ID from PVC
+func getopenStackVolumeIDFromClaim(client clientset.Interface, namespace string, claimName string) string {
+	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(claimName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	pv, err := client.CoreV1().PersistentVolumes().Get(pvclaim.Spec.VolumeName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	return pv.Spec.Cinder.VolumeID
+}
+
+func getOpenstackPodSpecWithVolumeIDs(volumeIDs []string, keyValuelabel map[string]string, commands []string) *v1.Pod {
+	var volumeMounts []v1.VolumeMount
+	var volumes []v1.Volume
+
+	for index, VolumeID := range volumeIDs {
+		name := fmt.Sprintf("volume%v", index+1)
+		volumeMounts = append(volumeMounts, v1.VolumeMount{Name: name, MountPath: "/mnt/" + name})
+		openstackVolume := new(v1.CinderVolumeSource)
+		openstackVolume.VolumeID = VolumeID
+		openstackVolume.FSType = "ext4"
+		volumes = append(volumes, v1.Volume{Name: name})
+		volumes[index].VolumeSource.Cinder = openstackVolume
+	}
+
+	if commands == nil || len(commands) == 0 {
+		commands = []string{
+			"/bin/sh",
+			"-c",
+			"while true; do sleep 2; done",
+		}
+	}
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "openstack-e2e-",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:         "openstack-e2e-container-" + string(uuid.NewUUID()),
+					Image:        "busybox",
+					Command:      commands,
+					VolumeMounts: volumeMounts,
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes:       volumes,
+		},
+	}
+
+	if keyValuelabel != nil {
+		pod.Spec.NodeSelector = keyValuelabel
+	}
+	return pod
+}
+
+// func to wait for volume status
+func WaitForVolumeStatus(os *openstack.OpenStack, volumeName string, status string) {
+	backoff := wait.Backoff{
+		Duration: volumeStatusInitDealy,
+		Factor:   volumeStatusFactor,
+		Steps:    volumeStatusSteps,
+	}
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		getVol, err := os.GetVolume(volumeName)
+		if err != nil {
+			return false, err
+		}
+		if getVol.Status == status {
+			fmt.Printf("Volume (%s) status changed to %s after %v seconds\n",
+				volumeName,
+				status,
+				volumeStatusTimeoutSeconds)
+			return true, nil
+		} else {
+			return false, nil
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		fmt.Printf("Volume (%s) status did not change to %s after %v seconds\n",
+			volumeName,
+			status,
+			volumeStatusTimeoutSeconds)
+		return
+	}
+	if err != nil {
+		fmt.Printf("Cannot get existing Cinder volume (%s): %v", volumeName, err)
+		return
+	}
+}
+
+// func to verify openstack volume accesibility
+func verifyOpenstackVolumesAccessible(c clientset.Interface, pod *v1.Pod, persistentvolumes []*v1.PersistentVolume, instanceID string, os *openstack.OpenStack) {
+	nodeName := pod.Spec.NodeName
+	namespace := pod.Namespace
+	for index, pv := range persistentvolumes {
+		isAttached, err := verifyOpenstackDiskAttached(c, os, instanceID, pv.Spec.Cinder.VolumeID, k8stype.NodeName(nodeName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk %v is not attached with the node", pv.Spec.Cinder.VolumeID))
+		filepath := filepath.Join("/mnt/", fmt.Sprintf("volume%v", index+1), "/emptyFile.txt")
+		_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/touch", filepath}, "", time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
+
+// func to get pod spec with given volume claim, node selector labels and command
+func getOpenstackPodSpecWithClaim(claimName string, nodeSelectorKV map[string]string, command string) *v1.Pod {
+	pod := &v1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Pod",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pod-pvc-",
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:    "volume-tester",
+					Image:   "busybox",
+					Command: []string{"/bin/sh"},
+					Args:    []string{"-c", command},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      "my-volume",
+							MountPath: "/mnt/test",
+						},
+					},
+				},
+			},
+			RestartPolicy: v1.RestartPolicyNever,
+			Volumes: []v1.Volume{
+				{
+					Name: "my-volume",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+							ClaimName: claimName,
+							ReadOnly:  false,
+						},
+					},
+				},
+			},
+		},
+	}
+	if nodeSelectorKV != nil {
+		pod.Spec.NodeSelector = nodeSelectorKV
+	}
+	return pod
+}
+
+// function to get openstack persistent volume spec with given selector labels.
+func getOpenstackPersistentVolumeClaimSpec(namespace string, labels map[string]string) *v1.PersistentVolumeClaim {
+	var (
+		pvc *v1.PersistentVolumeClaim
+	)
+	pvc = &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pvc-",
+			Namespace:    namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+				},
+			},
+		},
+	}
+	if labels != nil {
+		pvc.Spec.Selector = &metav1.LabelSelector{MatchLabels: labels}
+	}
+
+	return pvc
+}
+
+// function to create openstack volume spec with given VMDK volume path, Reclaim Policy and labels
+func getOpenstackPersistentVolumeSpec(volumeID string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy, labels map[string]string) *v1.PersistentVolume {
+	var (
+		pvConfig framework.PersistentVolumeConfig
+		pv       *v1.PersistentVolume
+		claimRef *v1.ObjectReference
+	)
+	pvConfig = framework.PersistentVolumeConfig{
+		NamePrefix: "openstackpv-",
+		PVSource: v1.PersistentVolumeSource{
+			Cinder: &v1.CinderVolumeSource{
+				VolumeID: volumeID,
+				FSType:   "ext4",
+			},
+		},
+		Prebind: nil,
+	}
+
+	pv = &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: pvConfig.NamePrefix,
+			Annotations: map[string]string{
+				util.VolumeGidAnnotationKey: "777",
+			},
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeReclaimPolicy: persistentVolumeReclaimPolicy,
+			Capacity: v1.ResourceList{
+				v1.ResourceName(v1.ResourceStorage): resource.MustParse("2Gi"),
+			},
+			PersistentVolumeSource: pvConfig.PVSource,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			ClaimRef: claimRef,
+		},
+	}
+	if labels != nil {
+		pv.Labels = labels
+	}
+	return pv
+}
+
+func waitForOpenstackDiskStatus(c clientset.Interface, instanceID string, osp *openstack.OpenStack, volumeID string, nodeName types.NodeName, expectedState volumeState) error {
+	var (
+		err          error
+		diskAttached bool
+		currentState volumeState
+		timeout      = 6 * time.Minute
+		pollTime     = 10 * time.Second
+	)
+
+	var attachedState = map[bool]volumeState{
+		true:  volumeStateAttached,
+		false: volumeStateDetached,
+	}
+
+	var attachedStateMsg = map[volumeState]string{
+		volumeStateAttached: "attached to",
+		volumeStateDetached: "detached from",
+	}
+
+	err = wait.Poll(pollTime, timeout, func() (bool, error) {
+		diskAttached, err = verifyOpenstackDiskAttached(c, osp, instanceID, volumeID, nodeName)
+		if err != nil {
+			return true, err
+		}
+
+		currentState = attachedState[diskAttached]
+		if currentState == expectedState {
+			framework.Logf("Volume %q has successfully %s %q", volumeID, attachedStateMsg[currentState], nodeName)
+			return true, nil
+		}
+		framework.Logf("Waiting for Volume %q to be %s %q.", volumeID, attachedStateMsg[expectedState], nodeName)
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if currentState != expectedState {
+		err = fmt.Errorf("Gave up waiting for Volume %q to be %s %q after %v", volumeID, attachedStateMsg[expectedState], nodeName, timeout)
+	}
+	return err
+}
+
+// Wait until openstack vmdk is attached from the given node or time out after 6 minutes
+func waitForOpenstackDiskToAttach(c clientset.Interface, instanceID string, osp *openstack.OpenStack, volumeID string, nodeName types.NodeName) error {
+	return waitForOpenstackDiskStatus(c, instanceID, osp, volumeID, nodeName, volumeStateAttached)
+}
+
+func waitForOpenstackDiskToDetach(c clientset.Interface, instanceID string, osp *openstack.OpenStack, volumeID string, nodeName types.NodeName) error {
+	return waitForOpenstackDiskStatus(c, instanceID, osp, volumeID, nodeName, volumeStateDetached)
+}
+
+func getOSTestStorageClasses(client clientset.Interface, policyName, datastoreName string) []*storage.StorageClass {
+	const (
+		storageclass1 = "sc-default"
+		storageclass2 = "sc-osan"
+		storageclass3 = "sc-spbm"
+		storageclass4 = "sc-user-specified-ds"
+	)
+	scNames := []string{storageclass1, storageclass2, storageclass3, storageclass4}
+	scArrays := make([]*storage.StorageClass, len(scNames))
+	for index, scname := range scNames {
+		// Create openstack Storage Class
+		var sc *storage.StorageClass
+		var err error
+		switch scname {
+		case storageclass1:
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass1, nil))
+		case storageclass2:
+			var scOSanParameters map[string]string
+			scOSanParameters = make(map[string]string)
+			scOSanParameters[PolicyHostFailuresToTolerate] = "1"
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass2, scOSanParameters))
+		case storageclass3:
+			var scSPBMPolicyParameters map[string]string
+			scSPBMPolicyParameters = make(map[string]string)
+			scSPBMPolicyParameters[SpbmStoragePolicy] = policyName
+			sc, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(storageclass3, scSPBMPolicyParameters))
+		case storageclass4:
+			var scWithDSParameters map[string]string
+			scWithDSParameters = make(map[string]string)
+			scWithDSParameters[Datastore] = datastoreName
+			scWithDatastoreSpec := getOpenstackStorageClassSpec(storageclass4, scWithDSParameters)
+			sc, err = client.StorageV1().StorageClasses().Create(scWithDatastoreSpec)
+		}
+		Expect(sc).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+		scArrays[index] = sc
+	}
+	return scArrays
+}
+
+// function to write content to the volume backed by given PVC
+func writeContentToOpenstackPV(client clientset.Interface, pvc *v1.PersistentVolumeClaim, expectedContent string) {
+	utils.RunInPodWithVolume(client, pvc.Namespace, pvc.Name, "echo "+expectedContent+" > /mnt/test/data")
+	framework.Logf("Done with writing content to volume")
+}
+
+func verifyContentOfOpenstackPV(client clientset.Interface, pvc *v1.PersistentVolumeClaim, expectedContent string) {
+	utils.RunInPodWithVolume(client, pvc.Namespace, pvc.Name, "grep '"+expectedContent+"' /mnt/test/data")
+	framework.Logf("Successfully verified content of the volume")
+}
+
+func verifyFilesExistOnOpenstackVolume(namespace string, podName string, filePaths []string) {
+	for _, filePath := range filePaths {
+		_, err := framework.RunKubectl("exec", fmt.Sprintf("--namespace=%s", namespace), podName, "--", "/bin/ls", filePath)
+		Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("failed to verify file: %q on the pod: %q", filePath, podName))
+	}
+}
+
+func createEmptyFilesOnOpenstackVolume(namespace string, podName string, filePaths []string) {
+	for _, filePath := range filePaths {
+		err := framework.CreateEmptyFileOnPod(namespace, podName, filePath)
+		Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/test/e2e/storage/openstack/openstack_volume_cluster_ds.go
+++ b/test/e2e/storage/openstack/openstack_volume_cluster_ds.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("Volume Provisioning On Clustered Datastore [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("volume-provision")
+
+	var client clientset.Interface
+	var namespace string
+	var scParameters map[string]string
+	var clusterDatastore string
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+
+		clusterDatastore = os.Getenv("CLUSTER_DATASTORE")
+		Expect(clusterDatastore).NotTo(BeEmpty(), "Please set CLUSTER_DATASTORE system environment. eg: export CLUSTER_DATASTORE=<cluster_name>/<datastore_name")
+	})
+
+	It("verify static provisioning on clustered datastore", func() {
+		var volumeID string
+		osp, id, err := getOpenstack(client)
+		Expect(err).NotTo(HaveOccurred())
+
+		volumeID, err = createOpenstackVolume(osp)
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			By("Deleting the openstack volume")
+			err = osp.DeleteVolume(volumeID)
+		}()
+
+		podspec := getOpenstackPodSpecWithVolumeIDs([]string{volumeID}, nil, nil)
+
+		By("Creating pod")
+		pod, err := client.CoreV1().Pods(namespace).Create(podspec)
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for pod to be ready")
+		Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+
+		// get fresh pod info
+		pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		nodeName := types.NodeName(pod.Spec.NodeName)
+
+		By("Verifying volume is attached")
+		isAttached, err := verifyOpenstackDiskAttached(client, osp, id, volumeID, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node: %v", volumeID, nodeName))
+
+		By("Deleting pod")
+		err = framework.DeletePodWithWait(f, client, pod)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for volumes to be detached from the node")
+		err = waitForOpenstackDiskToDetach(client, id, osp, volumeID, nodeName)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("verify dynamic provision with default parameter on clustered datastore", func() {
+		scParameters[Datastore] = clusterDatastore
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+
+	It("verify dynamic provision with spbm policy on clustered datastore", func() {
+		storagePolicy := os.Getenv("OPENSTACK_SPBM_POLICY_DS_CLUSTER")
+		Expect(storagePolicy).NotTo(BeEmpty(), "Please set OPENSTACK_SPBM_POLICY_DS_CLUSTER system environment")
+		scParameters[SpbmStoragePolicy] = storagePolicy
+		invokeValidPolicyTest(f, client, namespace, scParameters)
+	})
+})
+
+func invokeValidPolicyTest(f *framework.Framework, client clientset.Interface, namespace string, scParameters map[string]string) {
+	By("Creating Storage Class With storage policy params")
+	storageclass, err := client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec("storagepolicysc", scParameters))
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	By("Creating PVC using the Storage Class")
+	pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", storageclass))
+	Expect(err).NotTo(HaveOccurred())
+	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	By("Waiting for claim to be in bound phase")
+	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Creating pod to attach PV to the node")
+	// Create pod to attach Volume to Node
+	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
+	Expect(err).NotTo(HaveOccurred())
+
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+	By("Verify the volume is accessible and available in the pod")
+	verifyOpenstackVolumesAccessible(client, pod, persistentvolumes, id, osp)
+
+	By("Deleting pod")
+	framework.DeletePodWithWait(f, client, pod)
+
+	By("Waiting for volumes to be detached from the node")
+	waitForOpenstackDiskToDetach(client, id, osp, persistentvolumes[0].Spec.Cinder.VolumeID, types.NodeName(pod.Spec.NodeName))
+}

--- a/test/e2e/storage/openstack/openstack_volume_datastore.go
+++ b/test/e2e/storage/openstack/openstack_volume_datastore.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// data constants
+const (
+	InvalidDatastore = "invalidDatastore"
+	DatastoreSCName  = "datastoresc"
+)
+
+var _ = utils.SIGDescribe("Volume Provisioning on Datastore [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("volume-datastore")
+	var (
+		client       clientset.Interface
+		namespace    string
+		scParameters map[string]string
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("unable to find ready and schedulable Node")
+		}
+	})
+
+	It("verify dynamically provisioned pv using storageclass fails on an invalid datastore", func() {
+		By("Invoking Test for invalid datastore")
+		scParameters[Datastore] = InvalidDatastore
+		scParameters[DiskFormat] = ThinDisk
+		err := invokeOSInvalidDatastoreTestNeg(client, namespace, scParameters)
+		Expect(err).To(HaveOccurred())
+		errorMsg := `Failed to provision volume with StorageClass \"` + DatastoreSCName + `\": The specified datastore ` + InvalidDatastore + ` is not a shared datastore across node VMs`
+		if !strings.Contains(err.Error(), errorMsg) {
+			Expect(err).NotTo(HaveOccurred(), errorMsg)
+		}
+	})
+})
+
+func invokeOSInvalidDatastoreTestNeg(client clientset.Interface, namespace string, scParameters map[string]string) error {
+	By("Creating Storage Class With Invalid Datastore")
+	storageclass, err := client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(DatastoreSCName, scParameters))
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	By("Creating PVC using the Storage Class")
+	pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", storageclass))
+	Expect(err).NotTo(HaveOccurred())
+	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+	By("Expect claim to fail provisioning volume")
+	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+	Expect(err).To(HaveOccurred())
+
+	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
+	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
+}

--- a/test/e2e/storage/openstack/openstack_volume_disksize.go
+++ b/test/e2e/storage/openstack/openstack_volume_disksize.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// DiskSizeSCName
+const (
+	DiskSizeSCName = "disksizesc"
+)
+
+var _ = utils.SIGDescribe("Volume Disk Size [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("volume-disksize")
+	var (
+		client       clientset.Interface
+		namespace    string
+		scParameters map[string]string
+		datastore    string
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		scParameters = make(map[string]string)
+		datastore = os.Getenv("OPENSTACK_DATASTORE")
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if !(len(nodeList.Items) > 0) {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+	})
+
+	It("verify dynamically provisioned pv using storageclass with an invalid disk size fails", func() {
+		By("Invoking Test for invalid disk size")
+		scParameters[DiskFormat] = ThinDisk
+		diskSize := "1"
+		err := invokeInvalidOpenstackDiskSizeTestNeg(client, namespace, scParameters, diskSize)
+		Expect(err).To(HaveOccurred())
+		errorMsg := `Failed to provision volume with StorageClass \"` + DiskSizeSCName + `\": A specified parameter was not correct`
+		if !strings.Contains(err.Error(), errorMsg) {
+			Expect(err).NotTo(HaveOccurred(), errorMsg)
+		}
+	})
+})
+
+func invokeInvalidOpenstackDiskSizeTestNeg(client clientset.Interface, namespace string, scParameters map[string]string, diskSize string) error {
+	By("Creating Storage Class With invalid disk size")
+	storageclass, err := client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec(DiskSizeSCName, scParameters))
+	Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Failed to create storage class with err: %v", err))
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	By("Creating PVC using the Storage Class")
+	pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, diskSize, storageclass))
+	Expect(err).NotTo(HaveOccurred())
+	defer framework.DeletePersistentVolumeClaim(client, pvclaim.Name, namespace)
+
+	By("Expect claim to fail provisioning volume")
+	err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, client, pvclaim.Namespace, pvclaim.Name, framework.Poll, 2*time.Minute)
+	Expect(err).To(HaveOccurred())
+
+	eventList, err := client.CoreV1().Events(pvclaim.Namespace).List(metav1.ListOptions{})
+	return fmt.Errorf("Failure message: %+q", eventList.Items[0].Message)
+}

--- a/test/e2e/storage/openstack/openstack_volume_fstype.go
+++ b/test/e2e/storage/openstack/openstack_volume_fstype.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8stype "k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	openstack "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// Fstype constants
+const (
+	Ext4FSType    = "ext4"
+	Ext3FSType    = "ext3"
+	InvalidFSType = "ext10"
+	ExecCommand   = "/bin/df -T /mnt/volume1 | /bin/awk 'FNR == 2 {print $2}' > /mnt/volume1/fstype && while true ; do sleep 2 ; done"
+)
+
+var _ = utils.SIGDescribe("Volume FStype [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("volume-fstype")
+	var (
+		client    clientset.Interface
+		namespace string
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		Expect(len(nodeList.Items)).NotTo(BeZero(), "Unable to find ready and schedulable Node")
+	})
+
+	It("verify fstype - ext3 formatted volume", func() {
+		By("Invoking Test for fstype: ext3")
+		invokeTestForOSFstype(f, client, namespace, Ext3FSType, Ext3FSType)
+	})
+
+	It("verify fstype - default value should be ext4", func() {
+		By("Invoking Test for fstype: Default Value - ext4")
+		invokeTestForOSFstype(f, client, namespace, "", Ext4FSType)
+	})
+
+	It("verify invalid fstype", func() {
+		By("Invoking Test for fstype: invalid Value")
+		invokeTestForOSInvalidFstype(f, client, namespace, InvalidFSType)
+	})
+})
+
+func invokeTestForOSFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string, expectedContent string) {
+	framework.Logf("Invoking Test for fstype: %s", fstype)
+	scParameters := make(map[string]string)
+	scParameters["fstype"] = fstype
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create Persistent Volume
+	By("Creating Storage Class With Fstype")
+	pvclaim, persistentvolumes := createVolume(client, namespace, scParameters)
+
+	// Create Pod and verify the persistent volume is accessible
+	pod := createOSPodAndVerifyVolumeAccessible(client, namespace, pvclaim, persistentvolumes, osp, id)
+	_, err = framework.LookForStringInPodExec(namespace, pod.Name, []string{"/bin/cat", "/mnt/volume1/fstype"}, expectedContent, time.Minute)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Detach and delete volume
+	detachOSVolume(f, client, id, osp, pod, persistentvolumes[0].Spec.Cinder.VolumeID)
+	deleteVolume(client, pvclaim.Name, namespace)
+}
+
+func invokeTestForOSInvalidFstype(f *framework.Framework, client clientset.Interface, namespace string, fstype string) {
+	scParameters := make(map[string]string)
+	scParameters["fstype"] = fstype
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create Persistent Volume
+	By("Creating Storage Class With Invalid Fstype")
+	pvclaim, persistentvolumes := createVolume(client, namespace, scParameters)
+
+	By("Creating pod to attach PV to the node")
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	// Create pod to attach Volume to Node
+	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
+	Expect(err).To(HaveOccurred())
+
+	eventList, err := client.CoreV1().Events(namespace).List(metav1.ListOptions{})
+
+	// Detach and delete volume
+	detachOSVolume(f, client, id, osp, pod, persistentvolumes[0].Spec.Cinder.VolumeID)
+	deleteVolume(client, pvclaim.Name, namespace)
+
+	Expect(eventList.Items).NotTo(BeEmpty())
+	errorMsg := `MountVolume.MountDevice failed for volume "` + persistentvolumes[0].Name + `" : executable file not found`
+	isFound := false
+	for _, item := range eventList.Items {
+		if strings.Contains(item.Message, errorMsg) {
+			isFound = true
+		}
+	}
+	Expect(isFound).To(BeTrue(), "Unable to verify MountVolume.MountDevice failure")
+}
+
+func createOSPodAndVerifyVolumeAccessible(client clientset.Interface, namespace string, pvclaim *v1.PersistentVolumeClaim, persistentvolumes []*v1.PersistentVolume, osp *openstack.OpenStack, instanceID string) *v1.Pod {
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	By("Creating pod to attach PV to the node")
+	// Create pod to attach Volume to Node
+	pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, ExecCommand)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Asserts: Right disk is attached to the pod
+	By("Verify the volume is accessible and available in the pod")
+	verifyOpenstackVolumesAccessible(client, pod, persistentvolumes, instanceID, osp)
+	return pod
+}
+
+func createVolume(client clientset.Interface, namespace string, scParameters map[string]string) (*v1.PersistentVolumeClaim, []*v1.PersistentVolume) {
+	storageclass, err := client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec("fstype", scParameters))
+	Expect(err).NotTo(HaveOccurred())
+	defer client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+
+	By("Creating PVC using the Storage Class")
+	pvclaim, err := client.CoreV1().PersistentVolumeClaims(namespace).Create(getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", storageclass))
+	Expect(err).NotTo(HaveOccurred())
+
+	var pvclaims []*v1.PersistentVolumeClaim
+	pvclaims = append(pvclaims, pvclaim)
+	By("Waiting for claim to be in bound phase")
+	persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+	Expect(err).NotTo(HaveOccurred())
+	return pvclaim, persistentvolumes
+}
+
+func detachOSVolume(f *framework.Framework, client clientset.Interface, instanceID string, osp *openstack.OpenStack, pod *v1.Pod, volID string) {
+	By("Deleting pod")
+	framework.DeletePodWithWait(f, client, pod)
+
+	By("Waiting for volumes to be detached from the node")
+	waitForOpenstackDiskToDetach(client, instanceID, osp, volID, k8stype.NodeName(pod.Spec.NodeName))
+}
+
+func deleteVolume(client clientset.Interface, pvclaimName string, namespace string) {
+	framework.DeletePersistentVolumeClaim(client, pvclaimName, namespace)
+}

--- a/test/e2e/storage/openstack/openstack_volume_master_restart.go
+++ b/test/e2e/storage/openstack/openstack_volume_master_restart.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("Volume Attach Verify [Feature:openstack][Serial][Disruptive]", func() {
+	f := framework.NewDefaultFramework("restart-master")
+
+	const labelKey = "openstack_e2e_label"
+	var (
+		client                clientset.Interface
+		namespace             string
+		volumeIDs             []string
+		pods                  []*v1.Pod
+		numNodes              int
+		nodeKeyValueLabelList []map[string]string
+		nodeNameList          []string
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(client, framework.TestContext.NodeSchedulableTimeout))
+
+		nodes := framework.GetReadySchedulableNodesOrDie(client)
+		numNodes = len(nodes.Items)
+		if numNodes < 2 {
+			framework.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+		}
+
+		for i := 0; i < numNodes; i++ {
+			nodeName := nodes.Items[i].Name
+			nodeNameList = append(nodeNameList, nodeName)
+			nodeLabelValue := "openstack_e2e_" + string(uuid.NewUUID())
+			nodeKeyValueLabel := make(map[string]string)
+			nodeKeyValueLabel[labelKey] = nodeLabelValue
+			nodeKeyValueLabelList = append(nodeKeyValueLabelList, nodeKeyValueLabel)
+			framework.AddOrUpdateLabelOnNode(client, nodeName, labelKey, nodeLabelValue)
+		}
+	})
+
+	It("verify volume remains attached after master kubelet restart", func() {
+		osp, id, err := getOpenstack(client)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create pod on each node
+		for i := 0; i < numNodes; i++ {
+			By(fmt.Sprintf("%d: Creating a test openstack volume", i))
+			volumeID, err := createOpenstackVolume(osp)
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeIDs = append(volumeIDs, volumeID)
+
+			By(fmt.Sprintf("Creating pod %d on node %v", i, nodeNameList[i]))
+			podspec := getOpenstackPodSpecWithVolumeIDs([]string{volumeID}, nodeKeyValueLabelList[i], nil)
+			pod, err := client.CoreV1().Pods(namespace).Create(podspec)
+			Expect(err).NotTo(HaveOccurred())
+			defer framework.DeletePodWithWait(f, client, pod)
+
+			By("Waiting for pod to be ready")
+			Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+
+			pod, err = client.CoreV1().Pods(namespace).Get(pod.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			pods = append(pods, pod)
+
+			nodeName := types.NodeName(pod.Spec.NodeName)
+			By(fmt.Sprintf("Verify volume %s is attached to the pod %v", volumeID, nodeName))
+			isAttached, err := verifyOpenstackDiskAttached(client, osp, id, volumeID, types.NodeName(nodeName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node", volumeID))
+
+		}
+
+		By("Restarting kubelet on master node")
+		masterAddress := framework.GetMasterHost() + ":22"
+		err = framework.RestartKubelet(masterAddress)
+		Expect(err).NotTo(HaveOccurred(), "Unable to restart kubelet on master node")
+
+		By("Verifying the kubelet on master node is up")
+		err = framework.WaitForKubeletUp(masterAddress)
+		Expect(err).NotTo(HaveOccurred())
+
+		for i, pod := range pods {
+			volumeID := volumeIDs[i]
+
+			nodeName := types.NodeName(pod.Spec.NodeName)
+			By(fmt.Sprintf("After master restart, verify volume %v is attached to the pod %v", volumeID, nodeName))
+			isAttached, err := verifyOpenstackDiskAttached(client, osp, id, volumeIDs[i], types.NodeName(nodeName))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isAttached).To(BeTrue(), fmt.Sprintf("disk: %s is not attached with the node", volumeID))
+
+			By(fmt.Sprintf("Deleting pod on node %v", nodeName))
+			err = framework.DeletePodWithWait(f, client, pod)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Waiting for volume %s to be detached from the node %v", volumeID, nodeName))
+			err = waitForOpenstackDiskToDetach(client, id, osp, volumeID, types.NodeName(nodeName))
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Deleting volume %s", volumeID))
+			err = osp.DeleteVolume(volumeID)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	})
+})

--- a/test/e2e/storage/openstack/openstack_volume_ops_storm.go
+++ b/test/e2e/storage/openstack/openstack_volume_ops_storm.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	storage "k8s.io/api/storage/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	openstack "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("Volume Operations Storm [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("volume-ops-storm")
+	const DefaultVolumeOPSScale = 30
+	var (
+		client            clientset.Interface
+		namespace         string
+		storageclass      *storage.StorageClass
+		pvclaims          []*v1.PersistentVolumeClaim
+		persistentvolumes []*v1.PersistentVolume
+		err               error
+		volumeOpsScale    int
+		osp               *openstack.OpenStack
+	)
+
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		if len(nodeList.Items) == 0 {
+			framework.Failf("Unable to find ready and schedulable Node")
+		}
+		if os.Getenv("VOLUME_OPS_SCALE") != "" {
+			volumeOpsScale, err = strconv.Atoi(os.Getenv("VOLUME_OPS_SCALE"))
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			volumeOpsScale = DefaultVolumeOPSScale
+		}
+		pvclaims = make([]*v1.PersistentVolumeClaim, volumeOpsScale)
+	})
+	AfterEach(func() {
+		By("Deleting PVCs")
+		for _, claim := range pvclaims {
+			framework.DeletePersistentVolumeClaim(client, claim.Name, namespace)
+		}
+		By("Deleting StorageClass")
+		err = client.StorageV1().StorageClasses().Delete(storageclass.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create pod with many volumes and verify no attach call fails", func() {
+		By(fmt.Sprintf("Running test with VOLUME_OPS_SCALE: %v", volumeOpsScale))
+		By("Creating Storage Class")
+		scParameters := make(map[string]string)
+		scParameters["diskformat"] = "thin"
+		storageclass, err = client.StorageV1().StorageClasses().Create(getOpenstackStorageClassSpec("thinsc", scParameters))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating PVCs using the Storage Class")
+		count := 0
+		for count < volumeOpsScale {
+			pvclaims[count], err = framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", storageclass))
+			Expect(err).NotTo(HaveOccurred())
+			count++
+		}
+
+		By("Waiting for all claims to be in bound phase")
+		persistentvolumes, err = framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating pod to attach PVs to the node")
+		pod, err := framework.CreatePod(client, namespace, nil, pvclaims, false, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verify all volumes are accessible and available in the pod")
+		verifyOpenstackVolumesAccessible(client, pod, persistentvolumes, id, osp)
+
+		By("Deleting pod")
+		framework.ExpectNoError(framework.DeletePodWithWait(f, client, pod))
+
+		By("Waiting for volumes to be detached from the node")
+		for _, pv := range persistentvolumes {
+			WaitForVolumeStatus(osp, pv.Spec.Cinder.VolumeID, VolumeAvailableStatus)
+		}
+	})
+})

--- a/test/e2e/storage/openstack/openstack_volume_perf.go
+++ b/test/e2e/storage/openstack/openstack_volume_perf.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	storageV1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// volume performace constants
+const (
+	SCSIUnitsAvailablePerNode = 55
+	CreateOp                  = "CreateOp"
+	AttachOp                  = "AttachOp"
+	DetachOp                  = "DetachOp"
+	DeleteOp                  = "DeleteOp"
+)
+
+var _ = utils.SIGDescribe("osp-performance [Feature:openstack]", func() {
+	f := framework.NewDefaultFramework("osp-performance")
+
+	var (
+		client           clientset.Interface
+		namespace        string
+		nodeSelectorList []*NodeSelector
+		volumeCount      int
+		volumesPerPod    int
+		iterations       int
+		policyName       string
+		datastoreName    string
+	)
+
+	BeforeEach(func() {
+		var err error
+		framework.SkipUnlessProviderIs("openstack")
+		client = f.ClientSet
+		namespace = f.Namespace.Name
+
+		// Read the environment variables
+		volumeCountStr := os.Getenv("OSP_PERF_VOLUME_COUNT")
+		Expect(volumeCountStr).NotTo(BeEmpty(), "ENV OSP_PERF_VOLUME_COUNT is not set")
+		volumeCount, err = strconv.Atoi(volumeCountStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing VCP_PERF_VOLUME_COUNT")
+
+		volumesPerPodStr := os.Getenv("OSP_PERF_VOLUME_PER_POD")
+		Expect(volumesPerPodStr).NotTo(BeEmpty(), "ENV OSP_PERF_VOLUME_PER_POD is not set")
+		volumesPerPod, err = strconv.Atoi(volumesPerPodStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing OSP_PERF_VOLUME_PER_POD")
+
+		iterationsStr := os.Getenv("OSP_PERF_ITERATIONS")
+		Expect(iterationsStr).NotTo(BeEmpty(), "ENV OSP_PERF_ITERATIONS is not set")
+		iterations, err = strconv.Atoi(iterationsStr)
+		Expect(err).NotTo(HaveOccurred(), "Error Parsing OSP_PERF_ITERATIONS")
+
+		policyName = os.Getenv("OPENSTACK_SPBM_GOLD_POLICY")
+		datastoreName = os.Getenv("OPENSTACK_DATASTORE")
+		Expect(policyName).NotTo(BeEmpty(), "ENV OPENSTACK_SPBM_GOLD_POLICY is not set")
+		Expect(datastoreName).NotTo(BeEmpty(), "ENV OPENSTACK_DATASTORE is not set")
+
+		nodes := framework.GetReadySchedulableNodesOrDie(client)
+		Expect(len(nodes.Items)).To(BeNumerically(">=", 1), "Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+
+		msg := fmt.Sprintf("Cannot attach %d volumes to %d nodes. Maximum volumes that can be attached on %d nodes is %d", volumeCount, len(nodes.Items), len(nodes.Items), SCSIUnitsAvailablePerNode*len(nodes.Items))
+		Expect(volumeCount).To(BeNumerically("<=", SCSIUnitsAvailablePerNode*len(nodes.Items)), msg)
+
+		msg = fmt.Sprintf("Cannot attach %d volumes per pod. Maximum volumes that can be attached per pod is %d", volumesPerPod, SCSIUnitsAvailablePerNode)
+		Expect(volumesPerPod).To(BeNumerically("<=", SCSIUnitsAvailablePerNode), msg)
+
+		nodeSelectorList = createNodeLabels(client, namespace, nodes)
+	})
+
+	It("osp performance tests", func() {
+		scList := getTestStorageClasses(client, policyName, datastoreName)
+		defer func(scList []*storageV1.StorageClass) {
+			for _, sc := range scList {
+				client.StorageV1().StorageClasses().Delete(sc.Name, nil)
+			}
+		}(scList)
+
+		sumLatency := make(map[string]float64)
+		for i := 0; i < iterations; i++ {
+			latency := invokeOSVolumeLifeCyclePerformance(f, client, namespace, scList, volumesPerPod, volumeCount, nodeSelectorList)
+			for key, val := range latency {
+				sumLatency[key] += val
+			}
+		}
+
+		iterations64 := float64(iterations)
+		framework.Logf("Average latency for below operations")
+		framework.Logf("Creating %d PVCs and waiting for bound phase: %v seconds", volumeCount, sumLatency[CreateOp]/iterations64)
+		framework.Logf("Creating %v Pod: %v seconds", volumeCount/volumesPerPod, sumLatency[AttachOp]/iterations64)
+		framework.Logf("Deleting %v Pod and waiting for disk to be detached: %v seconds", volumeCount/volumesPerPod, sumLatency[DetachOp]/iterations64)
+		framework.Logf("Deleting %v PVCs: %v seconds", volumeCount, sumLatency[DeleteOp]/iterations64)
+
+	})
+})
+
+// invokeVolumeLifeCyclePerformance peforms full volume life cycle management and records latency for each operation
+func invokeOSVolumeLifeCyclePerformance(f *framework.Framework, client clientset.Interface, namespace string, sc []*storageV1.StorageClass, volumesPerPod int, volumeCount int, nodeSelectorList []*NodeSelector) (latency map[string]float64) {
+	var (
+		totalpvclaims [][]*v1.PersistentVolumeClaim
+		totalpos      [][]*v1.PersistentVolume
+		totalpods     []*v1.Pod
+	)
+	nodeVolumeMap := make(map[types.NodeName][]string)
+	latency = make(map[string]float64)
+	numPods := volumeCount / volumesPerPod
+
+	By(fmt.Sprintf("Creating %d PVCs", volumeCount))
+	start := time.Now()
+	for i := 0; i < numPods; i++ {
+		var pvclaims []*v1.PersistentVolumeClaim
+		for j := 0; j < volumesPerPod; j++ {
+			currsc := sc[((i*numPods)+j)%len(sc)]
+			pvclaim, err := framework.CreatePVC(client, namespace, getOpenstackClaimSpecWithStorageClassAnnotation(namespace, "2Gi", currsc))
+			Expect(err).NotTo(HaveOccurred())
+			pvclaims = append(pvclaims, pvclaim)
+		}
+		totalpvclaims = append(totalpvclaims, pvclaims)
+	}
+	for _, pvclaims := range totalpvclaims {
+		persistentvolumes, err := framework.WaitForPVClaimBoundPhase(client, pvclaims, framework.ClaimProvisionTimeout)
+		Expect(err).NotTo(HaveOccurred())
+		totalpos = append(totalpos, persistentvolumes)
+	}
+	elapsed := time.Since(start)
+	latency[CreateOp] = elapsed.Seconds()
+
+	By("Creating pod to attach PVs to the node")
+	start = time.Now()
+	for i, pvclaims := range totalpvclaims {
+		nodeSelector := nodeSelectorList[i%len(nodeSelectorList)]
+		pod, err := framework.CreatePod(client, namespace, map[string]string{nodeSelector.labelKey: nodeSelector.labelValue}, pvclaims, false, "")
+		Expect(err).NotTo(HaveOccurred())
+		totalpods = append(totalpods, pod)
+
+		defer framework.DeletePodWithWait(f, client, pod)
+	}
+	elapsed = time.Since(start)
+	latency[AttachOp] = elapsed.Seconds()
+
+	// Verify access to the volumes
+	osp, id, err := getOpenstack(client)
+	Expect(err).NotTo(HaveOccurred())
+
+	for i, pod := range totalpods {
+		verifyOpenstackVolumesAccessible(client, pod, totalpos[i], id, osp)
+	}
+
+	By("Deleting pods")
+	start = time.Now()
+	for _, pod := range totalpods {
+		err = framework.DeletePodWithWait(f, client, pod)
+		Expect(err).NotTo(HaveOccurred())
+	}
+	elapsed = time.Since(start)
+	latency[DetachOp] = elapsed.Seconds()
+
+	for i, pod := range totalpods {
+		for _, pv := range totalpos[i] {
+			nodeName := types.NodeName(pod.Spec.NodeName)
+			nodeVolumeMap[nodeName] = append(nodeVolumeMap[nodeName], pv.Spec.Cinder.VolumeID)
+		}
+	}
+
+	err = waitForOpenstackDisksToDetach(client, id, osp, nodeVolumeMap)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Deleting the PVCs")
+	start = time.Now()
+	for _, pvclaims := range totalpvclaims {
+		for _, pvc := range pvclaims {
+			err = framework.DeletePersistentVolumeClaim(client, pvc.Name, namespace)
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}
+	elapsed = time.Since(start)
+	latency[DeleteOp] = elapsed.Seconds()
+
+	return latency
+}
+
+func createNodeLabels(client clientset.Interface, namespace string, nodes *v1.NodeList) []*NodeSelector {
+	var nodeSelectorList []*NodeSelector
+	for i, node := range nodes.Items {
+		labelVal := "openstack_e2e_" + strconv.Itoa(i)
+		nodeSelector := &NodeSelector{
+			labelKey:   NodeLabelKey,
+			labelValue: labelVal,
+		}
+		nodeSelectorList = append(nodeSelectorList, nodeSelector)
+		framework.AddOrUpdateLabelOnNode(client, node.Name, NodeLabelKey, labelVal)
+	}
+	return nodeSelectorList
+}

--- a/test/e2e/storage/openstack/openstack_volume_placement.go
+++ b/test/e2e/storage/openstack/openstack_volume_placement.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	clientset "k8s.io/client-go/kubernetes"
+	openstack "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("Volume Placement", func() {
+	f := framework.NewDefaultFramework("volume-placement")
+	var (
+		c                  clientset.Interface
+		ns                 string
+		osp                *openstack.OpenStack
+		volumeIDs          []string
+		id                 string
+		node1Name          string
+		node1KeyValueLabel map[string]string
+		node2Name          string
+		node2KeyValueLabel map[string]string
+		isNodeLabeled      bool
+		err                error
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+		if !isNodeLabeled {
+			node1Name, node1KeyValueLabel, node2Name, node2KeyValueLabel = testSetupVolumePlacement(c, ns)
+			isNodeLabeled = true
+		}
+		By("creating vmdk")
+		osp, id, err = getOpenstack(c)
+		Expect(err).NotTo(HaveOccurred())
+		volumeID, err := createOpenstackVolume(osp)
+		Expect(err).NotTo(HaveOccurred())
+		volumeIDs = append(volumeIDs, volumeID)
+	})
+
+	AfterEach(func() {
+		for _, volumeID := range volumeIDs {
+			osp.DeleteVolume(volumeID)
+		}
+		volumeIDs = nil
+	})
+
+	framework.AddCleanupAction(func() {
+		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
+		if len(ns) > 0 {
+			if len(node1KeyValueLabel) > 0 {
+				framework.RemoveLabelOffNode(c, node1Name, "openstack_e2e_label")
+			}
+			if len(node2KeyValueLabel) > 0 {
+				framework.RemoveLabelOffNode(c, node2Name, "openstack_e2e_label")
+			}
+		}
+	})
+
+	It("should create and delete pod with the same volume source on the same worker node", func() {
+		var volumeFiles []string
+		pod := createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+
+		newEmptyFileName := fmt.Sprintf("/mnt/volume1/%v_1.txt", ns)
+		volumeFiles = append(volumeFiles, newEmptyFileName)
+		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+
+		By(fmt.Sprintf("Creating pod on the same node: %v", node1Name))
+		pod = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		newEmptyFileName = fmt.Sprintf("/mnt/volume1/%v_2.txt", ns)
+		volumeFiles = append(volumeFiles, newEmptyFileName)
+		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+	})
+
+	It("should create and delete pod with the same volume source attach/detach to different worker nodes", func() {
+		var volumeFiles []string
+		pod := createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		newEmptyFileName := fmt.Sprintf("/mnt/volume1/%v_1.txt", ns)
+		volumeFiles = append(volumeFiles, newEmptyFileName)
+		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+
+		By(fmt.Sprintf("Creating pod on the another node: %v", node2Name))
+		pod = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node2Name, node2KeyValueLabel, volumeIDs)
+
+		newEmptyFileName = fmt.Sprintf("/mnt/volume1/%v_2.txt", ns)
+		volumeFiles = append(volumeFiles, newEmptyFileName)
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		createAndVerifyFilesOnVolume(ns, pod.Name, []string{newEmptyFileName}, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node2Name, volumeIDs)
+	})
+
+	It("should create and delete pod with multiple volumes from same datastore", func() {
+		By("creating another vmdk")
+		volumeID, err := createOpenstackVolume(osp)
+		Expect(err).NotTo(HaveOccurred())
+		volumeIDs = append(volumeIDs, volumeID)
+
+		By(fmt.Sprintf("Creating pod on the node: %v with volume: %v and volume: %v", node1Name, volumeIDs[0], volumeIDs[1]))
+		pod := createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		volumeFiles := []string{
+			fmt.Sprintf("/mnt/volume1/%v_1.txt", ns),
+			fmt.Sprintf("/mnt/volume2/%v_1.txt", ns),
+		}
+		createAndVerifyFilesOnVolume(ns, pod.Name, volumeFiles, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v and volume: %v", node1Name, volumeIDs[0], volumeIDs[1]))
+		pod = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+		newEmptyFilesNames := []string{
+			fmt.Sprintf("/mnt/volume1/%v_2.txt", ns),
+			fmt.Sprintf("/mnt/volume2/%v_2.txt", ns),
+		}
+		volumeFiles = append(volumeFiles, newEmptyFilesNames[0])
+		volumeFiles = append(volumeFiles, newEmptyFilesNames[1])
+		createAndVerifyFilesOnVolume(ns, pod.Name, newEmptyFilesNames, volumeFiles)
+	})
+
+	It("should create and delete pod with multiple volumes from different datastore", func() {
+		By("creating another vmdk on non default shared datastore")
+		volumeID, err := createOpenstackVolume(osp)
+		Expect(err).NotTo(HaveOccurred())
+		volumeIDs = append(volumeIDs, volumeID)
+
+		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumeIDs[0], volumeIDs[1]))
+		pod := createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		volumeFiles := []string{
+			fmt.Sprintf("/mnt/volume1/%v_1.txt", ns),
+			fmt.Sprintf("/mnt/volume2/%v_1.txt", ns),
+		}
+		createAndVerifyFilesOnVolume(ns, pod.Name, volumeFiles, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+
+		By(fmt.Sprintf("Creating pod on the node: %v with volume :%v  and volume: %v", node1Name, volumeIDs[0], volumeIDs[1]))
+		pod = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, volumeIDs)
+		// Create empty files on the mounted volumes on the pod to verify volume is writable
+		// Verify newly and previously created files present on the volume mounted on the pod
+		newEmptyFileNames := []string{
+			fmt.Sprintf("/mnt/volume1/%v_2.txt", ns),
+			fmt.Sprintf("/mnt/volume2/%v_2.txt", ns),
+		}
+		volumeFiles = append(volumeFiles, newEmptyFileNames[0])
+		volumeFiles = append(volumeFiles, newEmptyFileNames[1])
+		createAndVerifyFilesOnVolume(ns, pod.Name, newEmptyFileNames, volumeFiles)
+		deletePodAndWaitForVolumeToDetach(f, c, pod, id, osp, node1Name, volumeIDs)
+	})
+
+	It("test back to back pod creation and deletion with different volume sources on the same worker node", func() {
+		var (
+			podA              *v1.Pod
+			podB              *v1.Pod
+			testvolumeIDsPodA []string
+			testvolumeIDsPodB []string
+			podAFiles         []string
+			podBFiles         []string
+		)
+
+		defer func() {
+			By("clean up undeleted pods")
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podA), "defer: Failed to delete pod ", podA.Name)
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podB), "defer: Failed to delete pod ", podB.Name)
+			By(fmt.Sprintf("wait for volumes to be detached from the node: %v", node1Name))
+			for _, volumeID := range volumeIDs {
+				framework.ExpectNoError(waitForOpenstackDiskToDetach(c, id, osp, volumeID, types.NodeName(node1Name)))
+			}
+		}()
+
+		testvolumeIDsPodA = append(testvolumeIDsPodA, volumeIDs[0])
+		// Create another VMDK Volume
+		By("creating another vmdk")
+		volumeID, err := createOpenstackVolume(osp)
+		Expect(err).NotTo(HaveOccurred())
+		volumeIDs = append(volumeIDs, volumeID)
+		testvolumeIDsPodB = append(testvolumeIDsPodA, volumeID)
+
+		for index := 0; index < 5; index++ {
+			By(fmt.Sprintf("Creating pod-A on the node: %v with volume: %v", node1Name, testvolumeIDsPodA[0]))
+			podA = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, testvolumeIDsPodA)
+
+			By(fmt.Sprintf("Creating pod-B on the node: %v with volume: %v", node1Name, testvolumeIDsPodB[0]))
+			podB = createPodWithVolumeAndNodeSelector(c, ns, id, osp, node1Name, node1KeyValueLabel, testvolumeIDsPodB)
+
+			podAFileName := fmt.Sprintf("/mnt/volume1/podA_%v_%v.txt", ns, index+1)
+			podBFileName := fmt.Sprintf("/mnt/volume1/podB_%v_%v.txt", ns, index+1)
+			podAFiles = append(podAFiles, podAFileName)
+			podBFiles = append(podBFiles, podBFileName)
+
+			// Create empty files on the mounted volumes on the pod to verify volume is writable
+			By("Creating empty file on volume mounted on pod-A")
+			framework.CreateEmptyFileOnPod(ns, podA.Name, podAFileName)
+
+			By("Creating empty file volume mounted on pod-B")
+			framework.CreateEmptyFileOnPod(ns, podB.Name, podBFileName)
+
+			// Verify newly and previously created files present on the volume mounted on the pod
+			By("Verify newly Created file and previously created files present on volume mounted on pod-A")
+			verifyFilesExistOnOpenstackVolume(ns, podA.Name, podAFiles)
+			By("Verify newly Created file and previously created files present on volume mounted on pod-B")
+			verifyFilesExistOnOpenstackVolume(ns, podB.Name, podBFiles)
+
+			By("Deleting pod-A")
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podA), "Failed to delete pod ", podA.Name)
+			By("Deleting pod-B")
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, podB), "Failed to delete pod ", podB.Name)
+		}
+	})
+})
+
+func testSetupVolumePlacement(client clientset.Interface, namespace string) (node1Name string, node1KeyValueLabel map[string]string, node2Name string, node2KeyValueLabel map[string]string) {
+	nodes := framework.GetReadySchedulableNodesOrDie(client)
+	if len(nodes.Items) < 2 {
+		framework.Skipf("Requires at least %d nodes (not %d)", 2, len(nodes.Items))
+	}
+	node1Name = nodes.Items[0].Name
+	node2Name = nodes.Items[1].Name
+	node1LabelValue := "openstack_e2e_" + string(uuid.NewUUID())
+	node1KeyValueLabel = make(map[string]string)
+	node1KeyValueLabel["openstack_e2e_label"] = node1LabelValue
+	framework.AddOrUpdateLabelOnNode(client, node1Name, "openstack_e2e_label", node1LabelValue)
+
+	node2LabelValue := "openstack_e2e_" + string(uuid.NewUUID())
+	node2KeyValueLabel = make(map[string]string)
+	node2KeyValueLabel["openstack_e2e_label"] = node2LabelValue
+	framework.AddOrUpdateLabelOnNode(client, node2Name, "openstack_e2e_label", node2LabelValue)
+	return node1Name, node1KeyValueLabel, node2Name, node2KeyValueLabel
+}
+
+func createPodWithVolumeAndNodeSelector(client clientset.Interface, namespace string, id string, osp *openstack.OpenStack, nodeName string, nodeKeyValueLabel map[string]string, volumeIDs []string) *v1.Pod {
+	var pod *v1.Pod
+	var err error
+	By(fmt.Sprintf("Creating pod on the node: %v", nodeName))
+	podspec := getOpenstackPodSpecWithVolumeIDs(volumeIDs, nodeKeyValueLabel, nil)
+
+	pod, err = client.CoreV1().Pods(namespace).Create(podspec)
+	Expect(err).NotTo(HaveOccurred())
+	By("Waiting for pod to be ready")
+	Expect(framework.WaitForPodNameRunningInNamespace(client, pod.Name, namespace)).To(Succeed())
+
+	By(fmt.Sprintf("Verify volume is attached to the node:%v", nodeName))
+	for _, volumeID := range volumeIDs {
+		isAttached, err := verifyOpenstackDiskAttached(client, osp, id, volumeID, types.NodeName(nodeName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(isAttached).To(BeTrue(), "disk:"+volumeID+" is not attached with the node")
+	}
+	return pod
+}
+
+func createAndVerifyFilesOnVolume(namespace string, podname string, newEmptyfilesToCreate []string, filesToCheck []string) {
+	// Create empty files on the mounted volumes on the pod to verify volume is writable
+	By(fmt.Sprintf("Creating empty file on volume mounted on: %v", podname))
+	createEmptyFilesOnOpenstackVolume(namespace, podname, newEmptyfilesToCreate)
+
+	// Verify newly and previously created files present on the volume mounted on the pod
+	By(fmt.Sprintf("Verify newly Created file and previously created files present on volume mounted on: %v", podname))
+	verifyFilesExistOnOpenstackVolume(namespace, podname, filesToCheck)
+}
+
+func deletePodAndWaitForVolumeToDetach(f *framework.Framework, c clientset.Interface, pod *v1.Pod, id string, osp *openstack.OpenStack, nodeName string, volumeIDs []string) {
+	By("Deleting pod")
+	framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod), "Failed to delete pod ", pod.Name)
+
+	By("Waiting for volume to be detached from the node")
+	for _, volumeID := range volumeIDs {
+		framework.ExpectNoError(waitForOpenstackDiskToDetach(c, id, osp, volumeID, types.NodeName(nodeName)))
+	}
+}

--- a/test/e2e/storage/openstack/persistent_volumes-openstack.go
+++ b/test/e2e/storage/openstack/persistent_volumes-openstack.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	utils "k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+// Testing configurations of single a PV/PVC pair attached to a openstack Disk
+var _ = utils.SIGDescribe("PersistentVolumes:openstack", func() {
+	var (
+		c         clientset.Interface
+		ns        string
+		volumeID  string
+		pv        *v1.PersistentVolume
+		pvc       *v1.PersistentVolumeClaim
+		clientPod *v1.Pod
+		pvConfig  framework.PersistentVolumeConfig
+		pvcConfig framework.PersistentVolumeClaimConfig
+		err       error
+		node      types.NodeName
+		volLabel  labels.Set
+		selector  *metav1.LabelSelector
+	)
+
+	f := framework.NewDefaultFramework("pv")
+	os, _, err := getOpenstack(c)
+	volumeID, err = createOpenstackVolume(os)
+	Expect(err).NotTo(HaveOccurred())
+
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		clientPod = nil
+		pvc = nil
+		pv = nil
+
+		volLabel = labels.Set{framework.VolumeSelectorKey: ns}
+		selector = metav1.SetAsLabelSelector(volLabel)
+
+		pvConfig = framework.PersistentVolumeConfig{
+			NamePrefix: "openstack-",
+			Labels:     volLabel,
+			PVSource: v1.PersistentVolumeSource{
+				Cinder: &v1.CinderVolumeSource{
+					VolumeID: volumeID,
+					FSType:   "ext3",
+					ReadOnly: false,
+				},
+			},
+			Prebind: nil,
+		}
+		pvcConfig = framework.PersistentVolumeClaimConfig{
+			Annotations: map[string]string{
+				v1.BetaStorageClassAnnotation: "",
+			},
+			Selector: selector,
+		}
+
+		By("Creating the PV and PVC")
+		pv, pvc, err = framework.CreatePVPVC(c, pvConfig, pvcConfig, ns, false)
+		Expect(err).NotTo(HaveOccurred())
+		framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
+
+		By("Creating the Client Pod")
+		clientPod, err = framework.CreateClientPod(c, ns, pvc)
+		Expect(err).NotTo(HaveOccurred())
+		node = types.NodeName(clientPod.Spec.NodeName)
+
+	})
+
+	AfterEach(func() {
+		framework.Logf("AfterEach: Cleaning up test resources")
+		if c != nil {
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "AfterEach: failed to delete pod ", clientPod.Name)
+
+			if pv != nil {
+				framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "AfterEach: failed to delete PV ", pv.Name)
+			}
+			if pvc != nil {
+				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "AfterEach: failed to delete PVC ", pvc.Name)
+			}
+		}
+	})
+
+	framework.AddCleanupAction(func() {
+		if len(ns) > 0 {
+			_, err = framework.LoadClientset()
+			if err != nil {
+				return
+			}
+			os.DeleteVolume(volumeID)
+		}
+	})
+
+	It("should test that deleting a PVC before the pod does not cause pod deletion to fail on openstack volume detach", func() {
+		By("Deleting the Claim")
+		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+		pvc = nil
+
+		By("Deleting the Pod")
+		framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "Failed to delete pod ", clientPod.Name)
+	})
+
+	It("should test that deleting the PV before the pod does not cause pod deletion to fail on openstack volume detach", func() {
+		By("Deleting the Persistent Volume")
+		framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
+		pv = nil
+
+		By("Deleting the pod")
+		framework.ExpectNoError(framework.DeletePodWithWait(f, c, clientPod), "Failed to delete pod ", clientPod.Name)
+	})
+
+	It("should test that a file written to the openstack volume mount before kubelet restart can be read after restart [Disruptive]", func() {
+		utils.TestKubeletRestartsAndRestoresMount(c, f, clientPod, pvc, pv)
+	})
+
+	It("should test that a openstack volume mounted to a pod that is deleted while the kubelet is down unmounts when the kubelet returns [Disruptive]", func() {
+		utils.TestVolumeUnmountsFromDeletedPod(c, f, clientPod, pvc, pv)
+	})
+
+	It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of openstack volume", func() {
+		By("Deleting the Namespace")
+		err := c.CoreV1().Namespaces().Delete(ns, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = framework.WaitForNamespacesDeleted(c, []string{ns}, 3*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying Persistent Disk detaches")
+		getVol, err := os.GetVolume(volumeID)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(getVol.Status).To(Equal(VolumeAvailableStatus))
+
+	})
+})

--- a/test/e2e/storage/openstack/pv_reclaimpolicy.go
+++ b/test/e2e/storage/openstack/pv_reclaimpolicy.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
+	openstack "k8s.io/kubernetes/pkg/cloudprovider/providers/openstack"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("PersistentVolumes [Feature:ReclaimPolicy]", func() {
+	f := framework.NewDefaultFramework("persistentvolumereclaim")
+	var (
+		c        clientset.Interface
+		ns       string
+		volumeID string
+		pv       *v1.PersistentVolume
+		pvc      *v1.PersistentVolumeClaim
+	)
+
+	BeforeEach(func() {
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+	})
+
+	utils.SIGDescribe("persistentvolumereclaim:openstack", func() {
+		BeforeEach(func() {
+			framework.SkipUnlessProviderIs("openstack")
+			pv = nil
+			pvc = nil
+			volumeID = ""
+		})
+
+		AfterEach(func() {
+			osp, _, err := getOpenstack(c)
+			Expect(err).NotTo(HaveOccurred())
+			testCleanupOpenstackPersistentVolumeReclaim(osp, c, ns, volumeID, pv, pvc)
+		})
+
+		It("should delete persistent volume when reclaimPolicy set to delete and associated claim is deleted", func() {
+			osp, _, err := getOpenstack(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeID, pv, pvc, err = testSetupOpenstackPersistentVolumeReclaim(osp, c, ns, v1.PersistentVolumeReclaimDelete)
+			Expect(err).NotTo(HaveOccurred())
+
+			deletePVCAfterBind(c, ns, pvc, pv)
+			pvc = nil
+
+			By("verify pv is deleted")
+			err = framework.WaitForPersistentVolumeDeleted(c, pv.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			pv = nil
+			volumeID = ""
+		})
+
+		It("should not detach and unmount PV when associated pvc with delete as reclaimPolicy is deleted when it is in use by the pod", func() {
+			osp, id, err := getOpenstack(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeID, pv, pvc, err = testSetupOpenstackPersistentVolumeReclaim(osp, c, ns, v1.PersistentVolumeReclaimDelete)
+			Expect(err).NotTo(HaveOccurred())
+			// Wait for PV and PVC to Bind
+			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
+
+			By("Creating the Pod")
+			pod, err := framework.CreateClientPod(c, ns, pvc)
+			Expect(err).NotTo(HaveOccurred())
+			node := types.NodeName(pod.Spec.NodeName)
+
+			By("Deleting the Claim")
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+			pvc = nil
+
+			// Verify PV is Present, after PVC is deleted and PV status should be Failed.
+			pv, err := c.CoreV1().PersistentVolumes().Get(pv.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(framework.WaitForPersistentVolumePhase(v1.VolumeFailed, c, pv.Name, 1*time.Second, 60*time.Second)).NotTo(HaveOccurred())
+
+			By("Verify the volume is attached to the node")
+			isVolumeAttached, verifyDiskAttachedError := verifyOpenstackDiskAttached(c, osp, id, pv.Spec.Cinder.VolumeID, node)
+			Expect(verifyDiskAttachedError).NotTo(HaveOccurred())
+			Expect(isVolumeAttached).To(BeTrue())
+
+			By("Verify the volume is accessible and available in the pod")
+			verifyOpenstackVolumesAccessible(c, pod, []*v1.PersistentVolume{pv}, id, osp)
+			framework.Logf("Verified that Volume is accessible in the POD after deleting PV claim")
+
+			By("Deleting the Pod")
+			framework.ExpectNoError(framework.DeletePodWithWait(f, c, pod), "Failed to delete pod ", pod.Name)
+
+			By("Verify PV is detached from the node after Pod is deleted")
+			Expect(waitForOpenstackDiskToDetach(c, id, osp, pv.Spec.Cinder.VolumeID, types.NodeName(pod.Spec.NodeName))).NotTo(HaveOccurred())
+
+			By("Verify PV should be deleted automatically")
+			framework.ExpectNoError(framework.WaitForPersistentVolumeDeleted(c, pv.Name, 1*time.Second, 30*time.Second))
+			pv = nil
+			volumeID = ""
+		})
+
+		It("should retain persistent volume when reclaimPolicy set to retain when associated claim is deleted", func() {
+			var volumeFileContent = "hello from openstack cloud provider, Random Content is :" + strconv.FormatInt(time.Now().UnixNano(), 10)
+			osp, _, err := getOpenstack(c)
+			Expect(err).NotTo(HaveOccurred())
+
+			volumeID, pv, pvc, err = testSetupOpenstackPersistentVolumeReclaim(osp, c, ns, v1.PersistentVolumeReclaimRetain)
+			Expect(err).NotTo(HaveOccurred())
+
+			writeContentToOpenstackPV(c, pvc, volumeFileContent)
+
+			By("Delete PVC")
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+			pvc = nil
+
+			By("Verify PV is retained")
+			framework.Logf("Waiting for PV %v to become Released", pv.Name)
+			err = framework.WaitForPersistentVolumePhase(v1.VolumeReleased, c, pv.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
+
+			By("Creating the PV for same volume path")
+			pv = getOpenstackPersistentVolumeSpec(volumeID, v1.PersistentVolumeReclaimRetain, nil)
+			pv, err = c.CoreV1().PersistentVolumes().Create(pv)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the pvc")
+			pvc = getOpenstackPersistentVolumeClaimSpec(ns, nil)
+			pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("wait for the pv and pvc to bind")
+			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
+			verifyContentOfOpenstackPV(c, pvc, volumeFileContent)
+
+		})
+	})
+})
+
+// Test Setup for persistentvolumereclaim tests for openstack Provider
+func testSetupOpenstackPersistentVolumeReclaim(osp *openstack.OpenStack, c clientset.Interface, ns string, persistentVolumeReclaimPolicy v1.PersistentVolumeReclaimPolicy) (volumeID string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim, err error) {
+	By("running testSetupOpenstackPersistentVolumeReclaim")
+	By("creating vmdk")
+	volumeID, err = createOpenstackVolume(osp)
+	if err != nil {
+		return
+	}
+	By("creating the pv")
+	pv = getOpenstackPersistentVolumeSpec(volumeID, persistentVolumeReclaimPolicy, nil)
+	pv, err = c.CoreV1().PersistentVolumes().Create(pv)
+	if err != nil {
+		return
+	}
+	By("creating the pvc")
+	pvc = getOpenstackPersistentVolumeClaimSpec(ns, nil)
+	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvc)
+	return
+}
+
+// Test Cleanup for persistentvolumereclaim tests for openstack Provider
+func testCleanupOpenstackPersistentVolumeReclaim(osp *openstack.OpenStack, c clientset.Interface, ns string, volumeID string, pv *v1.PersistentVolume, pvc *v1.PersistentVolumeClaim) {
+	By("running testCleanupOpenstackPersistentVolumeReclaim")
+	if len(volumeID) > 0 {
+		osp.DeleteVolume(volumeID)
+	}
+	if pv != nil {
+		framework.ExpectNoError(framework.DeletePersistentVolume(c, pv.Name), "Failed to delete PV ", pv.Name)
+	}
+	if pvc != nil {
+		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+	}
+}
+
+// func to wait until PV and PVC bind and once bind completes, delete the PVC
+func deletePVCAfterBind(c clientset.Interface, ns string, pvc *v1.PersistentVolumeClaim, pv *v1.PersistentVolume) {
+	var err error
+
+	By("wait for the pv and pvc to bind")
+	framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pv, pvc))
+
+	By("delete pvc")
+	framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "Failed to delete PVC ", pvc.Name)
+	pvc, err = c.CoreV1().PersistentVolumeClaims(ns).Get(pvc.Name, metav1.GetOptions{})
+	if !apierrs.IsNotFound(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+}

--- a/test/e2e/storage/openstack/pvc_label_selector.go
+++ b/test/e2e/storage/openstack/pvc_label_selector.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
+)
+
+var _ = utils.SIGDescribe("PersistentVolumes [Feature:LabelSelector]", func() {
+	f := framework.NewDefaultFramework("pvclabelselector")
+	var (
+		c          clientset.Interface
+		ns         string
+		pvssd      *v1.PersistentVolume
+		pvcssd     *v1.PersistentVolumeClaim
+		pvcvvol    *v1.PersistentVolumeClaim
+		volumeID   string
+		ssdlabels  map[string]string
+		vvollabels map[string]string
+		err        error
+	)
+	BeforeEach(func() {
+		framework.SkipUnlessProviderIs("openstack")
+		c = f.ClientSet
+		ns = f.Namespace.Name
+		framework.ExpectNoError(framework.WaitForAllNodesSchedulable(c, framework.TestContext.NodeSchedulableTimeout))
+		ssdlabels = make(map[string]string)
+		ssdlabels["volume-type"] = "ssd"
+		vvollabels = make(map[string]string)
+		vvollabels["volume-type"] = "vvol"
+
+	})
+
+	utils.SIGDescribe("Selector-Label Volume Binding:openstack", func() {
+		AfterEach(func() {
+			By("Running clean up actions")
+			if framework.ProviderIs("openstack") {
+				testCleanupOpenstackPVClabelselector(c, ns, volumeID, pvssd, pvcssd, pvcvvol)
+			}
+		})
+		It("should bind volume with claim for given label", func() {
+			volumeID, pvssd, pvcssd, pvcvvol, err = testSetupOpenstackPVClabelselector(c, ns, ssdlabels, vvollabels)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("wait for the pvcssd to bind with pvssd")
+			framework.ExpectNoError(framework.WaitOnPVandPVC(c, ns, pvssd, pvcssd))
+
+			By("Verify status of pvcvvol is pending")
+			err = framework.WaitForPersistentVolumeClaimPhase(v1.ClaimPending, c, ns, pvcvvol.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("delete pvcssd")
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvcssd.Name, ns), "Failed to delete PVC ", pvcssd.Name)
+
+			By("verify pvssd is deleted")
+			err = framework.WaitForPersistentVolumeDeleted(c, pvssd.Name, 3*time.Second, 300*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+			volumeID = ""
+
+			By("delete pvcvvol")
+			framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvcvvol.Name, ns), "Failed to delete PVC ", pvcvvol.Name)
+		})
+	})
+})
+
+func testSetupOpenstackPVClabelselector(c clientset.Interface, ns string, ssdlabels map[string]string, vvollabels map[string]string) (volumeID string, pvssd *v1.PersistentVolume, pvcssd *v1.PersistentVolumeClaim, pvcvvol *v1.PersistentVolumeClaim, err error) {
+	volumeID = ""
+	By("creating vmdk")
+	osp, _, err := getOpenstack(c)
+	Expect(err).NotTo(HaveOccurred())
+	volumeID, err = createOpenstackVolume(osp)
+	if err != nil {
+		return
+	}
+
+	By("creating the pv with lable volume-type:ssd")
+	pvssd = getOpenstackPersistentVolumeSpec(volumeID, v1.PersistentVolumeReclaimDelete, ssdlabels)
+	pvssd, err = c.CoreV1().PersistentVolumes().Create(pvssd)
+	if err != nil {
+		return
+	}
+
+	By("creating pvc with label selector to match with volume-type:vvol")
+	pvcvvol = getOpenstackPersistentVolumeClaimSpec(ns, vvollabels)
+	pvcvvol, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvcvvol)
+	if err != nil {
+		return
+	}
+
+	By("creating pvc with label selector to match with volume-type:ssd")
+	pvcssd = getOpenstackPersistentVolumeClaimSpec(ns, ssdlabels)
+	pvcssd, err = c.CoreV1().PersistentVolumeClaims(ns).Create(pvcssd)
+	return
+}
+
+func testCleanupOpenstackPVClabelselector(c clientset.Interface, ns string, volumeID string, pvssd *v1.PersistentVolume, pvcssd *v1.PersistentVolumeClaim, pvcvvol *v1.PersistentVolumeClaim) {
+	By("running testCleanupOpenstackPVClabelselector")
+	if len(volumeID) > 0 {
+		osp, _, err := getOpenstack(c)
+		Expect(err).NotTo(HaveOccurred())
+		osp.DeleteVolume(volumeID)
+	}
+	if pvcssd != nil {
+		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvcssd.Name, ns), "Failed to delete PVC ", pvcssd.Name)
+	}
+	if pvcvvol != nil {
+		framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvcvvol.Name, ns), "Failed to delete PVC ", pvcvvol.Name)
+	}
+	if pvssd != nil {
+		framework.ExpectNoError(framework.DeletePersistentVolume(c, pvssd.Name), "Faled to delete PV ", pvssd.Name)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes #50246

**Summary of progress**

- [x] Scale
- [x] Stress
- [x] Statefulness
- [x] Persistent volumes
-  [x] Performance
-  [x] Volume Disksize
-  [x] Volume FStype
-  [x] Volume Provisioning on Datastore
-  [x] Volume Provisioning On Clustered Datastore  
-  [x] Volume Operations Storm
-  [x] Volume master restart
-  [x] persistent volume reclaim policy
-  [x] persistent volume Label selector
-  [x] Storage Policy Based Volume Provisioning
- [x] Volume Placement

Other changes

I rearranged env variable loading in openstack.go as requested in one of the reviews.
Changed newOpenStack to NewOpenStack so that I could export it for tests

  
  
  