### PR TITLE
Pointed to community/contributors/guide/README.md (Partially fixes kubernetes/community#1413)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,7 @@
 # Contributing
 
-Information about contributing to the
-[kubernetes code repo](README.md) lives in the
-[kubernetes community repo](https://github.com/kubernetes/community)
-(it's a big topic).
+Welcome to Kubernetes! If you are interested in contributing to the [Kubernetes code repo](README.md) then checkout the [Contributor's Guide](https://git.k8s.io/community/contributors/guide/)
 
+The [Kubernetes community repo](https://github.com/kubernetes/community) contains information on how the community is organized and other information that is pertinent to contributing.
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/CONTRIBUTING.md?pixel)]()


### PR DESCRIPTION
What this PR does / why we need it:
This PR helps in the documentation for contributor's guideline by adding the link to community/contributors/guide/README.md in kubernetes/kubernetes/contributing.md

Which issue(s) this PR fixes
Partially fix for kubernetes/community#1413 (edit by @spiffxp to remove the "fixes" keyword)