### PR TITLE
Build Kubernetes binaries with valid Semantic Version

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -96,6 +96,13 @@ kube::version::get_version_vars() {
           KUBE_GIT_MINOR+="+"
         fi
       fi
+
+      # If KUBE_GIT_VERSION is not a valid Semantic Version, then refuse to build.
+      if ! [[ "${KUBE_GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+          echo "KUBE_GIT_VERSION should be a valid Semantic Version"
+          echo "Please see more details here: https://semver.org"
+          exit 1
+      fi
     fi
   fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Refuse to build Kubernetes when a version string like `v1.8.3+xx+xx`.

This PR is to restrict the `KUBE_GIT_VERSION`, if the version string does match the rule of Semantic Version, then refuse to build.

Since Kubernetes Conformance test needs the `KUBE_GIT_VERSION` to be a valid Semantic Version, so I think it's better to restrict the version string.

**Release note**:
```release-note
NONE
```