### PR TITLE
Automated cherry pick of #56550

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_storage.go
+++ b/pkg/cloudprovider/providers/azure/azure_storage.go
@@ -42,20 +42,24 @@ func (az *Cloud) CreateFileShare(name, storageAccount, storageType, location str
 			// find the access key with this account
 			key, err := az.getStorageAccesskey(account.Name)
 			if err != nil {
-				glog.V(2).Infof("no key found for storage account %s", account.Name)
+				err = fmt.Errorf("could not get storage key for storage account %s: %v", account.Name, err)
 				continue
 			}
 
 			err = az.createFileShare(account.Name, key, name, requestGB)
 			if err != nil {
-				glog.V(2).Infof("failed to create share in account %s: %v", account.Name, err)
+				err = fmt.Errorf("failed to create share %s in account %s: %v", name, account.Name, err)
 				continue
 			}
 			glog.V(4).Infof("created share %s in account %s", name, account.Name)
 			return account.Name, key, err
 		}
 	}
-	return "", "", fmt.Errorf("failed to find a matching storage account")
+
+	if err == nil {
+		err = fmt.Errorf("failed to find a matching storage account")
+	}
+	return "", "", err
 }
 
 // DeleteFileShare deletes a file share using storage account name and key


### PR DESCRIPTION
Cherry pick of #56550 on release-1.7.

#56550: return error when create azure share failed
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
fix incorrect error info when creating an azure file PVC failed
```