### PR TITLE
HugePages feature is beta in 1.10 release

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -153,7 +153,7 @@ const (
 	CPUManager utilfeature.Feature = "CPUManager"
 
 	// owner: @derekwaynecarr
-	// alpha: v1.8
+	// beta: v1.10
 	//
 	// Enable pods to consume pre-allocated huge pages of varying page sizes
 	HugePages utilfeature.Feature = "HugePages"
@@ -235,7 +235,7 @@ var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureS
 	RotateKubeletClientCertificate:              {Default: true, PreRelease: utilfeature.Beta},
 	PersistentLocalVolumes:                      {Default: false, PreRelease: utilfeature.Alpha},
 	LocalStorageCapacityIsolation:               {Default: false, PreRelease: utilfeature.Alpha},
-	HugePages:                                   {Default: false, PreRelease: utilfeature.Alpha},
+	HugePages:                                   {Default: true, PreRelease: utilfeature.Beta},
 	DebugContainers:                             {Default: false, PreRelease: utilfeature.Alpha},
 	PodPriority:                                 {Default: false, PreRelease: utilfeature.Alpha},
 	EnableEquivalenceClassCache:                 {Default: false, PreRelease: utilfeature.Alpha},


### PR DESCRIPTION
**What this PR does / why we need it**:
Graduate support of HugePages to beta.

**Which issue(s) this PR fixes**
Fixes #53672

**Special notes for your reviewer**:

```release-note
HugePages feature is beta
```
