### PR TITLE
gce/upgrade.sh: Prompt if etcd version is unspecified.

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -78,6 +78,10 @@ func masterUpgradeGCE(rawV string, enableKubeProxyDaemonSet bool) error {
 			"TEST_ETCD_VERSION="+TestContext.EtcdUpgradeVersion,
 			"STORAGE_BACKEND="+TestContext.EtcdUpgradeStorage,
 			"TEST_ETCD_IMAGE=3.1.10")
+	} else {
+		// In e2e tests, we skip the confirmation prompt about
+		// implicit etcd upgrades to simulate the user entering "y".
+		env = append(env, "TEST_ALLOW_IMPLICIT_ETCD_UPGRADE=true")
 	}
 
 	v := "v" + rawV


### PR DESCRIPTION
We shouldn't upgrade etcd without first warning the user that some etcd
version transitions can't be undone. We don't know what version the user
currently has, so we require either an explicit version and image, or an
interactive acknowledgement of this caveat.

This is modeled after the STORAGE_MEDIA_TYPE prompt just above.

@BenTheElder @krousey @wojtek-t If we do this, it would probably require all upgrade jobs to explicitly specify the etcd version, or otherwise add some variable to bypass this check. That's unfortunate coupling, but I think we need this or something like it to protect users. What do you think?

Fixes #57013

/hold
until we decide how to fix upgrade/downgrade e2e tests to account for this.

```release-note
NONE
```