### PR TITLE
Take node into consideration when generating hash for static pod

### DIFF
--- a/pkg/kubelet/config/common_test.go
+++ b/pkg/kubelet/config/common_test.go
@@ -254,7 +254,6 @@ func TestStaticPodNameGenerate(t *testing.T) {
 func TestApplyDefaults(t *testing.T) {
 	staticpod1 := staticPod{
 		nodeName: "nodefoo",
-		source:   "/etc/kubernetes/manifests",
 		pod: &api.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "podfoo",
@@ -273,7 +272,6 @@ func TestApplyDefaults(t *testing.T) {
 	// staticpod2 has the same spec but is on another node
 	staticpod2 := staticPod{
 		nodeName: "nodebar",
-		source:   "/etc/kubernetes/manifests",
 		pod: &api.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "podfoo",
@@ -289,13 +287,13 @@ func TestApplyDefaults(t *testing.T) {
 		},
 	}
 
-	err := applyDefaults(staticpod1.pod, staticpod1.source, true, staticpod1.nodeName)
+	err := applyDefaults(staticpod1.pod, "/etc/kubernetes/manifests", true, staticpod1.nodeName)
 	if err != nil {
 		t.Errorf("applyDefaults error: %v", err)
 	}
 	uid1 := staticpod1.pod.UID
 
-	err = applyDefaults(staticpod1.pod, staticpod1.source, true, staticpod1.nodeName)
+	err = applyDefaults(staticpod1.pod, "/etc/kubernetes/manifests", true, staticpod1.nodeName)
 	if err != nil {
 		t.Errorf("applyDefaults error: %v", err)
 	}
@@ -303,7 +301,7 @@ func TestApplyDefaults(t *testing.T) {
 		t.Error("applyDefaults error: the same pod shouldn't change UID")
 	}
 
-	err = applyDefaults(staticpod2.pod, staticpod2.source, true, staticpod2.nodeName)
+	err = applyDefaults(staticpod2.pod, "/etc/kubernetes/manifests", true, staticpod2.nodeName)
 	if err != nil {
 		t.Errorf("applyDefaults error: %v", err)
 	}

--- a/pkg/kubelet/pod/mirror_client.go
+++ b/pkg/kubelet/pod/mirror_client.go
@@ -109,3 +109,7 @@ func getPodHash(pod *v1.Pod) string {
 	// The annotation exists for all static pods.
 	return pod.Annotations[kubetypes.ConfigHashAnnotationKey]
 }
+
+func getPodLegacyHash(pod *v1.Pod) string {
+	return pod.Annotations[kubetypes.ConfigLegacyHashAnnotationKey]
+}

--- a/pkg/kubelet/pod/pod_manager.go
+++ b/pkg/kubelet/pod/pod_manager.go
@@ -330,7 +330,10 @@ func (pm *basicManager) IsMirrorPodOf(mirrorPod, pod *v1.Pod) bool {
 	if !ok {
 		return false
 	}
-	return hash == getPodHash(pod)
+	if hash == getPodHash(pod) {
+		return true
+	}
+	return hash == getPodLegacyHash(pod)
 }
 
 func podsMapToPods(UIDMap map[kubetypes.ResolvedPodUID]*v1.Pod) []*v1.Pod {

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -26,11 +26,12 @@ import (
 )
 
 const (
-	ConfigSourceAnnotationKey    = "kubernetes.io/config.source"
-	ConfigMirrorAnnotationKey    = v1.MirrorPodAnnotationKey
-	ConfigFirstSeenAnnotationKey = "kubernetes.io/config.seen"
-	ConfigHashAnnotationKey      = "kubernetes.io/config.hash"
-	CriticalPodAnnotationKey     = "scheduler.alpha.kubernetes.io/critical-pod"
+	ConfigSourceAnnotationKey     = "kubernetes.io/config.source"
+	ConfigMirrorAnnotationKey     = v1.MirrorPodAnnotationKey
+	ConfigFirstSeenAnnotationKey  = "kubernetes.io/config.seen"
+	ConfigHashAnnotationKey       = "kubernetes.io/config.hash"
+	ConfigLegacyHashAnnotationKey = "kubernetes.io/config.legacyhash"
+	CriticalPodAnnotationKey      = "scheduler.alpha.kubernetes.io/critical-pod"
 )
 
 // PodOperation defines what changes will be made on a pod configuration.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Static pods with the same spec on different nodes may have the same config.hash.
For more details, see: https://github.com/weaveworks/scope/issues/2931
Forwarded by @luxas . This also hits kubeadm.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/weaveworks/scope/issues/2931

**Special notes for your reviewer**:
/cc @luxas @rade @kubernetes/sig-node-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required: WARNING: static pods hash will change after the kubelet in-place upgrading. This will cause these pods restart.
```
