### PR TITLE
Fix RBAC permissions for metadata agent.

### DIFF
--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent-rbac.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent-rbac.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:metadata-agent
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - ""
+  - "apps"
+  - "extensions"
+  resources:
+  - "*"
+  verbs:
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:metadata-agent
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metadata-agent
+subjects:
+- kind: ServiceAccount
+  name: metadata-agent
+  namespace: kube-system

--- a/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
+++ b/cluster/addons/metadata-agent/stackdriver/metadata-agent.yaml
@@ -1,23 +1,33 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: metadata-agent
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+---
 kind: DaemonSet
 apiVersion: extensions/v1beta1
 metadata:
   labels:
-    app: stackdriver-agents
+    app: metadata-agent
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-  name: stackdriver-agents
+  name: metadata-agent
   namespace: kube-system
 spec:
   selector:
     matchLabels:
-      app: stackdriver-agents
+      app: metadata-agent
   template:
     metadata:
       labels:
-        app: stackdriver-agents
+        app: metadata-agent
     spec:
+      serviceAccountName: metadata-agent
       containers:
-      - image: us.gcr.io/container-monitoring-storage/stackdriver-metadata-agent:{{ metadata_agent_version }}
+      - image: gcr.io/stackdriver-agents/stackdriver-metadata-agent:{{ metadata_agent_version }}
         imagePullPolicy: IfNotPresent
         name: metadata-agent
         ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Allows Stackdriver Metadata Agent to watch nodes and pods

**Release note**:
```release-note
Fix RBAC permissions for Stackdriver Metadata Agent.
```
