### PR TITLE
Psp metrics

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/BUILD
+++ b/plugin/pkg/admission/security/podsecuritypolicy/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission/metrics:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
     ],

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission_test.go
@@ -49,13 +49,10 @@ const defaultContainerName = "test-c"
 // NewTestAdmission provides an admission plugin with test implementations of internal structs.  It uses
 // an authorizer that always returns true.
 func NewTestAdmission(lister extensionslisters.PodSecurityPolicyLister) kadmission.Interface {
-	return &podSecurityPolicyPlugin{
-		Handler:         kadmission.NewHandler(kadmission.Create, kadmission.Update),
-		strategyFactory: kpsp.NewSimpleStrategyFactory(),
-		pspMatcher:      getMatchingPolicies,
-		authz:           &TestAuthorizer{},
-		lister:          lister,
-	}
+	plugin := NewPlugin(kpsp.NewSimpleStrategyFactory(), getMatchingPolicies, false)
+	plugin.SetAuthorizer(&TestAuthorizer{})
+	plugin.lister = lister
+	return plugin
 }
 
 // TestAlwaysAllowedAuthorizer is a testing struct for testing that fulfills the authorizer interface.

--- a/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
+++ b/staging/src/k8s.io/apiextensions-apiserver/Godeps/Godeps.json
@@ -847,6 +847,10 @@
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},
 		{
+			"ImportPath": "k8s.io/apiserver/pkg/admission/metrics",
+			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+		},
+		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle",
 			"Rev": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 		},

