### PR TITLE
Fixing vSphere Cloud Provider to use "vsphere-cloud-provider" to create ClientBuilder

### DIFF
--- a/pkg/cloudprovider/providers/vsphere/vsphere.go
+++ b/pkg/cloudprovider/providers/vsphere/vsphere.go
@@ -217,7 +217,7 @@ func (vs *VSphere) Initialize(clientBuilder controller.ControllerClientBuilder) 
 
 	// Only on controller node it is required to register listeners.
 	// Register callbacks for node updates
-	client := clientBuilder.ClientOrDie("vSphere-cloud-provider")
+	client := clientBuilder.ClientOrDie("vsphere-cloud-provider")
 	factory := informers.NewSharedInformerFactory(client, 5*time.Minute)
 	nodeInformer := factory.Core().V1().Nodes()
 	nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{


### PR DESCRIPTION
**What this PR does / why we need it**:
vSphere cloud Provider is not using lower case naming while creating clientBuilder.
With this fix, ClientBuilder is created using lowercase naming.
With mixed upper-lower case name, controller manager is crashing.

**Which issue(s) this PR fixes** 
Fixes # https://github.com/kubernetes/kubernetes/issues/57279

**Special notes for your reviewer**:
None

**Release note**:
```release-note
Fixes controller manager crash in certain vSphere cloud provider environment.
```
