### PR TITLE
add PV size grow feature for azure file

### DIFF
--- a/cmd/kube-controller-manager/app/plugins.go
+++ b/cmd/kube-controller-manager/app/plugins.go
@@ -102,6 +102,7 @@ func ProbeExpandableVolumePlugins(config componentconfig.VolumeConfiguration) []
 	allPlugins = append(allPlugins, glusterfs.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, rbd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, azure_dd.ProbeVolumePlugins()...)
+	allPlugins = append(allPlugins, azure_file.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, photon_pd.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, scaleio.ProbeVolumePlugins()...)
 	allPlugins = append(allPlugins, storageos.ProbeVolumePlugins()...)

--- a/pkg/cloudprovider/providers/azure/azure_fakes.go
+++ b/pkg/cloudprovider/providers/azure/azure_fakes.go
@@ -930,11 +930,15 @@ func (fRTC *fakeRouteTablesClient) Get(resourceGroupName string, routeTableName 
 type fakeFileClient struct {
 }
 
-func (fFC *fakeFileClient) createFileShare(accountName, accountKey, name string, sizeGB int) error {
+func (fFC *fakeFileClient) createFileShare(accountName, accountKey, name string, sizeGiB int) error {
 	return nil
 }
 
 func (fFC *fakeFileClient) deleteFileShare(accountName, accountKey, name string) error {
+	return nil
+}
+
+func (fFC *fakeFileClient) resizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
 	return nil
 }
 

--- a/pkg/cloudprovider/providers/azure/azure_file.go
+++ b/pkg/cloudprovider/providers/azure/azure_file.go
@@ -33,6 +33,7 @@ const (
 type FileClient interface {
 	createFileShare(accountName, accountKey, name string, sizeGiB int) error
 	deleteFileShare(accountName, accountKey, name string) error
+	resizeFileShare(accountName, accountKey, name string, sizeGiB int) error
 }
 
 // create file share
@@ -42,6 +43,10 @@ func (az *Cloud) createFileShare(accountName, accountKey, name string, sizeGiB i
 
 func (az *Cloud) deleteFileShare(accountName, accountKey, name string) error {
 	return az.FileClient.deleteFileShare(accountName, accountKey, name)
+}
+
+func (az *Cloud) resizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
+	return az.FileClient.resizeFileShare(accountName, accountKey, name, sizeGiB)
 }
 
 type azureFileClient struct {
@@ -79,6 +84,25 @@ func (f *azureFileClient) deleteFileShare(accountName, accountKey, name string) 
 		return err
 	}
 	return fileClient.GetShareReference(name).Delete(nil)
+}
+
+func (f *azureFileClient) resizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
+	fileClient, err := f.getFileSvcClient(accountName, accountKey)
+	if err != nil {
+		return err
+	}
+	share := fileClient.GetShareReference(name)
+	if share.Properties.Quota >= sizeGiB {
+		glog.Warningf("file share size(%dGi) is already greater or equal than requested size(%dGi), accountName: %s, shareName: %s",
+			share.Properties.Quota, sizeGiB, accountName, name)
+		return nil
+	}
+	share.Properties.Quota = sizeGiB
+	if err = share.SetProperties(nil); err != nil {
+		return fmt.Errorf("failed to set quota on file share %s, err: %v", name, err)
+	}
+	glog.V(4).Infof("resize file share completed, accountName: %s, shareName: %s, sizeGiB: %d", accountName, name, sizeGiB)
+	return nil
 }
 
 func (f *azureFileClient) getFileSvcClient(accountName, accountKey string) (*azs.FileServiceClient, error) {

--- a/pkg/cloudprovider/providers/azure/azure_file.go
+++ b/pkg/cloudprovider/providers/azure/azure_file.go
@@ -31,13 +31,13 @@ const (
 // FileClient is the interface for creating file shares, interface for test
 // injection.
 type FileClient interface {
-	createFileShare(accountName, accountKey, name string, sizeGB int) error
+	createFileShare(accountName, accountKey, name string, sizeGiB int) error
 	deleteFileShare(accountName, accountKey, name string) error
 }
 
 // create file share
-func (az *Cloud) createFileShare(accountName, accountKey, name string, sizeGB int) error {
-	return az.FileClient.createFileShare(accountName, accountKey, name, sizeGB)
+func (az *Cloud) createFileShare(accountName, accountKey, name string, sizeGiB int) error {
+	return az.FileClient.createFileShare(accountName, accountKey, name, sizeGiB)
 }
 
 func (az *Cloud) deleteFileShare(accountName, accountKey, name string) error {
@@ -48,7 +48,7 @@ type azureFileClient struct {
 	env azure.Environment
 }
 
-func (f *azureFileClient) createFileShare(accountName, accountKey, name string, sizeGB int) error {
+func (f *azureFileClient) createFileShare(accountName, accountKey, name string, sizeGiB int) error {
 	fileClient, err := f.getFileSvcClient(accountName, accountKey)
 	if err != nil {
 		return err
@@ -62,7 +62,7 @@ func (f *azureFileClient) createFileShare(accountName, accountKey, name string, 
 	if err = share.Create(nil); err != nil {
 		return fmt.Errorf("failed to create file share, err: %v", err)
 	}
-	share.Properties.Quota = sizeGB
+	share.Properties.Quota = sizeGiB
 	if err = share.SetProperties(nil); err != nil {
 		if err := share.Delete(nil); err != nil {
 			glog.Errorf("Error deleting share: %v", err)

--- a/pkg/cloudprovider/providers/azure/azure_storage.go
+++ b/pkg/cloudprovider/providers/azure/azure_storage.go
@@ -72,21 +72,5 @@ func (az *Cloud) DeleteFileShare(accountName, key, name string) error {
 
 // ResizeFileShare resizes a file share
 func (az *Cloud) ResizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
-	fileClient, err := az.getFileSvcClient(accountName, accountKey)
-	if err != nil {
-		return err
-	}
-
-	share := fileClient.GetShareReference(name)
-	if share.Properties.Quota >= sizeGiB {
-		glog.Warningf("file share size(%dGi) is already greater or equal than requested size(%dGi), accountName: %s, shareName: %s",
-			share.Properties.Quota, sizeGiB, accountName, name)
-		return nil
-	}
-	share.Properties.Quota = sizeGiB
-	if err = share.SetProperties(nil); err != nil {
-		return fmt.Errorf("failed to set quota on file share %s, err: %v", name, err)
-	}
-	glog.V(4).Infof("resize file share completed, accountName: %s, shareName: %s, sizeGiB: %d", accountName, name, sizeGiB)
-	return nil
+	return az.resizeFileShare(accountName, accountKey, name, sizeGiB)
 }

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -21,16 +21,16 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/cloudprovider"
+	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	"k8s.io/kubernetes/pkg/util/mount"
 	kstrings "k8s.io/kubernetes/pkg/util/strings"
 	"k8s.io/kubernetes/pkg/volume"
-
-	"github.com/golang/glog"
-	"k8s.io/kubernetes/pkg/cloudprovider"
-	"k8s.io/kubernetes/pkg/cloudprovider/providers/azure"
 	"k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -45,6 +45,7 @@ type azureFilePlugin struct {
 
 var _ volume.VolumePlugin = &azureFilePlugin{}
 var _ volume.PersistentVolumePlugin = &azureFilePlugin{}
+var _ volume.ExpandableVolumePlugin = &azureFilePlugin{}
 
 const (
 	azureFilePluginName = "kubernetes.io/azure-file"
@@ -137,6 +138,41 @@ func (plugin *azureFilePlugin) newUnmounterInternal(volName string, podUID types
 		plugin:          plugin,
 		MetricsProvider: volume.NewMetricsStatFS(getPath(podUID, volName, plugin.host)),
 	}}, nil
+}
+
+func (plugin *azureFilePlugin) RequiresFSResize() bool {
+	return false
+}
+
+func (plugin *azureFilePlugin) ExpandVolumeDevice(
+	spec *volume.Spec,
+	newSize resource.Quantity,
+	oldSize resource.Quantity) (resource.Quantity, error) {
+
+	if spec.PersistentVolume != nil || spec.PersistentVolume.Spec.AzureFile == nil {
+		return oldSize, fmt.Errorf("invalid PV spec")
+	}
+	shareName := spec.PersistentVolume.Spec.AzureFile.ShareName
+	azure, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
+	if err != nil {
+		return oldSize, err
+	}
+
+	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
+	if err != nil {
+		return oldSize, err
+	}
+
+	accountName, accountKey, err := (&azureSvc{}).GetAzureCredentials(plugin.host, secretNamespace, secretName)
+	if err != nil {
+		return oldSize, err
+	}
+
+	if err := azure.ResizeFileShare(accountName, accountKey, shareName, int(volume.RoundUpToGiB(newSize))); err != nil {
+		return oldSize, err
+	}
+
+	return newSize, nil
 }
 
 func (plugin *azureFilePlugin) ConstructVolumeSpec(volName, mountPath string) (*volume.Spec, error) {

--- a/plugin/pkg/admission/persistentvolume/resize/admission.go
+++ b/plugin/pkg/admission/persistentvolume/resize/admission.go
@@ -161,5 +161,8 @@ func (pvcr *persistentVolumeClaimResize) checkVolumePlugin(pv *api.PersistentVol
 		return true
 	}
 
+	if pv.Spec.AzureFile != nil {
+		return true
+	}
 	return false
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
According to kubernetes/features#284, add size grow feature for azure file

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56462 

**Special notes for your reviewer**:
Since azure file is using SMB 3.0 protocal, there is no necessary to resize filesystem on agent side, the agent node will detect the changed size automatically.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
add size grow feature for azure file
```
/sig azure
@gnufied @rootfs @brendandburns 