### PR TITLE
Use old dns-ip mechanism with older cdk-addons.

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -572,6 +572,7 @@ def configure_cdk_addons():
     dnsEnabled = str(hookenv.config('enable-kube-dns')).lower()
     args = [
         'arch=' + arch(),
+        'dns-ip=' + get_deprecated_dns_ip(),
         'dns-domain=' + hookenv.config('dns_domain'),
         'enable-dashboard=' + dbEnabled,
         'enable-kube-dns=' + dnsEnabled
@@ -962,6 +963,14 @@ def get_dns_ip():
     output = check_output(cmd, shell=True).decode()
     svc = json.loads(output)
     return svc['spec']['clusterIP']
+
+
+def get_deprecated_dns_ip():
+    '''We previously hardcoded the dns ip. This function returns the old
+    hardcoded value for use with older versions of cdk_addons.'''
+    interface = ipaddress.IPv4Interface(service_cidr())
+    ip = interface.network.network_address + 10
+    return ip.exploded
 
 
 def get_kubernetes_service_ip():


### PR DESCRIPTION
**What this PR does / why we need it**: Use old dns-ip mechanism with older cdk-addons.

**Release note**:
```release-note
Use old dns-ip mechanism with older cdk-addons.
```
