### PR TITLE
#57109 Verification of connection to apiserver in kube-proxy

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -384,6 +384,10 @@ func createClients(config kubeproxyconfig.ClientConnectionConfiguration, masterO
 	if len(config.KubeConfigFile) == 0 && len(masterOverride) == 0 {
 		glog.Info("Neither kubeconfig file nor master URL was specified. Falling back to in-cluster config.")
 		kubeConfig, err = rest.InClusterConfig()
+		if err != nil {
+			// return an error if called from a process not running in a kubernetes environment
+			return nil, nil, err
+		}
 	} else {
 		// This creates a client, first loading any specified kubeconfig
 		// file, and then overriding the Master flag, if non-empty.

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -111,7 +111,7 @@ func NewProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 	var healthzServer *healthcheck.HealthzServer
 	var healthzUpdater healthcheck.HealthzUpdater
 	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
+		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef, client)
 		healthzUpdater = healthzServer
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Extended kube-proxy healthcheck to verify connection with apiserver.

regarding what @discordianfish said:
> When for whatever reason kube-proxy can't reach the apiserver, it retries but the pod stays in ready state.

> kube-proxy should fail or have a health check that would indicate such issues.

**Which issue(s) this PR fixes** 
Fixes #57109 



