### PR TITLE
Add more validators when run kubectl get with --raw

### DIFF
--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -25,6 +25,8 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
+	"net/url"
+
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -212,6 +214,12 @@ func (options *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 func (options *GetOptions) Validate(cmd *cobra.Command) error {
 	if len(options.Raw) > 0 && (options.Watch || options.WatchOnly || len(options.LabelSelector) > 0 || options.Export) {
 		return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
+	}
+	if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
+		return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
+	}
+	if _, err := url.ParseRequestURI(options.Raw); err != nil {
+		return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
 	}
 	if cmdutil.GetFlagBool(cmd, "show-labels") {
 		outputOption := cmd.Flags().Lookup("output").Value.String()

--- a/pkg/kubectl/cmd/resource/get.go
+++ b/pkg/kubectl/cmd/resource/get.go
@@ -212,14 +212,16 @@ func (options *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 
 // Validate checks the set of flags provided by the user.
 func (options *GetOptions) Validate(cmd *cobra.Command) error {
-	if len(options.Raw) > 0 && (options.Watch || options.WatchOnly || len(options.LabelSelector) > 0 || options.Export) {
-		return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
-	}
-	if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
-		return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
-	}
-	if _, err := url.ParseRequestURI(options.Raw); err != nil {
-		return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
+	if len(options.Raw) > 0 {
+		if options.Watch || options.WatchOnly || len(options.LabelSelector) > 0 || options.Export {
+			return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
+		}
+		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
+			return cmdutil.UsageErrorf(cmd, "--raw and --output are mutually exclusive")
+		}
+		if _, err := url.ParseRequestURI(options.Raw); err != nil {
+			return cmdutil.UsageErrorf(cmd, "--raw must be a valid URL path: %v", err)
+		}
 	}
 	if cmdutil.GetFlagBool(cmd, "show-labels") {
 		outputOption := cmd.Flags().Lookup("output").Value.String()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
1. Make --raw and --output mutually exclusive for kubectl get cmd
2. Add url/ParseRequestURI check for the specified raw URI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57379

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
