### PR TITLE
Fix Heapster and Metrics Server configuration to enable overriding resource requirements.

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -20,6 +20,32 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,7 +90,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: heapster-nanny
           resources:
             limits:
@@ -73,6 +99,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountMath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -84,6 +113,7 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu={{ base_metrics_cpu }}
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
@@ -93,7 +123,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: eventer-nanny
           resources:
             limits:
@@ -111,8 +141,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: eventer-config-volume
+            mountMath: /etc/config
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu=100m
             - --extra-cpu=0m
             - --memory={{base_eventer_memory}}
@@ -122,6 +156,14 @@ spec:
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+      volumes:
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -20,6 +20,32 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -66,7 +92,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: heapster-nanny
           resources:
             limits:
@@ -75,6 +101,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -86,6 +115,7 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu={{ base_metrics_cpu }}
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
@@ -95,7 +125,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: eventer-nanny
           resources:
             limits:
@@ -104,6 +134,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: eventer-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -115,6 +148,7 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu=100m
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
@@ -124,6 +158,13 @@ spec:
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -20,6 +20,32 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: eventer-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -64,7 +90,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: heapster-nanny
           resources:
             limits:
@@ -82,8 +108,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu={{ base_metrics_cpu }}
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
@@ -93,7 +123,7 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: eventer-nanny
           resources:
             limits:
@@ -111,8 +141,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: eventer-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu=100m
             - --extra-cpu=0m
             - --memory={{ base_eventer_memory }}
@@ -122,6 +156,13 @@ spec:
             - --container=eventer
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
+        - name: eventer-config-volume
+          configMap:
+            name: eventer-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -18,6 +18,19 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -76,7 +89,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: heapster-nanny
           resources:
             limits:
@@ -85,6 +98,9 @@ spec:
             requests:
               cpu: 50m
               memory: {{ nanny_memory }}
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           env:
             - name: MY_POD_NAME
               valueFrom:
@@ -96,6 +112,7 @@ spec:
                   fieldPath: metadata.namespace
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu={{ base_metrics_cpu }}
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
@@ -105,6 +122,10 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -18,6 +18,19 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: heapster-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -55,7 +68,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: gcr.io/google_containers/addon-resizer:1.7
+        - image: gcr.io/google_containers/addon-resizer:1.8.1
           name: heapster-nanny
           resources:
             limits:
@@ -73,8 +86,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          volumeMounts:
+          - name: heapster-config-volume
+            mountPath: /etc/config
           command:
             - /pod_nanny
+            - --config-dir=/etc/config
             - --cpu={{ base_metrics_cpu }}
             - --extra-cpu={{ metrics_cpu_per_node }}m
             - --memory={{ base_metrics_memory }}
@@ -84,6 +101,10 @@ spec:
             - --container=heapster
             - --poll-period=300000
             - --estimator=exponential
+      volumes:
+        - name: heapster-config-volume
+          configMap:
+            name: heapster-config
       serviceAccountName: heapster
       tolerations:
         - key: "CriticalAddonsOnly"

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -7,6 +7,19 @@ metadata:
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: metrics-server-config
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: EnsureExists
+data:
+  NannyConfiguration: |-
+    apiVersion: nannyconfig/v1alpha1
+    kind: NannyConfiguration
+---
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -43,7 +56,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: gcr.io/google_containers/addon-resizer:1.7
+        image: gcr.io/google_containers/addon-resizer:1.8.1
         resources:
           limits:
             cpu: 100m
@@ -60,8 +73,12 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        volumeMounts:
+        - name: metrics-server-config-volume
+          mountPath: /etc/config
         command:
           - /pod_nanny
+          - --config-dir=/etc/config
           - --cpu=40m
           - --extra-cpu=0.5m
           - --memory=140Mi
@@ -71,6 +88,10 @@ spec:
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential
+      volumes:
+        - name: metrics-server-config-volume
+          configMap:
+            name: metrics-server-config
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"


### PR DESCRIPTION
**What this PR does / why we need it**:
Configure resources for Heapster and Metrics Servier using Component Config. This will enable overriding default resource requirements for these components.

**Release note**:
```release-note
Fix Heapster configuration and Metrics Server configuration to enable overriding default resource requirements.
```