### PR TITLE
Device plugin stub: Take device health dynamically

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
+++ b/pkg/kubelet/cm/deviceplugin/device_plugin_stub.go
@@ -120,7 +120,7 @@ func (m *Stub) ListAndWatch(e *pluginapi.Empty, s pluginapi.DevicePlugin_ListAnd
 	for _, d := range m.devs {
 		devs = append(devs, &pluginapi.Device{
 			ID:     d.ID,
-			Health: pluginapi.Healthy,
+			Health: d.Health,
 		})
 	}
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, in the stub, device health is hardcoded to 'healthy'.
This PR brings a minor fix to take the health from passed device object.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
/sig node

/cc @jiayingz @ConnorDoyle @vishh @tengqm @ScorpioCPH 