### PR TITLE
make sure that 'ldflags' are space-safe

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -133,8 +133,8 @@ kube::version::ldflag() {
   local val=${2}
 
   # If you update these, also update the list pkg/version/def.bzl.
-  echo "-X ${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}"
-  echo "-X ${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}"
+  echo "-X '${KUBE_GO_PACKAGE}/pkg/version.${key}=${val}'"
+  echo "-X '${KUBE_GO_PACKAGE}/vendor/k8s.io/client-go/pkg/version.${key}=${val}'"
 }
 
 # Prints the value that needs to be passed to the -ldflags parameter of go build


### PR DESCRIPTION
**What this PR does / why we need it**:
Recently I met the problem as #56216 described, I download the source-tar of 1.8.5 and run `make` command failed because of invalid ldflag: 
 `-X k8s.io/kubernetes/pkg/version.gitTreeState=git archive`

Though #56249 has change version string `git archive` to `archive`, i think we should avoid this problem happen again.

cc @ixdy 

**Release note**: NONE
