### PR TITLE
Gke spec tweaks

### DIFF
--- a/pkg/cloudprovider/providers/azure/OWNERS
+++ b/pkg/cloudprovider/providers/azure/OWNERS
@@ -1,6 +1,14 @@
 approvers:
+- andyzhangx
 - brendandburns
 - colemickens
+- feiskyer
 - jdumars
+- khenidak
 reviewers:
 - andyzhangx
+- brendandburns
+- colemickens
+- feiskyer
+- jdumars
+- khenidak

--- a/pkg/volume/azure_dd/OWNERS
+++ b/pkg/volume/azure_dd/OWNERS
@@ -1,11 +1,16 @@
 approvers:
+- andyzhangx
 - brendandburns
+- feiskyer
+- khenidak
 - rootfs
 reviewers:
-- rootfs
-- brendandburns
-- saad-ali
-- jsafrane
-- jingxu97
-- msau42
 - andyzhangx
+- brendandburns
+- feiskyer
+- jingxu97
+- jsafrane
+- msau42
+- khenidak
+- rootfs
+- saad-ali

--- a/pkg/volume/azure_file/OWNERS
+++ b/pkg/volume/azure_file/OWNERS
@@ -1,11 +1,16 @@
 approvers:
+- andyzhangx
 - brendandburns
+- feiskyer
+- khenidak
 - rootfs
 reviewers:
-- rootfs
+- andyzhangx
 - brendandburns
-- saad-ali
+- feiskyer
 - jsafrane
 - jingxu97
+- khenidak
 - msau42
-- andyzhangx
+- rootfs
+- saad-ali

--- a/test/e2e_node/system/specs/gke.yaml
+++ b/test/e2e_node/system/specs/gke.yaml
@@ -220,7 +220,6 @@ packageSpecs:
   versionRange: '>=4.2.0'
 - name: less
   versionRange: '>=481'
-- name: linux-headers-${KERNEL_RELEASE}
 - name: netcat-openbsd
   versionRange: '>=1.10'
 - name: python

--- a/test/e2e_node/system/specs/gke.yaml
+++ b/test/e2e_node/system/specs/gke.yaml
@@ -235,8 +235,6 @@ packageSpecs:
   versionRange: '>=1.28'
 - name: util-linux
   versionRange: '>=2.27.1'
-- name: vim
-  versionRange: '>=7.4.712'
 - name: wget
   versionRange: '>=1.18'
 - name: gce-compute-image-packages


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR removes two unnecessary requirements for the GKE node image validation spec:
- The "vim" package doesn't need to be installed, as a vim environment is already available and the full "vim" pacakge installation takes some precious disk space.
- The linux headers are not needed for the kubernetes node and cluster tests to succeed, and again, take unnecessary disk space. 

**Special notes for your reviewer**:
None.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
