### PR TITLE
Automated cherry pick of #57172

### DIFF
--- a/cluster/addons/rbac/legacy-kubelet-user-disable/kubelet-binding.yaml
+++ b/cluster/addons/rbac/legacy-kubelet-user-disable/kubelet-binding.yaml
@@ -10,6 +10,20 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: system:node
+subjects: []
+---
+# This is required so that new clusters still have bootstrap permissions
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-bootstrap
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
   name: system:node-bootstrapper
 subjects:
 - apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Cherry pick of #57172 on release-1.9.

#57172: gce: split legacy kubelet node role binding and bootstrapper

```release-note
NONE
```