### PR TITLE
Implement VisitArbitrary in schemavisitors

### DIFF
--- a/pkg/kubectl/apply/parse/openapi.go
+++ b/pkg/kubectl/apply/parse/openapi.go
@@ -104,6 +104,12 @@ func (v *baseSchemaVisitor) VisitKind(*proto.Kind) {
 	v.Err = fmt.Errorf("Kind type not expected")
 }
 
+// VisitArbitrary implements openapi
+func (v *baseSchemaVisitor) VisitArbitrary(schema *proto.Arbitrary) {
+	v.Kind = "arbitrary"
+	v.Err = fmt.Errorf("Arbitrary type not expected")
+}
+
 // VisitReference implements openapi
 func (v *baseSchemaVisitor) VisitReference(reference proto.Reference) {
 	v.Kind = "reference"

--- a/pkg/kubectl/explain/field_lookup.go
+++ b/pkg/kubectl/explain/field_lookup.go
@@ -89,6 +89,12 @@ func (f *fieldLookup) VisitKind(k *proto.Kind) {
 	subSchema.Accept(f)
 }
 
+// VisitArbitrary stops the operation and returns itself as the found
+// schema, even if it had more path to walk.
+func (f *fieldLookup) VisitArbitrary(a *proto.Arbitrary) {
+	f.Schema = a
+}
+
 // VisitReference is mostly a passthrough.
 func (f *fieldLookup) VisitReference(r proto.Reference) {
 	if f.SaveLeafSchema(r) {

--- a/pkg/kubectl/explain/field_lookup_test.go
+++ b/pkg/kubectl/explain/field_lookup_test.go
@@ -64,6 +64,11 @@ func TestFindField(t *testing.T) {
 			path: []string{"field1", ""},
 			err:  `field "" does not exist`,
 		},
+		{
+			name:         "test6",
+			path:         []string{"field1", "arbitrary"},
+			expectedPath: "OtherKind.arbitrary",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/kubectl/explain/fields_printer.go
+++ b/pkg/kubectl/explain/fields_printer.go
@@ -70,6 +70,11 @@ func (f *regularFieldsPrinter) VisitPrimitive(p *proto.Primitive) {
 	// Nothing to do. Shouldn't really happen.
 }
 
+// VisitArbitrary prints an Arbitrary type. It stops the recursion.
+func (f *regularFieldsPrinter) VisitArbitrary(a *proto.Arbitrary) {
+	// Nothing to do. Shouldn't really happen.
+}
+
 // VisitReference prints a Reference type. It is just a passthrough.
 func (f *regularFieldsPrinter) VisitReference(r proto.Reference) {
 	r.SubSchema().Accept(f)

--- a/pkg/kubectl/explain/model_printer.go
+++ b/pkg/kubectl/explain/model_printer.go
@@ -72,6 +72,16 @@ func (m *modelPrinter) PrintDescription(schema proto.Schema) error {
 	return nil
 }
 
+func (m *modelPrinter) PrintField(schema proto.Schema) error {
+	if m.Type == "" {
+		m.Type = GetTypeName(schema)
+	}
+	if err := m.Writer.Write("FIELD:    %s <%s>\n", m.Name, m.Type); err != nil {
+		return err
+	}
+	return m.PrintDescription(schema)
+}
+
 // VisitArray recurses inside the subtype, while collecting the type if
 // not done yet, and the description.
 func (m *modelPrinter) VisitArray(a *proto.Array) {
@@ -124,14 +134,12 @@ func (m *modelPrinter) VisitPrimitive(p *proto.Primitive) {
 		return
 	}
 
-	if m.Type == "" {
-		m.Type = GetTypeName(p)
-	}
-	if err := m.Writer.Write("FIELD:    %s <%s>\n", m.Name, m.Type); err != nil {
-		m.Error = err
-		return
-	}
-	m.Error = m.PrintDescription(p)
+	m.Error = m.PrintField(p)
+}
+
+// VisitArbitrary prints an Arbitrary field type.
+func (m *modelPrinter) VisitArbitrary(a *proto.Arbitrary) {
+	m.Error = m.PrintField(a)
 }
 
 // VisitReference recurses inside the subtype, while collecting the description.

--- a/pkg/kubectl/explain/model_printer_test.go
+++ b/pkg/kubectl/explain/model_printer_test.go
@@ -124,7 +124,7 @@ DESCRIPTION:
 			path: []string{"field1", "array"},
 		},
 		{
-			want: `FIELD: arbitrary <anyType>
+			want: `FIELD:    arbitrary <anyType>
 
 DESCRIPTION:
      This can be a primitive, an object, or an array

--- a/pkg/kubectl/explain/model_printer_test.go
+++ b/pkg/kubectl/explain/model_printer_test.go
@@ -79,6 +79,9 @@ DESCRIPTION:
      This is another kind of Kind
 
 FIELDS:
+   arbitrary	<anyType>
+     This can be a primitive, an object, or an array
+
    array	<[]integer>
      This array must be an array of int
 
@@ -119,6 +122,14 @@ DESCRIPTION:
      This is an int in an array
 `,
 			path: []string{"field1", "array"},
+		},
+		{
+			want: `FIELD: arbitrary <anyType>
+
+DESCRIPTION:
+     This can be a primitive, an object, or an array
+`,
+			path: []string{"field1", "arbitrary"},
 		},
 	}
 

--- a/pkg/kubectl/explain/recursive_fields_printer.go
+++ b/pkg/kubectl/explain/recursive_fields_printer.go
@@ -62,6 +62,11 @@ func (f *recursiveFieldsPrinter) VisitPrimitive(p *proto.Primitive) {
 	// Nothing to do.
 }
 
+// VisitArbitrary does nothing, since sub-fields aren't defined in the schema.
+func (f *recursiveFieldsPrinter) VisitArbitrary(r *proto.Arbitrary) {
+	// Nothing to do.
+}
+
 // VisitReference is just a passthrough.
 func (f *recursiveFieldsPrinter) VisitReference(r proto.Reference) {
 	r.SubSchema().Accept(f)

--- a/pkg/kubectl/explain/recursive_fields_printer_test.go
+++ b/pkg/kubectl/explain/recursive_fields_printer_test.go
@@ -34,6 +34,7 @@ func TestRecursiveFields(t *testing.T) {
 	}
 
 	want := `field1	<Object>
+   arbitrary	<anyType>
    array	<[]integer>
    int	<integer>
    object	<map[string]string>

--- a/pkg/kubectl/explain/test-swagger.json
+++ b/pkg/kubectl/explain/test-swagger.json
@@ -69,6 +69,9 @@
             "type": "string"
           }
         },
+        "arbitrary": {
+          "description": "This can be a primitive, an object, or an array"
+        },
         "primitive": {
           "$ref": "#/definitions/PrimitiveDef"
         }

--- a/pkg/kubectl/explain/typename.go
+++ b/pkg/kubectl/explain/typename.go
@@ -53,6 +53,11 @@ func (t *typeName) VisitPrimitive(p *proto.Primitive) {
 	t.Name = p.Type
 }
 
+// VisitArbitrary simply returns "anyType"
+func (t *typeName) VisitArbitrary(schema *proto.Arbitrary) {
+	t.Name = "anyType"
+}
+
 // VisitReference is just a passthrough.
 func (t *typeName) VisitReference(r proto.Reference) {
 	r.SubSchema().Accept(t)

--- a/pkg/kubectl/explain/typename_test.go
+++ b/pkg/kubectl/explain/typename_test.go
@@ -70,6 +70,11 @@ func TestReferenceTypename(t *testing.T) {
 			path:     []string{"field1", "array"},
 			expected: "[]integer",
 		},
+		{
+			// Arbitrary value
+			path:     []string{"field1", "arbitrary"},
+			expected: "anyType",
+		},
 	}
 
 	for _, tt := range tests {

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/types.go
@@ -75,6 +75,7 @@ func (item *kindItem) VisitMap(schema *openapi.Map) {
 }
 
 func (item *kindItem) VisitArbitrary(schema *openapi.Arbitrary) {
+	item.err = errors.New("expected kind, but got arbitrary value")
 }
 
 func (item *kindItem) VisitReference(schema openapi.Reference) {
@@ -145,6 +146,7 @@ func (item *sliceItem) VisitMap(schema *openapi.Map) {
 }
 
 func (item *sliceItem) VisitArbitrary(schema *openapi.Arbitrary) {
+	item.err = errors.New("expected slice, but got arbitrary value")
 }
 
 func (item *sliceItem) VisitReference(schema openapi.Reference) {

--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/types.go
@@ -74,6 +74,9 @@ func (item *kindItem) VisitMap(schema *openapi.Map) {
 	item.err = errors.New("expected kind, but got map")
 }
 
+func (item *kindItem) VisitArbitrary(schema *openapi.Arbitrary) {
+}
+
 func (item *kindItem) VisitReference(schema openapi.Reference) {
 	if !item.hasVisitKind {
 		schema.SubSchema().Accept(item)
@@ -139,6 +142,9 @@ func (item *sliceItem) VisitArray(schema *openapi.Array) {
 
 func (item *sliceItem) VisitMap(schema *openapi.Map) {
 	item.err = errors.New("expected slice, but got map")
+}
+
+func (item *sliceItem) VisitArbitrary(schema *openapi.Arbitrary) {
 }
 
 func (item *sliceItem) VisitReference(schema openapi.Reference) {


### PR DESCRIPTION
**What this PR does / why we need it**:
SchemaVisitors now require an additional `VisitArbitrary` method, because of https://github.com/kubernetes/kube-openapi/pull/25

This PR adds implementations of said method to all SchemaVisitors

**Release note**:
```release-note
NONE
```

Fixes https://github.com/kubernetes/kubernetes/issues/57147