### PR TITLE
Add code-of-conduct.md to staging repos

### DIFF
--- a/staging/src/k8s.io/api/code-of-conduct.md
+++ b/staging/src/k8s.io/api/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/apiextensions-apiserver/code-of-conduct.md
+++ b/staging/src/k8s.io/apiextensions-apiserver/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/apimachinery/code-of-conduct.md
+++ b/staging/src/k8s.io/apimachinery/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/apiserver/code-of-conduct.md
+++ b/staging/src/k8s.io/apiserver/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/client-go/code-of-conduct.md
+++ b/staging/src/k8s.io/client-go/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/code-generator/code-of-conduct.md
+++ b/staging/src/k8s.io/code-generator/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/kube-aggregator/code-of-conduct.md
+++ b/staging/src/k8s.io/kube-aggregator/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/metrics/code-of-conduct.md
+++ b/staging/src/k8s.io/metrics/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/sample-apiserver/code-of-conduct.md
+++ b/staging/src/k8s.io/sample-apiserver/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)

--- a/staging/src/k8s.io/sample-controller/code-of-conduct.md
+++ b/staging/src/k8s.io/sample-controller/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Kubernetes Community Code of Conduct
+
+Please refer to our [Kubernetes Community Code of Conduct](https://git.k8s.io/community/code-of-conduct.md)


### PR DESCRIPTION
Instead of adding it directly to their published copies

Replaces
- https://github.com/kubernetes/api/pull/13
- https://github.com/kubernetes/apiextensions-apiserver/pull/21
- https://github.com/kubernetes/apimachinery/pull/33
- https://github.com/kubernetes/apiserver/pull/28
- https://github.com/kubernetes/client-go/pull/350
- https://github.com/kubernetes/code-generator/pull/29
- https://github.com/kubernetes/kube-aggregator/pull/11
- https://github.com/kubernetes/metrics/pull/12
- https://github.com/kubernetes/sample-apiserver/pull/18
- https://github.com/kubernetes/sample-controller/pull/3

ref: kubernetes/community#1527