### PR TITLE
Fix garbage collector when leader-elect=false

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -162,7 +162,9 @@ func Run(s *options.CMServer) error {
 	}
 
 	if !s.LeaderElection.LeaderElect {
-		run(nil)
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		run(stopCh)
 		panic("unreachable")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In a 1.8.x master with --leader-elect=false, the garbage collector controller
does not work.

When deleting a deployment with v1meta.DeletePropagationForeground, the deployment
had its deletionTimestamp set and a foreground Deletion finalizer was added,
but the deployment, rs and pod were not deleted.

This is an issue with how the garbage collector graph_builder behaves when the
stopCh=nil.  This PR creates a dummy stop channel for the garbage collector controller (and other
controllers started by the controller-manager) so that they can work more like they do when
when the controller-manager is configured with --leader-elect=true.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57044

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix garbage collection and resource quota when the controller-manager uses --leader-elect=false
```
