### PR TITLE
Fix e2e test cleanup.

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -53,17 +53,15 @@ var _ = SIGDescribe("Aggregator", func() {
 	var c clientset.Interface
 	var aggrclient *aggregatorclient.Clientset
 	f := framework.NewDefaultFramework("aggregator")
-	framework.AddCleanupAction(func() {
-		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
-		if len(ns) > 0 {
-			cleanTest(c, aggrclient, ns)
-		}
-	})
 
 	BeforeEach(func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		aggrclient = f.AggregatorClient
+	})
+
+	AfterEach(func() {
+		cleanTest(c, aggrclient, ns)
 	})
 
 	It("Should be able to support the 1.7 Sample API Server using the current Aggregator", func() {


### PR DESCRIPTION
E2E test should use `AfterEach` instead of `AddCleanupAction`.
`CleanupAction` only runs once after all tests finish https://github.com/kubernetes/kubernetes/blob/master/test/e2e/e2e.go#L258.

I hit this issue very frequently that once `Aggregator` test fails, all following tests all fail because the cleanup function does not run after the test, and namespace controller stops working with full of errors:
```
unable to retrieve the complete list of server APIs: wardle.k8s.io/v1alpha1: the server could not find the requested resource
```

Examples:
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-cri-containerd-e2e-gci-gce/940
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/19115
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/18763
* https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce/18751

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
