### PR TITLE
stop using shared global state for validation

### DIFF
--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -84,6 +84,7 @@ go_test(
         "//pkg/apis/core/validation:go_default_library",
         "//pkg/apis/extensions:go_default_library",
         "//pkg/apis/extensions/v1beta1:go_default_library",
+        "//pkg/features:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
@@ -107,5 +108,6 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )

--- a/pkg/api/testing/backward_compatibility_test.go
+++ b/pkg/api/testing/backward_compatibility_test.go
@@ -22,9 +22,11 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/testing/compat"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
+	"k8s.io/kubernetes/pkg/features"
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
@@ -158,8 +160,12 @@ func TestCompatibility_v1_PodSecurityContext(t *testing.T) {
 		},
 	}
 
+	featureGates := feature.NewFeatureGate()
+	if err := featureGates.Add(features.DefaultKubernetesFeatureGates); err != nil {
+		t.Fatal(err)
+	}
 	validator := func(obj runtime.Object) field.ErrorList {
-		return validation.ValidatePodSpec(&(obj.(*api.Pod).Spec), field.NewPath("spec"))
+		return validation.ValidatePodSpec(&(obj.(*api.Pod).Spec), field.NewPath("spec"), featureGates)
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/apps/validation/BUILD
+++ b/pkg/apis/apps/validation/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 
@@ -32,6 +33,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -106,7 +107,7 @@ func TestValidateStatefulSet(t *testing.T) {
 		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateStatefulSet(&successCase); len(errs) != 0 {
+		if errs := ValidateStatefulSet(&successCase, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -275,7 +276,7 @@ func TestValidateStatefulSet(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateStatefulSet(&v)
+		errs := ValidateStatefulSet(&v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}

--- a/pkg/apis/batch/validation/BUILD
+++ b/pkg/apis/batch/validation/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 
@@ -33,6 +34,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -22,6 +22,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
@@ -96,7 +97,7 @@ func TestValidateJob(t *testing.T) {
 		},
 	}
 	for k, v := range successCases {
-		if errs := ValidateJob(&v); len(errs) != 0 {
+		if errs := ValidateJob(&v, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 	}
@@ -215,7 +216,7 @@ func TestValidateJob(t *testing.T) {
 	}
 
 	for k, v := range errorCases {
-		errs := ValidateJob(&v)
+		errs := ValidateJob(&v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		} else {
@@ -344,7 +345,7 @@ func TestValidateCronJob(t *testing.T) {
 		},
 	}
 	for k, v := range successCases {
-		if errs := ValidateCronJob(&v); len(errs) != 0 {
+		if errs := ValidateCronJob(&v, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 
@@ -352,7 +353,7 @@ func TestValidateCronJob(t *testing.T) {
 		// copy to avoid polluting the testcase object, set a resourceVersion to allow validating update, and test a no-op update
 		v = *v.DeepCopy()
 		v.ResourceVersion = "1"
-		if errs := ValidateCronJobUpdate(&v, &v); len(errs) != 0 {
+		if errs := ValidateCronJobUpdate(&v, &v, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 	}
@@ -586,7 +587,7 @@ func TestValidateCronJob(t *testing.T) {
 	}
 
 	for k, v := range errorCases {
-		errs := ValidateCronJob(&v)
+		errs := ValidateCronJob(&v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		} else {
@@ -601,7 +602,7 @@ func TestValidateCronJob(t *testing.T) {
 		// copy to avoid polluting the testcase object, set a resourceVersion to allow validating update, and test a no-op update
 		v = *v.DeepCopy()
 		v.ResourceVersion = "1"
-		errs = ValidateCronJobUpdate(&v, &v)
+		errs = ValidateCronJobUpdate(&v, &v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			if k == "metadata.name: must be no more than 52 characters" {
 				continue

--- a/pkg/apis/core/validation/BUILD
+++ b/pkg/apis/core/validation/BUILD
@@ -58,6 +58,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/helper:go_default_library",
         "//pkg/capabilities:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/apis/extensions/validation/BUILD
+++ b/pkg/apis/extensions/validation/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 
@@ -43,6 +44,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/apis/extensions/validation/validation_test.go
+++ b/pkg/apis/extensions/validation/validation_test.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/pkg/security/apparmor"
@@ -668,7 +669,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 		if len(successCase.old.ObjectMeta.ResourceVersion) == 0 || len(successCase.update.ObjectMeta.ResourceVersion) == 0 {
 			t.Errorf("%q has incorrect test setup with no resource version set", testName)
 		}
-		if errs := ValidateDaemonSetUpdate(&successCase.update, &successCase.old); len(errs) != 0 {
+		if errs := ValidateDaemonSetUpdate(&successCase.update, &successCase.old, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("%q expected no error, but got: %v", testName, errs)
 		}
 	}
@@ -886,7 +887,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			t.Errorf("%q has incorrect test setup with no resource version set", testName)
 		}
 		// Run the tests
-		if errs := ValidateDaemonSetUpdate(&errorCase.update, &errorCase.old); len(errs) != errorCase.expectedErrNum {
+		if errs := ValidateDaemonSetUpdate(&errorCase.update, &errorCase.old, feature.NewFeatureGate()); len(errs) != errorCase.expectedErrNum {
 			t.Errorf("%q expected %d errors, but got %d error: %v", testName, errorCase.expectedErrNum, len(errs), errs)
 		} else {
 			t.Logf("(PASS) %q got errors %v", testName, errs)
@@ -943,7 +944,7 @@ func TestValidateDaemonSet(t *testing.T) {
 		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateDaemonSet(&successCase); len(errs) != 0 {
+		if errs := ValidateDaemonSet(&successCase, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -1067,7 +1068,7 @@ func TestValidateDaemonSet(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateDaemonSet(&v)
+		errs := ValidateDaemonSet(&v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}
@@ -1141,7 +1142,7 @@ func TestValidateDeployment(t *testing.T) {
 		validDeployment(),
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateDeployment(successCase); len(errs) != 0 {
+		if errs := ValidateDeployment(successCase, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -1223,7 +1224,7 @@ func TestValidateDeployment(t *testing.T) {
 	errorCases["must be greater than minReadySeconds"] = invalidProgressDeadlineDeployment
 
 	for k, v := range errorCases {
-		errs := ValidateDeployment(v)
+		errs := ValidateDeployment(v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("[%s] expected failure", k)
 		} else if !strings.Contains(errs[0].Error(), k) {
@@ -2025,7 +2026,7 @@ func TestValidateReplicaSetUpdate(t *testing.T) {
 	for _, successCase := range successCases {
 		successCase.old.ObjectMeta.ResourceVersion = "1"
 		successCase.update.ObjectMeta.ResourceVersion = "1"
-		if errs := ValidateReplicaSetUpdate(&successCase.update, &successCase.old); len(errs) != 0 {
+		if errs := ValidateReplicaSetUpdate(&successCase.update, &successCase.old, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -2100,7 +2101,7 @@ func TestValidateReplicaSetUpdate(t *testing.T) {
 		},
 	}
 	for testName, errorCase := range errorCases {
-		if errs := ValidateReplicaSetUpdate(&errorCase.update, &errorCase.old); len(errs) == 0 {
+		if errs := ValidateReplicaSetUpdate(&errorCase.update, &errorCase.old, feature.NewFeatureGate()); len(errs) == 0 {
 			t.Errorf("expected failure: %s", testName)
 		}
 	}
@@ -2170,7 +2171,7 @@ func TestValidateReplicaSet(t *testing.T) {
 		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateReplicaSet(&successCase); len(errs) != 0 {
+		if errs := ValidateReplicaSet(&successCase, feature.NewFeatureGate()); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -2302,7 +2303,7 @@ func TestValidateReplicaSet(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateReplicaSet(&v)
+		errs := ValidateReplicaSet(&v, feature.NewFeatureGate())
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}

--- a/pkg/apis/settings/validation/BUILD
+++ b/pkg/apis/settings/validation/BUILD
@@ -15,6 +15,7 @@ go_test(
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/settings:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 
@@ -27,6 +28,7 @@ go_library(
         "//pkg/apis/settings:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/apis/settings/validation/validation_test.go
+++ b/pkg/apis/settings/validation/validation_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/settings"
 )
@@ -30,7 +31,7 @@ func TestValidateEmptyPodPreset(t *testing.T) {
 		Spec: settings.PodPresetSpec{},
 	}
 
-	errList := ValidatePodPreset(emptyPodPreset)
+	errList := ValidatePodPreset(emptyPodPreset, feature.NewFeatureGate())
 	if errList == nil {
 		t.Fatal("empty pod preset should return an error")
 	}
@@ -55,7 +56,7 @@ func TestValidateEmptyPodPresetItems(t *testing.T) {
 		},
 	}
 
-	errList := ValidatePodPreset(emptyPodPreset)
+	errList := ValidatePodPreset(emptyPodPreset, feature.NewFeatureGate())
 	if !strings.Contains(errList.ToAggregate().Error(), "must specify at least one") {
 		t.Fatal("empty pod preset with label selector should return an error")
 	}
@@ -95,7 +96,7 @@ func TestValidatePodPresets(t *testing.T) {
 		},
 	}
 
-	errList := ValidatePodPreset(p)
+	errList := ValidatePodPreset(p, feature.NewFeatureGate())
 	if errList != nil {
 		if errList.ToAggregate() != nil {
 			t.Fatalf("errors: %#v", errList.ToAggregate().Error())
@@ -138,7 +139,7 @@ func TestValidatePodPresets(t *testing.T) {
 		},
 	}
 
-	errList = ValidatePodPreset(p)
+	errList = ValidatePodPreset(p, feature.NewFeatureGate())
 	if errList != nil {
 		if errList.ToAggregate() != nil {
 			t.Fatalf("errors: %#v", errList.ToAggregate().Error())
@@ -183,7 +184,7 @@ func TestValidatePodPresetsiVolumeMountError(t *testing.T) {
 		},
 	}
 
-	errList := ValidatePodPreset(p)
+	errList := ValidatePodPreset(p, feature.NewFeatureGate())
 	if !strings.Contains(errList.ToAggregate().Error(), "spec.volumeMounts[0].name: Not found") {
 		t.Fatal("should have returned error for volume that does not exist")
 	}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -215,13 +215,13 @@ const (
 )
 
 func init() {
-	utilfeature.DefaultFeatureGate.Add(defaultKubernetesFeatureGates)
+	utilfeature.DefaultFeatureGate.Add(DefaultKubernetesFeatureGates)
 }
 
 // defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
-var defaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
+var DefaultKubernetesFeatureGates = map[utilfeature.Feature]utilfeature.FeatureSpec{
 	ExternalTrafficLocalOnly:                    {Default: true, PreRelease: utilfeature.GA},
 	AppArmor:                                    {Default: true, PreRelease: utilfeature.Beta},
 	DynamicKubeletConfig:                        {Default: false, PreRelease: utilfeature.Alpha},

--- a/pkg/kubelet/config/BUILD
+++ b/pkg/kubelet/config/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper"
 	// TODO: remove this import if
@@ -126,7 +127,8 @@ func tryDecodeSinglePod(data []byte, defaultFn defaultFunc) (parsed bool, pod *v
 	if err = defaultFn(newPod); err != nil {
 		return true, pod, err
 	}
-	if errs := validation.ValidatePod(newPod); len(errs) > 0 {
+	// TODO this is highlighting a big risk.  If the kubelet and apiserver don't agree on feature gates, this can fail.
+	if errs := validation.ValidatePod(newPod, feature.DefaultFeatureGate); len(errs) > 0 {
 		return true, pod, fmt.Errorf("invalid pod: %v", errs)
 	}
 	v1Pod := &v1.Pod{}
@@ -156,7 +158,8 @@ func tryDecodePodList(data []byte, defaultFn defaultFunc) (parsed bool, pods v1.
 		if err = defaultFn(newPod); err != nil {
 			return true, pods, err
 		}
-		if errs := validation.ValidatePod(newPod); len(errs) > 0 {
+		// TODO this is highlighting a big risk.  If the kubelet and apiserver don't agree on feature gates, this can fail.
+		if errs := validation.ValidatePod(newPod, feature.DefaultFeatureGate); len(errs) > 0 {
 			err = fmt.Errorf("invalid pod: %v", errs)
 			return true, pods, err
 		}

--- a/pkg/quota/evaluator/core/pods.go
+++ b/pkg/quota/evaluator/core/pods.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/apiserver/pkg/util/feature"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/helper/qos"
 	k8s_api_v1 "k8s.io/kubernetes/pkg/apis/core/v1"
@@ -125,11 +126,13 @@ func (p *podEvaluator) Constraints(required []api.ResourceName, item runtime.Obj
 	allErrs := field.ErrorList{}
 	fldPath := field.NewPath("spec").Child("containers")
 	for i, ctr := range pod.Spec.Containers {
-		allErrs = append(allErrs, validation.ValidateResourceRequirements(&ctr.Resources, fldPath.Index(i).Child("resources"))...)
+		// TODO this is highlighting a big risk.  If the controller and apiserver don't agree on feature gates, this can fail.
+		allErrs = append(allErrs, validation.ValidateResourceRequirements(&ctr.Resources, fldPath.Index(i).Child("resources"), feature.DefaultFeatureGate)...)
 	}
 	fldPath = field.NewPath("spec").Child("initContainers")
 	for i, ctr := range pod.Spec.InitContainers {
-		allErrs = append(allErrs, validation.ValidateResourceRequirements(&ctr.Resources, fldPath.Index(i).Child("resources"))...)
+		// TODO this is highlighting a big risk.  If the controller and apiserver don't agree on feature gates, this can fail.
+		allErrs = append(allErrs, validation.ValidateResourceRequirements(&ctr.Resources, fldPath.Index(i).Child("resources"), feature.DefaultFeatureGate)...)
 	}
 	if len(allErrs) > 0 {
 		return allErrs.ToAggregate()

--- a/pkg/registry/apps/statefulset/BUILD
+++ b/pkg/registry/apps/statefulset/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/apps/statefulset/strategy.go
+++ b/pkg/registry/apps/statefulset/strategy.go
@@ -26,6 +26,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -94,7 +95,7 @@ func (statefulSetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, 
 // Validate validates a new StatefulSet.
 func (statefulSetStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	statefulSet := obj.(*apps.StatefulSet)
-	return validation.ValidateStatefulSet(statefulSet)
+	return validation.ValidateStatefulSet(statefulSet, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -108,7 +109,7 @@ func (statefulSetStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (statefulSetStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	validationErrorList := validation.ValidateStatefulSet(obj.(*apps.StatefulSet))
+	validationErrorList := validation.ValidateStatefulSet(obj.(*apps.StatefulSet), feature.DefaultFeatureGate)
 	updateErrorList := validation.ValidateStatefulSetUpdate(obj.(*apps.StatefulSet), old.(*apps.StatefulSet))
 	return append(validationErrorList, updateErrorList...)
 }

--- a/pkg/registry/batch/cronjob/BUILD
+++ b/pkg/registry/batch/cronjob/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -22,6 +22,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -69,7 +70,7 @@ func (cronJobStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old 
 // Validate validates a new scheduled job.
 func (cronJobStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	cronJob := obj.(*batch.CronJob)
-	return validation.ValidateCronJob(cronJob)
+	return validation.ValidateCronJob(cronJob, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -87,7 +88,7 @@ func (cronJobStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (cronJobStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateCronJobUpdate(obj.(*batch.CronJob), old.(*batch.CronJob))
+	return validation.ValidateCronJobUpdate(obj.(*batch.CronJob), old.(*batch.CronJob), feature.DefaultFeatureGate)
 }
 
 type cronJobStatusStrategy struct {

--- a/pkg/registry/batch/job/BUILD
+++ b/pkg/registry/batch/job/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/batch"
@@ -81,7 +82,7 @@ func (jobStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) f
 	if job.Spec.ManualSelector == nil || *job.Spec.ManualSelector == false {
 		generateSelector(job)
 	}
-	return validation.ValidateJob(job)
+	return validation.ValidateJob(job, feature.DefaultFeatureGate)
 }
 
 // generateSelector adds a selector to a job and labels to its template
@@ -149,8 +150,8 @@ func (jobStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (jobStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	validationErrorList := validation.ValidateJob(obj.(*batch.Job))
-	updateErrorList := validation.ValidateJobUpdate(obj.(*batch.Job), old.(*batch.Job))
+	validationErrorList := validation.ValidateJob(obj.(*batch.Job), feature.DefaultFeatureGate)
+	updateErrorList := validation.ValidateJobUpdate(obj.(*batch.Job), old.(*batch.Job), feature.DefaultFeatureGate)
 	return append(validationErrorList, updateErrorList...)
 }
 

--- a/pkg/registry/core/limitrange/BUILD
+++ b/pkg/registry/core/limitrange/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/limitrange/strategy.go
+++ b/pkg/registry/core/limitrange/strategy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
@@ -52,7 +53,7 @@ func (limitrangeStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, o
 
 func (limitrangeStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	limitRange := obj.(*api.LimitRange)
-	return validation.ValidateLimitRange(limitRange)
+	return validation.ValidateLimitRange(limitRange, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -65,7 +66,7 @@ func (limitrangeStrategy) AllowCreateOnUpdate() bool {
 
 func (limitrangeStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	limitRange := obj.(*api.LimitRange)
-	return validation.ValidateLimitRange(limitRange)
+	return validation.ValidateLimitRange(limitRange, feature.DefaultFeatureGate)
 }
 
 func (limitrangeStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	pkgstorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -87,7 +88,7 @@ func (nodeStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old run
 // Validate validates a new node.
 func (nodeStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	node := obj.(*api.Node)
-	return validation.ValidateNode(node)
+	return validation.ValidateNode(node, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -96,8 +97,8 @@ func (nodeStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (nodeStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateNode(obj.(*api.Node))
-	return append(errorList, validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))...)
+	errorList := validation.ValidateNode(obj.(*api.Node), feature.DefaultFeatureGate)
+	return append(errorList, validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node), feature.DefaultFeatureGate)...)
 }
 
 func (nodeStrategy) AllowUnconditionalUpdate() bool {
@@ -138,7 +139,7 @@ func (nodeStatusStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, o
 }
 
 func (nodeStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))
+	return validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node), feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.

--- a/pkg/registry/core/persistentvolume/BUILD
+++ b/pkg/registry/core/persistentvolume/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolume/strategy.go
+++ b/pkg/registry/core/persistentvolume/strategy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	pvutil "k8s.io/kubernetes/pkg/api/persistentvolume"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -58,7 +59,7 @@ func (persistentvolumeStrategy) PrepareForCreate(ctx genericapirequest.Context, 
 
 func (persistentvolumeStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	persistentvolume := obj.(*api.PersistentVolume)
-	errorList := validation.ValidatePersistentVolume(persistentvolume)
+	errorList := validation.ValidatePersistentVolume(persistentvolume, feature.DefaultFeatureGate)
 	return append(errorList, volumevalidation.ValidatePersistentVolume(persistentvolume)...)
 }
 
@@ -82,9 +83,9 @@ func (persistentvolumeStrategy) PrepareForUpdate(ctx genericapirequest.Context, 
 
 func (persistentvolumeStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	newPv := obj.(*api.PersistentVolume)
-	errorList := validation.ValidatePersistentVolume(newPv)
+	errorList := validation.ValidatePersistentVolume(newPv, feature.DefaultFeatureGate)
 	errorList = append(errorList, volumevalidation.ValidatePersistentVolume(newPv)...)
-	return append(errorList, validation.ValidatePersistentVolumeUpdate(newPv, old.(*api.PersistentVolume))...)
+	return append(errorList, validation.ValidatePersistentVolumeUpdate(newPv, old.(*api.PersistentVolume), feature.DefaultFeatureGate)...)
 }
 
 func (persistentvolumeStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/persistentvolumeclaim/BUILD
+++ b/pkg/registry/core/persistentvolumeclaim/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/persistentvolumeclaim/strategy.go
+++ b/pkg/registry/core/persistentvolumeclaim/strategy.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	pvcutil "k8s.io/kubernetes/pkg/api/persistentvolumeclaim"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -57,7 +58,7 @@ func (persistentvolumeclaimStrategy) PrepareForCreate(ctx genericapirequest.Cont
 
 func (persistentvolumeclaimStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	pvc := obj.(*api.PersistentVolumeClaim)
-	return validation.ValidatePersistentVolumeClaim(pvc)
+	return validation.ValidatePersistentVolumeClaim(pvc, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -79,8 +80,8 @@ func (persistentvolumeclaimStrategy) PrepareForUpdate(ctx genericapirequest.Cont
 }
 
 func (persistentvolumeclaimStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidatePersistentVolumeClaim(obj.(*api.PersistentVolumeClaim))
-	return append(errorList, validation.ValidatePersistentVolumeClaimUpdate(obj.(*api.PersistentVolumeClaim), old.(*api.PersistentVolumeClaim))...)
+	errorList := validation.ValidatePersistentVolumeClaim(obj.(*api.PersistentVolumeClaim), feature.DefaultFeatureGate)
+	return append(errorList, validation.ValidatePersistentVolumeClaimUpdate(obj.(*api.PersistentVolumeClaim), old.(*api.PersistentVolumeClaim), feature.DefaultFeatureGate)...)
 }
 
 func (persistentvolumeclaimStrategy) AllowUnconditionalUpdate() bool {
@@ -101,7 +102,7 @@ func (persistentvolumeclaimStatusStrategy) PrepareForUpdate(ctx genericapireques
 }
 
 func (persistentvolumeclaimStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidatePersistentVolumeClaimStatusUpdate(obj.(*api.PersistentVolumeClaim), old.(*api.PersistentVolumeClaim))
+	return validation.ValidatePersistentVolumeClaimStatusUpdate(obj.(*api.PersistentVolumeClaim), old.(*api.PersistentVolumeClaim), feature.DefaultFeatureGate)
 }
 
 // GetAttrs returns labels and fields of a given object for filtering purposes.

--- a/pkg/registry/core/podtemplate/BUILD
+++ b/pkg/registry/core/podtemplate/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -52,7 +53,7 @@ func (podTemplateStrategy) PrepareForCreate(ctx genericapirequest.Context, obj r
 // Validate validates a new pod template.
 func (podTemplateStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	pod := obj.(*api.PodTemplate)
-	return validation.ValidatePodTemplate(pod)
+	return validation.ValidatePodTemplate(pod, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -75,7 +76,7 @@ func (podTemplateStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, 
 
 // ValidateUpdate is the default update validation for an end user.
 func (podTemplateStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidatePodTemplateUpdate(obj.(*api.PodTemplate), old.(*api.PodTemplate))
+	return validation.ValidatePodTemplateUpdate(obj.(*api.PodTemplate), old.(*api.PodTemplate), feature.DefaultFeatureGate)
 }
 
 func (podTemplateStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/replicationcontroller/BUILD
+++ b/pkg/registry/core/replicationcontroller/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -102,7 +103,7 @@ func (rcStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runti
 // Validate validates a new replication controller.
 func (rcStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	controller := obj.(*api.ReplicationController)
-	return validation.ValidateReplicationController(controller)
+	return validation.ValidateReplicationController(controller, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -120,8 +121,8 @@ func (rcStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime
 	oldRc := old.(*api.ReplicationController)
 	newRc := obj.(*api.ReplicationController)
 
-	validationErrorList := validation.ValidateReplicationController(newRc)
-	updateErrorList := validation.ValidateReplicationControllerUpdate(newRc, oldRc)
+	validationErrorList := validation.ValidateReplicationController(newRc, feature.DefaultFeatureGate)
+	updateErrorList := validation.ValidateReplicationControllerUpdate(newRc, oldRc, feature.DefaultFeatureGate)
 	errs := append(validationErrorList, updateErrorList...)
 
 	for key, value := range helper.NonConvertibleFields(oldRc.Annotations) {

--- a/pkg/registry/core/resourcequota/BUILD
+++ b/pkg/registry/core/resourcequota/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/resourcequota/strategy.go
+++ b/pkg/registry/core/resourcequota/strategy.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
@@ -57,7 +58,7 @@ func (resourcequotaStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj
 // Validate validates a new resourcequota.
 func (resourcequotaStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	resourcequota := obj.(*api.ResourceQuota)
-	return validation.ValidateResourceQuota(resourcequota)
+	return validation.ValidateResourceQuota(resourcequota, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -71,8 +72,8 @@ func (resourcequotaStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (resourcequotaStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	errorList := validation.ValidateResourceQuota(obj.(*api.ResourceQuota))
-	return append(errorList, validation.ValidateResourceQuotaUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))...)
+	errorList := validation.ValidateResourceQuota(obj.(*api.ResourceQuota), feature.DefaultFeatureGate)
+	return append(errorList, validation.ValidateResourceQuotaUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota), feature.DefaultFeatureGate)...)
 }
 
 func (resourcequotaStrategy) AllowUnconditionalUpdate() bool {
@@ -92,5 +93,5 @@ func (resourcequotaStatusStrategy) PrepareForUpdate(ctx genericapirequest.Contex
 }
 
 func (resourcequotaStatusStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	return validation.ValidateResourceQuotaStatusUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota))
+	return validation.ValidateResourceQuotaStatusUpdate(obj.(*api.ResourceQuota), old.(*api.ResourceQuota), feature.DefaultFeatureGate)
 }

--- a/pkg/registry/extensions/daemonset/BUILD
+++ b/pkg/registry/extensions/daemonset/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/extensions/daemonset/strategy.go
+++ b/pkg/registry/extensions/daemonset/strategy.go
@@ -27,6 +27,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -113,7 +114,7 @@ func (daemonSetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, ol
 // Validate validates a new daemon set.
 func (daemonSetStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	daemonSet := obj.(*extensions.DaemonSet)
-	return validation.ValidateDaemonSet(daemonSet)
+	return validation.ValidateDaemonSet(daemonSet, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -130,8 +131,8 @@ func (daemonSetStrategy) AllowCreateOnUpdate() bool {
 func (daemonSetStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	newDaemonSet := obj.(*extensions.DaemonSet)
 	oldDaemonSet := old.(*extensions.DaemonSet)
-	allErrs := validation.ValidateDaemonSet(obj.(*extensions.DaemonSet))
-	allErrs = append(allErrs, validation.ValidateDaemonSetUpdate(newDaemonSet, oldDaemonSet)...)
+	allErrs := validation.ValidateDaemonSet(obj.(*extensions.DaemonSet), feature.DefaultFeatureGate)
+	allErrs = append(allErrs, validation.ValidateDaemonSetUpdate(newDaemonSet, oldDaemonSet, feature.DefaultFeatureGate)...)
 
 	// Update is not allowed to set Spec.Selector for apps/v1 and apps/v1beta2 (allowed for extensions/v1beta1).
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/extensions/deployment/BUILD
+++ b/pkg/registry/extensions/deployment/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/extensions/deployment/strategy.go
+++ b/pkg/registry/extensions/deployment/strategy.go
@@ -28,6 +28,7 @@ import (
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -76,7 +77,7 @@ func (deploymentStrategy) PrepareForCreate(ctx genericapirequest.Context, obj ru
 // Validate validates a new deployment.
 func (deploymentStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	deployment := obj.(*extensions.Deployment)
-	return validation.ValidateDeployment(deployment)
+	return validation.ValidateDeployment(deployment, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -110,7 +111,7 @@ func (deploymentStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, o
 func (deploymentStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	newDeployment := obj.(*extensions.Deployment)
 	oldDeployment := old.(*extensions.Deployment)
-	allErrs := validation.ValidateDeploymentUpdate(newDeployment, oldDeployment)
+	allErrs := validation.ValidateDeploymentUpdate(newDeployment, oldDeployment, feature.DefaultFeatureGate)
 
 	// Update is not allowed to set Spec.Selector for all groups/versions except extensions/v1beta1.
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/extensions/replicaset/BUILD
+++ b/pkg/registry/extensions/replicaset/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/extensions/replicaset/strategy.go
+++ b/pkg/registry/extensions/replicaset/strategy.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	apistorage "k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/extensions"
@@ -107,7 +108,7 @@ func (rsStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, old runti
 // Validate validates a new ReplicaSet.
 func (rsStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	rs := obj.(*extensions.ReplicaSet)
-	return validation.ValidateReplicaSet(rs)
+	return validation.ValidateReplicaSet(rs, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -124,8 +125,8 @@ func (rsStrategy) AllowCreateOnUpdate() bool {
 func (rsStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
 	newReplicaSet := obj.(*extensions.ReplicaSet)
 	oldReplicaSet := old.(*extensions.ReplicaSet)
-	allErrs := validation.ValidateReplicaSet(obj.(*extensions.ReplicaSet))
-	allErrs = append(allErrs, validation.ValidateReplicaSetUpdate(newReplicaSet, oldReplicaSet)...)
+	allErrs := validation.ValidateReplicaSet(obj.(*extensions.ReplicaSet), feature.DefaultFeatureGate)
+	allErrs = append(allErrs, validation.ValidateReplicaSetUpdate(newReplicaSet, oldReplicaSet, feature.DefaultFeatureGate)...)
 
 	// Update is not allowed to set Spec.Selector for all groups/versions except extensions/v1beta1.
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/settings/podpreset/BUILD
+++ b/pkg/registry/settings/podpreset/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//vendor/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/storage/names:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )
 

--- a/pkg/registry/settings/podpreset/strategy.go
+++ b/pkg/registry/settings/podpreset/strategy.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	"k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/apis/settings"
@@ -64,7 +65,7 @@ func (podPresetStrategy) PrepareForUpdate(ctx genericapirequest.Context, obj, ol
 // Validate validates a new PodPreset.
 func (podPresetStrategy) Validate(ctx genericapirequest.Context, obj runtime.Object) field.ErrorList {
 	pip := obj.(*settings.PodPreset)
-	return validation.ValidatePodPreset(pip)
+	return validation.ValidatePodPreset(pip, feature.DefaultFeatureGate)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -77,8 +78,8 @@ func (podPresetStrategy) AllowCreateOnUpdate() bool {
 
 // ValidateUpdate is the default update validation for an end user.
 func (podPresetStrategy) ValidateUpdate(ctx genericapirequest.Context, obj, old runtime.Object) field.ErrorList {
-	validationErrorList := validation.ValidatePodPreset(obj.(*settings.PodPreset))
-	updateErrorList := validation.ValidatePodPresetUpdate(obj.(*settings.PodPreset), old.(*settings.PodPreset))
+	validationErrorList := validation.ValidatePodPreset(obj.(*settings.PodPreset), feature.DefaultFeatureGate)
+	updateErrorList := validation.ValidatePodPresetUpdate(obj.(*settings.PodPreset), old.(*settings.PodPreset), feature.DefaultFeatureGate)
 	return append(validationErrorList, updateErrorList...)
 }
 


### PR DESCRIPTION
Using shared global state (DefaultFeatureGates) for validation leads to problems.  In addition to be poor form (globals make all development hard) it makes the validation tests unmockable, since any change to the feature gate affects the global state for all parallel tests (see https://github.com/openshift/origin/issues/17769) and it is allowing trip dependencies to appear in unlikely places as kubelet and controllers are both relying on perfect parity of feature flags to run properly.

This pull eliminates the global and passes the required state through the function.

/assign @smarterclayton 
/assign @sttts 
@kubernetes/sig-api-machinery-bugs 
@kubernetes/sig-storage-bugs (looks like most of the flags are yours)