### PR TITLE
Register metav1 types into samplecontroller api scheme

### DIFF
--- a/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/register.go
+++ b/staging/src/k8s.io/sample-controller/pkg/apis/samplecontroller/v1alpha1/register.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -47,5 +48,6 @@ func addKnownTypes(scheme *runtime.Scheme) error {
 		&Foo{},
 		&FooList{},
 	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Registers metav1 resource types (e.g. ListOptions) with sample-controller scheme.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57205

**Release note**:
```release-note
Fix error message regarding conversion of `v1.ListOptions` to `samplecontroller.k8s.io/v1alpha1`.
```

/cc @sttts @nikhita 
