### PR TITLE
Automated cherry pick of #56551

### DIFF
--- a/pkg/volume/azure_file/azure_util.go
+++ b/pkg/volume/azure_file/azure_util.go
@@ -30,8 +30,8 @@ const (
 	fileMode        = "file_mode"
 	dirMode         = "dir_mode"
 	vers            = "vers"
-	defaultFileMode = "0700"
-	defaultDirMode  = "0700"
+	defaultFileMode = "0755"
+	defaultDirMode  = "0755"
 	defaultVers     = "3.0"
 )
 


### PR DESCRIPTION
Cherry pick of #56551 on release-1.9.

#56551: change default azure file/dir mode to 0755
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
change default azure file/dir mode to 0755
```