### PR TITLE
make quota reusable

### DIFF
--- a/pkg/controller/resourcequota/resource_quota_controller.go
+++ b/pkg/controller/resourcequota/resource_quota_controller.go
@@ -148,28 +148,31 @@ func NewResourceQuotaController(options *ResourceQuotaControllerOptions) (*Resou
 		rq.resyncPeriod(),
 	)
 
-	qm := &QuotaMonitor{
-		informersStarted:  options.InformersStarted,
-		informerFactory:   options.InformerFactory,
-		ignoredResources:  options.IgnoredResourcesFunc(),
-		resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
-		resyncPeriod:      options.ReplenishmentResyncPeriod,
-		replenishmentFunc: rq.replenishQuota,
-		registry:          rq.registry,
-	}
-	rq.quotaMonitor = qm
+	if options.DiscoveryFunc != nil {
+		qm := &QuotaMonitor{
+			informersStarted:  options.InformersStarted,
+			informerFactory:   options.InformerFactory,
+			ignoredResources:  options.IgnoredResourcesFunc(),
+			resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
+			resyncPeriod:      options.ReplenishmentResyncPeriod,
+			replenishmentFunc: rq.replenishQuota,
+			registry:          rq.registry,
+		}
 
-	// do initial quota monitor setup
-	resources, err := GetQuotableResources(options.DiscoveryFunc)
-	if err != nil {
-		return nil, err
-	}
-	if err = qm.syncMonitors(resources); err != nil {
-		utilruntime.HandleError(fmt.Errorf("initial monitor sync has error: %v", err))
-	}
+		rq.quotaMonitor = qm
 
-	// only start quota once all informers synced
-	rq.informerSyncedFuncs = append(rq.informerSyncedFuncs, qm.IsSynced)
+		// do initial quota monitor setup
+		resources, err := GetQuotableResources(options.DiscoveryFunc)
+		if err != nil {
+			return nil, err
+		}
+		if err = qm.SyncMonitors(resources); err != nil {
+			utilruntime.HandleError(fmt.Errorf("initial monitor sync has error: %v", err))
+		}
+
+		// only start quota once all informers synced
+		rq.informerSyncedFuncs = append(rq.informerSyncedFuncs, qm.IsSynced)
+	}
 
 	return rq, nil
 }
