### PR TITLE
make kube-dns addon optional

### DIFF
--- a/cluster/juju/layers/kubernetes-master/config.yaml
+++ b/cluster/juju/layers/kubernetes-master/config.yaml
@@ -3,6 +3,10 @@ options:
     type: boolean
     default: True
     description: Deploy the Kubernetes Dashboard and Heapster addons
+  enable-kube-dns:
+    type: boolean
+    default: True
+    description: Deploy kube-dns addon
   dns_domain:
     type: string
     default: cluster.local

--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -518,7 +518,6 @@ def configure_kubelet(dns):
     kubelet_opts['v'] = '0'
     kubelet_opts['address'] = '0.0.0.0'
     kubelet_opts['port'] = '10250'
-    kubelet_opts['cluster-dns'] = dns['sdn-ip']
     kubelet_opts['cluster-domain'] = dns['domain']
     kubelet_opts['anonymous-auth'] = 'false'
     kubelet_opts['client-ca-file'] = ca_cert_path
@@ -526,6 +525,9 @@ def configure_kubelet(dns):
     kubelet_opts['tls-private-key-file'] = server_key_path
     kubelet_opts['logtostderr'] = 'true'
     kubelet_opts['fail-swap-on'] = 'false'
+
+    if (dns['enable-kube-dns']):
+        kubelet_opts['cluster-dns'] = dns['sdn-ip']
 
     privileged = is_state('kubernetes-worker.privileged')
     kubelet_opts['allow-privileged'] = 'true' if privileged else 'false'


### PR DESCRIPTION
**What this PR does / why we need it**: Makes the kube-dns addon optional so that users can deploy their own DNS solution.

**Release note**:
```release-note
Makes the kube-dns addon optional so that users can deploy their own DNS solution.
```
