### PR TITLE
fix a typo

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -302,12 +302,12 @@ func (r *Reflector) ListAndWatch(stopCh <-chan struct{}) error {
 		default:
 		}
 
-		timemoutseconds := int64(minWatchTimeout.Seconds() * (rand.Float64() + 1.0))
+		timeoutSeconds := int64(minWatchTimeout.Seconds() * (rand.Float64() + 1.0))
 		options = metav1.ListOptions{
 			ResourceVersion: resourceVersion,
 			// We want to avoid situations of hanging watchers. Stop any wachers that do not
 			// receive any events within the timeout window.
-			TimeoutSeconds: &timemoutseconds,
+			TimeoutSeconds: &timeoutSeconds,
 		}
 
 		r.metrics.numberOfWatches.Inc()


### PR DESCRIPTION
Just a typo, `timemoutseconds` should be `timeoutSeconds`.
