### PR TITLE
AWS reviewer for cloud provider, approver for storage

### DIFF
--- a/pkg/cloudprovider/providers/aws/OWNERS
+++ b/pkg/cloudprovider/providers/aws/OWNERS
@@ -6,3 +6,4 @@ reviewers:
 - jsafrane
 - justinsb
 - zmerlynn
+- chrislovecnm

--- a/pkg/credentialprovider/aws/OWNERS
+++ b/pkg/credentialprovider/aws/OWNERS
@@ -4,3 +4,4 @@ reviewers:
 - therc
 - lixiaobing10051267
 - goltermann
+- chrislovecnm

--- a/pkg/volume/aws_ebs/OWNERS
+++ b/pkg/volume/aws_ebs/OWNERS
@@ -3,6 +3,7 @@ approvers:
 - jingxu97
 - jsafrane
 - justinsb
+- chrislovecnm
 reviewers:
 - chrislovecnm
 - gnufied


### PR DESCRIPTION
## Reviewer for cloud provider

I have been working with this code base for a while, pinged @justinsb and
he recommended I start as a reviewer. I actually put in a PR a long time
ago for this, and it got closed.

## Adding myself as an approver to EBS storage

I have been a reviewer for months working with @jingxu97, @gnufied, and
@justinsb on many design aspects, including helping fix 1.4.8. Now I
would like to take an even more active role. Looking forward to making
this boring.  Stealing a great quote from Tim.

/assign @justinsb 
/cc @jingxu97 @gnufied 

Also noticed that https://github.com/kubernetes/kubernetes/compare/master...chrislovecnm:aws-reviewer?expand=1#diff-4d9ff7eed7da8c813393167c74d24eb2 
does not have approvers. 
@justinsb you want me to fix that? You probably are the only approver because
of your GitHub perms.