### PR TITLE
client-gen: remove base input dirs

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -27,12 +27,7 @@ import (
 	codegenutil "k8s.io/code-generator/pkg/util"
 )
 
-var DefaultInputDirs = []string{
-	"k8s.io/apimachinery/pkg/fields",
-	"k8s.io/apimachinery/pkg/labels",
-	"k8s.io/apimachinery/pkg/watch",
-	"k8s.io/apimachinery/pkg/apimachinery/registered",
-}
+var DefaultInputDirs = []string{}
 
 // ClientGenArgs is a wrapper for arguments to client-gen.
 type CustomArgs struct {


### PR DESCRIPTION
Were these dirs some kind of cargo cult? Removing them causes no change to the generated code.

Background: having those packages in the list of input dirs makes them mandatory to exist. If people use code-gen on a project that does not vendor them (due to vendor/ pruning), code-gen fails.

Fixes https://github.com/kubernetes/sample-controller/issues/8