### PR TITLE
Update kubeadm's minimum supported kubernetes to 1.9.

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/certs_test.go
+++ b/cmd/kubeadm/app/cmd/phases/certs_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // phaseTestK8sVersion is a fake kubernetes version to use when testing
-const phaseTestK8sVersion = "v1.8.0"
+const phaseTestK8sVersion = "v1.9.0"
 
 func TestCertsSubCommandsHasFlags(t *testing.T) {
 

--- a/cmd/kubeadm/app/cmd/phases/controlplane_test.go
+++ b/cmd/kubeadm/app/cmd/phases/controlplane_test.go
@@ -93,7 +93,7 @@ func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
 		{
 			command: "all",
 			additionalFlags: []string{
-				"--kubernetes-version=v1.8.0",
+				"--kubernetes-version=v1.9.0",
 				"--apiserver-advertise-address=1.2.3.4",
 				"--apiserver-bind-port=6443",
 				"--service-cidr=1.2.3.4/16",
@@ -108,7 +108,7 @@ func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
 		{
 			command: "apiserver",
 			additionalFlags: []string{
-				"--kubernetes-version=v1.8.0",
+				"--kubernetes-version=v1.9.0",
 				"--apiserver-advertise-address=1.2.3.4",
 				"--apiserver-bind-port=6443",
 				"--service-cidr=1.2.3.4/16",
@@ -118,7 +118,7 @@ func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
 		{
 			command: "controller-manager",
 			additionalFlags: []string{
-				"--kubernetes-version=v1.8.0",
+				"--kubernetes-version=v1.9.0",
 				"--pod-network-cidr=1.2.3.4/16",
 			},
 			expectedFiles: []string{"kube-controller-manager.yaml"},
@@ -126,7 +126,7 @@ func TestControlPlaneCreateFilesWithFlags(t *testing.T) {
 		{
 			command: "scheduler",
 			additionalFlags: []string{
-				"--kubernetes-version=v1.8.0",
+				"--kubernetes-version=v1.9.0",
 			},
 			expectedFiles: []string{"kube-scheduler.yaml"},
 		},

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -226,10 +226,10 @@ var (
 	MasterComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
-	MinimumControlPlaneVersion = version.MustParseSemantic("v1.8.0")
+	MinimumControlPlaneVersion = version.MustParseSemantic("v1.9.0")
 
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
-	MinimumKubeletVersion = version.MustParseSemantic("v1.8.0")
+	MinimumKubeletVersion = version.MustParseSemantic("v1.9.0")
 
 	// MinimumKubeProxyComponentConfigVersion specifies the minimum version for the kubeProxyComponent
 	MinimumKubeProxyComponentConfigVersion = version.MustParseSemantic("v1.9.0-alpha.3")

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -32,135 +32,135 @@ func TestEnforceVersionPolicies(t *testing.T) {
 	}{
 		{ // everything ok
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.5",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.5",
 			},
-			newK8sVersion: "v1.8.5",
+			newK8sVersion: "v1.9.5",
 		},
 		{ // everything ok
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.2",
-				kubeadmVersion: "v1.9.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.2",
+				kubeadmVersion: "v1.10.1",
 			},
-			newK8sVersion: "v1.9.0",
+			newK8sVersion: "v1.10.0",
 		},
 		{ // downgrades ok
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.3",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.3",
 			},
-			newK8sVersion: "v1.8.2",
+			newK8sVersion: "v1.9.2",
 		},
 		{ // upgrades without bumping the version number ok
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.3",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.3",
 			},
-			newK8sVersion: "v1.8.3",
+			newK8sVersion: "v1.9.3",
 		},
-		{ // new version must be higher than v1.8.0
+		{ // new version must be higher than v1.9.0
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.3",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.3",
 			},
-			newK8sVersion:         "v1.7.10",
-			expectedMandatoryErrs: 1, // version must be higher than v1.8.0
+			newK8sVersion:         "v1.8.10",
+			expectedMandatoryErrs: 1, // version must be higher than v1.9.0
 		},
 		{ // upgrading two minor versions in one go is not supported
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.10.0",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.11.0",
 			},
-			newK8sVersion:         "v1.10.0",
+			newK8sVersion:         "v1.11.0",
 			expectedMandatoryErrs: 1, // can't upgrade two minor versions
 			expectedSkippableErrs: 1, // kubelet <-> apiserver skew too large
 		},
 		{ // downgrading two minor versions in one go is not supported
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.10.3",
-				kubeletVersion: "v1.10.3",
-				kubeadmVersion: "v1.10.0",
+				clusterVersion: "v1.11.3",
+				kubeletVersion: "v1.11.3",
+				kubeadmVersion: "v1.11.0",
 			},
-			newK8sVersion:         "v1.8.3",
+			newK8sVersion:         "v1.9.3",
 			expectedMandatoryErrs: 1, // can't downgrade two minor versions
 		},
 		{ // kubeadm version must be higher than the new kube version. However, patch version skews may be forced
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.3",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.3",
 			},
-			newK8sVersion:         "v1.8.5",
+			newK8sVersion:         "v1.9.5",
 			expectedSkippableErrs: 1,
 		},
 		{ // kubeadm version must be higher than the new kube version. Trying to upgrade k8s to a higher minor version than kubeadm itself should never be supported
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.8.3",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.9.3",
 			},
-			newK8sVersion:         "v1.9.0",
+			newK8sVersion:         "v1.10.0",
 			expectedMandatoryErrs: 1,
 		},
 		{ // the maximum skew between the cluster version and the kubelet versions should be one minor version. This may be forced through though.
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.7.8",
-				kubeadmVersion: "v1.9.0",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.8.8",
+				kubeadmVersion: "v1.10.0",
 			},
-			newK8sVersion:         "v1.9.0",
+			newK8sVersion:         "v1.10.0",
 			expectedSkippableErrs: 1,
 		},
 		{ // experimental upgrades supported if the flag is set
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.9.0-beta.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.10.0-beta.1",
 			},
