### PR TITLE
add note prior to interactive confirm of kubeadm upgrade apply

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/apply.go
+++ b/cmd/kubeadm/app/cmd/upgrade/apply.go
@@ -153,6 +153,8 @@ func RunApply(flags *applyFlags) error {
 
 	// If the current session is interactive, ask the user whether they really want to upgrade
 	if flags.SessionIsInteractive() {
+		fmt.Println("[upgrade/note] If you wish to diff the manifests postupgrade, cp -r /etc/kubernetes/ to a different location.")
+		fmt.Println("")
 		if err := InteractivelyConfirmUpgrade("Are you sure you want to proceed with the upgrade?"); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
informs users when running `kubeadm upgrade apply` in interactive mode to first copy the existing config files in the event they are wanting to diff the changes between versions

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/489

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
