### PR TITLE
Add '/version/' to the system:discovery role, since that's what the spec says.

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -169,7 +169,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbac.PolicyRule{
 				rbac.NewRule("get").URLs(
-					"/healthz", "/version", "/version/*",
+					"/healthz", "/version", "/version/",
 					// remove once swagger 1.2 support is removed
 					"/swaggerapi", "/swaggerapi/*",
 					// do not expand this pattern for openapi discovery docs

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -169,7 +169,7 @@ func ClusterRoles() []rbac.ClusterRole {
 			ObjectMeta: metav1.ObjectMeta{Name: "system:discovery"},
 			Rules: []rbac.PolicyRule{
 				rbac.NewRule("get").URLs(
-					"/healthz", "/version",
+					"/healthz", "/version", "/version/*",
 					// remove once swagger 1.2 support is removed
 					"/swaggerapi", "/swaggerapi/*",
 					// do not expand this pattern for openapi discovery docs

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -640,7 +640,7 @@ items:
     - /swaggerapi
     - /swaggerapi/*
     - /version
-    - /version/*
+    - /version/
     verbs:
     - get
 - apiVersion: rbac.authorization.k8s.io/v1

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/cluster-roles.yaml
@@ -640,6 +640,7 @@ items:
     - /swaggerapi
     - /swaggerapi/*
     - /version
+    - /version/*
     verbs:
     - get
 - apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
See: https://github.com/kubernetes-client/java/issues/153

```release-note
Add the path '/version/' to the `system:discovery` cluster role.
```
