### PR TITLE
Point to the new contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,11 @@
 # Contributing
 
-Information about contributing to the
-[kubernetes code repo](README.md) lives in the
-[kubernetes community repo](https://github.com/kubernetes/community)
-(it's a big topic).
+Welcome to Kubernetes! If you are interested in contributing to the [Kubernetes
+code repo](README.md) then check out the  [Contributor
+Guide](https://git.k8s.io/community/contributing)
 
+The [Kubernetes community repo](https://github.com/kubernetes/community)
+contains information on how the community is organized and other information
+that is pertinent to contributing. 
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/CONTRIBUTING.md?pixel)]()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes the nebulous "It's complicated, so go to k/community" and instead points people to the in-progress contributor guide, which is incomplete, but already much better than just pointing people to k/community.

See also: https://github.com/kubernetes/community/issues/1413

