### PR TITLE
add semver metadata regex

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -89,7 +89,7 @@ kube::version::get_version_vars() {
       # Try to match the "git describe" output to a regex to try to extract
       # the "major" and "minor" versions and whether this is the exact tagged
       # version or whether the tree is between two tagged versions.
-      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?$ ]]; then
+      if [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
         KUBE_GIT_MAJOR=${BASH_REMATCH[1]}
         KUBE_GIT_MINOR=${BASH_REMATCH[2]}
         if [[ -n "${BASH_REMATCH[4]}" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: When building a release tag with optional semver metadata, the minor and major versions are not parsed correctly (empty strings). This fix adds optional support to the regex for the metadata component.

example:

```
~/w/g/s/k/kubernetes ❯❯❯ git tag v1.9.0+stable.0                                 fixes/semver_metadata ✭
~/w/g/s/k/kubernetes ❯❯❯ hack/print-workspace-status.sh                          fixes/semver_metadata ✭
STABLE_BUILD_GIT_COMMIT 63e2eacd22b5050140f9630d8ec430a54361d228
STABLE_BUILD_SCM_STATUS clean
STABLE_BUILD_SCM_REVISION v1.9.0+stable.0
STABLE_BUILD_MAJOR_VERSION 1
STABLE_BUILD_MINOR_VERSION 9
STABLE_DOCKER_TAG v1.9.0_stable.0
gitCommit 63e2eacd22b5050140f9630d8ec430a54361d228
gitTreeState clean
gitVersion v1.9.0+stable.0
gitMajor 1
gitMinor 9
buildDate 2017-12-19T21:08:48Z
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
