### PR TITLE
Update all staging repos to get valid dependency hashes

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/main.go
@@ -22,7 +22,6 @@ import (
 	"flag"
 	"fmt"
 
-	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -35,6 +34,7 @@ import (
 	crv1 "k8s.io/apiextensions-apiserver/examples/client-go/apis/cr/v1"
 	exampleclient "k8s.io/apiextensions-apiserver/examples/client-go/client"
 	examplecontroller "k8s.io/apiextensions-apiserver/examples/client-go/controller"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 )
 
 func main() {

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
+
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"

--- a/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/apiserver/install/install.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/apiserver/pkg/apis/apiserver"
 	"k8s.io/apiserver/pkg/apis/apiserver/v1alpha1"
 )

--- a/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
+++ b/staging/src/k8s.io/client-go/discovery/discovery_client_test.go
@@ -25,12 +25,13 @@ import (
 	"testing"
 
 	"github.com/emicklei/go-restful-swagger12"
-
 	"github.com/go-openapi/spec"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/version"
+
 	. "k8s.io/client-go/discovery"
 	"k8s.io/client-go/pkg/api/v1"
 	restclient "k8s.io/client-go/rest"

--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_proxy_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 )
 

--- a/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
+++ b/staging/src/k8s.io/metrics/pkg/apis/metrics/install/install.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/metrics/pkg/apis/metrics"
 	"k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 )

--- a/staging/src/k8s.io/sample-apiserver/main.go
+++ b/staging/src/k8s.io/sample-apiserver/main.go
@@ -23,6 +23,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/util/logs"
+
 	"k8s.io/sample-apiserver/pkg/cmd/server"
 )
 


### PR DESCRIPTION
**This PR unblocks further client-go 4.0 releases**.

To fix the syncing of 1.7 branches in staging repos, we need a change that touches all repos. Then the branch HEADs would get valid dependency hashes and the publishing bot can sync again.

Fixes compilation of `release-1.7` branch of apiextensions-apiserver because of the typo here: https://github.com/kubernetes/apiextensions-apiserver/blob/release-1.7/pkg/apis/apiextensions/doc.go#L21. This would pick up the cherry picked PR: https://github.com/kubernetes/kubernetes/pull/53426.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

/assign sttts caesarxuchao 
  