### PR TITLE
increase the podLogTimeout for downward volume test

### DIFF
--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -32,7 +32,7 @@ import (
 
 var _ = Describe("[sig-storage] Downward API volume", func() {
 	// How long to wait for a log pod to be displayed
-	const podLogTimeout = 2 * time.Minute
+	const podLogTimeout = 3 * time.Minute
 	f := framework.NewDefaultFramework("downward-api")
 	var podClient *framework.PodClient
 	BeforeEach(func() {


### PR DESCRIPTION
Based on https://github.com/openshift/origin/pull/17627, increasing the timeout seems to fix the problem.

```release-note
NONE
```