### PR TITLE
Kubelet status manager sync the status of local Pods

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -142,7 +142,15 @@ func (kl *Kubelet) getPodContainerDir(podUID types.UID, ctrName string) string {
 // GetPods returns all pods bound to the kubelet and their spec, and the mirror
 // pods.
 func (kl *Kubelet) GetPods() []*v1.Pod {
-	return kl.podManager.GetPods()
+	pods := kl.podManager.GetPods()
+	// a kubelet running without apiserver requires an additional
+	// update of the static pod status. See #57106
+	for _, p := range pods {
+		if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
+			p.Status = status
+		}
+	}
+	return pods
 }
 
 // GetRunningPods returns all pods running on kubelet from looking at the

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1359,18 +1359,15 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 		Status: v1.ConditionTrue,
 	})
 
-	if kl.kubeClient != nil {
-		hostIP, err := kl.getHostIPAnyWay()
-		if err != nil {
-			glog.V(4).Infof("Cannot get host IP: %v", err)
-		} else {
-			s.HostIP = hostIP.String()
-			if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
-				s.PodIP = hostIP.String()
-			}
-		}
+	hostIP, err := kl.getHostIPAnyWay()
+	if err != nil {
+		glog.V(4).Infof("Cannot get host IP: %v", err)
+		return *s
 	}
-
+	s.HostIP = hostIP.String()
+	if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
+		s.PodIP = hostIP.String()
+	}
 	return *s
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In the kubelet, when using `--pod-manifest-path` the kubelet creates static pods but doesn't update the status accordingly in the `PodList`.

This PR fixes the incorrect status of each Pod in the kubelet's `PodList`.

This is the setup used to reproduce the issue:

**manifest**:

```bash
cat ~/kube/staticpod.yaml
```

```yaml
apiVersion: v1
kind: Pod
metadata:
  labels:
    app: nginx
  name: nginx
  namespace: default
spec:
  hostNetwork: true
  containers:
  - name: nginx
    image: nginx:latest
    imagePullPolicy: IfNotPresent
    volumeMounts:
    - name: os-release
      mountPath: /usr/share/nginx/html/index.html
      readOnly: true

  volumes:
  - name: os-release
    hostPath:
      path: /etc/os-release
```


**kubelet**:

```bash
~/go/src/k8s.io/kubernetes/_output/bin/kubelet --pod-manifest-path ~/kube/ --cloud-provider="" --register-node --kubeconfig kubeconfig.yaml
```


You can observe this by querying the kubelet API `/pods`:

```bash
curl -s 127.0.0.1:10255/pods | jq .
```

```json
{
  "kind": "PodList",
  "apiVersion": "v1",
  "metadata": {},
  "items": [
    {
      "metadata": {
        "name": "nginx-nodeName",
        "namespace": "default",
        "selfLink": "/api/v1/namespaces/default/pods/nginx-nodeName",
        "uid": "0fdfa64c73d9de39a9e5c05ef7967e72",
        "creationTimestamp": null,
        "labels": {
          "app": "nginx"
        },
        "annotations": {
          "kubernetes.io/config.hash": "0fdfa64c73d9de39a9e5c05ef7967e72",
          "kubernetes.io/config.seen": "2017-12-12T18:42:46.088157195+01:00",
          "kubernetes.io/config.source": "file"
        }
      },
      "spec": {
        "volumes": [
          {
            "name": "os-release",
            "hostPath": {
              "path": "/etc/os-release",
              "type": ""
            }
          }
        ],
        "containers": [
          {
            "name": "nginx",
            "image": "nginx:latest",
            "resources": {},
            "volumeMounts": [
              {
                "name": "os-release",
                "readOnly": true,
                "mountPath": "/usr/share/nginx/html/index.html"
              }
            ],
            "terminationMessagePath": "/dev/termination-log",
            "terminationMessagePolicy": "File",
            "imagePullPolicy": "IfNotPresent"
          }
        ],
        "restartPolicy": "Always",
        "terminationGracePeriodSeconds": 30,
        "dnsPolicy": "ClusterFirst",
        "nodeName": "nodeName",
        "hostNetwork": true,
        "securityContext": {},
        "schedulerName": "default-scheduler",
        "tolerations": [
          {
            "operator": "Exists",
            "effect": "NoExecute"
          }
        ]
      },
      "status": {
        "phase": "Pending",
        "conditions": [
          {
            "type": "PodScheduled",
            "status": "True",
            "lastProbeTime": null,
            "lastTransitionTime": "2017-12-12T17:42:51Z"
          }
        ]
      }
    }
  ]
}
```

The status of the nginx `Pod` will remain in **Pending** state phase.

```bash
curl -I 127.0.0.1
HTTP/1.1 200 OK
```

It's reported as expected on the apiserver side:

```bash
kubectl get po --all-namespaces -w

NAMESPACE   NAME                    READY     STATUS    RESTARTS   AGE
default     nginx-nodeName   0/1       Pending   0          0s
default     nginx-nodeName   1/1       Running   0          2s
```


It doesn't work either with a standalone kubelet:

```bash
~/go/src/k8s.io/kubernetes/_output/bin/kubelet --pod-manifest-path ~/kube/ --cloud-provider="" --register-node false
```

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
