### PR TITLE
Fix YAMLDecoder Read behaviour

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder.go
@@ -122,7 +122,7 @@ func (d *YAMLDecoder) Read(data []byte) (n int, err error) {
 	if left <= len(data) {
 		copy(data, d.remaining)
 		d.remaining = nil
-		return len(d.remaining), nil
+		return left, nil
 	}
 
 	// caller will need to reread

--- a/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/yaml/decoder_test.go
@@ -22,11 +22,25 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestYAMLDecoder(t *testing.T) {
+	d := `---
+stuff: 1
+	test-foo: 1
+`
+	s := NewDocumentDecoder(ioutil.NopCloser(bytes.NewReader([]byte(d))))
+	b := make([]byte, len(d))
+	n, err := s.Read(b)
+	if err != nil || n != len(d) {
+		t.Fatalf("unexpected body: %d / %v", n, err)
+	}
+}
 
 func TestSplitYAMLDocument(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Makes YAMLDecoder adhere to the Read contract by returning the number of bytes
read.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56999

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
YAMLDecoder Read now returns the number of bytes read
```
