### PR TITLE
Convert scheduler_perf tests to use subtest.

### DIFF
--- a/test/integration/scheduler_perf/scheduler_bench_test.go
+++ b/test/integration/scheduler_perf/scheduler_bench_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package benchmark
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,28 +28,19 @@ import (
 	"github.com/golang/glog"
 )
 
-// BenchmarkScheduling100Nodes0Pods benchmarks the scheduling rate
-// when the cluster has 100 nodes and 0 scheduled pods
-func BenchmarkScheduling100Nodes0Pods(b *testing.B) {
-	benchmarkScheduling(100, 0, b)
-}
-
-// BenchmarkScheduling100Nodes1000Pods benchmarks the scheduling rate
-// when the cluster has 100 nodes and 1000 scheduled pods
-func BenchmarkScheduling100Nodes1000Pods(b *testing.B) {
-	benchmarkScheduling(100, 1000, b)
-}
-
-// BenchmarkScheduling1000Nodes0Pods benchmarks the scheduling rate
-// when the cluster has 1000 nodes and 0 scheduled pods
-func BenchmarkScheduling1000Nodes0Pods(b *testing.B) {
-	benchmarkScheduling(1000, 0, b)
-}
-
-// BenchmarkScheduling1000Nodes1000Pods benchmarks the scheduling rate
-// when the cluster has 1000 nodes and 1000 scheduled pods
-func BenchmarkScheduling1000Nodes1000Pods(b *testing.B) {
-	benchmarkScheduling(1000, 1000, b)
+// BenchmarkScheduling benchmarks the scheduling rate when the cluster has
+// various quantities of nodes and scheduled pods.
+func BenchmarkScheduling(b *testing.B) {
+	tests := []struct{ nodes, pods int }{
+		{nodes: 100, pods: 0},
+		{nodes: 100, pods: 1000},
+		{nodes: 1000, pods: 0},
+		{nodes: 1000, pods: 1000},
+	}
+	for _, test := range tests {
+		name := fmt.Sprintf("%vNodes/%vPods", test.nodes, test.pods)
+		b.Run(name, func(b *testing.B) { benchmarkScheduling(test.nodes, test.pods, b) })
+	}
 }
 
 // benchmarkScheduling benchmarks scheduling rate with specific number of nodes


### PR DESCRIPTION
Combine four separate tests into a table-driven test that uses subtests
to logically organize the tests.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Simplifies integration test code in test/integration/scheduler_perf.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig scheduling