### PR TITLE
Update kubeadm supported etcd version to 3.2.14 in 1.10

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/plan_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/plan_test.go
@@ -133,7 +133,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 			},
@@ -149,7 +149,7 @@ Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
 Kube DNS             1.14.5    1.14.8
-Etcd                 3.0.17    3.1.10
+Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
 
@@ -194,7 +194,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0",
 						KubeadmVersion: "v1.9.0",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 			},
@@ -230,7 +230,7 @@ Controller Manager   v1.8.3    v1.9.0
 Scheduler            v1.8.3    v1.9.0
 Kube Proxy           v1.8.3    v1.9.0
 Kube DNS             1.14.5    1.14.8
-Etcd                 3.0.17    3.1.10
+Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
 
@@ -259,7 +259,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0-beta.1",
 						KubeadmVersion: "v1.9.0-beta.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 			},
@@ -275,7 +275,7 @@ Controller Manager   v1.8.5    v1.9.0-beta.1
 Scheduler            v1.8.5    v1.9.0-beta.1
 Kube Proxy           v1.8.5    v1.9.0-beta.1
 Kube DNS             1.14.5    1.14.8
-Etcd                 3.0.17    3.1.10
+Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
 
@@ -304,7 +304,7 @@ _____________________________________________________________________
 						KubeVersion:    "v1.9.0-rc.1",
 						KubeadmVersion: "v1.9.0-rc.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 			},
@@ -320,7 +320,7 @@ Controller Manager   v1.8.5    v1.9.0-rc.1
 Scheduler            v1.8.5    v1.9.0-rc.1
 Kube Proxy           v1.8.5    v1.9.0-rc.1
 Kube DNS             1.14.5    1.14.8
-Etcd                 3.0.17    3.1.10
+Etcd                 3.0.17    3.1.11
 
 You can now apply the upgrade by executing the following command:
 

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -165,10 +165,10 @@ const (
 	KubeletBaseConfigurationFile = "kubelet"
 
 	// MinExternalEtcdVersion indicates minimum external etcd version which kubeadm supports
-	MinExternalEtcdVersion = "3.0.14"
+	MinExternalEtcdVersion = "3.1.11"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.1.10"
+	DefaultEtcdVersion = "3.2.14"
 
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
@@ -237,10 +237,9 @@ var (
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
-		8:  "3.0.17",
-		9:  "3.1.10",
-		10: "3.1.10",
-		11: "3.1.10",
+		9:  "3.1.11",
+		10: "3.2.14",
+		11: "3.2.14",
 	}
 )
 

