### PR TITLE
 Remove kube-proxy 1.8 configmap and daemonset manifests in kubeadm

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -231,9 +231,6 @@ var (
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
 	MinimumKubeletVersion = version.MustParseSemantic("v1.8.0")
 
-	// MinimumKubeProxyComponentConfigVersion specifies the minimum version for the kubeProxyComponent
-	MinimumKubeProxyComponentConfigVersion = version.MustParseSemantic("v1.9.0-alpha.3")
-
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{
 		8:  "3.0.17",

--- a/cmd/kubeadm/app/phases/addons/proxy/BUILD
+++ b/cmd/kubeadm/app/phases/addons/proxy/BUILD
@@ -41,7 +41,6 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/scheme:go_default_library",
         "//pkg/proxy/apis/kubeproxyconfig/v1alpha1:go_default_library",
-        "//pkg/util/version:go_default_library",
         "//plugin/pkg/scheduler/algorithm:go_default_library",
         "//vendor/k8s.io/api/apps/v1beta2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/cmd/kubeadm/app/phases/addons/proxy/manifests.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/manifests.go
@@ -17,37 +17,6 @@ limitations under the License.
 package proxy
 
 const (
-	// KubeProxyConfigMap18 is the proxy ConfigMap manifest for Kubernetes version 1.8
-	KubeProxyConfigMap18 = `
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: kube-proxy
-  namespace: kube-system
-  labels:
-    app: kube-proxy
-data:
-  kubeconfig.conf: |
-    apiVersion: v1
-    kind: Config
-    clusters:
-    - cluster:
-        certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        server: {{ .MasterEndpoint }}
-      name: default
-    contexts:
-    - context:
-        cluster: default
-        namespace: default
-        user: default
-      name: default
-    current-context: default
-    users:
-    - name: default
-      user:
-        tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-`
-
 	// KubeProxyConfigMap19 is the proxy ConfigMap manifest for Kubernetes 1.9 and above
 	KubeProxyConfigMap19 = `
 kind: ConfigMap
@@ -79,65 +48,6 @@ data:
         tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
   config.conf: |-
 {{ .ProxyConfig}}
-`
-	// KubeProxyDaemonSet18 is the proxy DaemonSet manifest for Kubernetes version 1.8
-	KubeProxyDaemonSet18 = `
-apiVersion: apps/v1beta2
-kind: DaemonSet
-metadata:
-  labels:
-    k8s-app: kube-proxy
-  name: kube-proxy
-  namespace: kube-system
-spec:
-  selector:
-    matchLabels:
-      k8s-app: kube-proxy
-  updateStrategy:
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        k8s-app: kube-proxy
-    spec:
-      containers:
-      - name: kube-proxy
-        image: {{ if .ImageOverride }}{{ .ImageOverride }}{{ else }}{{ .ImageRepository }}/kube-proxy-{{ .Arch }}:{{ .Version }}{{ end }}
-        imagePullPolicy: IfNotPresent
-        command:
-        - /usr/local/bin/kube-proxy
-        - --kubeconfig=/var/lib/kube-proxy/kubeconfig.conf
-        {{ .ClusterCIDR }}
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - mountPath: /var/lib/kube-proxy
-          name: kube-proxy
-        - mountPath: /run/xtables.lock
-          name: xtables-lock
-          readOnly: false
-        - mountPath: /lib/modules
-          name: lib-modules
-          readOnly: true
-      hostNetwork: true
-      serviceAccountName: kube-proxy
-      tolerations:
-      - key: {{ .MasterTaintKey }}
-        effect: NoSchedule
-      - key: {{ .CloudTaintKey }}
-        value: "true"
-        effect: NoSchedule
-      volumes:
-      - name: kube-proxy
-        configMap:
-          name: kube-proxy
-      - name: xtables-lock
-        hostPath:
-          path: /run/xtables.lock
-          type: FileOrCreate
-      - name: lib-modules
-        hostPath:
-          path: /lib/modules
 `
 
 	// KubeProxyDaemonSet19 is the proxy DaemonSet manifest for Kubernetes 1.9 and above

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	kubeproxyconfigscheme "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/scheme"
 	kubeproxyconfigv1alpha1 "k8s.io/kubernetes/pkg/proxy/apis/kubeproxyconfig/v1alpha1"
-	"k8s.io/kubernetes/pkg/util/version"
 	"k8s.io/kubernetes/plugin/pkg/scheduler/algorithm"
 )
 
@@ -63,58 +62,28 @@ func EnsureProxyAddon(cfg *kubeadmapi.MasterConfiguration, client clientset.Inte
 	if err != nil {
 		return fmt.Errorf("error when marshaling: %v", err)
 	}
-	// Parse the given kubernetes version
-	k8sVersion, err := version.ParseSemantic(cfg.KubernetesVersion)
-	if err != nil {
-		return fmt.Errorf("couldn't parse kubernetes version %q: %v", cfg.KubernetesVersion, err)
-	}
 	var proxyConfigMapBytes, proxyDaemonSetBytes []byte
-	if k8sVersion.AtLeast(kubeadmconstants.MinimumKubeProxyComponentConfigVersion) {
-		proxyConfigMapBytes, err = kubeadmutil.ParseTemplate(KubeProxyConfigMap19,
-			struct {
-				MasterEndpoint string
-				ProxyConfig    string
-			}{
-				MasterEndpoint: masterEndpoint,
-				ProxyConfig:    proxyBytes,
-			})
-		if err != nil {
-			return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
-		}
-		proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
-			ImageRepository: cfg.GetControlPlaneImageRepository(),
-			Arch:            runtime.GOARCH,
-			Version:         kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion),
-			ImageOverride:   cfg.UnifiedControlPlaneImage,
-			MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
-			CloudTaintKey:   algorithm.TaintExternalCloudProvider,
+	proxyConfigMapBytes, err = kubeadmutil.ParseTemplate(KubeProxyConfigMap19,
+		struct {
+			MasterEndpoint string
+			ProxyConfig    string
+		}{
+			MasterEndpoint: masterEndpoint,
+			ProxyConfig:    proxyBytes,
 		})
-		if err != nil {
-			return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)
-		}
-	} else {
-		proxyConfigMapBytes, err = kubeadmutil.ParseTemplate(KubeProxyConfigMap18,
-			struct {
-				MasterEndpoint string
-			}{
-				MasterEndpoint: masterEndpoint,
-			})
-		if err != nil {
-			return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
-		}
-
-		proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet18, struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
-			ImageRepository: cfg.GetControlPlaneImageRepository(),
-			Arch:            runtime.GOARCH,
-			Version:         kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion),
-			ImageOverride:   cfg.UnifiedControlPlaneImage,
-			ClusterCIDR:     getClusterCIDR(cfg.Networking.PodSubnet),
-			MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
-			CloudTaintKey:   algorithm.TaintExternalCloudProvider,
-		})
-		if err != nil {
-			return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)
-		}
+	if err != nil {
+		return fmt.Errorf("error when parsing kube-proxy configmap template: %v", err)
+	}
+	proxyDaemonSetBytes, err = kubeadmutil.ParseTemplate(KubeProxyDaemonSet19, struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
+		ImageRepository: cfg.GetControlPlaneImageRepository(),
+		Arch:            runtime.GOARCH,
+		Version:         kubeadmutil.KubernetesVersionToImageTag(cfg.KubernetesVersion),
+		ImageOverride:   cfg.UnifiedControlPlaneImage,
+		MasterTaintKey:  kubeadmconstants.LabelNodeRoleMaster,
+		CloudTaintKey:   algorithm.TaintExternalCloudProvider,
+	})
+	if err != nil {
+		return fmt.Errorf("error when parsing kube-proxy daemonset template: %v", err)
 	}
 	if err := createKubeProxyAddon(proxyConfigMapBytes, proxyDaemonSetBytes, client); err != nil {
 		return err

--- a/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
+++ b/cmd/kubeadm/app/phases/addons/proxy/proxy_test.go
@@ -114,34 +114,12 @@ func TestCompileManifests(t *testing.T) {
 		expected bool
 	}{
 		{
-			manifest: KubeProxyConfigMap18,
-			data: struct {
-				MasterEndpoint, ProxyConfig string
-			}{
-				MasterEndpoint: "foo",
-			},
-			expected: true,
-		},
-		{
 			manifest: KubeProxyConfigMap19,
 			data: struct {
 				MasterEndpoint, ProxyConfig string
 			}{
 				MasterEndpoint: "foo",
 				ProxyConfig:    "  bindAddress: 0.0.0.0\n  clusterCIDR: 192.168.1.1\n  enableProfiling: false",
-			},
-			expected: true,
-		},
-		{
-			manifest: KubeProxyDaemonSet18,
-			data: struct{ ImageRepository, Arch, Version, ImageOverride, ClusterCIDR, MasterTaintKey, CloudTaintKey string }{
-				ImageRepository: "foo",
-				Arch:            "foo",
-				Version:         "foo",
-				ImageOverride:   "foo",
-				ClusterCIDR:     "foo",
-				MasterTaintKey:  "foo",
-				CloudTaintKey:   "foo",
 			},
 			expected: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Remove unsupported manifests of kube-proxy in kubeadm of 1.10.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubernetes/kubeadm/issues/622

**Special notes for your reviewer**:
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
