### PR TITLE
correct annotations of pkg/kubelet/rkt/config.go

### DIFF
--- a/pkg/kubelet/rkt/config.go
+++ b/pkg/kubelet/rkt/config.go
@@ -76,7 +76,7 @@ func (c *Config) buildGlobalOptions() []string {
 
 // getConfig gets configurations from the rkt API service
 // and merge it with the existing config. The merge rule is
-// that the fields in the provided config will override the
+// that the fields in the provided config will be overridden by the
 // result that get from the rkt api service.
 func (r *Runtime) getConfig(cfg *Config) (*Config, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), r.requestTimeout)


### PR DESCRIPTION
**What this PR does / why we need it**:
the merge rule in the pkg/kubelet/rkt/config.go seems not match the code's behavior.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```NONE
