### PR TITLE
iscsi: set node.startup to manual

### DIFF
--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -279,8 +279,8 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			lastErr = fmt.Errorf("iscsi: failed to attach disk: Error: %s (%v)", string(out), err)
 			continue
 		}
-                // in case of node failure/restart, explicitly set to manual login so it doesn't hang on boot
-                out, err = b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "node.startup", "-v", "manual")
+		// in case of node failure/restart, explicitly set to manual login so it doesn't hang on boot
+		out, err = b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "node.startup", "-v", "manual")
 		if err != nil {
 			// don't fail if we can't set startup mode, but log warning so there is a clue
 			glog.Warningf("Warning: Failed to set iSCSI login mode to manual. Error: %v", err)

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -279,6 +279,12 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 			lastErr = fmt.Errorf("iscsi: failed to attach disk: Error: %s (%v)", string(out), err)
 			continue
 		}
+                // in case of node failure/restart, explicitly set to manual login so it doesn't hang on boot
+                out, err = b.exec.Run("iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "node.startup", "-v", "manual")
+		if err != nil {
+			// don't fail if we can't set startup mode, but log warning so there is a clue
+			glog.Warningf("Warning: Failed to set iSCSI login mode to manual. Error: %v", err)
+		}
 		if exist := waitForPathToExist(&devicePath, 10, iscsiTransport); !exist {
 			glog.Errorf("Could not attach disk: Timeout after 10s")
 			// update last error


### PR DESCRIPTION
If the default iSCSI node.startup is set to automatic, if there is a node failure,
any pods on that node will get rescheduled to another node. If the failed node is
later brought back up it will then try to log back in to any iSCSI sessions it had
prior to the failure, which may no longer exist or may be now in-use by the other
nodes.

It appears most platforms keep the open-iscsi default of node.startup-automatic.
But in case this system-wide setting has been changed, and just to be explicit, this
sets node.startup values for kubernetes controlled volumes to manual.

Fixes #21305

```release-note
iSCSI sessions managed by kubernetes will now explicitly set startup.mode to 'manual' to
prevent automatic login after node failure recovery. This is the default open-iscsi mode, so
this change will only impact users who have changed their startup.mode to be 'automatic'
in /etc/iscsi/iscsid.conf.
```
