### PR TITLE
Automated cherry pick of #54040

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -212,7 +212,10 @@ func (m *kubeGenericRuntimeManager) Type() string {
 }
 
 func newRuntimeVersion(version string) (*utilversion.Version, error) {
-	return utilversion.ParseSemantic(version)
+	if ver, err := utilversion.ParseSemantic(version); err == nil {
+		return ver, err
+	}
+	return utilversion.ParseGeneric(version)
 }
 
 func (m *kubeGenericRuntimeManager) getTypedVersion() (*runtimeapi.VersionResponse, error) {


### PR DESCRIPTION
Cherry pick of #54040 on release-1.8.

#54040: kubelet falls back to parse generic version string if not