### PR TITLE
E2E autoscaling test scenario "should add node to the particular mig" fix

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -415,6 +415,15 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 			}
 		}
 
+		if minSize == 0 {
+			newSizes := make(map[string]int)
+			for mig, size := range originalSizes {
+				newSizes[mig] = size
+			}
+			newSizes[minMig] = 1
+			setMigSizes(newSizes)
+		}
+
 		removeLabels := func(nodesToClean sets.String) {
 			By("Removing labels from nodes")
 			for node := range nodesToClean {


### PR DESCRIPTION
Resize targeted MIG to one to fix flakes when initial size of it is zero. Scale-up from zero doesn't make sense in this scenario, and the test assumes there will be always at least one node.