### PR TITLE
Automated cherry pick of #57252: Reduce CPU and memory requests for Metrics Server Nanny

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -49,8 +49,8 @@ spec:
             cpu: 100m
             memory: 300Mi
           requests:
-            cpu: 50m
-            memory: 100Mi
+            cpu: 5m
+            memory: 50Mi
         env:
           - name: MY_POD_NAME
             valueFrom:


### PR DESCRIPTION
Cherry pick of #57252 on release-1.9.

#57252: Reduce CPU and memory requests for Metrics Server Nanny

**Release note**:
```release-note
Free up CPU and memory requested but unused by Metrics Server Pod Nanny.
```