### PR TITLE
Evicted pods should not be marked as failing since they respawn

### DIFF
--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1243,8 +1243,7 @@ def all_kube_system_pods_running():
         status = pod['status']['phase']
         # Evicted nodes should re-spawn
         if status != 'Running' and \
-                ('reason' in pod['status'].keys()
-                 and pod['status']['reason'] != 'Evicted'):
+                        pod['status'].get('reason', '') != 'Evicted':
             return False
 
     return True

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1242,7 +1242,9 @@ def all_kube_system_pods_running():
     for pod in result['items']:
         status = pod['status']['phase']
         # Evicted nodes should re-spawn
-        if status != 'Running' and pod['status']['reason'] != 'Evicted':
+        if status != 'Running' and \
+                ('reason' in pod['status'].keys()
+                 and pod['status']['reason'] != 'Evicted'):
             return False
 
     return True

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1243,7 +1243,7 @@ def all_kube_system_pods_running():
         status = pod['status']['phase']
         # Evicted nodes should re-spawn
         if status != 'Running' and \
-                        pod['status'].get('reason', '') != 'Evicted':
+           pod['status'].get('reason', '') != 'Evicted':
             return False
 
     return True

--- a/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
+++ b/cluster/juju/layers/kubernetes-master/reactive/kubernetes_master.py
@@ -1241,7 +1241,8 @@ def all_kube_system_pods_running():
     result = json.loads(output)
     for pod in result['items']:
         status = pod['status']['phase']
-        if status != 'Running':
+        # Evicted nodes should re-spawn
+        if status != 'Running' and pod['status']['reason'] != 'Evicted':
             return False
 
     return True


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Juju deployments should not report evicted pods as failing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```NONE

```
