### PR TITLE
Fix device manager to scan resources.Requests

### DIFF
--- a/pkg/kubelet/cm/deviceplugin/manager.go
+++ b/pkg/kubelet/cm/deviceplugin/manager.go
@@ -550,7 +550,10 @@ func (m *ManagerImpl) allocateContainerResources(pod *v1.Pod, container *v1.Cont
 	podUID := string(pod.UID)
 	contName := container.Name
 	allocatedDevicesUpdated := false
-	for k, v := range container.Resources.Limits {
+	// NOTE: Skipping the Resources.Limits is safe here because:
+	// 1. If container Spec mentions Limits only, implicitly Requests, equal to Limits, will get added to the Spec.
+	// 2. If container Spec mentions Limits, which are greater than or less than Requests, will fail at validation.
+	for k, v := range container.Resources.Requests {
 		resource := string(k)
 		needed := int(v.Value())
 		glog.V(3).Infof("needs %d %s", needed, resource)

--- a/pkg/kubelet/cm/deviceplugin/manager_test.go
+++ b/pkg/kubelet/cm/deviceplugin/manager_test.go
@@ -366,7 +366,7 @@ func (m *MockEndpoint) allocate(devs []string) (*pluginapi.AllocateResponse, err
 	return nil, nil
 }
 
-func makePod(limits v1.ResourceList) *v1.Pod {
+func makePod(requests v1.ResourceList) *v1.Pod {
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			UID: uuid.NewUUID(),
@@ -375,7 +375,7 @@ func makePod(limits v1.ResourceList) *v1.Pod {
 			Containers: []v1.Container{
 				{
 					Resources: v1.ResourceRequirements{
-						Limits: limits,
+						Requests: requests,
 					},
 				},
 			},
@@ -616,7 +616,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 				{
 					Name: string(uuid.NewUUID()),
 					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
+						Requests: v1.ResourceList{
 							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
 						},
 					},
@@ -624,7 +624,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 				{
 					Name: string(uuid.NewUUID()),
 					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
+						Requests: v1.ResourceList{
 							v1.ResourceName(res1.resourceName): res1.resourceQuantity,
 						},
 					},
@@ -634,7 +634,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 				{
 					Name: string(uuid.NewUUID()),
 					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
+						Requests: v1.ResourceList{
 							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
 							v1.ResourceName(res2.resourceName): res2.resourceQuantity,
 						},
@@ -643,7 +643,7 @@ func TestInitContainerDeviceAllocation(t *testing.T) {
 				{
 					Name: string(uuid.NewUUID()),
 					Resources: v1.ResourceRequirements{
-						Limits: v1.ResourceList{
+						Requests: v1.ResourceList{
 							v1.ResourceName(res1.resourceName): res2.resourceQuantity,
 							v1.ResourceName(res2.resourceName): res2.resourceQuantity,
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR makes device manager to scan resources.Requests from the container spec. Currently
it scans resources.Limits. For extended resources, it is not mandatory for resources.Limits to be present in the container spec and if Limits are present, validation logic ensures that Limits will always be equal to Requests. 

Fixes #57276 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
/sig node

/cc @ConnorDoyle @vishh @jiayingz @RenaudWasTaken @tengqm @resouer @mindprince 