### PR TITLE
let kubelet use cri container runtime endpoint defined in cadvisor

### DIFF
--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/types:go_default_library",
+        "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
         "//vendor/github.com/google/cadvisor/events:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v2:go_default_library",

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -21,6 +21,7 @@ package cadvisor
 import (
 	"fmt"
 
+	"github.com/google/cadvisor/container/crio"
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
 
@@ -43,7 +44,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 		// This is a temporary workaround to get stats for cri-o from cadvisor
 		// and should be removed.
 		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == "/var/run/crio.sock" {
+		if i.runtimeEndpoint == crio.CrioSocket {
 			return cadvisorfs.LabelCrioImages, nil
 		}
 	}

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -19,6 +19,7 @@ package cadvisor
 import (
 	goruntime "runtime"
 
+	"github.com/google/cadvisor/container/crio"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapi2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
@@ -71,5 +72,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
 	return runtime == kubetypes.RktContainerRuntime ||
 		(runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == "/var/run/crio.sock"
+		runtimeEndpoint == crio.CrioSocket
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
To make cri container runtime endpoint consistent, kubelet (currently using `"/var/run/crio.sock"` ) should use `CrioSocket` defined in `cadvisor`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57005

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
use cri container runtime endpoint defined in cadivsor/crio
```
