### PR TITLE
propagate http_proxy to hyperkube build

### DIFF
--- a/cluster/images/hyperkube/Makefile
+++ b/cluster/images/hyperkube/Makefile
@@ -41,7 +41,7 @@ endif
 
 	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	docker build --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
+	docker build --build-arg http_proxy=${HTTP_PROXY} --pull -t ${REGISTRY}/hyperkube-${ARCH}:${VERSION} ${TEMP_DIR}
 	rm -rf "${TEMP_DIR}"
 
 push: build


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR propagates the http_proxy variable to the hyperkube building container. Without this change it is not possible to build hyperkube on a network that requires the use of an HTTP proxy.

