### PR TITLE
Node e2e test: do not return error if Docker's check-config.sh fails

### DIFF
--- a/test/e2e_node/gke_environment_test.go
+++ b/test/e2e_node/gke_environment_test.go
@@ -139,10 +139,10 @@ func checkDockerConfig() error {
 		if _, err := os.Stat(bin); os.IsNotExist(err) {
 			continue
 		}
-		output, err := runCommand(bin)
-		if err != nil {
-			return err
-		}
+		// We don't check the return code because it's OK if the script returns
+		// a non-zero exit code just because the configs in the whitelist are
+		// missing.
+		output, _ := runCommand(bin)
 		for _, line := range strings.Split(output, "\n") {
 			if !strings.Contains(line, "missing") {
 				continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR fixes the issue in https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/ci-kubernetes-e2enode-ubuntudev2-k8sbeta-gkespec/1#k8sio-gke-system-requirements-conformance-featuregkeenv-the-docker-configuration-validation-should-pass

https://github.com/moby/moby/pull/28007 changed the Docker's check-config.sh to return a non-zero exit code if the check fails. But we expect certain configs to be missing, so we should ignore the exit code.

This needs to be cherry-picked into 1.9.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

/area node-e2e
/kind bug
/assign @dchen1107 