### PR TITLE
Reduce CPU request of Dashboard addon

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 100m
+            cpu: 50m
             memory: 100Mi
         ports:
         - containerPort: 8443


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reduces request of Dashboard addon to free up cluster resources for user pods and other addons. Dashboard is bound on memory and under-utilizes CPU

**Release note**:
```release-note
NONE
```