--- a/cmd/kubeadm/app/constants/constants_test.go
+++ b/cmd/kubeadm/app/constants/constants_test.go
@@ -121,44 +121,47 @@ func TestEtcdSupportedVersion(t *testing.T) {
 		expectedError     error
 	}{
 		{
-			kubernetesVersion: "1.8.0",
-			expectedVersion:   version.MustParseSemantic("3.0.17"),
-			expectedError:     nil,
-		},
-		{
-			kubernetesVersion: "1.80.0",
+			kubernetesVersion: "1.99.0",
 			expectedVersion:   nil,
 			expectedError:     fmt.Errorf("Unsupported or unknown kubernetes version"),
 		},
 		{
 			kubernetesVersion: "1.9.0",
-			expectedVersion:   version.MustParseSemantic("3.1.10"),
+			expectedVersion:   version.MustParseSemantic("3.1.11"),
+			expectedError:     nil,
+		},
+		{
+			kubernetesVersion: "1.9.2",
+			expectedVersion:   version.MustParseSemantic("3.1.11"),
 			expectedError:     nil,
 		},
 		{
 			kubernetesVersion: "1.10.0",
-			expectedVersion:   version.MustParseSemantic("3.1.10"),
+			expectedVersion:   version.MustParseSemantic("3.2.14"),
 			expectedError:     nil,
 		},
 		{
-			kubernetesVersion: "1.8.6",
-			expectedVersion:   version.MustParseSemantic("3.0.17"),
+			kubernetesVersion: "1.10.1",
+			expectedVersion:   version.MustParseSemantic("3.2.14"),
 			expectedError:     nil,
 		},
 	}
 	for _, rt := range tests {
 		actualVersion, actualError := EtcdSupportedVersion(rt.kubernetesVersion)
 		if actualError != nil {
-			if actualError.Error() != rt.expectedError.Error() {
+			if rt.expectedError == nil {
+				t.Errorf("failed EtcdSupportedVersion:\n\texpected no error, but got: %v", actualError)
+			} else if actualError.Error() != rt.expectedError.Error() {
 				t.Errorf(
 					"failed EtcdSupportedVersion:\n\texpected error: %v\n\t  actual error: %v",
 					rt.expectedError,
 					actualError,
 				)
 			}
-
 		} else {
-			if strings.Compare(actualVersion.String(), rt.expectedVersion.String()) != 0 {
+			if rt.expectedError != nil {
+				t.Errorf("failed EtcdSupportedVersion:\n\texpected error: %v, but got no error", rt.expectedError)
+			} else if strings.Compare(actualVersion.String(), rt.expectedVersion.String()) != 0 {
 				t.Errorf(
 					"failed EtcdSupportedVersion:\n\texpected version: %s\n\t  actual version: %s",
 					rt.expectedVersion.String(),

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -64,7 +64,7 @@ type fakeEtcdCluster struct{}
 
 func (f fakeEtcdCluster) GetEtcdClusterStatus() (*clientv3.StatusResponse, error) {
 	client := &clientv3.StatusResponse{}
-	client.Version = "3.1.10"
+	client.Version = "3.1.11"
 	return client, nil
 }
 
@@ -108,13 +108,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.2",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.9.3",
 						KubeadmVersion: "v1.9.3",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 			},
@@ -140,13 +140,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.10.0",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0",
 						KubeadmVersion: "v1.10.0",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -172,13 +172,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.9.5",
 						KubeadmVersion: "v1.9.5", // Note: The kubeadm version mustn't be "downgraded" here
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 				},
 				{
@@ -190,13 +190,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.1",
 						KubeadmVersion: "v1.10.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -237,13 +237,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-alpha.2",
 						KubeadmVersion: "v1.10.0-alpha.2",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -270,13 +270,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-alpha.2",
 						KubeadmVersion: "v1.10.0-alpha.2",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -304,13 +304,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-beta.1",
 						KubeadmVersion: "v1.10.0-beta.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -338,13 +338,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-rc.1",
 						KubeadmVersion: "v1.10.0-rc.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -372,13 +372,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.6-rc.1",
 						KubeadmVersion: "v1.10.6-rc.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -406,13 +406,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.10.0-rc.1",
 						KubeadmVersion: "v1.10.0-rc.1",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 				{
@@ -424,13 +424,13 @@ func TestGetAvailableUpgrades(t *testing.T) {
 						},
 						KubeadmVersion: "v1.9.5",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.1.11",
 					},
 					After: ClusterState{
 						KubeVersion:    "v1.11.0-alpha.2",
 						KubeadmVersion: "v1.11.0-alpha.2",
 						DNSVersion:     "1.14.8",
-						EtcdVersion:    "3.1.10",
+						EtcdVersion:    "3.2.14",
 					},
 				},
 			},
@@ -444,7 +444,6 @@ func TestGetAvailableUpgrades(t *testing.T) {
 	// kubernetes release.
 	testCluster := fakeEtcdCluster{}
 	for _, rt := range tests {
-
 		actualUpgrades, actualErr := GetAvailableUpgrades(rt.vg, rt.allowExperimental, rt.allowRCs, testCluster, featureGates)
 		if !reflect.DeepEqual(actualUpgrades, rt.expectedUpgrades) {
 			t.Errorf("failed TestGetAvailableUpgrades\n\texpected upgrades: %v\n\tgot: %v", rt.expectedUpgrades, actualUpgrades)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Kubernetes will upgrade to etcd server 3.2.14 in 1.10 cycle (#58645), update DefaultEtcdVersion in kubeadm to this version.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
relevant PR: #57480 #58645
fixes: https://github.com/kubernetes/kubeadm/issues/621

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
kubeadm don't need to advertise this in release notes.
  