### PR TITLE
enabling log rotate for api logs in nginx

### DIFF
--- a/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
+++ b/cluster/juju/layers/kubeapi-load-balancer/reactive/load_balancer.py
@@ -21,6 +21,7 @@ import subprocess
 from charms import layer
 from charms.reactive import when, when_any, when_not
 from charms.reactive import set_state, remove_state
+from charms.reactive import hook
 from charmhelpers.core import hookenv
 from charmhelpers.core import host
 from charmhelpers.contrib.charmsupport import nrpe
@@ -34,6 +35,25 @@ from subprocess import PIPE
 from subprocess import STDOUT
 from subprocess import CalledProcessError
 
+
+apilb_nginx = """/var/log/nginx.*.log {
+	daily
+	missingok
+	rotate 14
+	compress
+	delaycompress
+	notifempty
+	create 0640 www-data adm
+	sharedscripts
+	prerotate
+		if [ -d /etc/logrotate.d/httpd-prerotate ]; then \\
+			run-parts /etc/logrotate.d/httpd-prerotate; \\
+		fi \\
+	endscript
+	postrotate
+		invoke-rc.d nginx rotate >/dev/null 2>&1
+	endscript
+}"""
 
 @when('certificates.available')
 def request_server_certificates(tls):
@@ -89,6 +109,14 @@ def close_old_port():
         hookenv.log('Port %d already closed, skipping.' % old_port)
 
 
+def maybe_write_apilb_logrotate_config():
+    filename = '/etc/logrotate.d/apilb_nginx'
+    if not os.path.exists(filename):
+        # Set log rotation for apilb log file
+        with open(filename, 'w+') as fp:
+            fp.write(apilb_nginx)
+
+
 @when('nginx.available', 'apiserver.available',
       'certificates.server.cert.available')
 def install_load_balancer(apiserver, tls):
@@ -123,7 +151,14 @@ def install_load_balancer(apiserver, tls):
                 server_certificate=server_cert_path,
                 server_key=server_key_path,
         )
+
+        maybe_write_apilb_logrotate_config()
         hookenv.status_set('active', 'Loadbalancer ready.')
+
+
+@hook('upgrade-charm')
+def upgrade_charm():
+    maybe_write_apilb_logrotate_config()
 
 
 @when('nginx.available')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Prevent the load balancer from filling the disk with logs from the api server
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/449
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enabled log rotation for load balancer's api logs to prevent running out of disk space.
```
