### PR TITLE
Change dynamic client api path to /apis

### DIFF
--- a/staging/src/k8s.io/client-go/dynamic/client.go
+++ b/staging/src/k8s.io/client-go/dynamic/client.go
@@ -96,7 +96,7 @@ func NewClient(conf *restclient.Config) (*Client, error) {
 	conf.ContentConfig = contentConfig
 
 	if conf.APIPath == "" {
-		conf.APIPath = "/api"
+		conf.APIPath = "/apis"
 	}
 
 	if len(conf.UserAgent) == 0 {


### PR DESCRIPTION
Signed-off-by: xianlubird <xianlubird@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Change dynamic client default api path from `api` to `apis`


**Special notes for your reviewer**:
k8s resources api begin with /apis like `/apis/apps/v1/namespaces/{namespace}/deployments` .
Default api path set to /apis will help developer to work.   
/api is strange here.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Change dynamic client api path to /apis
```
