### PR TITLE
Automated cherry pick of #57293

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -217,7 +217,7 @@ func asCSIAccessMode(am api.PersistentVolumeAccessMode) csipb.VolumeCapability_A
 	case api.ReadWriteOnce:
 		return csipb.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
 	case api.ReadOnlyMany:
-		return csipb.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER
+		return csipb.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
 	case api.ReadWriteMany:
 		return csipb.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
 	}


### PR DESCRIPTION
Cherry pick of #57293 on release-1.9.

#57293: fix accessmode mapping error

```release-note
Fixed incorrect info being passed from kubelet to CSI driver because of accessmode mapping error
```
