### PR TITLE
Improve DaemonSet deletion user experience

### DIFF
--- a/pkg/kubectl/delete.go
+++ b/pkg/kubectl/delete.go
@@ -289,8 +289,10 @@ func (reaper *DaemonSetReaper) Stop(namespace, name string, timeout time.Duratio
 	// to not be set on any node so the DameonSetController will start deleting
 	// daemon pods. Once it's done deleting the daemon pods, it's safe to delete
 	// the DaemonSet.
+	// The name this nodeSelector should make it clear that this is a result of
+	// an incomplete delete operation.
 	ds.Spec.Template.Spec.NodeSelector = map[string]string{
-		string(uuid.NewUUID()): string(uuid.NewUUID()),
+		fmt.Sprintf("pending-deletion-started-at-%v", time.Now().Format("2006-01-02-15-04-05")): string(uuid.NewUUID()),
 	}
 	// force update to avoid version conflict
 	ds.ResourceVersion = ""


### PR DESCRIPTION
**What this PR does / why we need it**:

> The name or value of this special node selector should make it clear that this is a result of an incomplete delete operation. Perhaps just make the value "pending deletion started at YYYY-MM-DD HH:MM:SS" instead of or in addition to the current random one.

instead of 
`df98126b-df31-11e7-9c8e-42010a8e0002=df9812e4-df31-11e7-9c8e-42010a8e0002`
we will have
 `pending-deletion-started-at-2006-01-02-15-04-05=df9812e4-df31-11e7-9c8e-42010a8e0002`

**Which issue(s) this PR fixes**:
Fixes #57398 

