### PR TITLE
Avoid string concatenation when comparing pods.

### DIFF
--- a/plugin/pkg/scheduler/schedulercache/node_info.go
+++ b/plugin/pkg/scheduler/schedulercache/node_info.go
@@ -510,12 +510,11 @@ func getPodKey(pod *v1.Pod) (string, error) {
 // matches NodeInfo.node and the pod is not found in the pods list. Otherwise,
 // returns true.
 func (n *NodeInfo) Filter(pod *v1.Pod) bool {
-	pFullName := util.GetPodFullName(pod)
 	if pod.Spec.NodeName != n.node.Name {
 		return true
 	}
 	for _, p := range n.pods {
-		if util.GetPodFullName(p) == pFullName {
+		if p.Name == pod.Name && p.Namespace == pod.Namespace {
 			return true
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
4. If the PR is unfinished, see how to mark it: https://github.com/kubernetes/community/blob/master/contributors/devel/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Pod comparison in (*NodeInfo).Filter was using GetPodFullName before
comparing pod names. This is a concatenation of pod name and pod
namespace, and it is significantly faster to compare name & namespace
instead.

This is a set of 3 PRs targeting affinity predicate performance. (#57476, #57477, #57478) The key takeaway is approximately 2x speedup in the large affinity benchmark.

The unexpected increase in BenchmarkScheduling/1000Nodes/1000Pods seems to be an outlier, and did not recur on subsequent runs. The benchmarks have a moderate amount of variance to them, and I did not run them enough times to measure mean and standard deviation.

| test | b.N | master | #57476 | #57477 | #57478 | combined |
| ---- | --- | ------ | ------ | ---------- | ---------- | -------- |
| BenchmarkScheduling/100Nodes/0Pods                | 100 |  39629010 ns/op | 36898566 ns/op (-6.89%)   |  38461530 ns/op (-2.95%)  |  36214136 ns/op (-8.62%)  |  43090781 ns/op (+8.74%)  |
| BenchmarkScheduling/100Nodes/1000Pods             | 100 |  85489577 ns/op | 69538016 ns/op (-18.66%)  |  70104254 ns/op (-18.00%) |  75015585 ns/op (-12.25%) |  80986960 ns/op (-5.27%)  |
| BenchmarkScheduling/1000Nodes/0Pods               | 100 | 219356660 ns/op | 200149051 ns/op (-8.76%)  | 192867469 ns/op (-12.08%) | 196896770 ns/op (-10.24%) | 212563662 ns/op (-3.10%)  |
| BenchmarkScheduling/1000Nodes/1000Pods            | 100 | 380368238 ns/op | 381786369 ns/op (+0.37%)  | 387224973 ns/op (+1.80%)  | 417974358 ns/op (+9.89%)  | 411140230 ns/op (+8.09%)  |
| BenchmarkSchedulingAntiAffinity/500Nodes/250Pods  | 250 | 124399176 ns/op | 97568988 ns/op (-21.57%)  | 112027363 ns/op (-9.95%)  | 129134326 ns/op (+3.81%)  |  98607941 ns/op (-20.73%) |
| BenchmarkSchedulingAntiAffinity/500Nodes/5000Pods | 250 | 491677096 ns/op | 441562422 ns/op (-10.19%) | 278127757 ns/op (-43.43%) | 447355609 ns/op (-9.01%)  | 226310721 ns/op (-53.97%) |

Combined performance contains all three patches.
Percentages are relative to master.

Methodology:

I ran the tests on each branch with this command.
```
make test-integration WHAT="./test/integration/scheduler_perf" KUBE_TEST_ARGS="-run=xxxx -bench=."
```

The benchmarks have a fair amount of variance to them, and I did not run them enough times to measure mean and standard deviation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

The three PRs in this set should collectively fix #54189.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve scheduler performance of MatchInterPodAffinity predicate.
```

