### PR TITLE
Add custom metrics e2e test with two metrics.

### DIFF
--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/instrumentation/common:go_default_library",
-        "//test/utils/image:go_default_library",
         "//vendor/github.com/influxdata/influxdb/client/v2:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_deployments.go
@@ -25,14 +25,14 @@ import (
 	rbac "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 var (
-	CustomMetricName  = "foo"
-	UnusedMetricName  = "unused"
-	CustomMetricValue = int64(448)
-	UnusedMetricValue = int64(446)
+	CustomMetricName    = "foo"
+	UnusedMetricName    = "unused"
+	CustomMetricValue   = int64(448)
+	UnusedMetricValue   = int64(446)
+	StackdriverExporter = "stackdriver-exporter"
 	// HPAPermissions is a ClusterRoleBinding that grants unauthenticated user permissions granted for
 	// HPA for testing purposes, i.e. it should grant permission to read custom metrics.
 	HPAPermissions = &rbac.ClusterRoleBinding{
@@ -54,9 +54,37 @@ var (
 	}
 )
 
-// StackdriverExporterDeployment is a Deployment of simple application that exports a metric of
+// CustomMetricContainerSpec allows to specify a config for StackdriverExporterDeployment
+// with multiple containers exporting different metrics.
+type CustomMetricContainerSpec struct {
+	Name        string
+	MetricName  string
+	MetricValue int64
+}
+
+// SimpleStackdriverExporterDeployment is a Deployment of simple application that exports a metric of
 // fixed value to Stackdriver in a loop.
-func StackdriverExporterDeployment(name, namespace string, replicas int32, metricValue int64) *extensions.Deployment {
+func SimpleStackdriverExporterDeployment(name, namespace string, replicas int32, metricValue int64) *extensions.Deployment {
+	return StackdriverExporterDeployment(name, namespace, replicas,
+		[]CustomMetricContainerSpec{
+			{
+				Name:        StackdriverExporter,
+				MetricName:  CustomMetricName,
+				MetricValue: metricValue,
+			},
+		})
+}
+
+// StackdriverExporterDeployment is a Deployment of an application that can expose
+// an arbitrary amount of metrics of fixed value to Stackdriver in a loop. Each metric
+// is exposed by a different container in one pod.
+// The metric names and values are configured via the containers parameter.
+func StackdriverExporterDeployment(name, namespace string, replicas int32, containers []CustomMetricContainerSpec) *extensions.Deployment {
+	podSpec := corev1.PodSpec{Containers: []corev1.Container{}}
+	for _, containerSpec := range containers {
+		podSpec.Containers = append(podSpec.Containers, stackdriverExporterContainerSpec(containerSpec.Name, containerSpec.MetricName, containerSpec.MetricValue))
+	}
+
 	return &extensions.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -72,7 +100,7 @@ func StackdriverExporterDeployment(name, namespace string, replicas int32, metri
 						"name": name,
 					},
 				},
-				Spec: stackdriverExporterPodSpec(CustomMetricName, metricValue),
+				Spec: podSpec,
 			},
 			Replicas: &replicas,
 		},
@@ -90,31 +118,29 @@ func StackdriverExporterPod(podName, namespace, podLabel, metricName string, met
 				"name": podLabel,
 			},
 		},
-		Spec: stackdriverExporterPodSpec(metricName, metricValue),
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{stackdriverExporterContainerSpec(StackdriverExporter, metricName, metricValue)},
+		},
 	}
 }
 
-func stackdriverExporterPodSpec(metricName string, metricValue int64) corev1.PodSpec {
-	return corev1.PodSpec{
-		Containers: []corev1.Container{
+func stackdriverExporterContainerSpec(name string, metricName string, metricValue int64) corev1.Container {
+	return corev1.Container{
+		Name:            name,
+		Image:           "gcr.io/google-containers/sd-dummy-exporter:v0.1.0",
+		ImagePullPolicy: corev1.PullPolicy("Always"),
+		Command:         []string{"/sd_dummy_exporter", "--pod-id=$(POD_ID)", "--metric-name=" + metricName, fmt.Sprintf("--metric-value=%v", metricValue)},
+		Env: []corev1.EnvVar{
 			{
-				Name:            "stackdriver-exporter",
-				Image:           imageutils.GetE2EImage(imageutils.SDDummyExporter),
-				ImagePullPolicy: corev1.PullPolicy("Always"),
-				Command:         []string{"/sd_dummy_exporter", "--pod-id=$(POD_ID)", "--metric-name=" + metricName, fmt.Sprintf("--metric-value=%v", metricValue)},
-				Env: []corev1.EnvVar{
-					{
-						Name: "POD_ID",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.uid",
-							},
-						},
+				Name: "POD_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: "metadata.uid",
 					},
 				},
-				Ports: []corev1.ContainerPort{{ContainerPort: 80}},
 			},
 		},
+		Ports: []corev1.ContainerPort{{ContainerPort: 80}},
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds an e2e test for HPA, where a deployment is scaled based on two custom metrics.

**Release note**:
```
NONE
```
