### PR TITLE
Bump Metrics Server to version v0.2.1

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,31 +23,31 @@ data:
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.2.0
+  name: metrics-server-v0.2.1
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.2.0
+    version: v0.2.1
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.2.0
+      version: v0.2.1
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.2.0
+        version: v0.2.1
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: gcr.io/google_containers/metrics-server-amd64:v0.2.0
+        image: gcr.io/google_containers/metrics-server-amd64:v0.2.1
         command:
         - /metrics-server
         - --source=kubernetes.summary_api:''
@@ -84,7 +84,7 @@ spec:
           - --memory=140Mi
           - --extra-memory=4Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.2.0
+          - --deployment=metrics-server-v0.2.1
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps Metrics Server to version v0.2.1, which exposes standard apiserver metrics via /metric endpoint.

**Release note**:
```release-note
Expose Metrics Server metrics via /metric endpoint.
```
