### PR TITLE
Restrict url conditions when run kubectl create with --raw

### DIFF
--- a/pkg/kubectl/cmd/create.go
+++ b/pkg/kubectl/cmd/create.go
@@ -123,7 +123,7 @@ func (o *CreateOptions) ValidateArgs(cmd *cobra.Command, args []string) error {
 		if len(o.FilenameOptions.Filenames) != 1 {
 			return cmdutil.UsageErrorf(cmd, "--raw can only use a single local file or stdin")
 		}
-		if strings.HasPrefix(o.FilenameOptions.Filenames[0], "http") {
+		if strings.Index(o.FilenameOptions.Filenames[0], "http://") == 0 || strings.Index(o.FilenameOptions.Filenames[0], "https://") == 0 {
 			return cmdutil.UsageErrorf(cmd, "--raw cannot read from a url")
 		}
 		if o.FilenameOptions.Recursive {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently when run kubectl create with --raw, it will raise "--raw cannot read from a url " if the filename has prefix "http", which is not proper as we may have filenames like "httptest" or similar.

This PR restrict the URL check conditions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57370 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
