### PR TITLE
Make sure we let the world know when the preStop is done

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -483,7 +483,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(pod *v1.Pod, containerID 
 	glog.V(3).Infof("Running preStop hook for container %q", containerID.String())
 
 	start := metav1.Now()
-	done := make(chan struct{})
+	done := make(chan bool)
 	go func() {
 		defer close(done)
 		defer utilruntime.HandleCrash()
@@ -491,6 +491,7 @@ func (m *kubeGenericRuntimeManager) executePreStopHook(pod *v1.Pod, containerID 
 			glog.Errorf("preStop hook for container %q failed: %v", containerSpec.Name, err)
 			m.recordContainerEvent(pod, containerSpec, containerID.ID, v1.EventTypeWarning, events.FailedPreStopHook, msg)
 		}
+		done <- true
 	}()
 
 	select {


### PR DESCRIPTION
**What this PR does / why we need it**: Bug fix

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #45140 

**Special notes for your reviewer**:
I tried adding tests for this, as described in the issue, however I was unable to actually reproduce this given the current tests. I'd love to add a test for this if you could point me in the right direction! :-)

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where using preStop hooks with terminationGracePeriodSeconds, would make the container not shut down until terminationGracePeriodSeconds has expired.
```
