### PR TITLE
E2E Test should not use AddCleanupActions to do cleanup.

### DIFF
--- a/test/e2e/storage/persistent_volumes-vsphere.go
+++ b/test/e2e/storage/persistent_volumes-vsphere.go
@@ -122,17 +122,14 @@ var _ = SIGDescribe("PersistentVolumes:vsphere", func() {
 				framework.ExpectNoError(framework.DeletePersistentVolumeClaim(c, pvc.Name, ns), "AfterEach: failed to delete PVC ", pvc.Name)
 			}
 		}
-	})
-	/*
-		Clean up
+		/*
+			Clean up
 
-		1. Wait and verify volume is detached from the node
-		2. Delete PV
-		3. Delete Volume (vmdk)
-	*/
-	framework.AddCleanupAction(func() {
-		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
-		if len(ns) > 0 && len(volumePath) > 0 {
+			1. Wait and verify volume is detached from the node
+			2. Delete PV
+			3. Delete Volume (vmdk)
+		*/
+		if len(volumePath) > 0 {
 			client, err := framework.LoadClientset()
 			if err != nil {
 				return

--- a/test/e2e/storage/vsphere_scale.go
+++ b/test/e2e/storage/vsphere_scale.go
@@ -113,12 +113,9 @@ var _ = SIGDescribe("vcp at scale [Feature:vsphere] ", func() {
 	/*
 		Remove labels from all the nodes
 	*/
-	framework.AddCleanupAction(func() {
-		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
-		if len(namespace) > 0 {
-			for _, node := range nodes.Items {
-				framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
-			}
+	AfterEach(func() {
+		for _, node := range nodes.Items {
+			framework.RemoveLabelOffNode(client, node.Name, NodeLabelKey)
 		}
 	})
 

--- a/test/e2e/storage/vsphere_volume_diskformat.go
+++ b/test/e2e/storage/vsphere_volume_diskformat.go
@@ -80,9 +80,8 @@ var _ = SIGDescribe("Volume Disk Format [Feature:vsphere]", func() {
 			isNodeLabeled = true
 		}
 	})
-	framework.AddCleanupAction(func() {
-		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
-		if len(namespace) > 0 && len(nodeLabelValue) > 0 {
+	AfterEach(func() {
+		if len(nodeLabelValue) > 0 {
 			framework.RemoveLabelOffNode(client, nodeName, "vsphere_e2e_label")
 		}
 	})

--- a/test/e2e/storage/vsphere_volume_placement.go
+++ b/test/e2e/storage/vsphere_volume_placement.go
@@ -69,24 +69,19 @@ var _ = SIGDescribe("Volume Placement", func() {
 			vsp.DeleteVolume(volumePath)
 		}
 		volumePaths = nil
-	})
-
-	/*
-		Steps
-		1. Remove labels assigned to node 1 and node 2
-		2. Delete VMDK volume
-	*/
-	framework.AddCleanupAction(func() {
-		// Cleanup actions will be called even when the tests are skipped and leaves namespace unset.
-		if len(ns) > 0 {
-			if len(node1KeyValueLabel) > 0 {
-				framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
-			}
-			if len(node2KeyValueLabel) > 0 {
-				framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
-			}
+		/*
+			Steps
+			1. Remove labels assigned to node 1 and node 2
+			2. Delete VMDK volume
+		*/
+		if len(node1KeyValueLabel) > 0 {
+			framework.RemoveLabelOffNode(c, node1Name, "vsphere_e2e_label")
+		}
+		if len(node2KeyValueLabel) > 0 {
+			framework.RemoveLabelOffNode(c, node2Name, "vsphere_e2e_label")
 		}
 	})
+
 	/*
 		Steps
 


### PR DESCRIPTION
Related to https://github.com/kubernetes/kubernetes/pull/57254.

`RunCleanupActions` only runs once after the whole test suite finishes. A single test should use `AfterEach` instead.
For example, `volumePath` may change in each `BeforeEach`, if `Cleanup` only run once at the end of the test suite, some `voluemPath` will not be cleaned up.

/cc @divyenpatel @saad-ali 
@kubernetes/sig-storage-pr-reviews 

Signed-off-by: Lantao Liu <lantaol@google.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
