### PR TITLE
small nit in the annotations of pkg/kubelet/container/os.go

### DIFF
--- a/pkg/kubelet/container/os.go
+++ b/pkg/kubelet/container/os.go
@@ -43,7 +43,7 @@ type OSInterface interface {
 // RealOS is used to dispatch the real system level operations.
 type RealOS struct{}
 
-// MkDir will will call os.Mkdir to create a directory.
+// MkdirAll will call os.MkdirAll to create a directory.
 func (RealOS) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
just a small nit in the annotations of container/os.go, but, it looks quite uncomfortable cause others all get right.
