### PR TITLE
Use an s390x default-http-backend

### DIFF
--- a/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
+++ b/cluster/juju/layers/kubernetes-worker/reactive/kubernetes_worker.py
@@ -605,6 +605,12 @@ def launch_default_ingress_controller():
     context['arch'] = arch()
     addon_path = '/root/cdk/addons/{}'
 
+    context['defaultbackend_image'] = \
+        "gcr.io/google_containers/defaultbackend:1.4"
+    if arch() == 's390x':
+        context['defaultbackend_image'] = \
+            "gcr.io/google_containers/defaultbackend-s390x:1.4"
+
     # Render the default http backend (404) replicationcontroller manifest
     manifest = addon_path.format('default-http-backend.yaml')
     render('default-http-backend.yaml', manifest, context)

--- a/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
+++ b/cluster/juju/layers/kubernetes-worker/templates/default-http-backend.yaml
@@ -17,7 +17,7 @@ spec:
         # Any image is permissable as long as:
         # 1. It serves a 404 page at /
         # 2. It serves 200 on a /healthz endpoint
-        image: gcr.io/google_containers/defaultbackend:1.0
+        image: {{ defaultbackend_image }}
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This needs to be refactored to eventually say all non x86 architectures place a -arch() in the image name to support ppc64el, arm, etc.

Most all gcr.io/google_containers have -arch() image names.


**What this PR does / why we need it**:

Adds s390x images for when deploying to z system mainframes for default-http-backend image

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/455

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
