### PR TITLE
add "Not Found" error for ipset set & entry delete

### DIFF
--- a/pkg/proxy/ipvs/ipset.go
+++ b/pkg/proxy/ipvs/ipset.go
@@ -114,7 +114,9 @@ func (set *IPSet) syncIPSetEntries() {
 		// Clean legacy entries
 		for _, entry := range currentIPSetEntries.Difference(set.activeEntries).List() {
 			if err := set.handle.DelEntry(entry, set.Name); err != nil {
-				glog.Errorf("Failed to delete ip set entry: %s from ip set: %s, error: %v", entry, set.Name, err)
+				if !utilipset.IsNotFoundError(err) {
+					glog.Errorf("Failed to delete ip set entry: %s from ip set: %s, error: %v", entry, set.Name, err)
+				}
 			} else {
 				glog.V(3).Infof("Successfully delete legacy ip set entry: %s from ip set: %s", entry, set.Name)
 			}

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -806,6 +806,7 @@ func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset
 		encounteredError = false
 		err := ipvs.Flush()
 		if err != nil {
+			glog.Errorf("Error flushing IPVS rules: %v", err)
 			encounteredError = true
 		}
 	}
@@ -813,6 +814,7 @@ func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset
 	nl := NewNetLinkHandle()
 	err := nl.DeleteDummyDevice(DefaultDummyDevice)
 	if err != nil {
+		glog.Errorf("Error deleting dummy device %s created by IPVS proxier: %v", DefaultDummyDevice, err)
 		encounteredError = true
 	}
 	// Clear iptables created by ipvs Proxier.

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -824,7 +824,10 @@ func CleanupLeftovers(ipvs utilipvs.Interface, ipt utiliptables.Interface, ipset
 	for _, set := range ipSetsToDestroy {
 		err = ipset.DestroySet(set)
 		if err != nil {
-			encounteredError = true
+			if !utilipset.IsNotFoundError(err) {
+				glog.Errorf("Error removing ipset %s, error: %v", set, err)
+				encounteredError = true
+			}
 		}
 	}
 	return encounteredError

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -329,10 +329,13 @@ func IsNotFoundError(err error) bool {
 	es := err.Error()
 	if strings.Contains(es, "does not exist") {
 		// set with the same name already exists
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/errcode.c#L32-L33
 		return true
 	}
 	if strings.Contains(es, "element is missing") {
 		// entry is missing from the set
+		// xref: https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1904
+		// https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1925
 		return true
 	}
 	return false

--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -322,4 +322,20 @@ func validatePortRange(portRange string) bool {
 	return true
 }
 
+// IsNotFoundError returns true if the error indicates "not found".  It parses
+// the error string looking for known values, which is imperfect but works in
+// practice.
+func IsNotFoundError(err error) bool {
+	es := err.Error()
+	if strings.Contains(es, "does not exist") {
+		// set with the same name already exists
+		return true
+	}
+	if strings.Contains(es, "element is missing") {
+		// entry is missing from the set
+		return true
+	}
+	return false
+}
+
 var _ = Interface(&runner{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add "not found error" for ipset set and entry delete. For example,

```
[root@SHA1000130405 k8s-yml]# ipset list
Name: KUBE-LOOP-BACK
Type: hash:ip,port,ip
Revision: 2
Header: family inet hashsize 1024 maxelem 65536
Size in memory: 16776
References: 1
Members:
172.17.0.2,udp:53,172.17.0.2
172.17.0.2,tcp:53,172.17.0.2
100.106.89.164,tcp:6443,100.106.89.164

[root@SHA1000130405 k8s-yml]# ipset delete foo
ipset v6.19: The set with the given name does not exist

[root@SHA1000130405 k8s-yml]# ipset del KUBE-LOOP-BACK 1.2.3.4,tcp:80,1.2.3.4
ipset v6.19: Syntax error: Third element is missing from 1.2.3.4,tcp:80,1.2.3.4.
```
Just need to filter the error message "does not exist" or "element is missing". We should ignore these error when try to make sure they are deleted.

**Which issue(s) this PR fixes**:
Fixes #57318

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
