### PR TITLE
[WIP] [Prototype] Make portforward support udp

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4433,6 +4433,15 @@ const (
 	// Value for streamType header for terminal resize stream
 	StreamTypeResize = "resize"
 
+	// Name of header that specifies PortForward protocol type
+	PortForwardProtocolType = "protocolType"
+	// Value for PortForwardProtocolType header for TCP4 protocol
+	PortForwardProtocolTypeTcp4 = "TCP4"
+	// Value for PortForwardProtocolType header for TCP6 protocol
+	PortForwardProtocolTypeTcp6 = "TCP6"
+	// Value for PortForwardProtocolType header for UDP protocol
+	PortForwardProtocolTypeUdp = "UDP"
+
 	// Name of header that specifies the port being forwarded
 	PortHeader = "port"
 	// Name of header that specifies a request ID used to associate the error

--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -4439,8 +4439,10 @@ const (
 	PortForwardProtocolTypeTcp4 = "TCP4"
 	// Value for PortForwardProtocolType header for TCP6 protocol
 	PortForwardProtocolTypeTcp6 = "TCP6"
-	// Value for PortForwardProtocolType header for UDP protocol
-	PortForwardProtocolTypeUdp = "UDP"
+	// Value for PortForwardProtocolType header for UDP4 protocol
+	PortForwardProtocolTypeUdp4 = "UDP4"
+	// Value for PortForwardProtocolType header for UDP6 protocol
+	PortForwardProtocolTypeUdp6 = "UDP6"
 
 	// Name of header that specifies the port being forwarded
 	PortHeader = "port"

--- a/pkg/client/tests/portfoward_test.go
+++ b/pkg/client/tests/portfoward_test.go
@@ -51,7 +51,8 @@ type fakePortForwarder struct {
 
 var _ portforward.PortForwarder = &fakePortForwarder{}
 
-func (pf *fakePortForwarder) PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
+//need udp
+func (pf *fakePortForwarder) PortForward(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
 	defer stream.Close()
 
 	// read from the client

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -117,6 +117,11 @@ func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts Po
 // Complete completes all the required options for port-forward cmd.
 func (o *PortForwardOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	var err error
+	o.PortForwardProtocol = cmdutil.GetFlagString(cmd, "protocol")
+	if len(o.PortForwardProtocol) == 0 {
+		o.PortForwardProtocol = api.PortForwardProtocolTypeTcp4
+	}
+
 	o.PodName = cmdutil.GetFlagString(cmd, "pod")
 	if len(o.PodName) == 0 && len(args) == 0 {
 		return cmdutil.UsageErrorf(cmd, "POD is required for port-forward")

--- a/pkg/kubectl/cmd/portforward.go
+++ b/pkg/kubectl/cmd/portforward.go
@@ -39,15 +39,16 @@ import (
 
 // PortForwardOptions contains all the options for running the port-forward cli command.
 type PortForwardOptions struct {
-	Namespace     string
-	PodName       string
-	RESTClient    *restclient.RESTClient
-	Config        *restclient.Config
-	PodClient     coreclient.PodsGetter
-	Ports         []string
-	PortForwarder portForwarder
-	StopChannel   chan struct{}
-	ReadyChannel  chan struct{}
+	Namespace           string
+	PodName             string
+	RESTClient          *restclient.RESTClient
+	Config              *restclient.Config
+	PodClient           coreclient.PodsGetter
+	PortForwardProtocol string
+	Ports               []string
+	PortForwarder       portForwarder
+	StopChannel         chan struct{}
+	ReadyChannel        chan struct{}
 }
 
 var (
@@ -87,6 +88,7 @@ func NewCmdPortForward(f cmdutil.Factory, cmdOut, cmdErr io.Writer) *cobra.Comma
 		},
 	}
 	cmd.Flags().StringP("pod", "p", "", "Pod name")
+	cmd.Flags().StringP("protocol", "", "tcp", "Forward Protocol: currently support TCP4 and UDP")
 	// TODO support UID
 	return cmd
 }
@@ -105,7 +107,7 @@ func (f *defaultPortForwarder) ForwardPorts(method string, url *url.URL, opts Po
 		return err
 	}
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, method, url)
-	fw, err := portforward.New(dialer, opts.Ports, opts.StopChannel, opts.ReadyChannel, f.cmdOut, f.cmdErr)
+	fw, err := portforward.New(dialer, opts.PortForwardProtocol, opts.Ports, opts.StopChannel, opts.ReadyChannel, f.cmdOut, f.cmdErr)
 	if err != nil {
 		return err
 	}

--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -82,6 +82,7 @@ go_library(
     }),
     importpath = "k8s.io/kubernetes/pkg/kubelet/dockershim",
     deps = [
+        "//pkg/apis/core:go_default_library",
         "//pkg/credentialprovider:go_default_library",
         "//pkg/kubelet/apis/cri:go_default_library",
         "//pkg/kubelet/apis/cri/v1alpha1/runtime:go_default_library",
@@ -119,6 +120,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//vendor/k8s.io/client-go/tools/portforward:go_default_library",
         "//vendor/k8s.io/client-go/tools/remotecommand:go_default_library",
     ],
 )

--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
+	"k8s.io/apiserver/pkg/storage/names"
+	"strconv"
 )
 
 type streamingRuntime struct {
@@ -217,7 +219,8 @@ func protForwardTcp(containerPid int, port int32, stream io.ReadWriteCloser) err
 
 func portForwardUdp(containerPid int, port int32, stream io.ReadWriteCloser) error {
 	unixDomainSocketPath := "/tmp/my.sock"
-	unixDomainSocketPath1 := "/tmp/1.sock"
+	unixDomainSocketPath1 := "/tmp/"+names.SimpleNameGenerator.GenerateName(strconv.Itoa(containerPid))+".sock"
+
 	socatPath, lookupErr := exec.LookPath("socat")
 	if lookupErr != nil {
 		return fmt.Errorf("unable to do port forwarding: socat not found.")

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1620,9 +1620,10 @@ func (kl *Kubelet) AttachContainer(podFullName string, podUID types.UID, contain
 	return streamingRuntime.AttachContainer(container.ID, stdin, stdout, stderr, tty, resize)
 }
 
+//need udp
 // PortForward connects to the pod's port and copies data between the port
 // and the stream.
-func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, port int32, stream io.ReadWriteCloser) error {
+func (kl *Kubelet) PortForward(podFullName string, podUID types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
 	streamingRuntime, ok := kl.containerRuntime.(kubecontainer.DirectStreamingRuntime)
 	if !ok {
 		return fmt.Errorf("streaming methods not supported by runtime")

--- a/pkg/kubelet/server/portforward/httpstream.go
+++ b/pkg/kubelet/server/portforward/httpstream.go
@@ -239,11 +239,17 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
 	defer p.dataStream.Close()
 	defer p.errorStream.Close()
 
+	protocol := p.dataStream.Headers().Get(api.PortForwardProtocolType)
+	if protocol == "" {
+		// use tcp4 if no specify
+		protocol = api.PortForwardProtocolTypeTcp4
+	}
+
 	portString := p.dataStream.Headers().Get(api.PortHeader)
 	port, _ := strconv.ParseInt(portString, 10, 32)
 
 	glog.V(5).Infof("(conn=%p, request=%s) invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
-	err := h.forwarder.PortForward(h.pod, h.uid, int32(port), p.dataStream)
+	err := h.forwarder.PortForward(h.pod, h.uid, protocol, int32(port), p.dataStream)
 	glog.V(5).Infof("(conn=%p, request=%s) done invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
 
 	if err != nil {

--- a/pkg/kubelet/server/portforward/httpstream.go
+++ b/pkg/kubelet/server/portforward/httpstream.go
@@ -236,8 +236,8 @@ Loop:
 // portForward invokes the httpStreamHandler's forwarder.PortForward
 // function for the given stream pair.
 func (h *httpStreamHandler) portForward(p *httpStreamPair) {
-	defer p.dataStream.Close()
-	defer p.errorStream.Close()
+	//defer p.dataStream.Close()
+	//defer p.errorStream.Close()
 
 	protocol := p.dataStream.Headers().Get(api.PortForwardProtocolType)
 	if protocol == "" {
@@ -247,6 +247,8 @@ func (h *httpStreamHandler) portForward(p *httpStreamPair) {
 
 	portString := p.dataStream.Headers().Get(api.PortHeader)
 	port, _ := strconv.ParseInt(portString, 10, 32)
+
+	glog.V(3).Infof("haha: into func (h *httpStreamHandler) portForward(p *httpStreamPair) {")
 
 	glog.V(5).Infof("(conn=%p, request=%s) invoking forwarder.PortForward for port %s", h.conn, p.requestID, portString)
 	err := h.forwarder.PortForward(h.pod, h.uid, protocol, int32(port), p.dataStream)

--- a/pkg/kubelet/server/portforward/portforward.go
+++ b/pkg/kubelet/server/portforward/portforward.go
@@ -30,7 +30,7 @@ import (
 // in a pod.
 type PortForwarder interface {
 	// PortForwarder copies data between a data stream and a port in a pod.
-	PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
+	PortForward(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error
 }
 
 // ServePortForward handles a port forwarding request.  A single request is

--- a/pkg/kubelet/server/portforward/websocket.go
+++ b/pkg/kubelet/server/portforward/websocket.go
@@ -186,7 +186,7 @@ func (h *websocketStreamHandler) portForward(p *websocketStreamPair) {
 	defer p.errorStream.Close()
 
 	glog.V(5).Infof("(conn=%p) invoking forwarder.PortForward for port %d", h.conn, p.port)
-	err := h.forwarder.PortForward(h.pod, h.uid, p.port, p.dataStream)
+	err := h.forwarder.PortForward(h.pod, h.uid, "", p.port, p.dataStream)
 	glog.V(5).Infof("(conn=%p) done invoking forwarder.PortForward for port %d", h.conn, p.port)
 
 	if err != nil {

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -176,7 +176,8 @@ type HostInterface interface {
 	AttachContainer(name string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
 	GetKubeletContainerLogs(podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
 	ServeLogs(w http.ResponseWriter, req *http.Request)
-	PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
+	//need udp
+	PortForward(name string, uid types.UID, protocal string, port int32, stream io.ReadWriteCloser) error
 	StreamingConnectionIdleTimeout() time.Duration
 	ResyncInterval() time.Duration
 	GetHostname() string

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -75,7 +75,7 @@ type fakeKubelet struct {
 	runFunc                            func(podFullName string, uid types.UID, containerName string, cmd []string) ([]byte, error)
 	execFunc                           func(pod string, uid types.UID, container string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool) error
 	attachFunc                         func(pod string, uid types.UID, container string, in io.Reader, out, err io.WriteCloser, tty bool) error
-	portForwardFunc                    func(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
+	portForwardFunc                    func(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error
 	containerLogsFunc                  func(podFullName, containerName string, logOptions *v1.PodLogOptions, stdout, stderr io.Writer) error
 	streamingConnectionIdleTimeoutFunc func() time.Duration
 	hostnameFunc                       func() string
@@ -145,8 +145,9 @@ func (fk *fakeKubelet) AttachContainer(name string, uid types.UID, container str
 	return fk.attachFunc(name, uid, container, in, out, err, tty)
 }
 
-func (fk *fakeKubelet) PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
-	return fk.portForwardFunc(name, uid, port, stream)
+//need udp
+func (fk *fakeKubelet) PortForward(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
+	return fk.portForwardFunc(name, uid, protocol, port, stream)
 }
 
 func (fk *fakeKubelet) GetExec(podFullName string, podUID types.UID, containerName string, cmd []string, streamOpts remotecommandserver.Options) (*url.URL, error) {
@@ -1494,7 +1495,7 @@ func TestServePortForward(t *testing.T) {
 
 		portForwardFuncDone := make(chan struct{})
 
-		fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
+		fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
 			defer close(portForwardFuncDone)
 
 			if e, a := expectedPodName, name; e != a {

--- a/pkg/kubelet/server/server_websocket_test.go
+++ b/pkg/kubelet/server/server_websocket_test.go
@@ -70,7 +70,7 @@ func TestServeWSPortForward(t *testing.T) {
 
 		portForwardFuncDone := make(chan struct{})
 
-		fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
+		fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
 			defer close(portForwardFuncDone)
 
 			if e, a := expectedPodName, name; e != a {
@@ -205,7 +205,7 @@ func TestServeWSMultiplePortForward(t *testing.T) {
 	portsMutex := sync.Mutex{}
 	portsForwarded := map[int32]struct{}{}
 
-	fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error {
+	fw.fakeKubelet.portForwardFunc = func(name string, uid types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
 		defer portForwardWG.Done()
 
 		if e, a := expectedPodName, name; e != a {

--- a/pkg/kubelet/server/streaming/server.go
+++ b/pkg/kubelet/server/streaming/server.go
@@ -62,7 +62,7 @@ type Server interface {
 type Runtime interface {
 	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
 	Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
-	PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error
+	PortForward(podSandboxID string, protocol string, port int32, stream io.ReadWriteCloser) error
 }
 
 // Config defines the options used for running the stream server.
@@ -369,6 +369,7 @@ func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container
 	return a.Runtime.Attach(container, in, out, err, tty, resize)
 }
 
-func (a *criAdapter) PortForward(podName string, podUID types.UID, port int32, stream io.ReadWriteCloser) error {
-	return a.Runtime.PortForward(podName, port, stream)
+//need udp
+func (a *criAdapter) PortForward(podName string, podUID types.UID, protocol string, port int32, stream io.ReadWriteCloser) error {
+	return a.Runtime.PortForward(podName, protocol, port, stream)
 }

--- a/pkg/kubelet/server/streaming/server_test.go
+++ b/pkg/kubelet/server/streaming/server_test.go
@@ -426,7 +426,8 @@ func (f *fakeRuntime) Attach(containerID string, stdin io.Reader, stdout, stderr
 	return nil
 }
 
-func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+//need udp
+func (f *fakeRuntime) PortForward(podSandboxID string, protocol string, port int32, stream io.ReadWriteCloser) error {
 	assert.Equal(f.t, testPodSandboxID, podSandboxID)
 	assert.EqualValues(f.t, testPort, port)
 	doServerStreams(f.t, "portforward", stream, stream, nil)

--- a/plugin/cmd/kube-scheduler/BUILD
+++ b/plugin/cmd/kube-scheduler/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
         "//plugin/cmd/kube-scheduler/app:go_default_library",
+        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/logs:go_default_library",
     ],
 )

--- a/plugin/cmd/kube-scheduler/app/BUILD
+++ b/plugin/cmd/kube-scheduler/app/BUILD
@@ -38,7 +38,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//vendor/k8s.io/apiserver/pkg/util/flag:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/informers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/informers/storage/v1:go_default_library",

--- a/plugin/cmd/kube-scheduler/app/server.go
+++ b/plugin/cmd/kube-scheduler/app/server.go
@@ -68,11 +68,9 @@ import (
 	"k8s.io/kubernetes/plugin/pkg/scheduler/factory"
 
 	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	utilflag "k8s.io/apiserver/pkg/util/flag"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // SchedulerServer has all the context and params needed to run a Scheduler
@@ -344,7 +342,6 @@ through the API as necessary.`,
 	}
 
 	opts.AddFlags(pflag.CommandLine)
-	utilflag.InitFlags()
 
 	cmd.MarkFlagFilename("config", "yaml", "yml", "json")
 

--- a/plugin/cmd/kube-scheduler/scheduler.go
+++ b/plugin/cmd/kube-scheduler/scheduler.go
@@ -19,6 +19,7 @@ package main
 import (
 	"os"
 
+	utilflag "k8s.io/apiserver/pkg/util/flag"
 	"k8s.io/apiserver/pkg/util/logs"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
@@ -28,6 +29,7 @@ import (
 func main() {
 	command := app.NewSchedulerCommand()
 
+	utilflag.InitFlags()
 	logs.InitLogs()
 	defer logs.FlushLogs()
 

--- a/staging/src/k8s.io/client-go/tools/portforward/BUILD
+++ b/staging/src/k8s.io/client-go/tools/portforward/BUILD
@@ -11,7 +11,10 @@ go_test(
     srcs = ["portforward_test.go"],
     embed = [":go_default_library"],
     importpath = "k8s.io/client-go/tools/portforward",
-    deps = ["//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library"],
+    deps = [
+        "//pkg/apis/core:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
+    ],
 )
 
 go_library(
@@ -19,6 +22,8 @@ go_library(
     srcs = [
         "doc.go",
         "portforward.go",
+        "tcp_portforward.go",
+        "udp_portforward.go",
     ],
     importpath = "k8s.io/client-go/tools/portforward",
     deps = [

--- a/staging/src/k8s.io/client-go/tools/portforward/BUILD
+++ b/staging/src/k8s.io/client-go/tools/portforward/BUILD
@@ -22,6 +22,7 @@ go_library(
     ],
     importpath = "k8s.io/client-go/tools/portforward",
     deps = [
+        "//pkg/apis/core:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -20,14 +20,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
-	"net/http"
 	"strconv"
 	"strings"
 	"sync"
 
-	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -152,14 +149,6 @@ func New(dialer httpstream.Dialer, protocol string, ports []string, stopChan <-c
 	}, nil
 }
 
-func (pf *PortForwarder) isUdp() bool {
-	if pf.portForwardProtocol == api.PortForwardProtocolTypeUdp4 ||
-		pf.portForwardProtocol == api.PortForwardProtocolTypeUdp6 {
-		return true
-	}
-	return false
-}
-
 // ForwardPorts formats and executes a port forwarding request. The connection will remain
 // open until stopChan is closed.
 func (pf *PortForwarder) ForwardPorts() error {
@@ -181,28 +170,17 @@ func (pf *PortForwarder) ForwardPorts() error {
 func (pf *PortForwarder) forward() error {
 	if pf.isUdp() {
 		for _, port := range pf.ports {
-			ServerAddr, err := net.ResolveUDPAddr("udp", strconv.Itoa(int(port.Local)))
-			if err != nil {
-
+			addr := net.UDPAddr{
+				Port: int(port.Local),
+				IP:   net.ParseIP("127.0.0.1"),
 			}
-			conn, err := net.ListenUDP("udp", ServerAddr)
+			conn, err := net.ListenUDP("udp", &addr)
 			if err != nil {
-
+				return fmt.Errorf("ListenUDP error %s", err.Error())
 			}
-			go pf.handleConnection(conn, port)
-
-			//defer conn.Close()
-
-			//buf := make([]byte, 1024)
-			//for {
-			//	n,addr,err := conn.ReadFromUDP(buf)
-			//	fmt.Println("Received ",string(buf[0:n]), " from ",addr)
-			//
-			//	if err != nil {
-			//		fmt.Println("Error: ",err)
-			//	}
-			//}
+			go pf.waitForUDPSocket(conn, port)
 		}
+
 	} else {
 		var err error
 		listenSuccess := false
@@ -234,157 +212,6 @@ func (pf *PortForwarder) forward() error {
 		runtime.HandleError(errors.New("lost connection to pod"))
 	}
 	return nil
-}
-
-// listenOnPort delegates tcp4 and tcp6 listener creation and waits for connections on both of these addresses.
-// If both listener creation fail, an error is raised.
-func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
-	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
-	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "[::1]")
-	if errTcp4 != nil && errTcp6 != nil {
-		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
-	}
-	return nil
-}
-
-// listenOnPortAndAddress delegates listener creation and waits for new connections
-// in the background f
-func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
-	listener, err := pf.getListener(protocol, address, port)
-	if err != nil {
-		return err
-	}
-	pf.listeners = append(pf.listeners, listener)
-	go pf.waitForConnection(listener, *port)
-	return nil
-}
-
-// getListener creates a listener on the interface targeted by the given hostname on the given port with
-// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
-func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
-	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
-	if err != nil {
-		return nil, fmt.Errorf("Unable to create listener: Error %s", err)
-	}
-	listenerAddress := listener.Addr().String()
-	host, localPort, _ := net.SplitHostPort(listenerAddress)
-	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
-
-	if err != nil {
-		return nil, fmt.Errorf("Error parsing local port: %s from %s (%s)", err, listenerAddress, host)
-	}
-	port.Local = uint16(localPortUInt)
-	if pf.out != nil {
-		fmt.Fprintf(pf.out, "Forwarding from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
-	}
-
-	return listener, nil
-}
-
-// waitForConnection waits for new connections to listener and handles them in
-// the background.
-func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
-	for {
-		conn, err := listener.Accept()
-		if err != nil {
-			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
-			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
-				runtime.HandleError(fmt.Errorf("Error accepting connection on port %d: %v", port.Local, err))
-			}
-			return
-		}
-		go pf.handleConnection(conn, port)
-	}
-}
-
-func (pf *PortForwarder) nextRequestID() int {
-	pf.requestIDLock.Lock()
-	defer pf.requestIDLock.Unlock()
-	id := pf.requestID
-	pf.requestID++
-	return id
-}
-
-// handleConnection copies data between the local connection and the stream to
-// the remote server.
-func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
-	defer conn.Close()
-
-	if pf.out != nil {
-		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
-	}
-
-	requestID := pf.nextRequestID()
-
-	// create error stream
-	headers := http.Header{}
-	headers.Set(v1.StreamType, v1.StreamTypeError)
-	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
-	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
-	errorStream, err := pf.streamConn.CreateStream(headers)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
-		return
-	}
-	// we're not writing to this stream
-	errorStream.Close()
-
-	errorChan := make(chan error)
-	go func() {
-		message, err := ioutil.ReadAll(errorStream)
-		switch {
-		case err != nil:
-			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
-		case len(message) > 0:
-			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
-		}
-		close(errorChan)
-	}()
-
-	// create data stream
-	headers.Set(v1.StreamType, v1.StreamTypeData)
-	dataStream, err := pf.streamConn.CreateStream(headers)
-	if err != nil {
-		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
-		return
-	}
-
-	localError := make(chan struct{})
-	remoteDone := make(chan struct{})
-
-	go func() {
-		// Copy from the remote side to the local port.
-		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
-		}
-
-		// inform the select below that the remote copy is done
-		close(remoteDone)
-	}()
-
-	go func() {
-		// inform server we're not sending any more data after copy unblocks
-		defer dataStream.Close()
-
-		// Copy from the local port to the remote side.
-		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
-			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
-			// break out of the select below without waiting for the other copy to finish
-			close(localError)
-		}
-	}()
-
-	// wait for either a local->remote error or for copying from remote->local to finish
-	select {
-	case <-remoteDone:
-	case <-localError:
-	}
-
-	// always expect something on errorChan (it may be nil)
-	err = <-errorChan
-	if err != nil {
-		runtime.HandleError(err)
-	}
 }
 
 func (pf *PortForwarder) Close() {

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/httpstream"
+	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
 type fakeDialer struct {
@@ -77,7 +78,7 @@ func TestParsePortsAndNew(t *testing.T) {
 		dialer := &fakeDialer{}
 		expectedStopChan := make(chan struct{})
 		readyChan := make(chan struct{})
-		pf, err := New(dialer, test.input, expectedStopChan, readyChan, os.Stdout, os.Stderr)
+		pf, err := New(dialer, api.PortForwardProtocolTypeTcp4, test.input, expectedStopChan, readyChan, os.Stdout, os.Stderr)
 		haveError = err != nil
 		if e, a := test.expectNewError, haveError; e != a {
 			t.Fatalf("%d: New: error expected=%t, got %t: %s", i, e, a, err)

--- a/staging/src/k8s.io/client-go/tools/portforward/tcp_portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/tcp_portforward.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// listenOnPort delegates tcp4 and tcp6 listener creation and waits for connections on both of these addresses.
+// If both listener creation fail, an error is raised.
+func (pf *PortForwarder) listenOnPort(port *ForwardedPort) error {
+	errTcp4 := pf.listenOnPortAndAddress(port, "tcp4", "127.0.0.1")
+	errTcp6 := pf.listenOnPortAndAddress(port, "tcp6", "[::1]")
+	if errTcp4 != nil && errTcp6 != nil {
+		return fmt.Errorf("All listeners failed to create with the following errors: %s, %s", errTcp4, errTcp6)
+	}
+	return nil
+}
+
+// listenOnPortAndAddress delegates listener creation and waits for new connections
+// in the background f
+func (pf *PortForwarder) listenOnPortAndAddress(port *ForwardedPort, protocol string, address string) error {
+	listener, err := pf.getListener(protocol, address, port)
+	if err != nil {
+		return err
+	}
+	pf.listeners = append(pf.listeners, listener)
+	go pf.waitForConnection(listener, *port)
+	return nil
+}
+
+// getListener creates a listener on the interface targeted by the given hostname on the given port with
+// the given protocol. protocol is in net.Listen style which basically admits values like tcp, tcp4, tcp6
+func (pf *PortForwarder) getListener(protocol string, hostname string, port *ForwardedPort) (net.Listener, error) {
+	listener, err := net.Listen(protocol, net.JoinHostPort(hostname, strconv.Itoa(int(port.Local))))
+	if err != nil {
+		return nil, fmt.Errorf("Unable to create listener: Error %s", err)
+	}
+	listenerAddress := listener.Addr().String()
+	host, localPort, _ := net.SplitHostPort(listenerAddress)
+	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error parsing local port: %s from %s (%s)", err, listenerAddress, host)
+	}
+	port.Local = uint16(localPortUInt)
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Forwarding from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)
+	}
+
+	return listener, nil
+}
+
+// waitForConnection waits for new connections to listener and handles them in
+// the background.
+func (pf *PortForwarder) waitForConnection(listener net.Listener, port ForwardedPort) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// TODO consider using something like https://github.com/hydrogen18/stoppableListener?
+			if !strings.Contains(strings.ToLower(err.Error()), "use of closed network connection") {
+				runtime.HandleError(fmt.Errorf("Error accepting connection on port %d: %v", port.Local, err))
+			}
+			return
+		}
+		go pf.handleConnection(conn, port)
+	}
+}
+
+func (pf *PortForwarder) nextRequestID() int {
+	pf.requestIDLock.Lock()
+	defer pf.requestIDLock.Unlock()
+	id := pf.requestID
+	pf.requestID++
+	return id
+}
+
+// handleConnection copies data between the local connection and the stream to
+// the remote server.
+func (pf *PortForwarder) handleConnection(conn net.Conn, port ForwardedPort) {
+	defer conn.Close()
+
+	if pf.out != nil {
+		fmt.Fprintf(pf.out, "Handling connection for %d\n", port.Local)
+	}
+
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+	// we're not writing to this stream
+	errorStream.Close()
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err))
+		return
+	}
+
+	localError := make(chan struct{})
+	remoteDone := make(chan struct{})
+
+	go func() {
+		// Copy from the remote side to the local port.
+		if _, err := io.Copy(conn, dataStream); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from remote stream to local connection: %v", err))
+		}
+
+		// inform the select below that the remote copy is done
+		close(remoteDone)
+	}()
+
+	go func() {
+		// inform server we're not sending any more data after copy unblocks
+		defer dataStream.Close()
+
+		// Copy from the local port to the remote side.
+		if _, err := io.Copy(dataStream, conn); err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
+			runtime.HandleError(fmt.Errorf("error copying from local connection to remote stream: %v", err))
+			// break out of the select below without waiting for the other copy to finish
+			close(localError)
+		}
+	}()
+
+	// wait for either a local->remote error or for copying from remote->local to finish
+	select {
+	case <-remoteDone:
+	case <-localError:
+	}
+
+	// always expect something on errorChan (it may be nil)
+	err = <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/udp_portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/udp_portforward.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package portforward
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	api "k8s.io/kubernetes/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+func (pf *PortForwarder) isUdp() bool {
+	if pf.portForwardProtocol == api.PortForwardProtocolTypeUdp4 ||
+		pf.portForwardProtocol == api.PortForwardProtocolTypeUdp6 {
+		return true
+	}
+	return false
+}
+
+type UDPSocket map[net.UDPAddr]io.ReadWriteCloser
+
+func (pf *PortForwarder) setupBackToUDPClient(stream httpstream.Stream, connUDP *net.UDPConn, addr *net.UDPAddr) {
+	bufRecv := make([]byte, 1024)
+	//forever loop
+	fmt.Fprintf(pf.out, "setupBackToUDPClient started...\n")
+	for {
+		_, err := stream.Read(bufRecv)
+		if err != nil {
+			fmt.Fprintf(pf.out, "setupBackToUDPClient: Error read from spdy: %s\n", err)
+			break
+		} else {
+			fmt.Fprintf(pf.out, "setupBackToUDPClient 2: received from spdy, data: %s\n", string(bufRecv[:1024]))
+		}
+
+		_, err = connUDP.WriteToUDP(bufRecv[:1024], addr)
+		if err != nil {
+			fmt.Fprintln(pf.out, "setupBackToUDPClient 2: Error write to udp %v: %s \n", addr, err)
+			break
+		} else {
+			fmt.Fprintf(pf.out, "setupBackToUDPClient 2: send to udp %v\n, data: %s\n", addr, string(bufRecv[:1024]))
+		}
+	}
+}
+
+func (pf *PortForwarder) waitForUDPSocket(conn *net.UDPConn, port ForwardedPort) {
+	bufSend := make([]byte, 1024)
+	var socket UDPSocket
+
+	fmt.Fprintf(pf.out, "waitForUDPSocket started\n")
+
+	for {
+		rn, rmAddr, err := conn.ReadFromUDP(bufSend)
+		if err != nil {
+			fmt.Fprintf(pf.out, "ReadFromUDP wrong\n")
+		}
+
+		if socket[*rmAddr] == nil {
+			dataStream, errorStream, err := pf.createStream(conn, port)
+			if err != nil {
+				runtime.HandleError(err)
+				continue
+			}
+
+			go pf.handleErrorStream(errorStream, port)
+			go pf.setupBackToUDPClient(dataStream, conn, rmAddr)
+			socket[*rmAddr] = dataStream
+		}
+
+		_, err = socket[*rmAddr].Write(bufSend[:rn])
+		if err != nil {
+			fmt.Fprintf(pf.out, "goroutine 1: Error write to spdy:", err)
+			break
+		} else {
+			fmt.Fprintf(pf.out, "goroutine 1: send to spdy, data: %s\n", string(bufSend[:rn]))
+		}
+	}
+}
+
+func (pf *PortForwarder) handleErrorStream(errorStream httpstream.Stream, port ForwardedPort) {
+	// we're not writing to this stream
+	errorStream.Close()
+
+	errorChan := make(chan error)
+	go func() {
+		message, err := ioutil.ReadAll(errorStream)
+		switch {
+		case err != nil:
+			errorChan <- fmt.Errorf("error reading from error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+		case len(message) > 0:
+			errorChan <- fmt.Errorf("an error occurred forwarding %d -> %d: %v", port.Local, port.Remote, string(message))
+		}
+		close(errorChan)
+	}()
+
+	err := <-errorChan
+	if err != nil {
+		runtime.HandleError(err)
+	}
+
+}
+func (pf *PortForwarder) createStream(conn *net.UDPConn, port ForwardedPort) (httpstream.Stream, httpstream.Stream, error) {
+	requestID := pf.nextRequestID()
+
+	// create error stream
+	headers := http.Header{}
+	headers.Set(api.PortForwardProtocolType, api.PortForwardProtocolTypeUdp4)
+	headers.Set(v1.StreamType, v1.StreamTypeError)
+	headers.Set(v1.PortHeader, fmt.Sprintf("%d", port.Remote))
+	headers.Set(v1.PortForwardRequestIDHeader, strconv.Itoa(requestID))
+	errorStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating error stream for port %d -> %d: %v", port.Local, port.Remote, err)
+	}
+	// create data stream
+	headers.Set(v1.StreamType, v1.StreamTypeData)
+	dataStream, err := pf.streamConn.CreateStream(headers)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error creating forwarding stream for port %d -> %d: %v", port.Local, port.Remote, err)
+	}
+
+	return dataStream, errorStream, nil
+}
+
+func ReadFromStreamAndSendToUDP(stream io.ReadWriteCloser, connUDP *net.UnixConn) error {
+	bufSend := make([]byte, 1024)
+	bufRecv := make([]byte, 1024)
+	glog.V(3).Infof("haha:  we are into ReadFromStreamAndSendToUDP \n")
+
+	go func() error {
+		glog.V(3).Infof("haha: goroutine 1 started...\n")
+		//forever loop
+		for {
+			n, err := stream.Read(bufSend)
+			if err != nil {
+				glog.V(3).Infof("haha: goroutine 1: error read from spdy: %s\n", err)
+				break
+			} else {
+				glog.V(3).Infof("haha: goroutine 1: received from spdy, data: %s\n", string(bufSend))
+			}
+			_, err = connUDP.Write(bufSend[:n])
+			if err != nil {
+				glog.V(3).Infof("haha: goroutine 1: error write to udp: %s\n", err)
+				break
+			} else {
+				glog.V(3).Infof("haha: goroutine 1: send to udp, data: %s\n", string(bufSend))
+			}
+		}
+		return nil
+	}()
+
+	go func() error {
+		//forever loop
+		glog.V(3).Infof("haha: goroutine 2 started...\n")
+		for {
+			_, addr, err := connUDP.ReadFrom(bufRecv)
+			if err != nil {
+				glog.V(3).Infof("haha: goroutine 2: error read from udp: %s\n", err)
+				break
+			} else {
+				glog.V(3).Infof("haha: goroutine 2: received from udp, data: %s, from %s\n", string(bufRecv), addr)
+			}
+			_, err = stream.Write(bufRecv)
+			if err != nil {
+				glog.V(3).Infof("haha: goroutine 2: error write to spdy: %s\n", err)
+				break
+			} else {
+				glog.V(3).Infof("haha: goroutine 2: send to spdy, data: %s\n", string(bufRecv))
+			}
+		}
+		return nil
+	}()
+
+	return nil
+}
+
+func ReadFromUDPAndSendToStream(out io.Writer, stream io.ReadWriteCloser, connUDP *net.UDPConn) error {
+
+	bufSend := make([]byte, 1024)
+	bufRecv := make([]byte, 1024)
+
+	var TMP *net.UDPAddr
+
+	go func() error {
+		//forever loop
+		fmt.Fprintf(out, "goroutine 1 started...\n")
+		for {
+			rn, rmAddr, err := connUDP.ReadFromUDP(bufSend)
+			if err != nil {
+				fmt.Fprintf(out, "goroutine 1: Error read from udp:", err)
+				break
+			} else {
+				TMP = rmAddr
+				fmt.Fprintf(out, "goroutine 1: received from udp, data: %s\n", string(bufSend[:rn]))
+			}
+			/////////////////////////////////////////////////////////
+			_, err = stream.Write(bufSend[:rn])
+			if err != nil {
+				fmt.Fprintf(out, "goroutine 1: Error write to spdy:", err)
+				break
+			} else {
+				fmt.Fprintf(out, "goroutine 1: send to spdy, data: %s\n", string(bufSend[:rn]))
+			}
+		}
+		return nil
+	}()
+
+	go func() error {
+		//forever loop
+		fmt.Fprintf(out, "goroutine 2 started...\n")
+		for {
+			_, err := stream.Read(bufRecv)
+			if err != nil {
+				fmt.Fprintf(out, "goroutine 2: Error read from spdy: %s\n", err)
+				break
+			} else {
+				fmt.Fprintf(out, "goroutine 2: received from spdy, data: %s\n", string(bufRecv[:1024]))
+			}
+			/////////////////////////////////////////////////////////////////////
+
+			_, err = connUDP.WriteToUDP(bufRecv[:1024], TMP)
+			if err != nil {
+				fmt.Fprintln(out, "goroutine 2: Error write to udp %v: %s \n", TMP, err)
+				break
+			} else {
+				fmt.Fprintf(out, "goroutine 2: send to udp %v\n, data: %s\n", TMP, string(bufRecv[:1024]))
+			}
+
+		}
+		return nil
+	}()
+
+	return nil
+}

--- a/staging/src/k8s.io/client-go/tools/portforward/udp_portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/udp_portforward.go
@@ -94,10 +94,10 @@ func (pf *PortForwarder) waitForUDPSocket(conn *net.UDPConn, port ForwardedPort)
 
 		_, err = socketMap[createKey(rmAddr)].Write(bufSend[:rn])
 		if err != nil {
-			fmt.Fprintf(pf.out, "goroutine 1: Error write to spdy:", err)
+			fmt.Fprintf(pf.out, "waitForUDPSocket 1: Error write to spdy:", err)
 			break
 		} else {
-			fmt.Fprintf(pf.out, "goroutine 1: send to spdy, data: %s\n", string(bufSend[:rn]))
+			fmt.Fprintf(pf.out, "waitForUDPSocket 1: send to spdy, data: %s\n", string(bufSend[:rn]))
 		}
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/47862
Proposal draft: https://github.com/kubernetes/community/pull/1575

still wip early stage, `kubectl` and `socat` side using udp connections, transmission still using spdy. need to consider how we split stream into udp packages.

- [ ] kubectl/client-go side support `--protocol=udp` flags, ListenUDPPacket
- [ ] kubelet side socat support udp, dockershim && rkt (use udp socket instead of stdin&&stdout since udp is not stream)
- [ ] make spdy stream transmit udp possible (all udp package share one stream connection, and use an customized udp protocol to distinguish)
- [ ] tests

@smarterclayton @ncdc @resouer any advice ? do I have to write a proposal ?
  