@@ -274,7 +277,9 @@ func (rq *ResourceQuotaController) Run(workers int, stopCh <-chan struct{}) {
 	glog.Infof("Starting resource quota controller")
 	defer glog.Infof("Shutting down resource quota controller")
 
-	go rq.quotaMonitor.Run(stopCh)
+	if rq.quotaMonitor != nil {
+		go rq.quotaMonitor.Run(stopCh)
+	}
 
 	if !controller.WaitForCacheSync("resource quota", stopCh, rq.informerSyncedFuncs...) {
 		return
@@ -446,7 +451,7 @@ func (rq *ResourceQuotaController) Sync(discoveryFunc NamespacedResourcesFunc, p
 			utilruntime.HandleError(fmt.Errorf("failed to sync resource monitors: %v", err))
 			return
 		}
-		if !controller.WaitForCacheSync("resource quota", stopCh, rq.quotaMonitor.IsSynced) {
+		if rq.quotaMonitor != nil && !controller.WaitForCacheSync("resource quota", stopCh, rq.quotaMonitor.IsSynced) {
 			utilruntime.HandleError(fmt.Errorf("timed out waiting for quota monitor sync"))
 		}
 	}, period, stopCh)
@@ -455,10 +460,14 @@ func (rq *ResourceQuotaController) Sync(discoveryFunc NamespacedResourcesFunc, p
 // resyncMonitors starts or stops quota monitors as needed to ensure that all
 // (and only) those resources present in the map are monitored.
 func (rq *ResourceQuotaController) resyncMonitors(resources map[schema.GroupVersionResource]struct{}) error {
-	if err := rq.quotaMonitor.syncMonitors(resources); err != nil {
+	if rq.quotaMonitor == nil {
+		return nil
+	}
+
+	if err := rq.quotaMonitor.SyncMonitors(resources); err != nil {
 		return err
 	}
-	rq.quotaMonitor.startMonitors()
+	rq.quotaMonitor.StartMonitors()
 	return nil
 }
 

--- a/pkg/controller/resourcequota/resource_quota_monitor.go
+++ b/pkg/controller/resourcequota/resource_quota_monitor.go
@@ -100,6 +100,18 @@ type QuotaMonitor struct {
 	registry quota.Registry
 }
 
+func NewQuotaMonitor(informersStarted <-chan struct{}, informerFactory InformerFactory, ignoredResources map[schema.GroupResource]struct{}, resyncPeriod controller.ResyncPeriodFunc, replenishmentFunc ReplenishmentFunc, registry quota.Registry) *QuotaMonitor {
+	return &QuotaMonitor{
+		informersStarted:  informersStarted,
+		informerFactory:   informerFactory,
+		ignoredResources:  ignoredResources,
+		resourceChanges:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "resource_quota_controller_resource_changes"),
+		resyncPeriod:      resyncPeriod,
+		replenishmentFunc: replenishmentFunc,
+		registry:          registry,
+	}
+}
+
 // monitor runs a Controller with a local stop channel.
 type monitor struct {
 	controller cache.Controller
@@ -171,13 +183,13 @@ func (qm *QuotaMonitor) controllerFor(resource schema.GroupVersionResource) (cac
 	return nil, fmt.Errorf("unable to monitor quota for resource %q", resource.String())
 }
 
-// syncMonitors rebuilds the monitor set according to the supplied resources,
+// SyncMonitors rebuilds the monitor set according to the supplied resources,
 // creating or deleting monitors as necessary. It will return any error
 // encountered, but will make an attempt to create a monitor for each resource
 // instead of immediately exiting on an error. It may be called before or after
 // Run. Monitors are NOT started as part of the sync. To ensure all existing
-// monitors are started, call startMonitors.
-func (qm *QuotaMonitor) syncMonitors(resources map[schema.GroupVersionResource]struct{}) error {
+// monitors are started, call StartMonitors.
+func (qm *QuotaMonitor) SyncMonitors(resources map[schema.GroupVersionResource]struct{}) error {
 	qm.monitorLock.Lock()
 	defer qm.monitorLock.Unlock()
 
@@ -232,12 +244,12 @@ func (qm *QuotaMonitor) syncMonitors(resources map[schema.GroupVersionResource]s
 	return utilerrors.NewAggregate(errs)
 }
 
-// startMonitors ensures the current set of monitors are running. Any newly
+// StartMonitors ensures the current set of monitors are running. Any newly
 // started monitors will also cause shared informers to be started.
 //
-// If called before Run, startMonitors does nothing (as there is no stop channel
+// If called before Run, StartMonitors does nothing (as there is no stop channel
 // to support monitor/informer execution).
-func (qm *QuotaMonitor) startMonitors() {
+func (qm *QuotaMonitor) StartMonitors() {
 	qm.monitorLock.Lock()
 	defer qm.monitorLock.Unlock()
 
@@ -295,7 +307,7 @@ func (qm *QuotaMonitor) Run(stopCh <-chan struct{}) {
 
 	// Start monitors and begin change processing until the stop channel is
 	// closed.
-	qm.startMonitors()
+	qm.StartMonitors()
 	wait.Until(qm.runProcessResourceChanges, 1*time.Second, stopCh)
 
 	// Stop any running monitors.

--- a/plugin/pkg/admission/resourcequota/BUILD
+++ b/plugin/pkg/admission/resourcequota/BUILD
@@ -59,6 +59,7 @@ go_test(
         "//pkg/client/clientset_generated/internalclientset/fake:go_default_library",
         "//pkg/client/informers/informers_generated/internalversion:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/quota/generic:go_default_library",
         "//pkg/quota/install:go_default_library",
         "//plugin/pkg/admission/resourcequota/apis/resourcequota:go_default_library",
         "//vendor/github.com/hashicorp/golang-lru:go_default_library",

--- a/plugin/pkg/admission/resourcequota/admission.go
+++ b/plugin/pkg/admission/resourcequota/admission.go
@@ -27,6 +27,7 @@ import (
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	kubeapiserveradmission "k8s.io/kubernetes/pkg/kubeapiserver/admission"
 	"k8s.io/kubernetes/pkg/quota"
+	"k8s.io/kubernetes/pkg/quota/generic"
 	resourcequotaapi "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota"
 	resourcequotaapiv1alpha1 "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/v1alpha1"
 	"k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota/validation"
@@ -103,7 +104,7 @@ func (a *QuotaAdmission) SetInternalKubeInformerFactory(f informers.SharedInform
 
 func (a *QuotaAdmission) SetQuotaConfiguration(c quota.Configuration) {
 	a.quotaConfiguration = c
-	a.evaluator = NewQuotaEvaluator(a.quotaAccessor, a.quotaConfiguration, nil, a.config, a.numEvaluators, a.stopCh)
+	a.evaluator = NewQuotaEvaluator(a.quotaAccessor, a.quotaConfiguration.IgnoredResources(), generic.NewRegistry(a.quotaConfiguration.Evaluators()), nil, a.config, a.numEvaluators, a.stopCh)
 }
 
 // ValidateInitialization ensures an authorizer is set.

--- a/plugin/pkg/admission/resourcequota/admission_test.go
+++ b/plugin/pkg/admission/resourcequota/admission_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset/fake"
 	informers "k8s.io/kubernetes/pkg/client/informers/informers_generated/internalversion"
 	"k8s.io/kubernetes/pkg/controller"
+	"k8s.io/kubernetes/pkg/quota/generic"
 	"k8s.io/kubernetes/pkg/quota/install"
 	resourcequotaapi "k8s.io/kubernetes/plugin/pkg/admission/resourcequota/apis/resourcequota"
 )
@@ -133,7 +134,7 @@ func TestAdmissionIgnoresDelete(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -169,7 +170,7 @@ func TestAdmissionIgnoresSubresources(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -214,7 +215,7 @@ func TestAdmitBelowQuotaLimit(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -298,7 +299,7 @@ func TestAdmitHandlesOldObjects(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -405,7 +406,7 @@ func TestAdmitHandlesNegativePVCUpdates(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -472,7 +473,7 @@ func TestAdmitHandlesPVCUpdates(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -571,7 +572,7 @@ func TestAdmitHandlesCreatingUpdates(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -666,7 +667,7 @@ func TestAdmitExceedQuotaLimit(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -711,7 +712,7 @@ func TestAdmitEnforceQuotaConstraints(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -766,7 +767,7 @@ func TestAdmitPodInNamespaceWithoutQuota(t *testing.T) {
 	quotaAccessor.liveLookupCache = liveLookupCache
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -833,7 +834,7 @@ func TestAdmitBelowTerminatingQuotaLimit(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -939,7 +940,7 @@ func TestAdmitBelowBestEffortQuotaLimit(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1032,7 +1033,7 @@ func TestAdmitBestEffortQuotaLimitIgnoresBurstable(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1118,7 +1119,7 @@ func TestAdmissionSetsMissingNamespace(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1164,7 +1165,7 @@ func TestAdmitRejectsNegativeUsage(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1211,7 +1212,7 @@ func TestAdmitWhenUnrelatedResourceExceedsQuota(t *testing.T) {
 	quotaAccessor.lister = informerFactory.Core().InternalVersion().ResourceQuotas().Lister()
 	config := &resourcequotaapi.Configuration{}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1248,7 +1249,7 @@ func TestAdmitLimitedResourceNoQuota(t *testing.T) {
 		},
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1282,7 +1283,7 @@ func TestAdmitLimitedResourceNoQuotaIgnoresNonMatchingResources(t *testing.T) {
 		},
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1329,7 +1330,7 @@ func TestAdmitLimitedResourceWithQuota(t *testing.T) {
 		},
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1388,7 +1389,7 @@ func TestAdmitLimitedResourceWithMultipleQuota(t *testing.T) {
 		},
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),
@@ -1437,7 +1438,7 @@ func TestAdmitLimitedResourceWithQuotaThatDoesNotCover(t *testing.T) {
 		},
 	}
 	quotaConfiguration := install.NewQuotaConfigurationForAdmission()
-	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration, nil, config, 5, stopCh)
+	evaluator := NewQuotaEvaluator(quotaAccessor, quotaConfiguration.IgnoredResources(), generic.NewRegistry(quotaConfiguration.Evaluators()), nil, config, 5, stopCh)
 
 	handler := &QuotaAdmission{
 		Handler:   admission.NewHandler(admission.Create, admission.Update),

--- a/plugin/pkg/admission/resourcequota/controller.go
+++ b/plugin/pkg/admission/resourcequota/controller.go
@@ -52,8 +52,7 @@ type quotaEvaluator struct {
 	// lockAcquisitionFunc acquires any required locks and returns a cleanup method to defer
 	lockAcquisitionFunc func([]api.ResourceQuota) func()
 
-	// how quota was configured
-	quotaConfiguration quota.Configuration
+	ignoredResources map[schema.GroupResource]struct{}
 
 	// registry that knows how to measure usage for objects
 	registry quota.Registry
@@ -110,7 +109,7 @@ func newAdmissionWaiter(a admission.Attributes) *admissionWaiter {
 // NewQuotaEvaluator configures an admission controller that can enforce quota constraints
 // using the provided registry.  The registry must have the capability to handle group/kinds that
 // are persisted by the server this admission controller is intercepting
-func NewQuotaEvaluator(quotaAccessor QuotaAccessor, quotaConfiguration quota.Configuration, lockAcquisitionFunc func([]api.ResourceQuota) func(), config *resourcequotaapi.Configuration, workers int, stopCh <-chan struct{}) Evaluator {
+func NewQuotaEvaluator(quotaAccessor QuotaAccessor, ignoredResources map[schema.GroupResource]struct{}, quotaRegistry quota.Registry, lockAcquisitionFunc func([]api.ResourceQuota) func(), config *resourcequotaapi.Configuration, workers int, stopCh <-chan struct{}) Evaluator {
 	// if we get a nil config, just create an empty default.
 	if config == nil {
 		config = &resourcequotaapi.Configuration{}
@@ -120,8 +119,8 @@ func NewQuotaEvaluator(quotaAccessor QuotaAccessor, quotaConfiguration quota.Con
 		quotaAccessor:       quotaAccessor,
 		lockAcquisitionFunc: lockAcquisitionFunc,
 
-		quotaConfiguration: quotaConfiguration,
-		registry:           generic.NewRegistry(quotaConfiguration.Evaluators()),
+		ignoredResources: ignoredResources,
+		registry:         quotaRegistry,
 
 		queue:      workqueue.NewNamed("admission_quota_controller"),
 		work:       map[string][]*admissionWaiter{},
@@ -524,7 +523,7 @@ func (e *quotaEvaluator) Evaluate(a admission.Attributes) error {
 	// is this resource ignored?
 	gvr := a.GetResource()
 	gr := gvr.GroupResource()
-	if _, ok := e.quotaConfiguration.IgnoredResources()[gr]; ok {
+	if _, ok := e.ignoredResources[gr]; ok {
 		return nil
 	}
 


### PR DESCRIPTION
Quota is logically a re-useable component so that replenishment and admission can be done in constituent servers.  This makes it possible to embed.  More cleanup is probably required, but this is the minimum.