### PR TITLE
fix the problem that 'kubectl get all' don't have kind information

### DIFF
--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -348,6 +348,10 @@ func (options *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []str
 				}
 				continue
 			}
+			// Don't need wrap sortingPrinter in printing each object
+			if sortingPrinter, found := printer.(*kubectl.SortingPrinter); found {
+				printer = sortingPrinter.Delegate
+			}
 
 			// TODO: this doesn't belong here
 			// add linebreak between resource groups (if there is more than one)


### PR DESCRIPTION

**What this PR does / why we need it**:
When using `kubectl get all --sort-by ***`, the result we got don't have resource kind information. For example: 
```shell
# k get all --sort-by=kind
NAME              READY     STATUS    RESTARTS   AGE
test-curl-9rczp   1/1       Running   243        16d
test-curl-qjfvn   1/1       Running   101        7d
whoami-7rvmh      1/1       Running   0          16d
whoami-tc6f5      1/1       Running   0          7d

NAME        DESIRED   CURRENT   READY     AGE
test-curl   2         2         2         16d
test-curl   2         2         2         16d

NAME      DESIRED   CURRENT   READY     AGE
whoami    2         2         2         16d

NAME         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
kubernetes   ClusterIP   10.96.0.1        <none>        443/TCP          16d
whoami       NodePort    10.110.153.125   <none>        3029:31531/TCP   16d
```

**What you expected to happen**:

```shell
# ./kubectl get all --sort-by=kind
NAME                 READY     STATUS    RESTARTS   AGE
po/test-curl-9rczp   1/1       Running   243        16d
po/test-curl-qjfvn   1/1       Running   101        7d
po/whoami-7rvmh      1/1       Running   0          16d
po/whoami-tc6f5      1/1       Running   0          7d

NAME           DESIRED   CURRENT   READY     AGE
rs/test-curl   2         2         2         16d
rs/test-curl   2         2         2         16d

NAME        DESIRED   CURRENT   READY     AGE
rc/whoami   2         2         2         16d

NAME             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
svc/kubernetes   ClusterIP   10.96.0.1        <none>        443/TCP          16d
svc/whoami       NodePort    10.110.153.125   <none>        3029:31531/TCP   16d
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes kubernetes/kubectl#175

**Release note**:
```release-note
NONE
```
