### PR TITLE
check and set promiscuous mode with netlink because netlink already supports it

### DIFF
--- a/pkg/kubelet/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/network/kubenet/kubenet_linux.go
@@ -334,19 +334,17 @@ func (plugin *kubenetNetworkPlugin) setup(namespace string, name string, id kube
 
 	// Put the container bridge into promiscuous mode to force it to accept hairpin packets.
 	// TODO: Remove this once the kernel bug (#20096) is fixed.
-	// TODO: check and set promiscuous mode with netlink once vishvananda/netlink supports it
 	if plugin.hairpinMode == kubeletconfig.PromiscuousBridge {
-		output, err := plugin.execer.Command("ip", "link", "show", "dev", BridgeName).CombinedOutput()
-		if err != nil || strings.Index(string(output), "PROMISC") < 0 {
-			_, err := plugin.execer.Command("ip", "link", "set", BridgeName, "promisc", "on").CombinedOutput()
-			if err != nil {
-				return fmt.Errorf("Error setting promiscuous mode on %s: %v", BridgeName, err)
-			}
-		}
-
 		link, err := netlink.LinkByName(BridgeName)
 		if err != nil {
 			return fmt.Errorf("failed to lookup %q: %v", BridgeName, err)
+		}
+		if link.Attrs().Promisc != 1 {
+			// promiscuous mode is not on, then turn it on.
+			err := netlink.SetPromiscOn(link)
+			if err != nil {
+				return fmt.Errorf("Error setting promiscuous mode on %s: %v", BridgeName, err)
+			}
 		}
 
 		// configure the ebtables rules to eliminate duplicate packets by best effort


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

check and set promiscuous mode with netlink because netlink already supports it.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I wanted to add tests for the changes, however I found upstream CI does not allow UT acquire root privilege :(

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/sig network
