### PR TITLE
suport pods.hostports in quota

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -211,6 +211,7 @@ var standardQuotaResources = sets.NewString(
 	string(core.ResourceConfigMaps),
 	string(core.ResourceServicesNodePorts),
 	string(core.ResourceServicesLoadBalancers),
+	string(core.ResourcePodsHostPorts),
 )
 
 // IsStandardQuotaResourceName returns true if the resource is known to
@@ -240,6 +241,7 @@ var standardResources = sets.NewString(
 	string(core.ResourceRequestsStorage),
 	string(core.ResourceServicesNodePorts),
 	string(core.ResourceServicesLoadBalancers),
+	string(core.ResourcePodsHostPorts),
 )
 
 // IsStandardResourceName returns true if the resource is known to the system

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4177,6 +4177,8 @@ const (
 	ResourceLimitsMemory ResourceName = "limits.memory"
 	// Local ephemeral storage limit, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
 	ResourceLimitsEphemeralStorage ResourceName = "limits.ephemeral-storage"
+	// Hostports bound to pod, number
+	ResourcePodsHostPorts ResourceName = "pods.hostports"
 )
 
 // The following identify resource prefix for Kubernetes object types

--- a/pkg/quota/evaluator/core/pods_test.go
+++ b/pkg/quota/evaluator/core/pods_test.go
@@ -274,6 +274,36 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},
+		"container hostports": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					// hostports in initContainers are not calculated.
+					InitContainers: []api.Container{{
+						Ports: []api.ContainerPort{
+							{HostPort: 80},
+							{HostPort: 8080},
+						},
+					}},
+					Containers: []api.Container{{
+						Ports: []api.ContainerPort{
+							{HostPort: 80},
+							{HostPort: 8080},
+						},
+					},
+						{
+							Ports: []api.ContainerPort{
+								{ContainerPort: 1000},
+							},
+						},
+					},
+				},
+			},
+			usage: api.ResourceList{
+				api.ResourcePodsHostPorts: resource.MustParse("2"),
+				api.ResourcePods:          resource.MustParse("1"),
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
 		"init container maximums override sum of containers": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{


### PR DESCRIPTION
Host port is a valuable resource. Now we have podSecurityPolicy to limit the allowed host ports in a pod spec. However the total amount of host ports in each namespace is not supported. This change adds "pods.hostports" quota to control the total amount of host ports.

**Release note**:
```release-note
support pods.hostport in resourcesquota.
```