### PR TITLE
Kubeadm: cleanup kube-proxy

### DIFF
--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -17,39 +17,8 @@ limitations under the License.
 package proxy
 
 const (
-	// KubeProxyConfigMap18 is the proxy ConfigMap manifest for Kubernetes version 1.8
-	KubeProxyConfigMap18 = `
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: kube-proxy
-  namespace: kube-system
-  labels:
-    app: kube-proxy
-data:
-  kubeconfig.conf: |
-    apiVersion: v1
-    kind: Config
-    clusters:
-    - cluster:
-        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: {{ .MasterEndpoint }}
-      name: default
-    contexts:
-    - context:
-        cluster: default
-        namespace: default
-        user: default
-      name: default
-    current-context: default
-    users:
-    - name: default
-      user:
-        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-`
-
-	// KubeProxyConfigMap19 is the proxy ConfigMap manifest for Kubernetes 1.9 and above
-	KubeProxyConfigMap19 = `
+	// KubeProxyConfigMap is the proxy ConfigMap manifest for Kubernetes 1.9 and above
+	KubeProxyConfigMap = `
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -80,68 +49,9 @@ data:
   config.conf: |-
 {{ .ProxyConfig}}
 `
-	// KubeProxyDaemonSet18 is the proxy DaemonSet manifest for Kubernetes version 1.8
-	KubeProxyDaemonSet18 = `
-apiVersion: apps/v1beta2
-kind: DaemonSet
-metadata:
-  labels:
-    k8s-app: kube-proxy
-  name: kube-proxy
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      k8s-app: kube-proxy
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        k8s-app: kube-proxy
-    spec:
-      containers:
-      - name: kube-proxy
-        image: {{ if .ImageOverride }}{{ .ImageOverride }}{{ else }}{{ .ImageRepository }}/kube-proxy-{{ .Arch }}:{{ .Version }}{{ end }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - /usr/local/bin/kube-proxy
-        - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
-        {{ .ClusterCIDR }}
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/kube-proxy
-          name: kube-proxy
-        - mountPath: /run/xtables.lock
-          name: xtables-lock
-          readOnly: false
-        - mountPath: /lib/modules
-          name: lib-modules
-          readOnly: true
-      hostNetwork: true
-      serviceAccountName: kube-proxy
-      tolerations:
-      - key: {{ .MasterTaintKey }}
-        effect: NoSchedule
-      - key: {{ .CloudTaintKey }}
-        value: "true"
-        effect: NoSchedule
-      volumes:
-      - name: kube-proxy
-        configMap:
-          name: kube-proxy
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-      - name: lib-modules
-        hostPath:
-          path: /lib/modules
-`
 
-	// KubeProxyDaemonSet19 is the proxy DaemonSet manifest for Kubernetes 1.9 and above
-	KubeProxyDaemonSet19 = `
+	// KubeProxyDaemonSet is the proxy DaemonSet manifest for Kubernetes 1.9 and above
+	KubeProxyDaemonSet = `
 apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -114,16 +114,7 @@ func TestCompileManifests(t *testing.T) {
 		expected bool
 	}{
 		{
-			manifest: KubeProxyConfigMap18,
-			data: struct {
-				MasterEndpoint, ProxyConfig string
-			}{
-				MasterEndpoint: "foo",
-			},
-			expected: true,
-		},
-		{
-			manifest: KubeProxyConfigMap19,
+			manifest: KubeProxyConfigMap,
 			data: struct {
 				MasterEndpoint, ProxyConfig string
 			}{
@@ -133,20 +124,7 @@ func TestCompileManifests(t *testing.T) {
 			expected: true,
 		},
 		{
-			manifest: KubeProxyDaemonSet18,
-			data: struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
-				ImageRepository: "foo",
-				Arch:            "foo",
-				Version:         "foo",
-				ImageOverride:   "foo",
-				ClusterCIDR:     "foo",
-				MasterTaintKey:  "foo",
-				CloudTaintKey:   "foo",
-			},
-			expected: true,
-		},
-		{
-			manifest: KubeProxyDaemonSet19,
+			manifest: KubeProxyDaemonSet,
 			data: struct{ ImageRepository, Arch, Version, ImageOverride, MasterTaintKey, CloudTaintKey string }{
 				ImageRepository: "foo",
 				Arch:            "foo",


### PR DESCRIPTION
**What this PR does / why we need it**:

When support for kube-proxy ComponentConfig was added in kubeadm for v1.9,
the previous config was maintained for version 1.8, this can now be removed
with the release of v1.9

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57151

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
