### PR TITLE
check for empty label before assigning

### DIFF
--- a/pkg/kubectl/resource/builder.go
+++ b/pkg/kubectl/resource/builder.go
@@ -341,6 +341,10 @@ func (b *Builder) LabelSelectorParam(s string) *Builder {
 // LabelSelector accepts a selector directly and will filter the resulting list by that object.
 // Use LabelSelectorParam instead for user input.
 func (b *Builder) LabelSelector(selector string) *Builder {
+	if len(selector) == 0 {
+		return b
+	}
+
 	b.labelSelector = &selector
 	return b
 }


### PR DESCRIPTION
Prevents an empty label from being assigned to the resource builder when calling its `LabelSelectorParam` parameter. Currently, we assign the address of the provided selector string, even if the string is empty - this has the potential of returning erroneous failures since we check to see [if a selector was provided here](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/resource/builder.go#L470), for example, by doing a nil check. Storing the pointer to [an empty string value](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/resource/builder.go#L344) would break this check as the pointer is no longer nil

**Release note**:
```release-note
NONE
```

cc @deads2k @smarterclayton 