--- a/staging/src/k8s.io/apiserver/pkg/admission/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/BUILD
@@ -63,6 +63,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/admission/metrics:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle:all-srcs",
     ],
     tags = ["automanaged"],

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/BUILD
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "k8s.io/apiserver/pkg/admission/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "metrics_test.go",
+        "testutil_test.go",
+    ],
+    importpath = "k8s.io/apiserver/pkg/admission/metrics",
+    library = ":go_default_library",
+    deps = [
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/admission:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	namespace = "apiserver"
+	subsystem = "admission"
+)
+
+var (
+	latencyBuckets       = prometheus.ExponentialBuckets(25000, 2.0, 7)
+	latencySummaryMaxAge = 5 * time.Hour
+
+	// Metrics provides access to all admission metrics.
+	Metrics = newAdmissionMetrics()
+)
+
+// ObserverFunc is a func that emits metrics.
+type ObserverFunc func(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string)
+
+const (
+	stepValidate = "validate"
+	stepAdmit    = "admit"
+)
+
+// WithControllerMetrics is a decorator for named admission handlers.
+func WithControllerMetrics(i admission.Interface, name string) admission.Interface {
+	return WithMetrics(i, Metrics.ObserveAdmissionController, name)
+}
+
+// WithStepMetrics is a decorator for a whole admission phase, i.e. admit or validation.admission step.
+func WithStepMetrics(i admission.Interface) admission.Interface {
+	return WithMetrics(i, Metrics.ObserveAdmissionStep)
+}
+
+// WithMetrics is a decorator for admission handlers with a generic observer func.
+func WithMetrics(i admission.Interface, observer ObserverFunc, extraLabels ...string) admission.Interface {
+	return &pluginHandlerWithMetrics{
+		Interface:   i,
+		observer:    observer,
+		extraLabels: extraLabels,
+	}
+}
+
+// pluginHandlerWithMetrics decorates a admission handler with metrics.
+type pluginHandlerWithMetrics struct {
+	admission.Interface
+	observer    ObserverFunc
+	extraLabels []string
+}
+
+// Admit performs a mutating admission control check and emit metrics.
+func (p pluginHandlerWithMetrics) Admit(a admission.Attributes) error {
+	mutatingHandler, ok := p.Interface.(admission.MutationInterface)
+	if !ok {
+		return nil
+	}
+
+	start := time.Now()
+	err := mutatingHandler.Admit(a)
+	p.observer(time.Since(start), err != nil, a, stepAdmit, p.extraLabels...)
+	return err
+}
+
+// Validate performs a non-mutating admission control check and emits metrics.
+func (p pluginHandlerWithMetrics) Validate(a admission.Attributes) error {
+	validatingHandler, ok := p.Interface.(admission.ValidationInterface)
+	if !ok {
+		return nil
+	}
+
+	start := time.Now()
+	err := validatingHandler.Validate(a)
+	p.observer(time.Since(start), err != nil, a, stepValidate, p.extraLabels...)
+	return err
+}
+
+// AdmissionMetrics instruments admission with prometheus metrics.
+type AdmissionMetrics struct {
+	step       *metricSet
+	controller *metricSet
+	webhook    *metricSet
+}
+
+// newAdmissionMetrics create a new AdmissionMetrics, configured with default metric names.
+func newAdmissionMetrics() *AdmissionMetrics {
+	// Admission metrics for a step of the admission flow. The entire admission flow is broken down into a series of steps
+	// Each step is identified by a distinct type label value.
+	step := newMetricSet("step",
+		[]string{"type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		"Admission sub-step %s, broken out for each operation and API resource and step type (validate or admit).")
+
+	// Built-in admission controller metrics. Each admission controller is identified by name.
+	controller := newMetricSet("controller",
+		[]string{"name", "type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		"Admission controller %s, identified by name and broken out for each operation and API resource and type (validate or admit).")
+
+	// Admission webhook metrics. Each webhook is identified by name.
+	webhook := newMetricSet("webhook",
+		[]string{"name", "type", "operation", "group", "version", "resource", "subresource", "rejected"},
+		"Admission webhook %s, identified by name and broken out for each operation and API resource and type (validate or admit).")
+
+	step.mustRegister()
+	controller.mustRegister()
+	webhook.mustRegister()
+	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook}
+}
+
+func (m *AdmissionMetrics) reset() {
+	m.step.reset()
+	m.controller.reset()
+	m.webhook.reset()
+}
+
+// ObserveAdmissionStep records admission related metrics for a admission step, identified by step type.
+func (m *AdmissionMetrics) ObserveAdmissionStep(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
+	gvr := attr.GetResource()
+	m.step.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+}
+
+// ObserveAdmissionController records admission related metrics for a built-in admission controller, identified by it's plugin handler name.
+func (m *AdmissionMetrics) ObserveAdmissionController(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
+	gvr := attr.GetResource()
+	m.controller.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+}
+
+// ObserveWebhook records admission related metrics for a admission webhook.
+func (m *AdmissionMetrics) ObserveWebhook(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
+	gvr := attr.GetResource()
+	m.webhook.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected))...)
+}
+
+type metricSet struct {
+	latencies        *prometheus.HistogramVec
+	latenciesSummary *prometheus.SummaryVec
+}
+
+func newMetricSet(name string, labels []string, helpTemplate string) *metricSet {
+	return &metricSet{
+		latencies: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      fmt.Sprintf("%s_admission_latencies_seconds", name),
+				Help:      fmt.Sprintf(helpTemplate, "latency histogram"),
+				Buckets:   latencyBuckets,
+			},
+			labels,
+		),
+		latenciesSummary: prometheus.NewSummaryVec(
+			prometheus.SummaryOpts{
+				Namespace: namespace,
+				Subsystem: subsystem,
+				Name:      fmt.Sprintf("%s_admission_latencies_seconds_summary", name),
+				Help:      fmt.Sprintf(helpTemplate, "latency summary"),
+				MaxAge:    latencySummaryMaxAge,
+			},
+			labels,
+		),
+	}
+}
+
+// MustRegister registers all the prometheus metrics in the metricSet.
+func (m *metricSet) mustRegister() {
+	prometheus.MustRegister(m.latencies)
+	prometheus.MustRegister(m.latenciesSummary)
+}
+
+// Reset resets all the prometheus metrics in the metricSet.
+func (m *metricSet) reset() {
+	m.latencies.Reset()
+	m.latenciesSummary.Reset()
+}
+
+// Observe records an observed admission event to all metrics in the metricSet.
+func (m *metricSet) observe(elapsed time.Duration, labels ...string) {
+	elapsedMicroseconds := float64(elapsed / time.Microsecond)
+	m.latencies.WithLabelValues(labels...).Observe(elapsedMicroseconds)
+	m.latenciesSummary.WithLabelValues(labels...).Observe(elapsedMicroseconds)
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -76,27 +76,9 @@ type pluginHandlerWithMetrics struct {
 
 // Admit performs a mutating admission control check and emit metrics.
 func (p pluginHandlerWithMetrics) Admit(a admission.Attributes) error {
-	mutatingHandler, ok := p.Interface.(admission.MutationInterface)
-	if !ok {
-		return nil
-	}
-
 	start := time.Now()
-	err := mutatingHandler.Admit(a)
+	err := p.Interface.Admit(a)
 	p.observer(time.Since(start), err != nil, a, stepAdmit, p.extraLabels...)
-	return err
-}
-
-// Validate performs a non-mutating admission control check and emits metrics.
-func (p pluginHandlerWithMetrics) Validate(a admission.Attributes) error {
-	validatingHandler, ok := p.Interface.(admission.ValidationInterface)
-	if !ok {
-		return nil
-	}
-
-	start := time.Now()
-	err := validatingHandler.Validate(a)
-	p.observer(time.Since(start), err != nil, a, stepValidate, p.extraLabels...)
 	return err
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+var (
+	kind     = schema.GroupVersionKind{Group: "kgroup", Version: "kversion", Kind: "kind"}
+	resource = schema.GroupVersionResource{Group: "rgroup", Version: "rversion", Resource: "resource"}
+	attr     = admission.NewAttributesRecord(nil, nil, kind, "ns", "name", resource, "subresource", admission.Create, nil)
+)
+
+func TestObserveAdmissionStep(t *testing.T) {
+	Metrics.reset()
+	handler := WithStepMetrics(&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create), true, true})
+	handler.(admission.MutationInterface).Admit(attr)
+	handler.(admission.ValidationInterface).Validate(attr)
+	wantLabels := map[string]string{
+		"operation":   string(admission.Create),
+		"group":       resource.Group,
+		"version":     resource.Version,
+		"resource":    resource.Resource,
+		"subresource": "subresource",
+		"type":        "admit",
+		"rejected":    "false",
+	}
+	expectHistogramCountTotal(t, "apiserver_admission_step_admission_latencies_seconds", wantLabels, 1)
+	expectFindMetric(t, "apiserver_admission_step_admission_latencies_seconds_summary", wantLabels)
+
+	wantLabels["type"] = "validate"
+	expectHistogramCountTotal(t, "apiserver_admission_step_admission_latencies_seconds", wantLabels, 1)
+	expectFindMetric(t, "apiserver_admission_step_admission_latencies_seconds_summary", wantLabels)
+}
+
+func TestObserveAdmissionController(t *testing.T) {
+	Metrics.reset()
+	handler := WithControllerMetrics(&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create), true, true}, "a")
+	handler.(admission.MutationInterface).Admit(attr)
+	handler.(admission.ValidationInterface).Validate(attr)
+	wantLabels := map[string]string{
+		"name":        "a",
+		"operation":   string(admission.Create),
+		"group":       resource.Group,
+		"version":     resource.Version,
+		"resource":    resource.Resource,
+		"subresource": "subresource",
+		"type":        "validate",
+		"rejected":    "false",
+	}
+	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
+	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
+
+	wantLabels["type"] = "validate"
+	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
+	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
+}
+
+func TestObserveWebhook(t *testing.T) {
+	Metrics.reset()
+	Metrics.ObserveWebhook(2*time.Second, false, attr, stepAdmit, "x")
+	wantLabels := map[string]string{
+		"name":        "x",
+		"operation":   string(admission.Create),
+		"group":       resource.Group,
+		"version":     resource.Version,
+		"resource":    resource.Resource,
+		"subresource": "subresource",
+		"type":        "admit",
+		"rejected":    "false",
+	}
+	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_latencies_seconds", wantLabels, 1)
+	expectFindMetric(t, "apiserver_admission_webhook_admission_latencies_seconds_summary", wantLabels)
+}
+
+func TestWithMetrics(t *testing.T) {
+	Metrics.reset()
+
+	type Test struct {
+		name            string
+		ns              string
+		operation       admission.Operation
+		handler         admission.Interface
+		admit, validate bool
+	}
+	for _, test := range []Test{
+		{
+			"both-interfaces-admit-and-validate",
+			"some-ns",
+			admission.Create,
+			&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), true, true},
+			true, true,
+		},
+		{
+			"both-interfaces-dont-admit",
+			"some-ns",
+			admission.Create,
+			&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), false, true},
+			false, true,
+		},
+		{
+			"both-interfaces-admit-dont-validate",
+			"some-ns",
+			admission.Create,
+			&mutatingAndValidatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), true, false},
+			true, false,
+		},
+		{
+			"validate-interfaces-validate",
+			"some-ns",
+			admission.Create,
+			&validatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), true},
+			true, true,
+		},
+		{
+			"validate-interfaces-dont-validate",
+			"some-ns",
+			admission.Create,
+			&validatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), true},
+			true, false,
+		},
+		{
+			"mutating-interfaces-admit",
+			"some-ns",
+			admission.Create,
+			&mutatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), true},
+			true, true,
+		},
+		{
+			"mutating-interfaces-dont-admit",
+			"some-ns",
+			admission.Create,
+			&mutatingFakeHandler{admission.NewHandler(admission.Create, admission.Update), false},
+			true, false,
+		},
+	} {
+		Metrics.reset()
+
+		h := WithMetrics(test.handler, Metrics.ObserveAdmissionController, test.name)
+
+		// test mutation
+		err := h.(admission.MutationInterface).Admit(admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, test.ns, "", schema.GroupVersionResource{}, "", test.operation, nil))
+		if test.admit && err != nil {
+			t.Errorf("expected admit to succeed, but failed: %v", err)
+			continue
+		} else if !test.admit && err == nil {
+			t.Errorf("expected admit to fail, but it succeeded")
+			continue
+		}
+
+		filter := map[string]string{"rejected": "false"}
+		if !test.admit {
+			filter["rejected"] = "true"
+		}
+		if _, mutating := test.handler.(admission.MutationInterface); mutating {
+			expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", filter, 1)
+		} else {
+			expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", filter, 0)
+		}
+
+		if err == nil {
+			// skip validation step if mutation failed
+			continue
+		}
+
+		// test validation
+		err = h.(admission.ValidationInterface).Validate(admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, test.ns, "", schema.GroupVersionResource{}, "", test.operation, nil))
+		if test.validate && err != nil {
+			t.Errorf("expected admit to succeed, but failed: %v", err)
+			continue
+		} else if !test.validate && err == nil {
+			t.Errorf("expected validation to fail, but it succeeded")
+			continue
+		}
+
+		filter = map[string]string{"rejected": "false"}
+		if !test.admit {
+			filter["rejected"] = "true"
+		}
+		if _, validating := test.handler.(admission.ValidationInterface); validating {
+			expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", filter, 1)
+		} else {
+			expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", filter, 0)
+		}
+	}
+}
+
+type mutatingAndValidatingFakeHandler struct {
+	*admission.Handler
+	admit    bool
+	validate bool
+}
+
+func (h *mutatingAndValidatingFakeHandler) Admit(a admission.Attributes) (err error) {
+	if h.admit {
+		return nil
+	}
+	return fmt.Errorf("don't admit")
+}
+
+func (h *mutatingAndValidatingFakeHandler) Validate(a admission.Attributes) (err error) {
+	if h.validate {
+		return nil
+	}
+	return fmt.Errorf("don't validate")
+}
+
+type validatingFakeHandler struct {
+	*admission.Handler
+	validate bool
+}
+
+func (h *validatingFakeHandler) Validate(a admission.Attributes) (err error) {
+	if h.validate {
+		return nil
+	}
+	return fmt.Errorf("don't validate")
+}
+
+type mutatingFakeHandler struct {
+	*admission.Handler
+	admit bool
+}
+
+func (h *mutatingFakeHandler) Amit(a admission.Attributes) (err error) {
+	if h.admit {
+		return nil
+	}
+	return fmt.Errorf("don't admit")
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -69,11 +69,9 @@ func TestObserveAdmissionController(t *testing.T) {
 		"rejected":    "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
 
 	wantLabels["type"] = "validate"
 	expectHistogramCountTotal(t, "apiserver_admission_controller_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_controller_admission_latencies_seconds_summary", wantLabels)
 }
 
 func TestObserveWebhook(t *testing.T) {
@@ -90,7 +88,6 @@ func TestObserveWebhook(t *testing.T) {
 		"rejected":    "false",
 	}
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_latencies_seconds", wantLabels, 1)
-	expectFindMetric(t, "apiserver_admission_webhook_admission_latencies_seconds_summary", wantLabels)
 }
 
 func TestWithMetrics(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/testutil_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/testutil_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	ptype "github.com/prometheus/client_model/go"
+)
+
+func labelsMatch(metric *ptype.Metric, labelFilter map[string]string) bool {
+	for _, lp := range metric.GetLabel() {
+		if value, ok := labelFilter[lp.GetName()]; ok && lp.GetValue() != value {
+			return false
+		}
+	}
+	return true
+}
+
+// expectFindMetric find a metric with the given name nad labels or reports a fatal test error.
+func expectFindMetric(t *testing.T, name string, expectedLabels map[string]string) *ptype.Metric {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %s", err)
+	}
+
+	for _, mf := range metrics {
+		if mf.GetName() == name {
+			for _, metric := range mf.GetMetric() {
+				if labelsMatch(metric, expectedLabels) {
+					gotLabelCount := len(metric.GetLabel())
+					wantLabelCount := len(expectedLabels)
+					if wantLabelCount != gotLabelCount {
+						t.Errorf("Got metric with %d labels, but wanted %d labels. Wanted %#+v for %s",
+							gotLabelCount, wantLabelCount, expectedLabels, metric.String())
+					}
+					return metric
+				}
+			}
+		}
+	}
+	t.Fatalf("No metric found with name %s and labels %#+v", name, expectedLabels)
+	return nil
+}
+
+// expectHistogramCountTotal ensures that the sum of counts of metrics matching the labelFilter is as
+// expected.
+func expectHistogramCountTotal(t *testing.T, name string, labelFilter map[string]string, wantCount int) {
+	metrics, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %s", err)
+	}
+
+	counterSum := 0
+	for _, mf := range metrics {
+		if mf.GetName() != name {
+			continue // Ignore other metrics.
+		}
+		for _, metric := range mf.GetMetric() {
+			if !labelsMatch(metric, labelFilter) {
+				continue
+			}
+			counterSum += int(metric.GetHistogram().GetSampleCount())
+		}
+	}
+	if wantCount != counterSum {
+		t.Errorf("Wanted count %d, got %d for metric %s with labels %#+v", wantCount, counterSum, name, labelFilter)
+		for _, mf := range metrics {
+			if mf.GetName() == name {
+				for _, metric := range mf.GetMetric() {
+					t.Logf("\tnear match: %s", metric.String())
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We need rejection counts in order to turn on the PodSecurityPolicy controller. Comprehensive metrics were added for all admission controllers in 1.9, but backporting all those metrics was deemed to risky. So instead, this PR only enables the metrics on the PodSecurityPolicy controller.

**Which issue(s) this PR fixes**:
Fixes #55030

**Special notes for your reviewer**:
The diff to add these ended up larger than I expected. See https://github.com/tallclair/kubernetes/commit/c1e7b424ef2ef93eba1085f0b8724966250a34cc for an alternative and more minimal approach.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add prometheus metrics for the PodSecurityPolicy admission controller
```
