### PR TITLE
Build etcd image for 3.1.11 version

### DIFF
--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[TAGS=2.2.1 2.3.7 3.0.17 3.1.10] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[TAGS=2.2.1 2.3.7 3.0.17 3.1.11] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any tag from here.
@@ -26,8 +26,8 @@
 # Except from etcd-$(tag) and etcdctl-$(tag) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last tag from $(TAGS).
-TAGS?=2.2.1 2.3.7 3.0.17 3.1.10
-REGISTRY_TAG?=3.1.10
+TAGS?=2.2.1 2.3.7 3.0.17 3.1.11
+REGISTRY_TAG?=3.1.11
 ARCH?=amd64
 REGISTRY?=k8s.gcr.io
 GOLANG_VERSION?=1.7.6


### PR DESCRIPTION
This is fixing some bugs in HA setups.

It should be cherrypicked to 1.9 branch.