### PR TITLE
#57162 upgrade resyncCheck period even when default is 0

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -307,8 +307,10 @@ func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEv
 
 		if resyncPeriod < s.resyncCheckPeriod || s.resyncCheckPeriod == 0 {
 			if s.started {
-				glog.Warningf("resyncPeriod %d is smaller than resyncCheckPeriod %d and the informer has already started. Changing it to %d", resyncPeriod, s.resyncCheckPeriod, s.resyncCheckPeriod)
-				resyncPeriod = s.resyncCheckPeriod
+				if s.resyncCheckPeriod != 0 {
+					glog.Warningf("resyncPeriod %d is smaller than resyncCheckPeriod %d and the informer has already started. Changing it to %d", resyncPeriod, s.resyncCheckPeriod, s.resyncCheckPeriod)
+					resyncPeriod = s.resyncCheckPeriod
+				}
 			} else {
 				// if the event handler's resyncPeriod is smaller than the current resyncCheckPeriod, update
 				// resyncCheckPeriod to match resyncPeriod and adjust the resync periods of all the listeners

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -305,7 +305,7 @@ func (s *sharedIndexInformer) AddEventHandlerWithResyncPeriod(handler ResourceEv
 			resyncPeriod = minimumResyncPeriod
 		}
 
-		if resyncPeriod < s.resyncCheckPeriod {
+		if resyncPeriod < s.resyncCheckPeriod || s.resyncCheckPeriod == 0 {
 			if s.started {
 				glog.Warningf("resyncPeriod %d is smaller than resyncCheckPeriod %d and the informer has already started. Changing it to %d", resyncPeriod, s.resyncCheckPeriod, s.resyncCheckPeriod)
 				resyncPeriod = s.resyncCheckPeriod

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -257,7 +257,7 @@ func TestUpgradeResyncCheckPeriod(t *testing.T) {
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
 	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}})
 
-	// create the shared informer and resync every 1s
+	// create the shared informer with no default resync period
 	informer := NewSharedInformer(source, &v1.Pod{}, 0).(*sharedIndexInformer)
 
 	clock := clock.NewFakeClock(time.Now())
@@ -276,20 +276,6 @@ func TestUpgradeResyncCheckPeriod(t *testing.T) {
 		t.Errorf("expected %d, got %d", e, a)
 	}
 
-	/*
-		if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
-			t.Errorf("expected %d, got %d", e, a)
-		}
-		if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
-			t.Errorf("expected %d, got %d", e, a)
-		}
-		if e, a := 55*time.Second, informer.processor.listeners[2].resyncPeriod; e != a {
-			t.Errorf("expected %d, got %d", e, a)
-		}
-		if e, a := 5*time.Second, informer.processor.listeners[3].resyncPeriod; e != a {
-			t.Errorf("expected %d, got %d", e, a)
-		}
-	*/
 	listeners := []*testListener{listener1, listener2}
 
 	stop := make(chan struct{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds support to upgrade an informer resyncCheckPeriod if default is 0 and handler adds a refreshPeriod.

**Which issue(s) this PR fixes**:
Fixes #57162

**Special notes for your reviewer**:

**Release note**:

```NONE```