-			newK8sVersion:     "v1.9.0-beta.1",
+			newK8sVersion:     "v1.10.0-beta.1",
 			allowExperimental: true,
 		},
 		{ // release candidate upgrades supported if the flag is set
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.9.0-rc.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.10.0-rc.1",
 			},
-			newK8sVersion: "v1.9.0-rc.1",
+			newK8sVersion: "v1.10.0-rc.1",
 			allowRCs:      true,
 		},
 		{ // release candidate upgrades supported if the flag is set
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.9.0-rc.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.10.0-rc.1",
 			},
-			newK8sVersion:     "v1.9.0-rc.1",
+			newK8sVersion:     "v1.10.0-rc.1",
 			allowExperimental: true,
 		},
 		{ // the user should not be able to upgrade to an experimental version if they haven't opted into that
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.9.0-beta.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.10.0-beta.1",
 			},
-			newK8sVersion:         "v1.9.0-beta.1",
+			newK8sVersion:         "v1.10.0-beta.1",
 			allowRCs:              true,
 			expectedSkippableErrs: 1,
 		},
 		{ // the user should not be able to upgrade to an release candidate version if they haven't opted into that
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.8.3",
-				kubeletVersion: "v1.8.3",
-				kubeadmVersion: "v1.9.0-rc.1",
+				clusterVersion: "v1.9.3",
+				kubeletVersion: "v1.9.3",
+				kubeadmVersion: "v1.10.0-rc.1",
 			},
-			newK8sVersion:         "v1.9.0-rc.1",
+			newK8sVersion:         "v1.10.0-rc.1",
 			expectedSkippableErrs: 1,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Update it in 1.10 cycle.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/622

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update kubeadm's minimum supported Kubernetes version in v1.10.x to v1.9.0
```
