### PR TITLE
add deads to quota owner

### DIFF
--- a/pkg/quota/OWNERS
+++ b/pkg/quota/OWNERS
@@ -1,8 +1,9 @@
 approvers:
+- deads2k
 - derekwaynecarr
 - vishh
 reviewers:
-- smarterclayton
 - deads2k
 - derekwaynecarr
+- smarterclayton
 - vishh


### PR DESCRIPTION
Looks like an oversight.

/assign derekwaynecarr

```release-note
NONE
```