### PR TITLE
Reduce CPU and memory requests for Metrics Server Nanny

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -49,8 +49,8 @@ spec:
             cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 50m
-            memory: 100Mi
+            cpu: 5m
+            memory: 50Mi
         env:
           - name: MY_POD_NAME
             valueFrom:


### PR DESCRIPTION
**What this PR does / why we need it**:
Metrics Server Nanny is a sidecar container that performs small computations every 5 minutes to scale Metrics Server resource requirements when cluster size changes. This change reduces the CPU and memory requests to free up unused resource.

**Release note**:
```release-note
Free up CPU and memory requested but unused by Metrics Server Pod Nanny.
```
