### PR TITLE
add custom endpoint restrictions in test matrix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/BUILD
@@ -14,6 +14,7 @@ go_test(
     deps = [
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],
 )
 


### PR DESCRIPTION
test enhance of https://github.com/kubernetes/kubernetes/pull/50603, comes from discussion here: https://github.com/kubernetes/kubernetes/pull/50603#issuecomment-350940425

/assign @liggitt 
/assign @smarterclayton 
/assign @caesarxuchao 

```release-note
NONE
```
