### PR TITLE
Wait for kubedns to be ready when collecting the cluster IP.

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -440,7 +440,13 @@ def send_cluster_dns_detail(kube_control):
     ''' Send cluster DNS info '''
     enableKubeDNS = hookenv.config('enable-kube-dns')
     dnsDomain = hookenv.config('dns_domain')
-    dns_ip = None if not enableKubeDNS else get_dns_ip()
+    dns_ip = None
+    if enableKubeDNS:
+        try:
+            dns_ip = get_dns_ip()
+        except CalledProcessError:
+            hookenv.log("kubedns not ready yet")
+            return
     kube_control.set_dns(53, dnsDomain, dns_ip, enableKubeDNS)
 
 


### PR DESCRIPTION
**What this PR does / why we need it**: Wait for kubedns to be ready when collecting the cluster IP.

**Release note**:
```release-note
Wait for kubedns to be ready when collecting the cluster IP.
```
