### PR TITLE
Temporary implementation of count metrics for PodSecurityPolicy

### DIFF
--- a/plugin/pkg/admission/security/podsecuritypolicy/BUILD
+++ b/plugin/pkg/admission/security/podsecuritypolicy/BUILD
@@ -8,7 +8,10 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["admission.go"],
+    srcs = [
+        "admission.go",
+        "metrics.go",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/extensions:go_default_library",
@@ -20,6 +23,7 @@ go_library(
         "//pkg/security/podsecuritypolicy/util:go_default_library",
         "//pkg/serviceaccount:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
@@ -44,7 +48,10 @@ go_test(
         "//pkg/security/podsecuritypolicy:go_default_library",
         "//pkg/security/podsecuritypolicy/seccomp:go_default_library",
         "//pkg/security/podsecuritypolicy/util:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -111,6 +111,12 @@ func (a *podSecurityPolicyPlugin) SetInternalKubeInformerFactory(f informers.Sha
 //     with the validated PSP.  If we don't find any reject the pod and give all errors from the
 //     failed attempts.
 func (c *podSecurityPolicyPlugin) Admit(a admission.Attributes) error {
+	err := c.admit(a)
+	ObserveAdmit(err != nil, a)
+	return err
+}
+
+func (c *podSecurityPolicyPlugin) admit(a admission.Attributes) error {
 	if a.GetResource().GroupResource() != api.Resource("pods") {
 		return nil
 	}

--- a/plugin/pkg/admission/security/podsecuritypolicy/metrics.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/metrics.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podsecuritypolicy
+
+import (
+	"strconv"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	namespace = "apiserver"
+	subsystem = "admission"
+)
+
+var (
+	admitCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "controller_admission_latencies_seconds_count",
+			Help:      "Admission controller counts, identified by name and broken out for each operation and API resource and type (validate or admit).",
+		},
+		[]string{"name", "type", "operation", "group", "version", "resource", "subresource", "rejected"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(admitCounter)
+}
+
+func ObserveAdmit(rejected bool, attr admission.Attributes) {
+	gvr := attr.GetResource()
+	labels := []string{PluginName, "admit", string(attr.GetOperation()), gvr.Group, gvr.Version, gvr.Resource, attr.GetSubresource(), strconv.FormatBool(rejected)}
+	admitCounter.WithLabelValues(labels...).Inc()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Alternative proposal to https://github.com/kubernetes/kubernetes/pull/57173

> We need rejection counts in order to turn on the PodSecurityPolicy controller. Comprehensive metrics were added for all admission controllers in 1.9, but backporting all those metrics was deemed to risky. So instead, this PR only enables the metrics on the PodSecurityPolicy controller.

**Which issue(s) this PR fixes**:
Fixes #55030

**Special notes for your reviewer**:
Most of the diff is tests & boiler plate. Most prod code changes are contained in metrics.go, with a small hook in admission.go.

This deviates from the metrics in HEAD, but some amount of drift between 1.8 and 1.9 is inevitable, due to the admission refactorings that went into 1.9.

**Release note**:
```release-note
Add prometheus metrics for the PodSecurityPolicy admission controller
```
