### PR TITLE
fix some k8s tool help information can't be used by grep command 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flag/flags.go
@@ -18,6 +18,7 @@ package flag
 
 import (
 	goflag "flag"
+	"os"
 	"strings"
 
 	"github.com/golang/glog"
@@ -47,6 +48,7 @@ func WarnWordSepNormalizeFunc(f *pflag.FlagSet, name string) pflag.NormalizedNam
 func InitFlags() {
 	pflag.CommandLine.SetNormalizeFunc(WordSepNormalizeFunc)
 	pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
+	pflag.CommandLine.SetOutput(os.Stdout)
 	pflag.Parse()
 	pflag.VisitAll(func(flag *pflag.Flag) {
 		glog.V(2).Infof("FLAG: --%s=%q", flag.Name, flag.Value)


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Before this patch, some of tools(kube-controller-manager,kubelet,kube-apiserver) can't use pipe to grep help information.

`Example: kubelet --help|grep default`

It doesn't work.This patch fix this.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
