### PR TITLE
Check ns setup error during e2e

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -378,7 +378,7 @@ func (f *Framework) CreateNamespace(baseName string, labels map[string]string) (
 		f.namespacesToDelete = append(f.namespacesToDelete, ns)
 	}
 
-	if !f.SkipPrivilegedPSPBinding {
+	if err == nil && !f.SkipPrivilegedPSPBinding {
 		CreatePrivilegedPSPBinding(f, ns.Name)
 	}
 


### PR DESCRIPTION
If namespace create fails during e2e setup, don't panic

/assign @tallclair 

```release-note
NONE
```