### PR TITLE
Fix problem accessing private docker registries

### DIFF
--- a/hack/make-rules/test-cmd-util.sh
+++ b/hack/make-rules/test-cmd-util.sh
@@ -2227,8 +2227,8 @@ run_secrets_test() {
   kubectl create secret docker-registry test-secret --docker-username=test-user --docker-password=test-password --docker-email='test-user@test.com' --namespace=test-secrets
   # Post-condition: secret exists and has expected values
   kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$id_field}}" 'test-secret'
-  kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$secret_type}}" 'kubernetes.io/dockercfg'
-  [[ "$(kubectl get secret/test-secret --namespace=test-secrets -o yaml "${kube_flags[@]}" | grep '.dockercfg:')" ]]
+  kube::test::get_object_assert 'secret/test-secret --namespace=test-secrets' "{{$secret_type}}" 'kubernetes.io/dockerconfigjson'
+  [[ "$(kubectl get secret/test-secret --namespace=test-secrets -o yaml "${kube_flags[@]}" | grep '.dockerconfigjson:')" ]]
   # Clean-up
   kubectl delete secret test-secret --namespace=test-secrets
 

--- a/pkg/kubectl/secret_for_docker_registry.go
+++ b/pkg/kubectl/secret_for_docker_registry.go
@@ -85,15 +85,15 @@ func (s SecretForDockerRegistryGeneratorV1) StructuredGenerate() (runtime.Object
 	if err := s.validate(); err != nil {
 		return nil, err
 	}
-	dockercfgContent, err := handleDockercfgContent(s.Username, s.Password, s.Email, s.Server)
+	dockercfgJsonContent, err := handleDockerCfgJsonContent(s.Username, s.Password, s.Email, s.Server)
 	if err != nil {
 		return nil, err
 	}
 	secret := &v1.Secret{}
 	secret.Name = s.Name
-	secret.Type = v1.SecretTypeDockercfg
+	secret.Type = v1.SecretTypeDockerConfigJson
 	secret.Data = map[string][]byte{}
-	secret.Data[v1.DockerConfigKey] = dockercfgContent
+	secret.Data[v1.DockerConfigJsonKey] = dockercfgJsonContent
 	if s.AppendHash {
 		h, err := hash.SecretHash(secret)
 		if err != nil {
@@ -133,17 +133,17 @@ func (s SecretForDockerRegistryGeneratorV1) validate() error {
 	return nil
 }
 
-// handleDockercfgContent serializes a dockercfg json file
-func handleDockercfgContent(username, password, email, server string) ([]byte, error) {
+// handleDockerCfgJsonContent serializes a ~/.docker/config.json file
+func handleDockerCfgJsonContent(username, password, email, server string) ([]byte, error) {
 	dockercfgAuth := credentialprovider.DockerConfigEntry{
 		Username: username,
 		Password: password,
 		Email:    email,
 	}
 
-	dockerCfg := credentialprovider.DockerConfigJson{
+	dockerCfgJson := credentialprovider.DockerConfigJson{
 		Auths: map[string]credentialprovider.DockerConfigEntry{server: dockercfgAuth},
 	}
 
-	return json.Marshal(dockerCfg)
+	return json.Marshal(dockerCfgJson)
 }

--- a/pkg/kubectl/secret_for_docker_registry_test.go
+++ b/pkg/kubectl/secret_for_docker_registry_test.go
@@ -26,11 +26,11 @@ import (
 
 func TestSecretForDockerRegistryGenerate(t *testing.T) {
 	username, password, email, server := "test-user", "test-password", "test-user@example.org", "https://index.docker.io/v1/"
-	secretData, err := handleDockercfgContent(username, password, email, server)
+	secretData, err := handleDockerCfgJsonContent(username, password, email, server)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	secretDataNoEmail, err := handleDockercfgContent(username, password, "", server)
+	secretDataNoEmail, err := handleDockerCfgJsonContent(username, password, "", server)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -53,9 +53,9 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 					Name: "foo",
 				},
 				Data: map[string][]byte{
-					v1.DockerConfigKey: secretData,
+					v1.DockerConfigJsonKey: secretData,
 				},
-				Type: v1.SecretTypeDockercfg,
+				Type: v1.SecretTypeDockerConfigJson,
 			},
 			expectErr: false,
 		},
@@ -70,12 +70,12 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 			},
 			expected: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "foo-94759gc65b",
+					Name: "foo-548cm7fgdh",
 				},
 				Data: map[string][]byte{
-					v1.DockerConfigKey: secretData,
+					v1.DockerConfigJsonKey: secretData,
 				},
-				Type: v1.SecretTypeDockercfg,
+				Type: v1.SecretTypeDockerConfigJson,
 			},
 			expectErr: false,
 		},
@@ -91,9 +91,9 @@ func TestSecretForDockerRegistryGenerate(t *testing.T) {
 					Name: "foo",
 				},
 				Data: map[string][]byte{
-					v1.DockerConfigKey: secretDataNoEmail,
+					v1.DockerConfigJsonKey: secretDataNoEmail,
 				},
-				Type: v1.SecretTypeDockercfg,
+				Type: v1.SecretTypeDockerConfigJson,
 			},
 			expectErr: false,
 		},


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In 027c8b9ef27ff85fb9eb4a18f04e3809d4065c7a, we added code to
move from .dockercfg to config.json file. But we forgot to use
the right secret type and the key to store the base64'ed creds

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #57427 #57273

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes issue creating docker secrets with kubectl 1.9 for accessing docker private registries.
```
