### PR TITLE
Deprecate the alpha Accelerators feature gate.

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -64,6 +64,8 @@ const (
 	// owner: @vishh
 	// alpha: v1.6
 	//
+	// This is deprecated and will be removed in v1.11. Use DevicePlugins instead.
+	//
 	// Enables support for GPUs as a schedulable resource.
 	// Only Nvidia GPUs are supported as of v1.6.
 	// Works only with Docker Container Runtime.

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -875,6 +875,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.softAdmitHandlers.AddPodAdmitHandler(lifecycle.NewNoNewPrivsAdmitHandler(klet.containerRuntime))
 	if utilfeature.DefaultFeatureGate.Enabled(features.Accelerators) {
 		if containerRuntime == kubetypes.DockerContainerRuntime {
+			glog.Warningln("Accelerators feature is deprecated and will be removed in v1.11. Please use device plugins instead. They can be enabled using the DevicePlugins feature gate.")
 			if klet.gpuManager, err = nvidia.NewNvidiaGPUManager(klet, kubeDeps.DockerClientConfig); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Encourage people to use DevicePlugins instead.

/kind cleanup

Related to https://github.com/kubernetes/features/issues/192 and https://github.com/kubernetes/features/issues/368

**Release note**:
```release-note
The alpha Accelerators feature gate is deprecated and will be removed in v1.11. Please use device plugins instead. They can be enabled using the DevicePlugins feature gate.
```

/sig node
/sig scheduling
/area hw-accelerators