### PR TITLE
Automated cherry pick of #56551: change default azure file/dir mode to 0755

### DIFF
--- a/pkg/volume/azure_file/azure_util.go
+++ b/pkg/volume/azure_file/azure_util.go
@@ -30,8 +30,8 @@ const (
 	fileMode        = "file_mode"
 	dirMode         = "dir_mode"
 	vers            = "vers"
-	defaultFileMode = "0700"
-	defaultDirMode  = "0700"
+	defaultFileMode = "0755"
+	defaultDirMode  = "0755"
 	defaultVers     = "3.0"
 )
 


### PR DESCRIPTION
Cherry pick of #56551 on release-1.8.

#56551: change default azure file/dir mode to 0755