### PR TITLE
WIP: debug: detect all calls to default convert

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/BUILD
@@ -30,7 +30,10 @@ go_library(
         "helper.go",
     ],
     importpath = "k8s.io/apimachinery/pkg/conversion",
-    deps = ["//vendor/k8s.io/apimachinery/third_party/forked/golang/reflect:go_default_library"],
+    deps = [
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/apimachinery/third_party/forked/golang/reflect:go_default_library",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
Scrubbing the master logs from tests should reveal the places from where the the default converter is called. With the list, we can fix the relevant code to use generated conversions instead.

/cc @deads2k @sttts @smarterclayton 