### PR TITLE
add disk io stats to stats api

### DIFF
--- a/pkg/kubelet/apis/stats/v1alpha1/types.go
+++ b/pkg/kubelet/apis/stats/v1alpha1/types.go
@@ -118,6 +118,9 @@ type ContainerStats struct {
 	// Stats pertaining to memory (RAM) resources.
 	// +optional
 	Memory *MemoryStats `json:"memory,omitempty"`
+	// Stats pertaining to disk io resources.
+	// +optional
+	DiskIo *DiskIoStats `json:"diskio,omitempty"`
 	// Metrics for Accelerators. Each Accelerator corresponds to one element in the array.
 	Accelerators []AcceleratorStats `json:"accelerators,omitempty"`
 	// Stats pertaining to container rootfs usage of filesystem resources.
@@ -157,6 +160,24 @@ type InterfaceStats struct {
 	// Cumulative count of transmit errors encountered.
 	// +optional
 	TxErrors *uint64 `json:"txErrors,omitempty"`
+}
+
+// PerDiskStats contains data about a single disk partition.
+type PerDiskStats struct {
+	Device string            `json:"device"`
+	Major  uint64            `json:"major"`
+	Minor  uint64            `json:"minor"`
+	Stats  map[string]uint64 `json:"stats"`
+}
+
+// DiskIoStats contains data about disk io resources.
+type DiskIoStats struct {
+	// The time at which these stats were updated.
+	Time metav1.Time `json:"time"`
+
+	// Number of bytes transferred to/from disks.
+	// unit: bytes
+	IoServiceBytes []PerDiskStats `json:"io_service_bytes,omitempty"`
 }
 
 // NetworkStats contains data about network resources.

--- a/pkg/kubelet/server/stats/summary_test.go
+++ b/pkg/kubelet/server/stats/summary_test.go
@@ -92,6 +92,7 @@ func TestSummaryProvider(t *testing.T) {
 		StartTime:          cgroupStatsMap["/kubelet"].cs.StartTime,
 		CPU:                cgroupStatsMap["/kubelet"].cs.CPU,
 		Memory:             cgroupStatsMap["/kubelet"].cs.Memory,
+		DiskIo:             cgroupStatsMap["/kubelet"].cs.DiskIo,
 		Accelerators:       cgroupStatsMap["/kubelet"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/kubelet"].cs.UserDefinedMetrics,
 	})
@@ -100,6 +101,7 @@ func TestSummaryProvider(t *testing.T) {
 		StartTime:          cgroupStatsMap["/misc"].cs.StartTime,
 		CPU:                cgroupStatsMap["/misc"].cs.CPU,
 		Memory:             cgroupStatsMap["/misc"].cs.Memory,
+		DiskIo:             cgroupStatsMap["/misc"].cs.DiskIo,
 		Accelerators:       cgroupStatsMap["/misc"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/misc"].cs.UserDefinedMetrics,
 	})
@@ -108,6 +110,7 @@ func TestSummaryProvider(t *testing.T) {
 		StartTime:          cgroupStatsMap["/runtime"].cs.StartTime,
 		CPU:                cgroupStatsMap["/runtime"].cs.CPU,
 		Memory:             cgroupStatsMap["/runtime"].cs.Memory,
+		DiskIo:             cgroupStatsMap["/runtime"].cs.DiskIo,
 		Accelerators:       cgroupStatsMap["/runtime"].cs.Accelerators,
 		UserDefinedMetrics: cgroupStatsMap["/runtime"].cs.UserDefinedMetrics,
 	})

--- a/pkg/kubelet/stats/helper.go
+++ b/pkg/kubelet/stats/helper.go
@@ -68,6 +68,33 @@ func cadvisorInfoToCPUandMemoryStats(info *cadvisorapiv2.ContainerInfo) (*statsa
 	return cpuStats, memoryStats
 }
 
+func cadvisorInfoToDiskIoStats(info *cadvisorapiv2.ContainerInfo) *statsapi.DiskIoStats {
+	cstat, found := latestContainerStats(info)
+	if !found {
+		return nil
+	}
+
+	var diskIoStats *statsapi.DiskIoStats
+	if info.Spec.HasDiskIo {
+		diskIoStats = &statsapi.DiskIoStats{
+			Time: metav1.NewTime(cstat.Timestamp),
+		}
+
+		if cstat.DiskIo != nil {
+			for _, perDiskIoServiceBytes := range cstat.DiskIo.IoServiceBytes {
+				diskIoStats.IoServiceBytes = append(diskIoStats.IoServiceBytes, statsapi.PerDiskStats{
+					Device: perDiskIoServiceBytes.Device,
+					Major:  perDiskIoServiceBytes.Major,
+					Minor:  perDiskIoServiceBytes.Minor,
+					Stats:  perDiskIoServiceBytes.Stats,
+				})
+			}
+		}
+	}
+
+	return diskIoStats
+}
+
 // cadvisorInfoToContainerStats returns the statsapi.ContainerStats converted
 // from the container and filesystem info.
 func cadvisorInfoToContainerStats(name string, info *cadvisorapiv2.ContainerInfo, rootFs, imageFs *cadvisorapiv2.FsInfo) *statsapi.ContainerStats {
@@ -83,6 +110,9 @@ func cadvisorInfoToContainerStats(name string, info *cadvisorapiv2.ContainerInfo
 	cpu, memory := cadvisorInfoToCPUandMemoryStats(info)
 	result.CPU = cpu
 	result.Memory = memory
+
+	diskIo := cadvisorInfoToDiskIoStats(info)
+	result.DiskIo = diskIo
 
 	if rootFs != nil {
 		// The container logs live on the node rootfs device

--- a/test/e2e_node/summary_test.go
+++ b/test/e2e_node/summary_test.go
@@ -101,6 +101,10 @@ var _ = framework.KubeDescribe("Summary API", func() {
 						"PageFaults":      bounded(1000, 1E9),
 						"MajorPageFaults": bounded(0, 100000),
 					}),
+					"DiskIo": Or(BeNil(), ptrMatchAllFields(gstruct.Fields{
+						"Time":           recent(maxStatsAge),
+						"IoServiceBytes": Not(BeNil()),
+					})),
 					"Accelerators":       BeEmpty(),
 					"Rootfs":             BeNil(),
 					"Logs":               BeNil(),
@@ -149,6 +153,10 @@ var _ = framework.KubeDescribe("Summary API", func() {
 							"RSSBytes":        bounded(1*framework.Kb, framework.Mb),
 							"PageFaults":      bounded(100, 1000000),
 							"MajorPageFaults": bounded(0, 10),
+						}),
+						"DiskIo": ptrMatchAllFields(gstruct.Fields{
+							"Time":           recent(maxStatsAge),
+							"IoServiceBytes": BeNil(),
 						}),
 						"Accelerators": BeEmpty(),
 						"Rootfs": ptrMatchAllFields(gstruct.Fields{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds disk io stats `io_service_bytes` to kubelet stats api. disk io stats will be consumed by Heapster later to add disk io metrics for heapster summary source api.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add disk io metrics to kubelet stats api
```
