### PR TITLE
Build position independent executables.

### DIFF
--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -15,7 +15,7 @@ go_binary(
             "-linkmode",
             "external",
             "-extldflags",
-            "-static",
+            "-buildmode=pie",
         ],
     }),
     importpath = "k8s.io/kubernetes/cmd/kubectl",

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -622,6 +622,8 @@ kube::golang::build_binaries() {
     # Use eval to preserve embedded quoted strings.
     local goflags goldflags gogcflags
     eval "goflags=(${GOFLAGS:-})"
+    # Add a build-mode, default to position independent executable (pie)
+    goflags+=("-buildmode=pie")
     goldflags="${GOLDFLAGS:-} $(kube::version::ldflags)"
     gogcflags="${GOGCFLAGS:-}"
 
@@ -684,7 +686,7 @@ kube::golang::build_binaries() {
       for platform in "${platforms[@]}"; do (
           kube::golang::set_platform_envs "${platform}"
           kube::log::status "${platform}: go build started"
-          kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-}
+          kube::golang::build_binaries_for_platform ${platform} ${use_go_build:-} 
           kube::log::status "${platform}: go build finished"
         ) &> "/tmp//${platform//\//_}.build" &
       done


### PR DESCRIPTION
[Position Independent Executables](https://access.redhat.com/blogs/766093/posts/1975793)

Are binaries that randomize the location of their libraries to prevent stack smashing and other sorts of attacks.

Use the `-buildmode` flag in golang to build pie binaries.