### PR TITLE
Update to use cAdvisor as source of truth for CRI-O socket

### DIFF
--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/kubelet/types:go_default_library",
+        "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
         "//vendor/github.com/google/cadvisor/events:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v2:go_default_library",

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -21,6 +21,7 @@ package cadvisor
 import (
 	"fmt"
 
+	"github.com/google/cadvisor/container/crio"
 	cadvisorfs "github.com/google/cadvisor/fs"
 )
 
@@ -43,7 +44,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 		// This is a temporary workaround to get stats for cri-o from cadvisor
 		// and should be removed.
 		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == CrioSocket {
+		if i.runtimeEndpoint == crio.CrioSocket {
 			return cadvisorfs.LabelCrioImages, nil
 		}
 	}

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -19,6 +19,7 @@ package cadvisor
 import (
 	goruntime "runtime"
 
+	"github.com/google/cadvisor/container/crio"
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	cadvisorapi2 "github.com/google/cadvisor/info/v2"
 	"k8s.io/api/core/v1"
@@ -27,12 +28,6 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
-)
-
-const (
-	// Please keep this in sync with the one in:
-	// github.com/google/cadvisor/container/crio/client.go
-	CrioSocket = "/var/run/crio/crio.sock"
 )
 
 func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
@@ -77,5 +72,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
 	return runtime == kubetypes.RktContainerRuntime ||
 		(runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == CrioSocket
+		runtimeEndpoint == crio.CrioSocket
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates kubelet code to defer to cAdvisor as CRI-O socket location source of truth.

**Release note**:
```release-note
NONE
```
